### PR TITLE
Buying a 'random uplink item' can no longer force objective / class changes

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_bundles.dm
+++ b/code/modules/uplink/uplink_items/uplink_bundles.dm
@@ -193,6 +193,8 @@
 			var/datum/uplink_item/I = uplink_items[category][item]
 			if(src == I || !I.item)
 				continue
+			if(istype(I, /datum/uplink_item/bundles_TC/reroll)) //oops!
+				continue
 			if(U.telecrystals < I.cost)
 				continue
 			if(I.limited_stock == 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Due to objective classes and the objective reroll being added, random item purchases could choose the 'reroll class' item, which is.. slightly unfortunate to whoever has it happen to them, as random item is often chosen for 'I still have tc, gimme some shit', not 'oh no I had 2 tc and wanted an item, but now I got weird objs instead'
This blacklists the 0tc contract reroll item from being able to be chosen by the random item 'bundle'
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having people get forced into another class when they just wanted a random item (or did the big mistake of hitting the button with 0 or just few tc, as the contract reroll is the only item with that cost besides the random item button)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Choosing a random item in your uplink will no longer sometimes reroll your contract.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
