### PR TITLE
fixes my speech pr so people can actually speak properly

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2744,7 +2744,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			qdel(T)
 		var/obj/item/organ/tongue/new_custom_tongue = new new_tongue
 		new_custom_tongue.Insert(character)
-	if(custom_speech_verb != "default" && GLOB.speech_verbs[custom_speech_verb])
+	if(custom_speech_verb != "default" && LAZYACCESS(GLOB.speech_verbs, custom_speech_verb))
 		character.dna.species.say_mod = custom_speech_verb
 
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2738,13 +2738,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//speech stuff
 	var/new_tongue = GLOB.roundstart_tongues[custom_tongue]
-	if(new_tongue)
+	if(new_tongue && custom_tongue != "default")
 		var/obj/item/organ/tongue/T = character.getorganslot(ORGAN_SLOT_TONGUE)
 		if(T)
 			qdel(T)
 		var/obj/item/organ/tongue/new_custom_tongue = new new_tongue
 		new_custom_tongue.Insert(character)
-	if(custom_speech_verb != "default")
+	if(custom_speech_verb != "default" && GLOB.speech_verbs[custom_speech_verb])
 		character.dna.species.say_mod = custom_speech_verb
 
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	33
+#define SAVEFILE_VERSION_MAX	34
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -199,6 +199,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		features["flavor_text"] = html_encode(features["flavor_text"])
 		features["silicon_flavor_text"] = html_encode(features["silicon_flavor_text"])
 		features["ooc_notes"] = html_encode(features["ooc_notes"])
+
+	if(current_version < 34)
+		S["custom_tongue"] = "default"
+		S["custom_speech_verb"] = "default"
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -201,8 +201,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		features["ooc_notes"] = html_encode(features["ooc_notes"])
 
 	if(current_version < 34)
-		S["custom_tongue"] = "default"
-		S["custom_speech_verb"] = "default"
+		custom_tongue = "default"
+		custom_speech_verb = "default"
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)


### PR DESCRIPTION
## About The Pull Request
few oversights made during the testing of my speech pr to do with existing characters / not having an option chosen, which is now fixed, and it should be handled like every other customization option (sorry for any inconveniences it caused)

makes sure tongue isn't default before replacing your tongue
makes sure your speech verb is in the global var storing all possible speech verbs, before applying it (so no null speech verbs)
also the buttons in customization won't start empty now either! (meaning you can't have nothing selected, it'll become 'default'!)

## Why It's Good For The Game
people speaking without a speech verb is probably bad (sorry)

## Changelog
:cl:
fix: people can't not have a speech verb now
/:cl:
