### PR TITLE
slightly tweaks the cooking oil damage formula

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -133,7 +133,7 @@
 			M.emote("scream")
 			playsound(M, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
 			var/oil_damage = max((holder.chem_temp / fry_temperature) * 0.33,1) //Damage taken per unit
-			M.adjustFireLoss(oil_damage * max(reac_volume,10)) //Damage caps at 10
+			M.adjustFireLoss(oil_damage * max(reac_volume,20)) //Damage caps at 20
 	else
 		..()
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -132,8 +132,8 @@
 			"<span class='userdanger'>You're covered in boiling oil!</span>")
 			M.emote("scream")
 			playsound(M, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
-			var/oil_damage = (holder.chem_temp / fry_temperature) * 0.33 //Damage taken per unit
-			M.adjustFireLoss(min(35, oil_damage * reac_volume)) //Damage caps at 35
+			var/oil_damage = max((holder.chem_temp / fry_temperature) * 0.33,1) //Damage taken per unit
+			M.adjustFireLoss(oil_damage * max(reac_volume,10)) //Damage caps at 10
 	else
 		..()
 	return TRUE
@@ -866,4 +866,3 @@
 	taste_mult = 2
 	taste_description = "fizzy sweetness"
 	value = REAGENT_VALUE_COMMON
-	

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -866,3 +866,4 @@
 	taste_mult = 2
 	taste_description = "fizzy sweetness"
 	value = REAGENT_VALUE_COMMON
+


### PR DESCRIPTION
## About The Pull Request
the maximum damage per unit of cooking oil is now 1, whereas previously it had no limit (meaning any amount of oil could do 35 burn (the cap of cooking oil damage) if it was heated up enough)

the volume multiplier is also now capped at 20, bringing the total damage of cooking oil to 20, when heated enough with 20u splashed

## Why It's Good For The Game
a single droplet of oil probably shouldn't do more damage than like, a real laser, or a sword, or, y'know, a gun.

## Changelog
:cl:
tweak: cooking oil is now far less lethal, requiring a higher volume of the reagent to deal more damage
/:cl:
