### PR TITLE
Silences the skill panel check_rights() call.

### DIFF
--- a/code/datums/skills/_check_skills.dm
+++ b/code/datums/skills/_check_skills.dm
@@ -40,7 +40,7 @@
 	. = list()
 	.["playername"] = owner.name
 	.["see_skill_mods"] = see_skill_mods
-	.["admin"] = check_rights(R_DEBUG)
+	.["admin"] = check_rights(R_DEBUG, FALSE)
 
 /datum/skill_holder/ui_act(action, params)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Title. Stops players from receiving the "Error: You do not have sufficient rights to do that. You require one of the following flags: +DEBUG." message.

## Why It's Good For The Game
Fixing idiocy.

## Changelog
:cl:
fix: Opening the View Skill Panel shouldn't trigger messages about insufficient admin priviledges anymore.
/:cl:
