### PR TITLE
Nerfing shaft miners' paycheck.

### DIFF
--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -16,7 +16,7 @@
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO, ACCESS_CARGO_BOT, ACCESS_MINING,
 				ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM)
 	minimal_access = list(ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING, ACCESS_MINERAL_STOREROOM)
-	paycheck = PAYCHECK_HARD
+	paycheck = PAYCHECK_EASY ///Not necessarily easy itself, but it can be trivial to make lot of cash on this job.
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_SHAFT_MINER


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
They can get cash from the coin press or by exchanging mining points at their own mining vendors, as well as other fun stuff.

## Changelog
:cl:
balance: Lowered shaft miners' paycheck, they have other ways to make cash.
/:cl: