### PR TITLE
piggyback carrying people is no longer comically slow

### DIFF
--- a/code/__DEFINES/mobs/slowdowns.dm
+++ b/code/__DEFINES/mobs/slowdowns.dm
@@ -3,7 +3,7 @@
 /// How much someone is slowed from fireman carrying a human
 #define FIREMAN_CARRY_SLOWDOWN 0
 /// How much someone is slowed by piggybacking a human
-#define PIGGYBACK_CARRY_SLOWDOWN .6
+#define PIGGYBACK_CARRY_SLOWDOWN 0
 /// slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
 #define SOFTCRIT_ADD_SLOWDOWN 2
 /// slowdown when crawling

--- a/code/__DEFINES/mobs/slowdowns.dm
+++ b/code/__DEFINES/mobs/slowdowns.dm
@@ -3,7 +3,7 @@
 /// How much someone is slowed from fireman carrying a human
 #define FIREMAN_CARRY_SLOWDOWN 0
 /// How much someone is slowed by piggybacking a human
-#define PIGGYBACK_CARRY_SLOWDOWN 1
+#define PIGGYBACK_CARRY_SLOWDOWN .6
 /// slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
 #define SOFTCRIT_ADD_SLOWDOWN 2
 /// slowdown when crawling

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -982,7 +982,7 @@
 				if(target.incapacitated(FALSE, TRUE) || incapacitated(FALSE, TRUE))
 					target.visible_message("<span class='warning'>[target] can't hang onto [src]!</span>")
 					return
-				buckle_mob(target, TRUE, TRUE, FALSE, 0, 2, FALSE)
+				buckle_mob(target, TRUE, TRUE, FALSE, 1, 2, FALSE)
 		else
 			visible_message("<span class='warning'>[target] fails to climb onto [src]!</span>")
 	else


### PR DESCRIPTION

## About The Pull Request

piggyback riding now takes up a hand on the part of the carrier as well, and no longer slows you down

## Why It's Good For The Game

originally was kneejerk nerfed to the point where piggyback carrying is just worse than fireman carrying all around and was generally just unpleasant to do, now it's statistically similar to fireman carrying.

## Changelog
:cl:
tweak: piggybacking is no longer absolutely inferior
/:cl:
