### PR TITLE
Ups melee stam cost multiplier from 0.8 back to 1, made stam cost for throwing mobs scale with mob_size

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -269,12 +269,12 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 
 //stamina cost defines.
 #define STAM_COST_ATTACK_OBJ_MULT	1.2
-#define STAM_COST_ATTACK_MOB_MULT	0.8
+#define STAM_COST_ATTACK_MOB_MULT	1
 #define STAM_COST_BATON_MOB_MULT	1
 #define STAM_COST_NO_COMBAT_MULT	1.25
 #define STAM_COST_W_CLASS_MULT		1.25
 #define STAM_COST_THROW_MULT		2
-#define STAM_COST_THROW_MOB			8 //multiplied by mob size + 1.
+#define STAM_COST_THROW_MOB			2.5 //multiplied by (mob size + 1)^2.
 
 ///Multiplier of the (STAMINA_NEAR_CRIT - user current stamina loss) : (STAMINA_NEAR_CRIT - STAMINA_SOFTCRIT) ratio used in damage penalties when stam soft-critted.
 #define STAM_CRIT_ITEM_ATTACK_PENALTY	0.66
@@ -287,9 +287,9 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 
 //stamina recovery defines. Blocked if combat mode is on.
 #define STAM_RECOVERY_STAM_CRIT		-7.5
-#define STAM_RECOVERY_RESTING		-5
-#define STAM_RECOVERY_NORMAL		-2
-#define STAM_RECOVERY_LIMB			3 //limbs recover stamina separately from handle_status_effects(), and aren't blocked by combat mode.
+#define STAM_RECOVERY_RESTING		-6
+#define STAM_RECOVERY_NORMAL		-3
+#define STAM_RECOVERY_LIMB			4 //limbs recover stamina separately from handle_status_effects(), and aren't blocked by combat mode.
 
 /**
   * should the current-attack-damage be lower than the item force multiplied by this value,

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -274,6 +274,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define STAM_COST_NO_COMBAT_MULT	1.25
 #define STAM_COST_W_CLASS_MULT		1.25
 #define STAM_COST_THROW_MULT		2
+#define STAM_COST_THROW_MOB			8 //multiplied by mob size + 1.
 
 ///Multiplier of the (STAMINA_NEAR_CRIT - user current stamina loss) : (STAMINA_NEAR_CRIT - STAMINA_SOFTCRIT) ratio used in damage penalties when stam soft-critted.
 #define STAM_CRIT_ITEM_ATTACK_PENALTY	0.66
@@ -283,6 +284,12 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define LYING_DAMAGE_PENALTY			0.5
 /// Added delay when firing guns stam-softcritted. Summed with a hardset CLICK_CD_RANGE delay, similar to STAM_CRIT_DAMAGE_DELAY otherwise.
 #define STAM_CRIT_GUN_DELAY			2.75
+
+//stamina recovery defines. Blocked if combat mode is on.
+#define STAM_RECOVERY_STAM_CRIT		-7.5
+#define STAM_RECOVERY_RESTING		-5
+#define STAM_RECOVERY_NORMAL		-2
+#define STAM_RECOVERY_LIMB			3 //limbs recover stamina separately from handle_status_effects(), and aren't blocked by combat mode.
 
 /**
   * should the current-attack-damage be lower than the item force multiplied by this value,

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -182,7 +182,7 @@
 				to_chat(src, "<span class='notice'>You gently let go of [throwable_mob].</span>")
 				return
 
-			adjustStaminaLossBuffered(STAM_COST_THROW_MOB * (throwable_mob.mob_size+1))// throwing an entire person shall be very tiring
+			adjustStaminaLossBuffered(STAM_COST_THROW_MOB * ((throwable_mob.mob_size+1)**2))// throwing an entire person shall be very tiring
 			var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 			var/turf/end_T = get_turf(target)
 			if(start_T && end_T)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -182,7 +182,7 @@
 				to_chat(src, "<span class='notice'>You gently let go of [throwable_mob].</span>")
 				return
 
-			adjustStaminaLossBuffered(25)//CIT CHANGE - throwing an entire person shall be very tiring
+			adjustStaminaLossBuffered(STAM_COST_THROW_MOB * (throwable_mob.mob_size+1))// throwing an entire person shall be very tiring
 			var/turf/start_T = get_turf(loc) //Get the start and target tile for the descriptors
 			var/turf/end_T = get_turf(target)
 			if(start_T && end_T)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -519,7 +519,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 /mob/living/carbon/handle_status_effects()
 	..()
 	if(getStaminaLoss() && !SEND_SIGNAL(src, COMSIG_COMBAT_MODE_CHECK, COMBAT_MODE_ACTIVE))		//CIT CHANGE - prevents stamina regen while combat mode is active
-		adjustStaminaLoss(!CHECK_MOBILITY(src, MOBILITY_STAND) ? ((combat_flags & COMBAT_FLAG_HARD_STAMCRIT) ? -7.5 : -6) : -3)//CIT CHANGE - decreases adjuststaminaloss to stop stamina damage from being such a joke
+		adjustStaminaLoss(!CHECK_MOBILITY(src, MOBILITY_STAND) ? ((combat_flags & COMBAT_FLAG_HARD_STAMCRIT) ? STAM_RECOVERY_STAM_CRIT : STAM_RECOVERY_RESTING) : STAM_RECOVERY_NORMAL)
 
 	if(!(combat_flags & COMBAT_FLAG_HARD_STAMCRIT) && incomingstammult != 1)
 		incomingstammult = max(0.01, incomingstammult)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -651,7 +651,7 @@
 	held_index = 1
 	px_x = -6
 	px_y = 0
-	stam_heal_tick = 4
+	stam_heal_tick = STAM_RECOVERY_LIMB
 
 /obj/item/bodypart/l_arm/is_disabled()
 	if(HAS_TRAIT(owner, TRAIT_PARALYSIS_L_ARM))
@@ -711,7 +711,7 @@
 	held_index = 2
 	px_x = 6
 	px_y = 0
-	stam_heal_tick = 4
+	stam_heal_tick = STAM_RECOVERY_LIMB
 	max_stamina_damage = 50
 
 /obj/item/bodypart/r_arm/is_disabled()
@@ -771,7 +771,7 @@
 	body_damage_coeff = 0.75
 	px_x = -2
 	px_y = 12
-	stam_heal_tick = 4
+	stam_heal_tick = STAM_RECOVERY_LIMB
 	max_stamina_damage = 50
 
 /obj/item/bodypart/l_leg/is_disabled()
@@ -830,7 +830,7 @@
 	px_x = 2
 	px_y = 12
 	max_stamina_damage = 50
-	stam_heal_tick = 4
+	stam_heal_tick = STAM_RECOVERY_LIMB
 
 /obj/item/bodypart/r_leg/is_disabled()
 	if(HAS_TRAIT(owner, TRAIT_PARALYSIS_R_LEG))


### PR DESCRIPTION
## About The Pull Request
Now that I loosened up the tediousness of the combat system a while ago, allowing people to keep fighting at low stamina albeit longer delays and lower damage, I think it's fine to undo the melee stamina cost reduction from #9532

## Why It's Good For The Game
See above, "soft stam crit" is not an equivalent of being a sitting duck anymore..

## Changelog
:cl:
balance: The stamina cost multiplier for swinging melee weapons against mobs has been brought back to 1 from 0.8
balance: The stamina cost for throwing mobs now scales with their mob size variable.
/:cl:
