### PR TITLE
prevents shunted AIs from doomsdaying (tg#51284)

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -257,6 +257,8 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		return
 	if (active)
 		return //prevent the AI from activating an already active doomsday
+	if (owner_AI.shunted)
+		return //prevent AI from activating doomsday while shunted.
 	active = TRUE
 	set_us_up_the_bomb(owner)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1141,6 +1141,7 @@
 		return
 	if(!is_station_level(z))
 		return
+	malf.ShutOffDoomsdayDevice()
 	occupier = new /mob/living/silicon/ai(src, malf.laws, malf) //DEAR GOD WHY?	//IKR????
 	occupier.adjustOxyLoss(malf.getOxyLoss())
 	if(!findtext(occupier.name, "APC Copy"))


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

tg considers this an exploit and so do I

## Changelog
:cl:
fix: malf AIs can no longer yeet the station while shunted
/:cl: