### PR TITLE
simple mob blood is no longer white

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -436,7 +436,7 @@
 	var/blood_id = get_blood_id()
 	if(!(blood_id in GLOB.blood_reagent_types))
 		return
-	return list("ANIMAL DNA" = "Y-")
+	return list("color" = list(BLOOD_COLOR_HUMAN), "ANIMAL DNA" = "Y-")
 
 /mob/living/carbon/get_blood_dna_list()
 	var/blood_id = get_blood_id()
@@ -452,7 +452,7 @@
 	return blood_dna
 
 /mob/living/carbon/alien/get_blood_dna_list()
-	return list("UNKNOWN DNA" = "X*")
+	return list("color" = list(BLOOD_COLOR_XENO), "UNKNOWN DNA" = "X*")
 
 //to add a mob's dna info into an object's blood_DNA list.
 /atom/proc/transfer_mob_blood_dna(mob/living/L)


### PR DESCRIPTION
## About The Pull Request
blood code is awful
non-alien mob blood defaults to human colour now (red)
alien mob blood defaults to xeno colour now (green)
i didn't realise simplemob blood colours were based off their blood dna like carbons, it's stupid but hey they initialise correctly now

## Why It's Good For The Game
seeing ian bleed white blood is weird

## Changelog
:cl:
fix: non-carbon blood is now not white
/:cl:
