### PR TITLE
fixes master (shuttles not loading)

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -872,6 +872,14 @@
 /atom/proc/GenerateTag()
 	return
 
+/**
+  * Called after a shuttle is loaded **from map template initially**.
+  *
+  * @params
+  * * port - Mobile port/shuttle
+  * * dock - Stationary dock the shuttle's at
+  * * idnum - ID number of the shuttle
+  */
 /atom/proc/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
 	return
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -35,11 +35,6 @@
 			M.unset_machine() //to properly reset the view of the users if the console is deleted.
 	return ..()
 
-/obj/machinery/computer/security/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
-	for(var/i in network)
-		network -= i
-		network += "[idnum][i]"
-
 /obj/machinery/computer/security/can_interact(mob/user)
 	if((!hasSiliconAccessInArea(user) && !Adjacent(user)) || is_blind(user) || !in_view_range(user, src))
 		return FALSE
@@ -262,3 +257,12 @@
 	name = "AI upload monitor"
 	desc = "A telescreen that connects to the AI upload's camera network."
 	network = list("aiupload")
+
+// Subtype that connects to shuttles.
+/obj/machinery/computer/security/shuttle
+	circuit = /obj/item/circuitboard/computer/security/shuttle
+
+/obj/machinery/computer/security/shuttle/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
+	for(var/i in network)
+		network -= i
+		network += "[idnum][i]"

--- a/code/game/machinery/shuttle/shuttle_engine.dm
+++ b/code/game/machinery/shuttle/shuttle_engine.dm
@@ -57,7 +57,16 @@
 	. = ..()
 	check_setup()
 
+/obj/machinery/shuttle/engine/Destroy()
+	attached_heater = FALSE
+	thruster_active = FALSE
+	return ..()
+
 /obj/machinery/shuttle/engine/proc/check_setup()
+	if(!anchored)
+		attached_heater = null
+		update_engine()
+		return
 	var/heater_turf
 	switch(dir)
 		if(NORTH)
@@ -124,15 +133,6 @@
 	env.temperature += deltaTemperature
 	air_update_turf()
 
-/obj/machinery/shuttle/engine/attackby(obj/item/I, mob/living/user, params)
-	check_setup()
-	if(default_deconstruction_screwdriver(user, icon_state_open, icon_state_closed, I))
-		return
-	if(default_pry_open(I))
-		return
-	if(panel_open)
-		if(default_change_direction_wrench(user, I))
-			return
-	if(default_deconstruction_crowbar(I))
-		return
-	return ..()
+/obj/machinery/shuttle/engine/default_change_direction_wrench(mob/user, obj/item/I)
+	. = ..()
+	update_engine()

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -14,6 +14,10 @@
 	name = "Security Cameras (Computer Board)"
 	build_path = /obj/machinery/computer/security
 
+/obj/item/circuitboard/computer/security/shuttle
+	name = "Shuttlelinking Security Cameras (Computer Board)"
+	build_path = /obj/machinery/computer/security/shuttle
+
 /obj/item/circuitboard/computer/xenobiology
 	name = "circuit board (Xenobiology Console)"
 	build_path = /obj/machinery/computer/camera_advanced/xenobio

--- a/code/modules/research/designs/comp_board_designs/comp_board_designs_sec.dm
+++ b/code/modules/research/designs/comp_board_designs/comp_board_designs_sec.dm
@@ -10,6 +10,14 @@
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/board/shuttleseccamera
+	name = "Computer Design (Shuttle-Linked Security Camera)"
+	desc = "Same as a regular security camera console, but when linked to a shuttle, will specifically access cameras on that shuttle."
+	id = "shuttleseccamera"
+	build_path = /obj/item/circuitboard/computer/security/shuttle
+	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/board/secdata
 	name = "Computer Design (Security Records Console)"
 	desc = "Allows for the construction of circuit boards used to build a security records console."

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -183,7 +183,7 @@
 		name = "dock[SSshuttle.stationary.len]"
 	if(!area_type)
 		var/area/place = get_area(src)
-		area_type = place?.type // We might be created in nullspace
+		area_type = place?.type || SHUTTLE_DEFAULT_UNDERLYING_AREA // We might be created in nullspace
 
 	if(mapload)
 		for(var/turf/T in return_turfs())
@@ -217,6 +217,9 @@
 		roundstart_template = SSmapping.shuttle_templates[sid]
 		if(!roundstart_template)
 			CRASH("Invalid path ([roundstart_template]) passed to docking port.")
+
+	if(roundstart_template)
+		SSshuttle.manipulator.action_load(roundstart_template, src)
 
 //returns first-found touching shuttleport
 /obj/docking_port/stationary/get_docked()
@@ -704,7 +707,7 @@
 	if(timeleft > 1 HOURS)
 		return "--:--"
 	else if(timeleft > 0)
-		return "[add_leading(num2text((timeleft / 60) % 60), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, " ")]"
+		return "[add_leading(num2text((timeleft / 60) % 60), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, "0")]"
 	else
 		return "00:00"
 

--- a/code/modules/shuttle/shuttle_creation/shuttle_upgrades.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_upgrades.dm
@@ -4,9 +4,9 @@
 	icon = 'icons/obj/module.dmi'
 	icon_state = "shuttledisk"
 	force = 0
-	throwforce = 8
-	throw_speed = 3
-	throw_range = 5
+	throwforce = 0
+	throw_speed = 1
+	throw_range = 7
 	density = FALSE
 	anchored = FALSE
 	item_flags = NOBLUDGEON


### PR DESCRIPTION
Fixes shuttle loading.

also some small "improvements" like less copypaste code on the engine and only updating engine when needed (wrench dir check) and making it unlink on destroy without relying on just weakrefs yeah 

also makes shuttle camera consoles not default to not being on the shuttle and adds a new console for that which won't really be used but i don't think it's necessary to make things like the emergency shuttle unable to access station cameras especially when it only even updates on load so you could just deconstruct/reconstruct it.