### PR TITLE
increased the amount of stuff the chem master can dispense from 10 to 20

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -258,9 +258,9 @@
 			var/amount = text2num(params["amount"])
 			if(amount == null)
 				amount = text2num(input(usr,
-					"Max 10. Buffer content will be split evenly.",
+					"Max 20. Buffer content will be split evenly.",
 					"How many to make?", 1))
-			amount = clamp(round(amount), 0, 10)
+			amount = clamp(round(amount), 0, 20)
 			if (amount <= 0)
 				return FALSE
 			// Get units per item


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As in the title, the chem masters inconvenient 10 item limit has been increased to 20.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less tedious and unnecessary button presses for chemists.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
