### PR TITLE
lowers shield blocking stamcost/second 3.5 to 2.5

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -26,7 +26,7 @@
 /datum/block_parry_data/shield
 	block_damage_multiplier = 0.25
 	block_stamina_efficiency = 2.5
-	block_stamina_cost_per_second = 3.5
+	block_stamina_cost_per_second = 2.5
 	block_slowdown = 0
 	block_lock_attacking = FALSE
 	block_lock_sprinting = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bit high rn, you get stamcritted too easily, although this probably needs a testmerge as it's a pretty big balance change
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
balance: shields take 2.5 stam instead of 3.5 stam per second to maintain block
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
