### PR TITLE
Disables the stray syndicate crate event

### DIFF
--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -85,8 +85,8 @@
 /datum/round_event_control/stray_cargo/syndicate
 	name = "Stray Syndicate Cargo Pod"
 	typepath = /datum/round_event/stray_cargo/syndicate
-	weight = 6
-	max_occurrences = 1
+	weight = 0
+	max_occurrences = 0
 	earliest_start = 30 MINUTES
 
 /datum/round_event/stray_cargo/syndicate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This disables the subtype of the stray crate event that drops at least 30tc of syndicate gear on the station in a random location by setting its max occurances and weight to 0.
Left in the code for if it's needed by any admins.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pretty sure that nonantags getting nullcrates was one of the reasons they were removed. Having them now spawn as a random event is.. not the best way to go about it, especially since 30tc of tot gear can cause a lot of annoyances.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Syndicate crate event cannot fire as a random event anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
