### PR TITLE
Splits Life() into procs for physical and biological life processes in preparation for stasis beds

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -232,6 +232,10 @@
 #define COMSIG_LIVING_STATUS_STAGGER "living_stagger"			//from base of mob/living/Stagger() (amount, update, ignore)
 	#define COMPONENT_NO_STUN 1			//For all of them
 
+#define COMSIG_LIVING_LIFE "life_tick"							//from base of mob/living/Life() (seconds, times_fired)
+	#define COMPONENT_INTERRUPT_LIFE_BIOLOGICAL 1		// interrupt biological processes
+	#define COMPONENT_INTERRUPT_LIFE_PHYSICAL 2			// interrupt physical handling
+
 // /mob/living/carbon signals
 #define COMSIG_CARBON_SOUNDBANG "carbon_soundbang"					//from base of mob/living/carbon/soundbang_act(): (list(intensity))
 #define COMSIG_CARBON_IDENTITY_TRANSFERRED_TO "carbon_id_transferred_to" //from datum/dna/transfer_identity(): (datum/dna, transfer_SE)

--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -6,10 +6,26 @@
 	#define RETURN_TYPE(X) set SpacemanDMM_return_type = X
 	#define SHOULD_CALL_PARENT(X) set SpacemanDMM_should_call_parent = X
 	#define UNLINT(X) SpacemanDMM_unlint(X)
+	#define SHOULD_NOT_OVERRIDE(X) set SpacemanDMM_should_not_override = X
+	#define SHOULD_NOT_SLEEP(X) set SpacemanDMM_should_not_sleep = X
+	#define SHOULD_BE_PURE(X) set SpacemanDMM_should_be_pure = X
+	#define PRIVATE_PROC(X) set SpacemanDMM_private_proc = X
+	#define PROTECTED_PROC(X) set SpacemanDMM_protected_proc = X
+	#define VAR_FINAL var/SpacemanDMM_final
+	#define VAR_PRIVATE var/SpacemanDMM_private
+	#define VAR_PROTECTED var/SpacemanDMM_protected
 #else
 	#define RETURN_TYPE(X)
 	#define SHOULD_CALL_PARENT(X)
 	#define UNLINT(X) X
+	#define SHOULD_NOT_OVERRIDE(X)
+	#define SHOULD_NOT_SLEEP(X)
+	#define SHOULD_BE_PURE(X)
+	#define PRIVATE_PROC(X)
+	#define PROTECTED_PROC(X)
+	#define VAR_FINAL var
+	#define VAR_PRIVATE var
+	#define VAR_PROTECTED var
 #endif
 
 /world/proc/enable_debugger()

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -76,7 +76,7 @@
 	if(check_click_intercept(params,A))
 		return
 
-	if(notransform)
+	if(mob_transforming)
 		return
 
 	if(SEND_SIGNAL(src, COMSIG_MOB_CLICKON, A, params) & COMSIG_MOB_CANCEL_CLICKON)

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(npcpool)
 		var/mob/living/simple_animal/SA = currentrun[currentrun.len]
 		--currentrun.len
 
-		if(!SA.ckey && !SA.notransform)
+		if(!SA.ckey && !SA.mob_transforming)
 			if(SA.stat != DEAD)
 				SA.handle_automated_movement()
 			if(SA.stat != DEAD)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -409,7 +409,7 @@ SUBSYSTEM_DEF(ticker)
 		var/mob/living = player.transfer_character()
 		if(living)
 			qdel(player)
-			living.notransform = TRUE
+			living.mob_transforming = TRUE
 			if(living.client)
 				if (living.client.prefs && living.client.prefs.auto_ooc)
 					if (living.client.prefs.chat_toggles & CHAT_OOC)
@@ -423,7 +423,7 @@ SUBSYSTEM_DEF(ticker)
 /datum/controller/subsystem/ticker/proc/release_characters(list/livings)
 	for(var/I in livings)
 		var/mob/living/L = I
-		L.notransform = FALSE
+		L.mob_transforming = FALSE
 
 /datum/controller/subsystem/ticker/proc/send_tip_of_the_round()
 	var/m

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -123,7 +123,9 @@
 		trauma = _trauma
 	return ..()
 
-/mob/living/split_personality/Life()
+/mob/living/split_personality/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(QDELETED(body))
 		qdel(src) //in case trauma deletion doesn't already do it
 
@@ -131,8 +133,6 @@
 	if(!body.client && trauma.initialized)
 		trauma.switch_personalities()
 		qdel(trauma)
-
-	..()
 
 /mob/living/split_personality/Login()
 	..()

--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -30,7 +30,7 @@ GLOBAL_LIST_EMPTY(cinematics)
 /datum/cinematic
 	var/id = CINEMATIC_DEFAULT
 	var/list/watching = list() //List of clients watching this
-	var/list/locked = list() //Who had notransform set during the cinematic
+	var/list/locked = list() //Who had mob_transforming set during the cinematic
 	var/is_global = FALSE //Global cinematics will override mob-specific ones
 	var/obj/screen/cinematic/screen
 	var/datum/callback/special_callback //For special effects synced with animation (explosions after the countdown etc)
@@ -45,7 +45,7 @@ GLOBAL_LIST_EMPTY(cinematics)
 	GLOB.cinematics -= src
 	QDEL_NULL(screen)
 	for(var/mob/M in locked)
-		M.notransform = FALSE
+		M.mob_transforming = FALSE
 	return ..()
 
 /datum/cinematic/proc/play(watchers)
@@ -70,7 +70,7 @@ GLOBAL_LIST_EMPTY(cinematics)
 
 	for(var/mob/M in GLOB.mob_list)
 		if(M in watchers)
-			M.notransform = TRUE //Should this be done for non-global cinematics or even at all ?
+			M.mob_transforming = TRUE //Should this be done for non-global cinematics or even at all ?
 			locked += M
 			//Close watcher ui's
 			SStgui.close_user_uis(M)
@@ -79,7 +79,7 @@ GLOBAL_LIST_EMPTY(cinematics)
 				M.client.screen += screen
 		else
 			if(is_global)
-				M.notransform = TRUE
+				M.mob_transforming = TRUE
 				locked += M
 
 	//Actually play it

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -109,7 +109,7 @@
 		AM.visible_message("<span class='boldwarning'>[AM] falls into [parent]!</span>", "<span class='userdanger'>[oblivion_message]</span>")
 		if (isliving(AM))
 			var/mob/living/L = AM
-			L.notransform = TRUE
+			L.mob_transforming = TRUE
 			L.Paralyze(200)
 
 		var/oldtransform = AM.transform

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -52,9 +52,9 @@
 			to_chat(affected_mob, pick(stage5))
 		if(QDELETED(affected_mob))
 			return
-		if(affected_mob.notransform)
+		if(affected_mob.mob_transforming)
 			return
-		affected_mob.notransform = 1
+		affected_mob.mob_transforming = 1
 		for(var/obj/item/W in affected_mob.get_equipped_items(TRUE))
 			affected_mob.dropItemToGround(W)
 		for(var/obj/item/I in affected_mob.held_items)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -545,7 +545,7 @@
 			to_chat(usr, "<span class='notice'>This unit already has an expand module installed!</span>")
 			return FALSE
 
-		R.notransform = TRUE
+		R.mob_transforming = TRUE
 		var/prev_locked_down = R.locked_down
 		R.SetLockdown(1)
 		R.anchored = TRUE
@@ -559,7 +559,7 @@
 		if(!prev_locked_down)
 			R.SetLockdown(0)
 		R.anchored = FALSE
-		R.notransform = FALSE
+		R.mob_transforming = FALSE
 		R.resize = 2
 		R.hasExpanded = TRUE
 		R.update_transform()

--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -103,7 +103,9 @@
 		factory.spores += src
 	. = ..()
 
-/mob/living/simple_animal/hostile/blob/blobspore/Life()
+/mob/living/simple_animal/hostile/blob/blobspore/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!is_zombie && isturf(src.loc))
 		for(var/mob/living/carbon/human/H in view(src,1)) //Only for corpse right next to/on same tile
 			if(H.stat == DEAD)
@@ -111,7 +113,6 @@
 				break
 	if(factory && z != factory.z)
 		death()
-	..()
 
 /mob/living/simple_animal/hostile/blob/blobspore/proc/Zombify(mob/living/carbon/human/H)
 	is_zombie = 1
@@ -233,39 +234,40 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/blob/blobbernaut/Life()
-	if(..())
-		var/list/blobs_in_area = range(2, src)
-		if(independent)
-			return // strong independent blobbernaut that don't need no blob
-		var/damagesources = 0
-		if(!(locate(/obj/structure/blob) in blobs_in_area))
-			damagesources++
-		if(!factory)
-			damagesources++
-		else
-			if(locate(/obj/structure/blob/core) in blobs_in_area)
-				adjustHealth(-maxHealth*0.1)
-				var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src)) //hello yes you are being healed
-				if(overmind)
-					H.color = overmind.blobstrain.complementary_color
-				else
-					H.color = "#000000"
-			if(locate(/obj/structure/blob/node) in blobs_in_area)
-				adjustHealth(-maxHealth*0.05)
-				var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src))
-				if(overmind)
-					H.color = overmind.blobstrain.complementary_color
-				else
-					H.color = "#000000"
-		if(damagesources)
-			for(var/i in 1 to damagesources)
-				adjustHealth(maxHealth*0.025) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both
-			var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.01)
-			I.appearance_flags = RESET_COLOR
+/mob/living/simple_animal/hostile/blob/blobbernaut/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	var/list/blobs_in_area = range(2, src)
+	if(independent)
+		return // strong independent blobbernaut that don't need no blob
+	var/damagesources = 0
+	if(!(locate(/obj/structure/blob) in blobs_in_area))
+		damagesources++
+	if(!factory)
+		damagesources++
+	else
+		if(locate(/obj/structure/blob/core) in blobs_in_area)
+			adjustHealth(-maxHealth*0.1)
+			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src)) //hello yes you are being healed
 			if(overmind)
-				I.color = overmind.blobstrain.complementary_color
-			flick_overlay_view(I, src, 8)
+				H.color = overmind.blobstrain.complementary_color
+			else
+				H.color = "#000000"
+		if(locate(/obj/structure/blob/node) in blobs_in_area)
+			adjustHealth(-maxHealth*0.05)
+			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(src))
+			if(overmind)
+				H.color = overmind.blobstrain.complementary_color
+			else
+				H.color = "#000000"
+	if(damagesources)
+		for(var/i in 1 to damagesources)
+			adjustHealth(maxHealth*0.025) //take 2.5% of max health as damage when not near the blob or if the naut has no factory, 5% if both
+		var/image/I = new('icons/mob/blob.dmi', src, "nautdamage", MOB_LAYER+0.01)
+		I.appearance_flags = RESET_COLOR
+		if(overmind)
+			I.color = overmind.blobstrain.complementary_color
+		flick_overlay_view(I, src, 8)
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()

--- a/code/modules/antagonists/bloodsucker/powers/mesmerize.dm
+++ b/code/modules/antagonists/bloodsucker/powers/mesmerize.dm
@@ -129,10 +129,10 @@
 	target.Stun(power_time)
 	to_chat(L, "<span class='notice'>[target] is fixed in place by your hypnotic gaze.</span>")
 	target.next_move = world.time + power_time // <--- Use direct change instead. We want an unmodified delay to their next move //    target.changeNext_move(power_time) // check click.dm
-	target.notransform = TRUE // <--- Fuck it. We tried using next_move, but they could STILL resist. We're just doing a hard freeze.
+	target.mob_transforming = TRUE // <--- Fuck it. We tried using next_move, but they could STILL resist. We're just doing a hard freeze.
 	spawn(power_time)
 	if(istype(target) && success)
-		target.notransform = FALSE
+		target.mob_transforming = FALSE
 		if(istype(L) && target.stat == CONSCIOUS && (target in L.fov_view(10))) // They Woke Up! (Notice if within view)
 			to_chat(L, "<span class='warning'>[target] has snapped out of their trance.</span>")
 

--- a/code/modules/antagonists/bloodsucker/powers/trespass.dm
+++ b/code/modules/antagonists/bloodsucker/powers/trespass.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	if(!.)
 		return
-	if(owner.notransform || !get_turf(owner))
+	if(owner.mob_transforming || !get_turf(owner))
 		return FALSE
 
 	return TRUE
@@ -83,7 +83,7 @@
 	// Freeze Me
 	user.next_move = world.time + mist_delay
 	user.Stun(mist_delay, ignore_canstun = TRUE)
-	user.notransform = TRUE
+	user.mob_transforming = TRUE
 	user.density = FALSE
 	var/invis_was = user.invisibility
 	user.invisibility = INVISIBILITY_MAXIMUM
@@ -106,7 +106,7 @@
 	user.dir = get_dir(my_turf, target_turf)
 	user.next_move = world.time + mist_delay / 2
 	user.Stun(mist_delay / 2, ignore_canstun = TRUE)
-	user.notransform = FALSE
+	user.mob_transforming = FALSE
 	user.density = 1
 	user.invisibility = invis_was
 

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -21,7 +21,7 @@
 	var/datum/changelingprofile/chosen_prof = changeling.get_dna(chosen_name)
 	if(!chosen_prof)
 		return
-	if(!user || user.notransform)
+	if(!user || user.mob_transforming)
 		return 0
 	to_chat(user, "<span class='notice'>We transform our appearance.</span>")
 

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -11,7 +11,7 @@
 
 //Transform into a monkey.
 /obj/effect/proc_holder/changeling/lesserform/sting_action(mob/living/carbon/human/user)
-	if(!user || user.notransform)
+	if(!user || user.mob_transforming)
 		return 0
 	to_chat(user, "<span class='warning'>Our genes cry out!</span>")
 

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -40,8 +40,9 @@
 	if(!shield_health)
 		return "<span class='warning'>Its shield has been destroyed!</span>"
 
-/mob/living/simple_animal/hostile/clockwork/marauder/Life()
-	..()
+/mob/living/simple_animal/hostile/clockwork/marauder/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	var/turf/T = get_turf(src)
 	var/turf/open/space/S = isspaceturf(T)? T : null
 	var/less_space_damage

--- a/code/modules/antagonists/devil/imp/imp.dm
+++ b/code/modules/antagonists/devil/imp/imp.dm
@@ -48,8 +48,9 @@
 	..()
 	boost = world.time + 30
 
-/mob/living/simple_animal/imp/Life()
-	..()
+/mob/living/simple_animal/imp/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(boost<world.time)
 		speed = 1
 	else

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -120,7 +120,7 @@
 		to_chat(src, "<span class='revenboldnotice'>You are once more concealed.</span>")
 	if(unstun_time && world.time >= unstun_time)
 		unstun_time = 0
-		notransform = FALSE
+		mob_transforming = FALSE
 		to_chat(src, "<span class='revenboldnotice'>You can move again!</span>")
 	if(essence_regenerating && !inhibited && essence < essence_regen_cap) //While inhibited, essence will not regenerate
 		essence = min(essence_regen_cap, essence+essence_regen_amount)
@@ -218,7 +218,7 @@
 		return 0
 	stasis = TRUE
 	to_chat(src, "<span class='revendanger'>NO! No... it's too late, you can feel your essence [pick("breaking apart", "drifting away")]...</span>")
-	notransform = TRUE
+	mob_transforming = TRUE
 	revealed = TRUE
 	invisibility = 0
 	playsound(src, 'sound/effects/screech.ogg', 100, 1)
@@ -260,7 +260,7 @@
 		return
 	if(time <= 0)
 		return
-	notransform = TRUE
+	mob_transforming = TRUE
 	if(!unstun_time)
 		to_chat(src, "<span class='revendanger'>You cannot move!</span>")
 		unstun_time = world.time + time
@@ -271,7 +271,7 @@
 
 /mob/living/simple_animal/revenant/proc/update_spooky_icon()
 	if(revealed)
-		if(notransform)
+		if(mob_transforming)
 			if(draining)
 				icon_state = icon_drain
 			else
@@ -320,7 +320,7 @@
 /mob/living/simple_animal/revenant/proc/death_reset()
 	revealed = FALSE
 	unreveal_time = 0
-	notransform = 0
+	mob_transforming = 0
 	unstun_time = 0
 	inhibited = FALSE
 	draining = FALSE

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -107,7 +107,9 @@
 		mind.add_antag_datum(/datum/antagonist/revenant)
 
 //Life, Stat, Hud Updates, and Say
-/mob/living/simple_animal/revenant/Life()
+/mob/living/simple_animal/revenant/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(stasis)
 		return
 	if(revealed && essence <= 0)
@@ -127,7 +129,6 @@
 		update_action_buttons_icon() //because we update something required by our spells in life, we need to update our buttons
 	update_spooky_icon()
 	update_health_hud()
-	..()
 
 /mob/living/simple_animal/revenant/Stat()
 	..()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -369,7 +369,7 @@
 	var/mob/living/carbon/last_user
 
 /obj/item/warpwhistle/proc/interrupted(mob/living/carbon/user)
-	if(!user || QDELETED(src) || user.notransform)
+	if(!user || QDELETED(src) || user.mob_transforming)
 		on_cooldown = FALSE
 		return TRUE
 	return FALSE

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -84,7 +84,7 @@
 		user.alpha = 255
 		user.update_atom_colour()
 		user.animate_movement = FORWARD_STEPS
-		user.notransform = 0
+		user.mob_transforming = 0
 		user.anchored = FALSE
 		teleporting = 0
 		for(var/obj/item/I in user.held_items)
@@ -125,7 +125,7 @@
 			ADD_TRAIT(I, TRAIT_NODROP, CHRONOSUIT_TRAIT)
 		user.animate_movement = NO_STEPS
 		user.changeNext_move(8 + phase_in_ds)
-		user.notransform = 1
+		user.mob_transforming = 1
 		user.anchored = TRUE
 		user.Stun(INFINITY)
 

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -56,8 +56,9 @@
 	cached_z = z
 	poof()
 
-/mob/living/simple_animal/jacq/Life()
-	..()
+/mob/living/simple_animal/jacq/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!ckey)
 		if((last_poof+3 MINUTES) < world.realtime)
 			poof()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -492,7 +492,7 @@
 	setDir(user.dir)
 
 	user.forceMove(src)
-	user.notransform = TRUE
+	user.mob_transforming = TRUE
 	user.status_flags |= GODMODE
 
 	can_destroy = FALSE
@@ -501,7 +501,7 @@
 
 /obj/effect/immortality_talisman/proc/unvanish(mob/user)
 	user.status_flags &= ~GODMODE
-	user.notransform = FALSE
+	user.mob_transforming = FALSE
 	user.forceMove(get_turf(src))
 
 	user.visible_message("<span class='danger'>[user] pops back into reality!</span>")

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -68,7 +68,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	set category = "OOC"
 	set name = "Server Hop!"
 	set desc= "Jump to the other server"
-	if(notransform)
+	if(mob_transforming)
 		return
 	var/list/csa = CONFIG_GET(keyed_list/cross_server)
 	var/pick
@@ -93,9 +93,9 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	to_chat(C, "<span class='notice'>Sending you to [pick].</span>")
 	new /obj/screen/splash(C)
 
-	notransform = TRUE
+	mob_transforming = TRUE
 	sleep(29)	//let the animation play
-	notransform = FALSE
+	mob_transforming = FALSE
 
 	if(!C)
 		return

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -37,10 +37,10 @@
 		C.put_in_hands(B1)
 		C.put_in_hands(B2)
 		C.regenerate_icons()
-	src.notransform = TRUE
+	src.mob_transforming = TRUE
 	spawn(0)
 		bloodpool_sink(B)
-		src.notransform = FALSE
+		src.mob_transforming = FALSE
 	return 1
 
 /mob/living/proc/bloodpool_sink(obj/effect/decal/cleanable/B)
@@ -155,7 +155,7 @@
 	addtimer(CALLBACK(src, /atom/.proc/remove_atom_colour, TEMPORARY_COLOUR_PRIORITY, newcolor), 6 SECONDS)
 
 /mob/living/proc/phasein(obj/effect/decal/cleanable/B)
-	if(src.notransform)
+	if(src.mob_transforming)
 		to_chat(src, "<span class='warning'>Finish eating first!</span>")
 		return 0
 	B.visible_message("<span class='warning'>[B] starts to bubble...</span>")

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -1,11 +1,7 @@
 
-/mob/living/brain/Life()
-	set invisibility = 0
-	if (notransform)
+/mob/living/brain/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
-	if(!loc)
-		return
-	. = ..()
 	handle_emp_damage()
 
 /mob/living/brain/update_stat()

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,14 +1,10 @@
-
-
-/mob/living/carbon/alien/larva/Life()
-	set invisibility = 0
-	if (notransform)
+/mob/living/carbon/alien/larva/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
-	if(..()) //not dead
-		// GROW!
-		if(amount_grown < max_grown)
-			amount_grown++
-			update_icons()
+	// GROW!
+	if(amount_grown < max_grown)
+		amount_grown++
+		update_icons()
 
 
 /mob/living/carbon/alien/larva/update_stat()

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,6 +1,7 @@
-/mob/living/carbon/alien/Life()
+/mob/living/carbon/alien/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	findQueen()
-	return..()
 
 /mob/living/carbon/alien/check_breath(datum/gas_mixture/breath)
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -92,7 +92,7 @@
 	ghost.transfer_ckey(new_xeno, FALSE)
 	SEND_SOUND(new_xeno, sound('sound/voice/hiss5.ogg',0,0,0,100))	//To get the player's attention
 	new_xeno.Paralyze(6)
-	new_xeno.notransform = TRUE
+	new_xeno.mob_transforming = TRUE
 	new_xeno.invisibility = INVISIBILITY_MAXIMUM
 
 	sleep(6)
@@ -102,7 +102,7 @@
 
 	if(new_xeno)
 		new_xeno.SetParalyzed(0)
-		new_xeno.notransform = FALSE
+		new_xeno.mob_transforming = FALSE
 		new_xeno.invisibility = 0
 
 	var/mob/living/carbon/old_owner = owner

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -18,31 +18,20 @@
 #define THERMAL_PROTECTION_HAND_LEFT	0.025
 #define THERMAL_PROTECTION_HAND_RIGHT	0.025
 
-/mob/living/carbon/human/Life(seconds, times_fired)
-	set invisibility = 0
-	if (mob_transforming)
+/mob/living/carbon/human/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
+	handle_active_genes()
+	//heart attack stuff
+	handle_heart()
+	dna.species.spec_life(src) // for mutantraces
+	return (stat != DEAD) && !QDELETED(src)
 
-	. = ..()
-
-	if (QDELETED(src))
-		return 0
-
-	if(.) //not dead
-		handle_active_genes()
-
-	if(stat != DEAD)
-		//heart attack stuff
-		handle_heart()
-
+/mob/living/carbon/human/PhysicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
-
-	dna.species.spec_life(src) // for mutantraces
-
-	if(stat != DEAD)
-		return 1
-
 
 /mob/living/carbon/human/calculate_affecting_pressure(pressure)
 	var/headless = !get_bodypart(BODY_ZONE_HEAD) //should the mob be perennially headless (see dullahans), we only take the suit into account, so they can into space.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -20,7 +20,7 @@
 
 /mob/living/carbon/human/Life(seconds, times_fired)
 	set invisibility = 0
-	if (notransform)
+	if (mob_transforming)
 		return
 
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -239,7 +239,7 @@
 		"<span class='notice'>You focus intently on moving your body while \
 		standing perfectly still...</span>")
 
-	H.notransform = TRUE
+	H.mob_transforming = TRUE
 
 	if(do_after(owner, delay=60, needhand=FALSE, target=owner, progress=TRUE))
 		if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
@@ -249,7 +249,7 @@
 	else
 		to_chat(H, "<span class='warning'>...but fail to stand perfectly still!</span>")
 
-	H.notransform = FALSE
+	H.mob_transforming = FALSE
 
 /datum/action/innate/split_body/proc/make_dupe()
 	var/mob/living/carbon/human/H = owner
@@ -267,7 +267,7 @@
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
 	H.blood_volume *= 0.45
-	H.notransform = 0
+	H.mob_transforming = 0
 
 	var/datum/species/jelly/slime/origin_datum = H.dna.species
 	origin_datum.bodies |= spare

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/Life()
 	set invisibility = 0
 
-	if(notransform)
+	if(mob_transforming)
 		return
 
 	if(damageoverlaytemp)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -13,6 +13,7 @@
 		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
 			updatehealth()
 	update_stamina()
+	doSprintBufferRegen()
 
 	if(stat != DEAD)
 		handle_brain_damage()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -1,24 +1,13 @@
-/mob/living/carbon/Life()
-	set invisibility = 0
-
-	if(mob_transforming)
-		return
-
-	if(damageoverlaytemp)
-		damageoverlaytemp = 0
-		update_damage_hud()
-
+/mob/living/carbon/BiologicalLife(seconds, times_fired)
+	if(stat == DEAD)
+		return FALSE
 	//Reagent processing needs to come before breathing, to prevent edge cases.
 	handle_organs()
-
-	. = ..()
-
-	if (QDELETED(src))
+	if(!(. = ..()))
 		return
-
-	if(.) //not dead
-		handle_blood()
-
+	handle_blood()
+	// handle_blood *could* kill us.
+	// we should probably have a better system for if we need to check for death or something in the future hmw
 	if(stat != DEAD)
 		var/bprv = handle_bodyparts()
 		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
@@ -35,12 +24,17 @@
 		stop_sound_channel(CHANNEL_HEARTBEAT)
 		handle_death()
 		rot()
+		. = FALSE
 
 	//Updates the number of stored chemicals for powers
 	handle_changeling()
 
-	if(stat != DEAD)
-		return 1
+/mob/living/carbon/PhysicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	if(damageoverlaytemp)
+		damageoverlaytemp = 0
+		update_damage_hud()
 
 //Procs called while dead
 /mob/living/carbon/proc/handle_death()

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -3,30 +3,26 @@
 /mob/living/carbon/monkey
 
 
-/mob/living/carbon/monkey/Life()
-	set invisibility = 0
-
-	if (mob_transforming)
+/mob/living/carbon/monkey/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
-
-	if(..())
-
-		if(!client)
-			if(stat == CONSCIOUS)
-				if(on_fire || buckled || restrained() || (!CHECK_MOBILITY(src, MOBILITY_STAND) && CHECK_MOBILITY(src, MOBILITY_MOVE))) //CIT CHANGE - makes it so monkeys attempt to resist if they're resting)
-					if(!resisting && prob(MONKEY_RESIST_PROB))
-						resisting = TRUE
-						walk_to(src,0)
-						resist()
-				else if(resisting)
-					resisting = FALSE
-				else if((mode == MONKEY_IDLE && !pickupTarget && !prob(MONKEY_SHENANIGAN_PROB)) || !handle_combat())
-					if(prob(25) && CHECK_MOBILITY(src, MOBILITY_MOVE) && isturf(loc) && !pulledby)
-						step(src, pick(GLOB.cardinals))
-					else if(prob(1))
-						emote(pick("scratch","jump","roll","tail"))
-			else
+	if(client)
+		return
+	if(stat == CONSCIOUS)
+		if(on_fire || buckled || restrained() || (!CHECK_MOBILITY(src, MOBILITY_STAND) && CHECK_MOBILITY(src, MOBILITY_MOVE))) //CIT CHANGE - makes it so monkeys attempt to resist if they're resting)
+			if(!resisting && prob(MONKEY_RESIST_PROB))
+				resisting = TRUE
 				walk_to(src,0)
+				resist()
+		else if(resisting)
+			resisting = FALSE
+		else if((mode == MONKEY_IDLE && !pickupTarget && !prob(MONKEY_SHENANIGAN_PROB)) || !handle_combat())
+			if(prob(25) && CHECK_MOBILITY(src, MOBILITY_MOVE) && isturf(loc) && !pulledby)
+				step(src, pick(GLOB.cardinals))
+			else if(prob(1))
+				emote(pick("scratch","jump","roll","tail"))
+	else
+		walk_to(src,0)
 
 /mob/living/carbon/monkey/handle_mutations_and_radiation()
 	if(radiation)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -6,7 +6,7 @@
 /mob/living/carbon/monkey/Life()
 	set invisibility = 0
 
-	if (notransform)
+	if (mob_transforming)
 		return
 
 	if(..())

--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -31,11 +31,12 @@
 	if(relic_mask)
 		equip_to_slot_or_del(new relic_mask, SLOT_WEAR_MASK)
 
-/mob/living/carbon/monkey/punpun/Life()
+/mob/living/carbon/monkey/punpun/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE, FALSE)
 		memory_saved = TRUE
-	..()
 
 /mob/living/carbon/monkey/punpun/death(gibbed)
 	if(!memory_saved)

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -12,7 +12,7 @@
 		overlays_standing[cache_index] = null
 
 /mob/living/carbon/regenerate_icons()
-	if(notransform)
+	if(mob_transforming)
 		return 1
 	update_inv_hands()
 	update_inv_handcuffed()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -3,8 +3,7 @@
   * Splits off into PhysicalLife() and BiologicalLife(). Override those instead of this.
   */
 /mob/living/proc/Life(seconds, times_fired)
-	SHOULD_NOT_OVERRIDE(TRUE)
-	SHOULD_NOT_SLEEP(TRUE)
+	set waitfor = FALSE		// yeah hey we're kind of on a subsystem, no sleeping will be tolerated here!
 	if(mob_transforming)
 		return
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -1,12 +1,21 @@
+/**
+  * Called by SSmobs at (hopefully) an interval of 1 second.
+  * Splits off into PhysicalLife() and BiologicalLife(). Override those instead of this.
+  */
 /mob/living/proc/Life(seconds, times_fired)
-	set waitfor = FALSE
-	set invisibility = 0
+	SHOULD_NOT_OVERRIDE(TRUE)
+	SHOULD_NOT_SLEEP(TRUE)
+	if(mob_transforming)
+		return
 
-	if(digitalinvis)
-		handle_diginvis() //AI becomes unable to see mob
+	. = SEND_SIGNAL(src, COMSIG_LIVING_LIFE, seconds, times_fired)
+	if(!(. & COMPONENT_INTERRUPT_LIFE_PHYSICAL))
+		PhysicalLife(seconds, times_fired)
+	if(!(. & COMPONENT_INTERRUPT_LIFE_BIOLOGICAL))
+		BiologicalLife(seconds, times_fired)
 
-	if((movement_type & FLYING) && !(movement_type & FLOATING))	//TODO: Better floating
-		float(on = TRUE)
+	// CODE BELOW SHOULD ONLY BE THINGS THAT SHOULD HAPPEN NO MATTER WHAT AND CAN NOT BE SUSPENDED!
+	// Otherwise, it goes into one of the two split Life procs!
 
 	if (client)
 		var/turf/T = get_turf(src)
@@ -30,28 +39,58 @@
 		log_game("Z-TRACKING: [src] of type [src.type] has a Z-registration despite not having a client.")
 		update_z(null)
 
-	if (notransform)
-		return
-	if(!loc)
-		return
-	var/datum/gas_mixture/environment = loc.return_air()
-
-	if(stat != DEAD)
-		//Mutations and radiation
-		handle_mutations_and_radiation()
-
-	if(stat != DEAD)
-		//Breathing, if applicable
-		handle_breathing(times_fired)
+/**
+  * Handles biological life processes like chemical metabolism, breathing, etc
+  * Returns TRUE or FALSE based on if we were interrupted. This is used by overridden variants to check if they should stop.
+  */
+/mob/living/proc/BiologicalLife(seconds, times_fired)
+	SHOULD_NOT_SLEEP(TRUE)
 
 	handle_diseases()// DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
 
-	if (QDELETED(src)) // diseases can qdel the mob via transformations
-		return
+	// Everything after this shouldn't process while dead (as of the time of writing)
+	if(stat == DEAD)
+		return FALSE
 
-	if(stat != DEAD)
-		//Random events (vomiting etc)
-		handle_random_events()
+	//Mutations and radiation
+	handle_mutations_and_radiation()
+
+	//Breathing, if applicable
+	handle_breathing(times_fired)
+
+	if (QDELETED(src)) // diseases can qdel the mob via transformations
+		return FALSE
+
+	//Random events (vomiting etc)
+	handle_random_events()
+
+	//stuff in the stomach
+	handle_stomach()
+
+	handle_block_parry(seconds)
+
+	// These two MIGHT need to be moved to base Life() if we get any in the future that's a "physical" effect that needs to fire even while in stasis.
+	handle_traits() // eye, ear, brain damages
+	handle_status_effects() //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc
+	return TRUE
+
+/**
+  * Handles physical life processes like being on fire. Don't ask why this is considered "Life".
+  * Returns TRUE or FALSE based on if we were interrupted. This is used by overridden variants to check if they should stop.
+  */
+/mob/living/proc/PhysicalLife(seconds, times_fired)
+	SHOULD_NOT_SLEEP(TRUE)
+	
+	if(digitalinvis)
+		handle_diginvis() //AI becomes unable to see mob
+
+	if((movement_type & FLYING) && !(movement_type & FLOATING))	//TODO: Better floating
+		float(on = TRUE)
+
+	if(!loc)
+		return FALSE
+
+	var/datum/gas_mixture/environment = loc.return_air()
 
 	//Handle temperature/pressure differences between body and environment
 	if(environment)
@@ -59,23 +98,11 @@
 
 	handle_fire()
 
-	//stuff in the stomach
-	handle_stomach()
-
 	handle_gravity()
-
-	handle_block_parry(seconds)
 
 	if(machine)
 		machine.check_eye(src)
-
-	if(stat != DEAD)
-		handle_traits() // eye, ear, brain damages
-	if(stat != DEAD)
-		handle_status_effects() //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc
-
-	if(stat != DEAD)
-		return 1
+	return TRUE
 
 /mob/living/proc/handle_breathing(times_fired)
 	return

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -43,8 +43,6 @@
   * Returns TRUE or FALSE based on if we were interrupted. This is used by overridden variants to check if they should stop.
   */
 /mob/living/proc/BiologicalLife(seconds, times_fired)
-	SHOULD_NOT_SLEEP(TRUE)
-
 	handle_diseases()// DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
 
 	// Everything after this shouldn't process while dead (as of the time of writing)
@@ -78,8 +76,6 @@
   * Returns TRUE or FALSE based on if we were interrupted. This is used by overridden variants to check if they should stop.
   */
 /mob/living/proc/PhysicalLife(seconds, times_fired)
-	SHOULD_NOT_SLEEP(TRUE)
-	
 	if(digitalinvis)
 		handle_diginvis() //AI becomes unable to see mob
 

--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -3,48 +3,48 @@
 #define POWER_RESTORATION_SEARCH_APC 2
 #define POWER_RESTORATION_APC_FOUND 3
 
-/mob/living/silicon/ai/Life()
-	if (stat == DEAD)
+/mob/living/silicon/ai/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
-	else //I'm not removing that shitton of tabs, unneeded as they are. -- Urist
+	//I'm not removing that shitton of tabs, unneeded as they are. -- Urist
 		//Being dead doesn't mean your temperature never changes
 
-		update_gravity(mob_has_gravity())
+	update_gravity(mob_has_gravity())
 
-		handle_status_effects()
+	handle_status_effects()
 
-		if(malfhack && malfhack.aidisabled)
-			deltimer(malfhacking)
-			// This proc handles cleanup of screen notifications and
-			// messenging the client
-			malfhacked(malfhack)
+	if(malfhack && malfhack.aidisabled)
+		deltimer(malfhacking)
+		// This proc handles cleanup of screen notifications and
+		// messenging the client
+		malfhacked(malfhack)
 
-		if(isturf(loc) && (QDELETED(eyeobj) || !eyeobj.loc))
-			view_core()
+	if(isturf(loc) && (QDELETED(eyeobj) || !eyeobj.loc))
+		view_core()
 
-		if(machine)
-			machine.check_eye(src)
+	if(machine)
+		machine.check_eye(src)
 
-		// Handle power damage (oxy)
-		if(aiRestorePowerRoutine)
-			// Lost power
-			adjustOxyLoss(1)
-		else
-			// Gain Power
-			if(getOxyLoss())
-				adjustOxyLoss(-1)
+	// Handle power damage (oxy)
+	if(aiRestorePowerRoutine)
+		// Lost power
+		adjustOxyLoss(1)
+	else
+		// Gain Power
+		if(getOxyLoss())
+			adjustOxyLoss(-1)
 
-		if(!lacks_power())
-			var/area/home = get_area(src)
-			if(home.powered(EQUIP))
-				home.use_power(1000, EQUIP)
+	if(!lacks_power())
+		var/area/home = get_area(src)
+		if(home.powered(EQUIP))
+			home.use_power(1000, EQUIP)
 
-			if(aiRestorePowerRoutine >= POWER_RESTORATION_SEARCH_APC)
-				ai_restore_power()
-				return
+		if(aiRestorePowerRoutine >= POWER_RESTORATION_SEARCH_APC)
+			ai_restore_power()
+			return
 
-		else if(!aiRestorePowerRoutine)
-			ai_lose_power()
+	else if(!aiRestorePowerRoutine)
+		ai_lose_power()
 
 /mob/living/silicon/ai/proc/lacks_power()
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -146,10 +146,11 @@
 	if(possible_chassis[chassis])
 		AddElement(/datum/element/mob_holder, chassis, 'icons/mob/pai_item_head.dmi', 'icons/mob/pai_item_rh.dmi', 'icons/mob/pai_item_lh.dmi', ITEM_SLOT_HEAD)
 
-/mob/living/silicon/pai/Life()
+/mob/living/silicon/pai/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(hacking)
 		process_hack()
-	return ..()
 
 /mob/living/silicon/pai/proc/process_hack()
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -283,17 +283,19 @@
 	. = ..()
 	. += "A personal AI in holochassis mode. Its master ID string seems to be [master]."
 
-/mob/living/silicon/pai/Life()
-	if(stat == DEAD)
-		return
+/mob/living/silicon/pai/PhysicalLife()
+	. = ..()
 	if(cable)
 		if(get_dist(src, cable) > 1)
 			var/turf/T = get_turf(src.loc)
 			T.visible_message("<span class='warning'>[src.cable] rapidly retracts back into its spool.</span>", "<span class='italics'>You hear a click and the sound of wire spooling rapidly.</span>")
 			qdel(src.cable)
 			cable = null
+
+/mob/living/silicon/pai/BiologicalLife()
+	if(!(. = ..()))
+		return
 	silent = max(silent - 1, 0)
-	. = ..()
 
 /mob/living/silicon/pai/updatehealth()
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon/robot/Life()
 	set invisibility = 0
-	if (src.notransform)
+	if (src.mob_transforming)
 		return
 
 	..()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,9 +1,6 @@
-/mob/living/silicon/robot/Life()
-	set invisibility = 0
-	if (src.mob_transforming)
+/mob/living/silicon/robot/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
-
-	..()
 	adjustOxyLoss(-10) //we're a robot!
 	handle_robot_hud_updates()
 	handle_robot_cell()

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -259,7 +259,7 @@
 	var/prev_locked_down = R.locked_down
 	sleep(1)
 	flick("[cyborg_base_icon]_transform", R)
-	R.notransform = TRUE
+	R.mob_transforming = TRUE
 	R.SetLockdown(1)
 	R.anchored = TRUE
 	sleep(1)
@@ -270,7 +270,7 @@
 		R.SetLockdown(0)
 	R.setDir(SOUTH)
 	R.anchored = FALSE
-	R.notransform = FALSE
+	R.mob_transforming = FALSE
 	R.update_headlamp()
 	R.notify_ai(NEW_MODULE)
 	if(R.hud_used)

--- a/code/modules/mob/living/simple_animal/astral.dm
+++ b/code/modules/mob/living/simple_animal/astral.dm
@@ -62,7 +62,7 @@
 			log_reagent("FERMICHEM: [src] has astrally transmitted [message] into [A]")
 
 //Delete the mob if there's no mind! Pay that mob no mind.
-/mob/living/simple_animal/astral/Life()
-	if(!mind)
-		qdel(src)
+/mob/living/simple_animal/astral/PhysicalLife(seconds, times_fired)
 	. = ..()
+	if(!mind && !QDELETED(src))
+		qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -115,13 +115,14 @@
 	Read_Memory()
 	. = ..()
 
-/mob/living/simple_animal/pet/cat/Runtime/Life()
+/mob/living/simple_animal/pet/cat/Runtime/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!cats_deployed && SSticker.current_state >= GAME_STATE_SETTING_UP)
 		Deploy_The_Cats()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory()
 		memory_saved = TRUE
-	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/make_babies()
 	var/mob/baby = ..()
@@ -177,7 +178,9 @@
 	gold_core_spawnable = NO_SPAWN
 	unique_pet = TRUE
 
-/mob/living/simple_animal/pet/cat/Life()
+/mob/living/simple_animal/pet/cat/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!stat && !buckled && !client)
 		if(prob(1))
 			emote("me", EMOTE_VISIBLE, pick("stretches out for a belly rub.", "wags its tail.", "lies down."))
@@ -269,8 +272,9 @@
 		to_chat(src, "<span class='notice'>Your name is now <b>\"new_name\"</b>!</span>")
 		name = new_name
 
-/mob/living/simple_animal/pet/cat/cak/Life()
-	..()
+/mob/living/simple_animal/pet/cat/cak/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(stat)
 		return
 	if(health < maxHealth)

--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -27,8 +27,9 @@
 	var/obj/item/inventory_mask
 	gold_core_spawnable = FRIENDLY_SPAWN
 
-/mob/living/simple_animal/crab/Life()
-	..()
+/mob/living/simple_animal/crab/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	//CRAB movement
 	if(!ckey && !stat)
 		if(isturf(loc) && !resting && !buckled)		//This is so it only moves if it's not inside a closet, gentics machine, etc.

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -366,11 +366,12 @@
 		RemoveElement(/datum/element/mob_holder, held_icon)
 		AddElement(/datum/element/mob_holder, "old_corgi")
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/Life()
+/mob/living/simple_animal/pet/dog/corgi/Ian/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE)
 		memory_saved = TRUE
-	..()
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/death()
 	if(!memory_saved)
@@ -490,8 +491,9 @@
 	nofur = TRUE
 	unique_pet = TRUE
 
-/mob/living/simple_animal/pet/dog/corgi/narsie/Life()
-	..()
+/mob/living/simple_animal/pet/dog/corgi/narsie/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	for(var/mob/living/simple_animal/pet/P in range(1, src))
 		if(P != src && prob(5))
 			visible_message("<span class='warning'>[src] devours [P]!</span>", \
@@ -615,8 +617,9 @@
 		return
 	..()
 
-/mob/living/simple_animal/pet/dog/corgi/Lisa/Life()
-	..()
+/mob/living/simple_animal/pet/dog/corgi/Lisa/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 
 	make_babies()
 
@@ -628,8 +631,9 @@
 					setDir(i)
 					sleep(1)
 
-/mob/living/simple_animal/pet/dog/pug/Life()
-	..()
+/mob/living/simple_animal/pet/dog/pug/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!stat && CHECK_MULTIPLE_BITFIELDS(mobility_flags, MOBILITY_STAND|MOBILITY_MOVE) && !buckled)
 		if(prob(1))
 			emote("me", EMOTE_VISIBLE, pick("chases its tail."))

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -420,8 +420,9 @@
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
 
-/mob/living/simple_animal/pet/dog/corgi/Ian/Life()
-	..()
+/mob/living/simple_animal/pet/dog/corgi/Ian/BiologicalLife()
+	if(!(. = ..()))
+		return
 
 	//Feeding, chasing food, FOOOOODDDD
 	if(!stat && CHECK_MULTIPLE_BITFIELDS(mobility_flags, MOBILITY_STAND|MOBILITY_MOVE) && !buckled)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -46,9 +46,10 @@
 	udder = null
 	return ..()
 
-/mob/living/simple_animal/hostile/retaliate/goat/Life()
-	. = ..()
-	if(.)
+/mob/living/simple_animal/hostile/retaliate/goat/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	if(stat == CONSCIOUS)
 		//chance to go crazy and start wacking stuff
 		if(!enemies.len && prob(1))
 			Retaliate()
@@ -57,7 +58,6 @@
 			enemies = list()
 			LoseTarget()
 			src.visible_message("<span class='notice'>[src] calms down.</span>")
-	if(stat == CONSCIOUS)
 		udder.generateMilk(milk_reagent)
 		eat_plants()
 		if(!pulledby)
@@ -160,8 +160,9 @@
 	else
 		return ..()
 
-/mob/living/simple_animal/cow/Life()
-	. = ..()
+/mob/living/simple_animal/cow/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(stat == CONSCIOUS)
 		udder.generateMilk(milk_reagent)
 
@@ -244,9 +245,8 @@
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
 
-/mob/living/simple_animal/chick/Life()
-	. =..()
-	if(!.)
+/mob/living/simple_animal/chick/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
 	if(!stat && !ckey)
 		amount_grown += rand(1,2)
@@ -254,8 +254,9 @@
 			new /mob/living/simple_animal/chicken(src.loc)
 			qdel(src)
 
-/mob/living/simple_animal/chick/holo/Life()
-	..()
+/mob/living/simple_animal/chick/holo/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	amount_grown = 0
 
 /mob/living/simple_animal/chicken
@@ -328,9 +329,8 @@
 	else
 		..()
 
-/mob/living/simple_animal/chicken/Life()
-	. =..()
-	if(!.)
+/mob/living/simple_animal/chicken/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
 	if((!stat && prob(3) && eggsleft > 0) && egg_type)
 		visible_message("<span class='alertalien'>[src] [pick(layMessage)]</span>")
@@ -403,9 +403,8 @@
 	. = ..()
 	++kiwi_count
 
-/mob/living/simple_animal/kiwi/Life()
-	. =..()
-	if(!.)
+/mob/living/simple_animal/kiwi/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
 	if((!stat && prob(3) && eggsleft > 0) && egg_type)
 		visible_message("[src] [pick(layMessage)]")
@@ -478,9 +477,8 @@
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
 
-/mob/living/simple_animal/babyKiwi/Life()
-	. =..()
-	if(!.)
+/mob/living/simple_animal/babyKiwi/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
 	if(!stat && !ckey)
 		amount_grown += rand(1,2)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -72,8 +72,8 @@
 		qdel(src)
 
 //low regen over time
-/mob/living/simple_animal/pet/plushie/Life()
-	if(stat)
+/mob/living/simple_animal/pet/plushie/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
 	if(health < maxHealth)
 		heal_overall_damage(5) //Decent life regen, they're not able to hurt anyone so this shouldn't be an issue (butterbear for reference has 10 regen)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	to_chat(src, "<span class='notice'>Your new name <span class='name'>[new_name]</span> anchors itself in your mind.</span>")
 	fully_replace_character_name(null, new_name)
 
-/mob/living/simple_animal/hostile/guardian/Life() //Dies if the summoner dies
+/mob/living/simple_animal/hostile/guardian/PhysicalLife() //Dies if the summoner dies
 	. = ..()
 	update_health_hud() //we need to update all of our health displays to match our summoner and we can't practically give the summoner a hook to do it
 	med_hud_set_health()

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -19,8 +19,9 @@
 	. = ..()
 	stealthcooldown = 0
 
-/mob/living/simple_animal/hostile/guardian/assassin/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/guardian/assassin/PhysicalLife()
+	if(!(. = ..()))
+		return
 	updatestealthalert()
 	if(loc == summoner && toggle)
 		ToggleMode(0)

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -11,8 +11,9 @@
 	var/charging = 0
 	var/obj/screen/alert/chargealert
 
-/mob/living/simple_animal/hostile/guardian/charger/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/guardian/charger/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(ranged_cooldown <= world.time)
 		if(!chargealert)
 			chargealert = throw_alert("charge", /obj/screen/alert/cancharge)

--- a/code/modules/mob/living/simple_animal/guardian/types/fire.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/fire.dm
@@ -13,8 +13,9 @@
 	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Crowd control modules activated. Holoparasite swarm online.</span>"
 	carp_fluff_string = "<span class='holoparasite'>CARP CARP CARP! You caught one! OH GOD, EVERYTHING'S ON FIRE. Except you and the fish.</span>"
 
-/mob/living/simple_animal/hostile/guardian/fire/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/guardian/fire/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(summoner)
 		summoner.ExtinguishMob()
 		summoner.adjust_fire_stacks(-20)

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -125,7 +125,7 @@ mob/living/simple_animal/hostile/bear/butter //The mighty companion to Cak. Seve
 	attack_verb_continuous = "slaps"
 	attack_verb_simple = "slap"
 
-/mob/living/simple_animal/hostile/bear/butter/Life() //Heals butter bear really fast when he takes damage.
+/mob/living/simple_animal/hostile/bear/butter/BiologicalLife(seconds, times_fired) //Heals butter bear really fast when he takes damage.
 	if(stat)
 		return
 	if(health < maxHealth)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -47,8 +47,9 @@
 	if(regen_amount)
 		regen_cooldown = world.time + REGENERATION_DELAY
 
-/mob/living/simple_animal/hostile/carp/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/carp/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(regen_amount && regen_cooldown < world.time)
 		heal_overall_damage(regen_amount)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -67,11 +67,10 @@
 	foes = null
 	return ..()
 
-/mob/living/simple_animal/hostile/Life()
-	. = ..()
-	if(!.) //dead
+/mob/living/simple_animal/hostile/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		walk(src, 0) //stops walking
-		return 0
+		return
 
 /mob/living/simple_animal/hostile/handle_automated_action()
 	if(AIStatus == AI_OFF)

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -23,12 +23,11 @@
 	deathmessage = "vanishes into thin air! It was a fake!"
 	has_field_of_vision = FALSE //not meant to be played anyway.
 
-
-/mob/living/simple_animal/hostile/illusion/Life()
-	..()
+/mob/living/simple_animal/hostile/illusion/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(world.time > life_span)
 		death()
-
 
 /mob/living/simple_animal/hostile/illusion/proc/Copy_Parent(mob/living/original, life = 50, hp = 100, damage = 0, replicate = 0 )
 	appearance = original.appearance

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -166,8 +166,9 @@
 		if(!hopping)
 			Hop()
 
-/mob/living/simple_animal/hostile/jungle/leaper/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/jungle/leaper/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	update_icons()
 
 /mob/living/simple_animal/hostile/jungle/leaper/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
@@ -197,7 +198,7 @@
 	hopping = TRUE
 	density = FALSE
 	pass_flags |= PASSMOB
-	notransform = TRUE
+	mob_transforming = TRUE
 	var/turf/new_turf = locate((target.x + rand(-3,3)),(target.y + rand(-3,3)),target.z)
 	if(player_hop)
 		new_turf = get_turf(target)
@@ -209,7 +210,7 @@
 
 /mob/living/simple_animal/hostile/jungle/leaper/proc/FinishHop()
 	density = TRUE
-	notransform = FALSE
+	mob_transforming = FALSE
 	pass_flags &= ~PASSMOB
 	hopping = FALSE
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 100, 1)
@@ -220,7 +221,7 @@
 /mob/living/simple_animal/hostile/jungle/leaper/proc/BellyFlop()
 	var/turf/new_turf = get_turf(target)
 	hopping = TRUE
-	notransform = TRUE
+	mob_transforming = TRUE
 	new /obj/effect/temp_visual/leaper_crush(new_turf)
 	addtimer(CALLBACK(src, .proc/BellyFlopHop, new_turf), 30)
 
@@ -231,7 +232,7 @@
 /mob/living/simple_animal/hostile/jungle/leaper/proc/Crush()
 	hopping = FALSE
 	density = TRUE
-	notransform = FALSE
+	mob_transforming = FALSE
 	playsound(src, 'sound/effects/meteorimpact.ogg', 200, 1)
 	for(var/mob/living/L in orange(1, src))
 		L.adjustBruteLoss(35)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
@@ -27,8 +27,9 @@
 
 	footstep_type = FOOTSTEP_MOB_CLAW
 
-/mob/living/simple_animal/hostile/jungle/mega_arachnid/Life()
-	..()
+/mob/living/simple_animal/hostile/jungle/mega_arachnid/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(target && ranged_cooldown > world.time && iscarbon(target))
 		var/mob/living/carbon/C = target
 		if(!C.legcuffed && C.health < 50)
@@ -39,7 +40,6 @@
 	retreat_distance = 0
 	minimum_distance = 0
 	alpha = 255
-
 
 /mob/living/simple_animal/hostile/jungle/mega_arachnid/Aggro()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -65,8 +65,9 @@ Difficulty: Hard
 	desc = "You're not quite sure how a signal can be bloody."
 	invisibility = 100
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/Life()
-	..()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	move_to_delay = clamp(round((health/maxHealth) * 10), 3, 10)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/OpenFire()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -731,7 +731,7 @@ Difficulty: Very Hard
 /obj/structure/closet/stasis/Entered(atom/A)
 	if(isliving(A) && holder_animal)
 		var/mob/living/L = A
-		L.notransform = 1
+		L.mob_transforming = 1
 		ADD_TRAIT(L, TRAIT_MUTE, STASIS_MUTE)
 		L.status_flags |= GODMODE
 		L.mind.transfer_to(holder_animal)
@@ -744,7 +744,7 @@ Difficulty: Very Hard
 	for(var/mob/living/L in src)
 		REMOVE_TRAIT(L, TRAIT_MUTE, STASIS_MUTE)
 		L.status_flags &= ~GODMODE
-		L.notransform = 0
+		L.mob_transforming = 0
 		if(holder_animal)
 			holder_animal.mind.transfer_to(L)
 			L.mind.RemoveSpell(/obj/effect/proc_holder/spell/targeted/exit_possession)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -88,9 +88,10 @@ Difficulty: Normal
 /mob/living/simple_animal/hostile/megafauna/hierophant/spawn_crusher_loot()
 	new /obj/item/crusher_trophy/vortex_talisman(get_turf(spawned_beacon))
 
-/mob/living/simple_animal/hostile/megafauna/hierophant/Life()
-	. = ..()
-	if(. && spawned_beacon && !QDELETED(spawned_beacon) && !client)
+/mob/living/simple_animal/hostile/megafauna/hierophant/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	if(spawned_beacon && !QDELETED(spawned_beacon) && !client)
 		if(target || loc == spawned_beacon.loc)
 			timeout_time = initial(timeout_time)
 		else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -73,14 +73,13 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 		step(R, ddir) //Step the swarmers, instead of spawning them there, incase the turf is solid
 
 
-/mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/Life()
-	. = ..()
-	if(.)
-		var/createtype = GetUncappedAISwarmerType()
-		if(createtype && world.time > swarmer_spawn_cooldown && GLOB.AISwarmers.len < (GetTotalAISwarmerCap()*0.5))
-			swarmer_spawn_cooldown = world.time + swarmer_spawn_cooldown_amt
-			new createtype(loc)
-
+/mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	var/createtype = GetUncappedAISwarmerType()
+	if(createtype && world.time > swarmer_spawn_cooldown && GLOB.AISwarmers.len < (GetTotalAISwarmerCap()*0.5))
+		swarmer_spawn_cooldown = world.time + swarmer_spawn_cooldown_amt
+		new createtype(loc)
 
 /mob/living/simple_animal/hostile/megafauna/swarmer_swarm_beacon/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -118,8 +118,9 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 		overlay_googly_eyes = FALSE
 	CopyObject(copy, creator, destroy_original)
 
-/mob/living/simple_animal/hostile/mimic/copy/Life()
-	..()
+/mob/living/simple_animal/hostile/mimic/copy/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(idledamage && !target && !ckey) //Objects eventually revert to normal if no one is around to terrorize
 		adjustBruteLoss(1)
 	for(var/mob/living/M in contents) //a fix for animated statues from the flesh to stone spell

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -88,8 +88,9 @@
 	wanted_objects = list(/obj/item/pen/survival, /obj/item/stack/ore/diamond)
 	field_of_vision_type = FOV_270_DEGREES //Obviously, it's one eyeball.
 
-/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(stat == CONSCIOUS)
 		consume_bait()
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -97,9 +97,8 @@
 		if(CALL_CHILDREN)
 			call_children()
 
-/mob/living/simple_animal/hostile/asteroid/elite/broodmother/Life()
-	. = ..()
-	if(!.) //Checks if they are dead as a rock.
+/mob/living/simple_animal/hostile/asteroid/elite/broodmother/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
 	if(health < maxHealth * 0.5 && rand_tent < world.time)
 		rand_tent = world.time + 30

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -95,8 +95,9 @@
 		if(AOE_SQUARES)
 			aoe_squares(target)
 
-/mob/living/simple_animal/hostile/asteroid/elite/pandora/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/asteroid/elite/pandora/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(health >= maxHealth * 0.5)
 		cooldown_time = 20
 		return

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -39,8 +39,9 @@
 
 	footstep_type = FOOTSTEP_MOB_HEAVY
 
-/mob/living/simple_animal/hostile/asteroid/goliath/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/asteroid/goliath/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	handle_preattack()
 
 /mob/living/simple_animal/hostile/asteroid/goliath/proc/handle_preattack()
@@ -129,9 +130,8 @@
 	var/turf/last_location
 	var/tentacle_recheck_cooldown = 100
 
-/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/Life()
-	. = ..()
-	if(!.) // dead
+/mob/living/simple_animal/hostile/asteroid/goliath/beast/ancient/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
 	if(isturf(loc))
 		if(!LAZYLEN(cached_tentacle_turfs) || loc != last_location || tentacle_recheck_cooldown <= world.time)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -114,8 +114,9 @@
 	name = "guthen"
 	gender = FEMALE
 
-/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/Life()
-	..()
+/mob/living/simple_animal/hostile/asteroid/gutlunch/guthen/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(udder.reagents.total_volume == udder.reagents.maximum_volume) //Only breed when we're full.
 		make_babies()
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -196,12 +196,13 @@
 	swarming = TRUE
 	var/can_infest_dead = FALSE
 
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/Life()
+/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(isturf(loc))
 		for(var/mob/living/carbon/human/H in view(src,1)) //Only for corpse right next to/on same tile
 			if(H.stat == UNCONSCIOUS || (can_infest_dead && H.stat == DEAD))
 				infest(H)
-	..()
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/proc/infest(mob/living/carbon/human/H)
 	visible_message("<span class='warning'>[name] burrows into the flesh of [H]!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -62,9 +62,10 @@
 	SLEEP_CHECK_DEATH(8)
 	return ..()
 
-/mob/living/simple_animal/hostile/asteroid/ice_demon/Life()
-	. = ..()
-	if(!. || target)
+/mob/living/simple_animal/hostile/asteroid/ice_demon/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	if(target)
 		return
 	adjustHealth(-maxHealth*0.025)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_whelp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_whelp.dm
@@ -43,9 +43,10 @@
 	var/list/burn_turfs = getline(src, T) - get_turf(src)
 	dragon_fire_line(src, burn_turfs)
 
-/mob/living/simple_animal/hostile/asteroid/ice_whelp/Life()
-	. = ..()
-	if(!. || target)
+/mob/living/simple_animal/hostile/asteroid/ice_whelp/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	if(target)
 		return
 	adjustHealth(-maxHealth*0.025)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/polarbear.dm
@@ -44,9 +44,10 @@
 		aggressive_message_said = TRUE
 	rapid_melee = 2
 
-/mob/living/simple_animal/hostile/asteroid/polarbear/Life()
-	. = ..()
-	if(!. || target)
+/mob/living/simple_animal/hostile/asteroid/polarbear/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	if(target)
 		return
 	adjustHealth(-maxHealth*0.025)
 	aggressive_message_said = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/wolf.dm
@@ -51,9 +51,10 @@
 		retreat_message_said = TRUE
 	retreat_distance = 30
 
-/mob/living/simple_animal/hostile/asteroid/wolf/Life()
-	. = ..()
-	if(!. || target)
+/mob/living/simple_animal/hostile/asteroid/wolf/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
+	if(target)
 		return
 	adjustHealth(-maxHealth*0.025)
 	retreat_message_said = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -48,8 +48,9 @@
 	else
 		. += "<span class='info'>It looks like it's been roughed up.</span>"
 
-/mob/living/simple_animal/hostile/mushroom/Life()
-	..()
+/mob/living/simple_animal/hostile/mushroom/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!stat)//Mushrooms slowly regenerate if conscious, for people who want to save them from being eaten
 		adjustBruteLoss(-2)
 

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -46,8 +46,9 @@
 	var/chosen_sound = pick(migo_sounds)
 	playsound(src, chosen_sound, 100, TRUE)
 
-/mob/living/simple_animal/hostile/netherworld/migo/Life()
-	..()
+/mob/living/simple_animal/hostile/netherworld/migo/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(stat)
 		return
 	if(prob(10))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -51,8 +51,9 @@
 	..()
 	playsound(src.loc, 'sound/items/bikehorn.ogg', 50, TRUE)
 
-/mob/living/simple_animal/hostile/retaliate/clown/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/retaliate/clown/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(banana_time && banana_time < world.time)
 		var/turf/T = get_turf(src)
 		var/list/adjacent =  T.GetAtmosAdjacentTurfs(1)

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -82,8 +82,9 @@
 		return 0
 	return ..()
 
-/mob/living/simple_animal/hostile/statue/Life()
-	..()
+/mob/living/simple_animal/hostile/statue/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!client && target) // If we have a target and we're AI controlled
 		var/mob/watching = can_be_seen()
 		// If they're not our target

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -44,8 +44,9 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	del_on_death = 1
 
-/mob/living/simple_animal/hostile/tree/Life()
-	..()
+/mob/living/simple_animal/hostile/tree/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(isopenturf(loc))
 		var/turf/open/T = src.loc
 		if(T.air && T.air.gases[/datum/gas/carbon_dioxide])

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -100,8 +100,9 @@
 /mob/living/simple_animal/hostile/venus_human_trap/ghost_playable
 	playable_plant = TRUE //For admins that want to buss some harmless plants
 
-/mob/living/simple_animal/hostile/venus_human_trap/Life()
-	. = ..()
+/mob/living/simple_animal/hostile/venus_human_trap/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	pull_vines()
 
 /mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -47,12 +47,13 @@
 	QDEL_NULL(E)
 	return ..()
 
-/mob/living/simple_animal/hostile/asteroid/fugu/Life()
+/mob/living/simple_animal/hostile/asteroid/fugu/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!wumbo)
 		inflate_cooldown = max((inflate_cooldown - 1), 0)
 	if(target && AIStatus == AI_ON)
 		E.Activate()
-	..()
 
 /mob/living/simple_animal/hostile/asteroid/fugu/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	if(!forced && wumbo)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -357,9 +357,9 @@
 /*
  * AI - Not really intelligent, but I'm calling it AI anyway.
  */
-/mob/living/simple_animal/parrot/Life()
-	..()
-
+/mob/living/simple_animal/parrot/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	//Sprite update for when a parrot gets pulled
 	if(pulledby && !stat && parrot_state != PARROT_WANDER)
 		if(buckled)
@@ -369,8 +369,6 @@
 		parrot_state = PARROT_WANDER
 		pixel_x = initial(pixel_x)
 		pixel_y = initial(pixel_y)
-		return
-
 
 //-----SPEECH
 	/* Parrot speech mimickry!
@@ -911,11 +909,12 @@
 	if(. && !client && prob(1) && prob(1)) //Only the one true bird may speak across dimensions.
 		world.TgsTargetedChatBroadcast("A stray squawk is heard... \"[message]\"", FALSE)
 
-/mob/living/simple_animal/parrot/Poly/Life()
+/mob/living/simple_animal/parrot/Poly/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
+		return
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE)
 		memory_saved = TRUE
-	..()
 
 /mob/living/simple_animal/parrot/Poly/death(gibbed)
 	if(!memory_saved)

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -7,19 +7,17 @@
 	var/SStun = 0 // stun variable
 
 
-/mob/living/simple_animal/slime/Life()
-	set invisibility = 0
-	if (notransform)
+/mob/living/simple_animal/slime/BiologicalLife(seconds, times_fired)
+	if(!(. = ..()))
 		return
-	if(..())
-		if(buckled)
-			handle_feeding()
-		if(!stat) // Slimes in stasis don't lose nutrition, don't change mood and don't respond to speech
-			handle_nutrition()
-			handle_targets()
-			if (!ckey)
-				handle_mood()
-				handle_speech()
+	if(buckled)
+		handle_feeding()
+	if(!stat) // Slimes in stasis don't lose nutrition, don't change mood and don't respond to speech
+		handle_nutrition()
+		handle_targets()
+		if (!ckey)
+			handle_mood()
+			handle_speech()
 
 // Unlike most of the simple animals, slimes support UNCONSCIOUS
 /mob/living/simple_animal/slime/update_stat()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -678,7 +678,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		return FALSE
 	if(anchored)
 		return FALSE
-	if(notransform)
+	if(mob_transforming)
 		return FALSE
 	if(restrained())
 		return FALSE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -37,7 +37,9 @@
 
 	var/next_move = null
 	var/create_area_cooldown
-	var/notransform = null	//Carbon
+	/// Whether or not the mob is currently being transformed into another mob or into another state of being. This will prevent it from moving or doing realistically anything.
+	/// Don't you DARE use this for a cheap way to ensure someone is stunned in your code.
+	var/mob_transforming = FALSE
 	var/eye_blind = 0		//Carbon
 	var/eye_blurry = 0		//Carbon
 	var/real_name = null

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -32,7 +32,7 @@
 	if(!n || !direction || !mob?.loc)
 		return FALSE
 	//GET RID OF THIS SOON AS MOBILITY FLAGS IS DONE
-	if(mob.notransform)
+	if(mob.mob_transforming)
 		return FALSE
 
 	if(mob.control_object)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/proc/monkeyize(tr_flags = (TR_KEEPITEMS | TR_KEEPVIRUS | TR_DEFAULTMSG))
-	if (notransform)
+	if (mob_transforming)
 		return
 	//Handle items on mob
 
@@ -29,7 +29,7 @@
 			dropItemToGround(W)
 
 	//Make mob invisible and spawn animation
-	notransform = TRUE
+	mob_transforming = TRUE
 	Stun(INFINITY, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
@@ -150,7 +150,7 @@
 //Could probably be merged with monkeyize but other transformations got their own procs, too
 
 /mob/living/carbon/proc/humanize(tr_flags = (TR_KEEPITEMS | TR_KEEPVIRUS | TR_DEFAULTMSG))
-	if (notransform)
+	if (mob_transforming)
 		return
 	//Handle items on mob
 
@@ -185,7 +185,7 @@
 
 
 	//Make mob invisible and spawn animation
-	notransform = TRUE
+	mob_transforming = TRUE
 	Stun(22, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
@@ -304,7 +304,7 @@
 	qdel(src)
 
 /mob/living/carbon/human/AIize()
-	if (notransform)
+	if (mob_transforming)
 		return
 	for(var/t in bodyparts)
 		qdel(t)
@@ -312,12 +312,12 @@
 	return ..()
 
 /mob/living/carbon/AIize()
-	if(notransform)
+	if(mob_transforming)
 		return
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
 	regenerate_icons()
-	notransform = TRUE
+	mob_transforming = TRUE
 	Paralyze(INFINITY)
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -353,7 +353,7 @@
 	qdel(src)
 
 /mob/living/carbon/human/proc/Robotize(delete_items = 0, transfer_after = TRUE)
-	if (notransform)
+	if (mob_transforming)
 		return
 	for(var/obj/item/W in src)
 		if(delete_items)
@@ -361,7 +361,7 @@
 		else
 			dropItemToGround(W)
 	regenerate_icons()
-	notransform = TRUE
+	mob_transforming = TRUE
 	Paralyze(INFINITY)
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -398,12 +398,12 @@
 
 //human -> alien
 /mob/living/carbon/human/proc/Alienize(mind_transfer = TRUE)
-	if (notransform)
+	if (mob_transforming)
 		return
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
 	regenerate_icons()
-	notransform = 1
+	mob_transforming = 1
 	Paralyze(INFINITY)
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -432,12 +432,12 @@
 	qdel(src)
 
 /mob/living/carbon/human/proc/slimeize(reproduce, mind_transfer = TRUE)
-	if (notransform)
+	if (mob_transforming)
 		return
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
 	regenerate_icons()
-	notransform = 1
+	mob_transforming = 1
 	Paralyze(INFINITY)
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -477,12 +477,12 @@
 
 
 /mob/living/carbon/human/proc/corgize(mind_transfer = TRUE)
-	if (notransform)
+	if (mob_transforming)
 		return
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
 	regenerate_icons()
-	notransform = TRUE
+	mob_transforming = TRUE
 	Paralyze(INFINITY)
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -501,7 +501,7 @@
 	qdel(src)
 
 /mob/living/carbon/proc/gorillize(mind_transfer = TRUE)
-	if(notransform)
+	if(mob_transforming)
 		return
 
 	SSblackbox.record_feedback("amount", "gorillas_created", 1)
@@ -512,7 +512,7 @@
 		dropItemToGround(W, TRUE)
 
 	regenerate_icons()
-	notransform = TRUE
+	mob_transforming = TRUE
 	Paralyze(INFINITY)
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
@@ -535,13 +535,13 @@
 	if(mind)
 		mind_transfer = alert("Want to transfer their mind into the new mob", "Mind Transfer", "Yes", "No") == "Yes" ? TRUE : FALSE
 
-	if(notransform)
+	if(mob_transforming)
 		return
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
 
 	regenerate_icons()
-	notransform = TRUE
+	mob_transforming = TRUE
 	Paralyze(INFINITY)
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -144,13 +144,13 @@
 	user.visible_message("<span class='warning'>[user] aims [src] at the ground! It looks like [user.p_theyre()] performing a sick rocket jump!</span>", \
 		"<span class='userdanger'>You aim [src] at the ground to perform a bisnasty rocket jump...</span>")
 	if(can_shoot())
-		user.notransform = TRUE
+		user.mob_transforming = TRUE
 		playsound(src, 'sound/vehicles/rocketlaunch.ogg', 80, 1, 5)
 		animate(user, pixel_z = 300, time = 30, easing = LINEAR_EASING)
 		sleep(70)
 		animate(user, pixel_z = 0, time = 5, easing = LINEAR_EASING)
 		sleep(5)
-		user.notransform = FALSE
+		user.mob_transforming = FALSE
 		process_fire(user, user, TRUE)
 		if(!QDELETED(user)) //if they weren't gibbed by the explosion, take care of them for good.
 			user.gib()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -121,10 +121,10 @@
 	qdel(src)
 
 /proc/wabbajack(mob/living/M)
-	if(!istype(M) || M.stat == DEAD || M.notransform || (GODMODE & M.status_flags))
+	if(!istype(M) || M.stat == DEAD || M.mob_transforming || (GODMODE & M.status_flags))
 		return
 
-	M.notransform = TRUE
+	M.mob_transforming = TRUE
 	M.Paralyze(INFINITY)
 	M.icon = null
 	M.cut_overlays()

--- a/code/modules/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/ruins/lavalandruin_code/puzzle.dm
@@ -289,7 +289,7 @@
 
 /obj/effect/sliding_puzzle/prison/dispense_reward()
 	prisoner.forceMove(get_turf(src))
-	prisoner.notransform = FALSE
+	prisoner.mob_transforming = FALSE
 	prisoner = null
 
 //Some armor so it's harder to kill someone by mistake.
@@ -329,7 +329,7 @@
 		return FALSE
 
 	//First grab the prisoner and move them temporarily into the generator so they won't get thrown around.
-	prisoner.notransform = TRUE
+	prisoner.mob_transforming = TRUE
 	prisoner.forceMove(cube)
 	to_chat(prisoner,"<span class='userdanger'>You're trapped by the prison cube! You will remain trapped until someone solves it.</span>")
 

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -413,13 +413,13 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	. = ..()
 	if(ismob(AM))
 		var/mob/M = AM
-		M.notransform = TRUE
+		M.mob_transforming = TRUE
 
 /obj/item/abstracthotelstorage/Exited(atom/movable/AM, atom/newLoc)
 	. = ..()
 	if(ismob(AM))
 		var/mob/M = AM
-		M.notransform = FALSE
+		M.mob_transforming = FALSE
 
 //Space Ruin stuff
 /area/ruin/space/has_grav/hilbertresearchfacility

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -504,7 +504,7 @@
 			if(M.mind && !istype(t, /turf/open/floor/plasteel/shuttle/red) && !istype(t, /turf/open/floor/mineral/plastitanium/red/brig))
 				M.mind.force_escaped = TRUE
 			// Ghostize them and put them in nullspace stasis (for stat & possession checks)
-			M.notransform = TRUE
+			M.mob_transforming = TRUE
 			M.ghostize(FALSE)
 			M.moveToNullspace()
 

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -118,14 +118,14 @@
 				revert_cast()
 				return ..()
 		else
-			user.notransform = TRUE
+			user.mob_transforming = TRUE
 			user.fakefire()
 			to_chat(src, "<span class='warning'>You begin to phase back into sinful flames.</span>")
 			if(do_mob(user,user,150))
 				user.infernalphaseout()
 			else
 				to_chat(user, "<span class='warning'>You must remain still while exiting.</span>")
-				user.notransform = FALSE
+				user.mob_transforming = FALSE
 				user.fakefireextinguish()
 		start_recharge()
 		return
@@ -149,11 +149,11 @@
 	ExtinguishMob()
 	forceMove(holder)
 	holder = holder
-	notransform = 0
+	mob_transforming = 0
 	fakefireextinguish()
 
 /mob/living/proc/infernalphasein()
-	if(notransform)
+	if(mob_transforming)
 		to_chat(src, "<span class='warning'>You're too busy to jaunt in.</span>")
 		return FALSE
 	fakefire()

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -22,14 +22,14 @@
 		INVOKE_ASYNC(src, .proc/do_jaunt, target)
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/do_jaunt(mob/living/target)
-	target.notransform = 1
+	target.mob_transforming = 1
 	var/turf/mobloc = get_turf(target)
 	var/obj/effect/dummy/phased_mob/spell_jaunt/holder = new /obj/effect/dummy/phased_mob/spell_jaunt(mobloc)
 	new jaunt_out_type(mobloc, target.dir)
 	target.ExtinguishMob()
 	target.forceMove(holder)
 	target.reset_perspective(holder)
-	target.notransform=0 //mob is safely inside holder now, no need for protection.
+	target.mob_transforming=0 //mob is safely inside holder now, no need for protection.
 	jaunt_steam(mobloc)
 
 	sleep(jaunt_duration)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -18,7 +18,7 @@
 		W.damage_bonus += spell_level * 20 //You do more damage when you upgrade the spell
 		W.start_turf = start
 		M.forceMove(W)
-		M.notransform = 1
+		M.mob_transforming = 1
 		M.status_flags |= GODMODE
 
 //Wizard Version of the Immovable Rod
@@ -37,7 +37,7 @@
 /obj/effect/immovablerod/wizard/Destroy()
 	if(wizard)
 		wizard.status_flags &= ~GODMODE
-		wizard.notransform = 0
+		wizard.mob_transforming = 0
 		wizard.forceMove(get_turf(src))
 	return ..()
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -100,7 +100,7 @@
 	if(stored.mind)
 		stored.mind.transfer_to(shape)
 	stored.forceMove(src)
-	stored.notransform = TRUE
+	stored.mob_transforming = TRUE
 	if(source.convert_damage)
 		var/damage_percent = (stored.maxHealth - stored.health)/stored.maxHealth;
 		var/damapply = damage_percent * shape.maxHealth;
@@ -148,7 +148,7 @@
 	restoring = TRUE
 	qdel(slink)
 	stored.forceMove(get_turf(src))
-	stored.notransform = FALSE
+	stored.mob_transforming = FALSE
 	if(shape.mind)
 		shape.mind.transfer_to(stored)
 	if(death)

--- a/modular_citadel/code/modules/mob/living/carbon/life.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/life.dm
@@ -1,3 +1,0 @@
-/mob/living/carbon/Life()
-	. = ..()
-	doSprintBufferRegen()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3441,7 +3441,6 @@
 #include "modular_citadel\code\modules\mob\living\living.dm"
 #include "modular_citadel\code\modules\mob\living\carbon\carbon.dm"
 #include "modular_citadel\code\modules\mob\living\carbon\damage_procs.dm"
-#include "modular_citadel\code\modules\mob\living\carbon\life.dm"
 #include "modular_citadel\code\modules\mob\living\carbon\reindex_screams.dm"
 #include "modular_citadel\code\modules\mob\living\carbon\human\human.dm"
 #include "modular_citadel\code\modules\mob\living\carbon\human\human_defense.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Yeah yeah, proccall overhead, but honestly worth not having to do that many IsInStasis checks. This also lets me do something where ticks are slowed rather than stopped.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: kevinz000
refactor: Life() is split into BiologicalLife() and PhysicalLife. A component signal has been added that can prevent either from ticking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
