### PR TITLE
Fixing the snore-pocalypse, and another not so critical issue.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -254,6 +254,9 @@
 #define COMSIG_OBJ_DECONSTRUCT 	"obj_deconstruct"				//from base of obj/deconstruct(): (disassembled)
 #define COMSIG_OBJ_BREAK		"obj_break"						//from base of /obj/obj_break(): (damage_flag)
 #define COMSIG_OBJ_SETANCHORED 	"obj_setanchored"				//called in /obj/structure/setAnchored(): (value)
+#define COMSIG_OBJ_ATTACK_GENERIC "obj_attack_generic"			//from base of atom/animal_attack(): (/mob/user)
+	#define COMPONENT_STOP_GENERIC_ATTACK 1
+
 
 // /machinery signals
 #define COMSIG_MACHINE_EJECT_OCCUPANT "eject_occupant"			//from base of obj/machinery/dropContents() (occupant)

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -37,7 +37,7 @@
 
 // Stopping clientless simple mobs' from indiscriminately bashing their own spawners due DestroySurroundings() et similars.
 /datum/component/spawner/proc/on_attack_generic(datum/source, mob/user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)
-	if(!user.client && (user in spawned_mobs))
+	if(!user.client && ((user.faction & faction) || (user in spawned_mobs)))
 		return COMPONENT_STOP_GENERIC_ATTACK
 
 /datum/component/spawner/proc/try_spawn_mob()

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -8,6 +8,8 @@
 	var/list/faction = list("mining")
 
 /datum/component/spawner/Initialize(_mob_types, _spawn_time, _faction, _spawn_text, _max_mobs)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
 	if(_spawn_time)
 		spawn_time=_spawn_time
 	if(_mob_types)
@@ -19,19 +21,24 @@
 	if(_max_mobs)
 		max_mobs=_max_mobs
 
-	RegisterSignal(parent, list(COMSIG_PARENT_QDELETING), .proc/stop_spawning)
+	RegisterSignal(parent, COMSIG_PARENT_QDELETING, .proc/stop_spawning)
+	RegisterSignal(parent, COMSIG_OBJ_ATTACK_GENERIC, .proc/on_attack_generic)
 	START_PROCESSING(SSprocessing, src)
 
 /datum/component/spawner/process()
 	try_spawn_mob()
 
-
-/datum/component/spawner/proc/stop_spawning(force, hint)
+/datum/component/spawner/proc/stop_spawning(datum/source, force, hint)
 	STOP_PROCESSING(SSprocessing, src)
 	for(var/mob/living/simple_animal/L in spawned_mobs)
 		if(L.nest == src)
 			L.nest = null
 	spawned_mobs = null
+
+// Stopping clientless simple mobs' from indiscriminately bashing their own spawners due DestroySurroundings() et similars.
+/datum/component/spawner/proc/on_attack_generic(datum/source, mob/user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)
+	if(!user.client && (user in spawned_mobs))
+		return COMPONENT_STOP_GENERIC_ATTACK
 
 /datum/component/spawner/proc/try_spawn_mob()
 	var/atom/P = parent

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -9,7 +9,6 @@
 /datum/status_effect/incapacitating/on_creation(mob/living/new_owner, set_duration, updating_canmove)
 	if(isnum(set_duration))
 		duration = set_duration
-	tick_interval = max(world.tick_lag, round(tick_interval, world.tick_lag))
 	. = ..()
 	if(.)
 		if(updating_canmove)
@@ -82,11 +81,10 @@
 		owner.adjustStaminaLoss(-0.5) //reduce stamina loss by 0.5 per tick, 10 per 2 seconds
 	if(human_owner && human_owner.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
-	if(prob(20))
-		if(carbon_owner)
-			carbon_owner.handle_dreams()
+	if(carbon_owner && !carbon_owner.dreaming && prob(2))
+		carbon_owner.dream()
 	// 2% per second, tick interval is in deciseconds
-	if(prob(tick_interval * 0.2) && owner.health > owner.crit_threshold)
+	if(prob((tick_interval+1) * 0.2) && owner.health > owner.crit_threshold)
 		owner.emote("snore")
 
 /datum/status_effect/staggered

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -6,6 +6,7 @@
 	var/id = "effect" //Used for screen alerts.
 	var/duration = -1 //How long the status effect lasts in DECISECONDS. Enter -1 for an effect that never ends unless removed through some means.
 	var/tick_interval = 10 //How many deciseconds between ticks, approximately. Leave at 10 for every second.
+	var/next_tick //The scheduled time for the next tick.
 	var/mob/living/owner //The mob affected by the status effect.
 	var/on_remove_on_mob_delete = FALSE //if we call on_remove() when the mob is deleted
 	var/examine_text //If defined, this text will appear when the mob is examined - to use he, she etc. use "SUBJECTPRONOUN" and replace it in the examines themselves
@@ -31,7 +32,7 @@
 		return
 	if(duration != -1)
 		duration = world.time + duration
-	tick_interval = world.time + tick_interval
+	next_tick = world.time + tick_interval
 	if(alert_type)
 		var/obj/screen/alert/status_effect/A = owner.throw_alert(id, alert_type)
 		A.attached_effect = src //so the alert can reference us, if it needs to
@@ -52,9 +53,9 @@
 	if(!owner)
 		qdel(src)
 		return
-	if(tick_interval < world.time)
+	if(next_tick < world.time)
 		tick()
-		tick_interval = world.time + initial(tick_interval)
+		next_tick = world.time + tick_interval
 	if(duration != -1 && duration < world.time)
 		qdel(src)
 
@@ -221,7 +222,7 @@
 			threshold_crossed = FALSE //resets threshold effect if we fall below threshold so threshold effect can trigger again
 			on_threshold_drop()
 		if(stacks_added > 0)
-			tick_interval += delay_before_decay //refreshes time until decay
+			next_tick += delay_before_decay //refreshes time until decay
 		stacks = min(stacks, max_stacks)
 		status_overlay.icon_state = "[overlay_state][stacks]"
 		status_underlay.icon_state = "[underlay_state][stacks]"

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -103,6 +103,8 @@
 	take_damage(400, BRUTE, "melee", 0, get_dir(src, B))
 
 /obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
+	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_GENERIC, user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration) & COMPONENT_STOP_GENERIC_ATTACK)
+		return FALSE
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
 	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,7 +1,3 @@
-/mob/living/carbon/proc/handle_dreams()
-	if(prob(10) && !dreaming)
-		dream()
-
 /mob/living/carbon/proc/dream()
 	set waitfor = FALSE
 	var/list/dream_fragments = list()


### PR DESCRIPTION
## About The Pull Request
Silicons' fix made things worse, actually.
Also fixing #12512, it was the original intent of this PR.

## Why It's Good For The Game
Fixing snoring spam. This will close #12512.
closes #12604 

## Changelog
:cl:
fix: Snore spam.
fix: Hostile mobs shouldn't hit their original spawner structures or thoses of the same faction.
/:cl:
