### PR TITLE
prevents duplicate chatboxes from typing indicators by inserting 28 macros into the basic macro sets that just trigger a nonsensical verb that does nothing

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -64,19 +64,33 @@ SUBSYSTEM_DEF(input)
 	// Misc
 	macroset_classic_input["Tab"] = "\".winset \\\"mainwindow.macro=[SKIN_MACROSET_CLASSIC_HOTKEYS] map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\""
 	macroset_classic_input["Escape"] = "\".winset \\\"input.text=\\\"\\\"\\\"\""
-
+	
 	// FINALLY, WE CAN DO SOMETHING MORE NORMAL FOR THE SNOWFLAKE-BUT-LESS KEYSET.
+	
+	// HAHA - SIKE. Because of BYOND weirdness (tl;dr not specifically binding this way results in potentially duplicate chatboxes when 
+	//  conflicts occur with something like say indicator vs say), we're going to snowflake this anyways
+	var/list/hard_binds = list(
+		"O" = "ooc",
+		"T" = "say",
+		"L" = "looc",
+		"M" = "me"
+		)
+	var/list/hard_bind_anti_collision = list()
+	var/list/anti_collision_modifiers = list("Ctrl", "Alt", "Shift", "Ctrl+Alt", "Ctrl+Shift", "Alt+Shift", "Ctrl+Alt+Shift")
+	for(var/key in hard_binds)
+		for(var/modifier in anti_collision_modifiers)
+			hard_bind_anti_collision["[modifier]+[key]"] = ".NONSENSICAL_VERB_THAT_DOES_NOTHING"
+	
 	macroset_classic_hotkey = list(
 	"Any" = "\"KeyDown \[\[*\]\]\"",
 	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 	"Tab" = "\".winset \\\"mainwindow.macro=[SKIN_MACROSET_CLASSIC_INPUT] input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 	"Escape" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
 	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
-	"O" = "ooc",
-	"T" = "say",
-	"L" = "looc",
-	"M" = "me"
 	)
+	
+	macroset_classic_hotkey |= hard_binds
+	macroset_classic_hotkey |= hard_bind_anti_collision
 
 	// And finally, the modern set.
 	macroset_hotkey = list(
@@ -85,11 +99,10 @@ SUBSYSTEM_DEF(input)
 	"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 	"Escape" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
 	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
-	"O" = "ooc",
-	"T" = "say",
-	"L" = "looc",
-	"M" = "me"
 	)
+	
+	macroset_hotkey |= hard_binds
+	macroset_hotkey |= hard_bind_anti_collision
 
 // Badmins just wanna have fun ♪
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()
@@ -104,3 +117,8 @@ SUBSYSTEM_DEF(input)
 	for(var/i in 1 to clients.len)
 		var/client/C = clients[i]
 		C.keyLoop()
+
+/// *sigh
+/client/verb/NONSENSICAL_VERB_THAT_DOES_NOTHING()
+	set name = ".NONSENSICAL_VERB_THAT_DOES_NOTHING"
+	set visible = FALSE

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -121,4 +121,4 @@ SUBSYSTEM_DEF(input)
 /// *sigh
 /client/verb/NONSENSICAL_VERB_THAT_DOES_NOTHING()
 	set name = ".NONSENSICAL_VERB_THAT_DOES_NOTHING"
-	set visible = FALSE
+	set hidden = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i hate input
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

i hate input
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: typing indicators no longer generates duplicate message boxes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
