### PR TITLE
adds a keybind to toggle active blocking instead of only press-hold 

### DIFF
--- a/code/modules/keybindings/keybind/combat.dm
+++ b/code/modules/keybindings/keybind/combat.dm
@@ -25,6 +25,17 @@
 	var/mob/living/L = user.mob
 	L.keybind_stop_active_blocking()
 
+/datum/keybinding/living/active_block_toggle
+	name = "active_block_toggle"
+	full_name = "Block (Toggle)"
+	category = CATEGORY_COMBAT
+	description = "Toggles active blocking system using currenet in hand object, or any found object if applicable."
+
+/datum/keybinding/living/active_block_toggle/down(client/user)
+	var/mob/living/L = user.mob
+	L.keybind_toggle_active_blocking()
+	return TRUE
+
 /datum/keybinding/living/active_parry
 	hotkey_keys = list("Insert", "G")
 	name = "active_parry"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

QoL
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
tweak: active blocking now has a toggle keybind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
