### PR TITLE
what if you could override the entire say verb/emphasis system to audibly emote with ! like in baycode servers

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 /// Quirky citadel proc for our custom sayverbs to strip the verb out. Snowflakey as hell, say rewrite 3.0 when?
 /atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mode)
-	if(input[1] == "!")
+	if((input[1] == "!") && (length_char(input) > 1))
 		return ""
 	var/pos = findtext(input, "*")
 	return pos? copytext(input, pos + 1) : input
@@ -146,12 +146,11 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return "[copytext_char("[freq]", 1, 4)].[copytext_char("[freq]", 4, 5)]"
 
 /atom/movable/proc/attach_spans(input, list/spans)
-	if(input[1] == "!")
-		input = copytext(input, 1, length(input) + 1)
-	else
-		var/customsayverb = findtext(input, "*")
-		if(customsayverb)
-			input = capitalize(copytext(input, customsayverb + length(input[customsayverb])))
+	if((input[1] == "!") && (length(input) > 2))
+		return
+	var/customsayverb = findtext(input, "*")
+	if(customsayverb)
+		input = capitalize(copytext(input, customsayverb + length(input[customsayverb])))
 	if(input)
 		return "[message_spans_start(spans)][input]</span>"
 	else

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -110,6 +110,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 /// Quirky citadel proc for our custom sayverbs to strip the verb out. Snowflakey as hell, say rewrite 3.0 when?
 /atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mode)
+	if(input[1] == "!")
+		return ""
 	var/pos = findtext(input, "*")
 	return pos? copytext(input, pos + 1) : input
 

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -146,9 +146,12 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return "[copytext_char("[freq]", 1, 4)].[copytext_char("[freq]", 4, 5)]"
 
 /atom/movable/proc/attach_spans(input, list/spans)
-	var/customsayverb = findtext(input, "*")
-	if(customsayverb)
-		input = capitalize(copytext(input, customsayverb + length(input[customsayverb])))
+	if(input[1] == "!")
+		input = copytext(input, 1, length(input) + 1)
+	else
+		var/customsayverb = findtext(input, "*")
+		if(customsayverb)
+			input = capitalize(copytext(input, customsayverb + length(input[customsayverb])))
 	if(input)
 		return "[message_spans_start(spans)][input]</span>"
 	else

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -50,14 +50,16 @@
 	usr.emote("me",1,message,TRUE)
 
 /mob/say_mod(input, message_mode)
-	if(input[1] == "!")
-		return ""
+	if(message_mode == MODE_WHISPER_CRIT)
+		return ..()
+	if((input[1] == "!") && (length_char(input) > 1))
+		message_mode = MODE_CUSTOM_SAY
+		return copytext_char(input, 2)
 	var/customsayverb = findtext(input, "*")
-	if(customsayverb && message_mode != MODE_WHISPER_CRIT)
+	if(customsayverb)
 		message_mode = MODE_CUSTOM_SAY
 		return lowertext(copytext_char(input, 1, customsayverb))
-	else
-		return ..()
+	return ..()
 
 /mob/proc/whisper_keybind()
 	var/message = input(src, "", "whisper") as text|null

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -50,6 +50,8 @@
 	usr.emote("me",1,message,TRUE)
 
 /mob/say_mod(input, message_mode)
+	if(input[1] == "!")
+		return ""
 	var/customsayverb = findtext(input, "*")
 	if(customsayverb && message_mode != MODE_WHISPER_CRIT)
 		message_mode = MODE_CUSTOM_SAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

! at start of message
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

better than * which forces the entire message to be lowercase'd
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: You can now "audibly emote" by having ! at the start of a sentence.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
