### PR TITLE
Trashbag Whitelist Update

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -48,7 +48,8 @@
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 	STR.max_combined_w_class = 30
 	STR.max_items = 30
-	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear))
+	STR.can_hold_extra = typecacheof(list(/obj/item/organ/lungs, /obj/item/organ/liver, /obj/item/organ/stomach, /obj/item/clothing/shoes)) - typesof(/obj/item/clothing/shoes/magboots, /obj/item/clothing/shoes/clown_shoes, /obj/item/clothing/shoes/jackboots, /obj/item/clothing/shoes/workboots)
+	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear, /obj/item/storage/wallet, /obj/item/organ/brain))
 	STR.limited_random_access = TRUE
 	STR.limited_random_access_stack_position = 3
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

**Trashbag can now hold:**
All Organs
Most Shoes

**Trashbags cannot hold:**
Jackbooks
Workboots
Magboots
Clown Shoes
Nuke Disk
Wallets (Nuke Disk Nesting)
Brains

## Why It's Good For The Game

People literally leave shoes everywhere all the time (among other things) when they run off the shuttle. Also, it helps clean up after explosions and monkey riots. It's really annoying that all other organs fit, but you can't slide a few livers into your bag.

## Changelog
:cl:
tweak: Trashbags can now hold most shoes, and organs.
balance: You can no longer nest nuke disks or hold brains in the trash.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
