### PR TITLE
attempts to port Wizard Gamemode now ends when all wizards and wizard apprentices are dead #47514

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -44,7 +44,7 @@
 
 
 /datum/game_mode/wizard/are_special_antags_dead()
-	for(var/datum/mind/wizard in wizards)
+	for(var/datum/mind/wizard in wizards | apprentices)
 		if(isliving(wizard.current) && wizard.current.stat!=DEAD)
 			return FALSE
 
@@ -57,6 +57,14 @@
 		SSevents.resetFrequency()
 
 	return TRUE
+
+/datum/game_mode/wizard/check_finished()
+	. = ..()
+	if(.)
+		finished = TRUE
+	else if(gamemode_ready && are_special_antags_dead() && !CONFIG_GET(keyed_list/continuous)[config_tag])
+		finished = TRUE
+		. = TRUE
 
 /datum/game_mode/wizard/set_round_result()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/tgstation/tgstation/pull/47514

i cant test this so im praying that it worked because it didnt break everything suddenly

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

i hate summon events and i dont think anyone else likes them if im being honest

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: the round should now automatically end when the wizard inevitably eats shit regardless of present antagonists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
