### PR TITLE
Popping the north monastery tunnel on Pubby

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32562,15 +32562,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "bxZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "bya" = (
@@ -54866,14 +54861,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"hCb" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/hallway/secondary/entry)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -56250,12 +56237,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "kIc" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
@@ -82971,7 +82953,7 @@ bbR
 bbR
 aZx
 kIc
-hCb
+kIc
 bAJ
 bBX
 bBX

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -39686,6 +39686,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMu" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -33843,9 +33843,8 @@
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/turf/open/space/basic,
+/area/space)
 "bAJ" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
@@ -38135,10 +38134,12 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bIY" = (
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/area/hallway/secondary/entry)
+/turf/open/space/basic,
+/area/space)
 "bIZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -39182,9 +39183,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bLp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bLq" = (
@@ -39207,20 +39206,17 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bLr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
 /area/chapel/dock)
 "bLs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/chapel/dock)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -39693,9 +39689,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMu" = (
@@ -40164,11 +40158,11 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bNu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
@@ -40589,6 +40583,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bOy" = (
@@ -40601,6 +40596,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
@@ -40870,6 +40868,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bPo" = (
@@ -40886,6 +40885,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bPp" = (
@@ -41182,6 +41182,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/sand,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/chapel/asteroid/monastery)
 "bQg" = (
@@ -44378,14 +44379,23 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "bWX" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
+/area/chapel/dock)
 "bWZ" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -44715,6 +44725,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "bXJ" = (
@@ -45420,6 +45431,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
 "bZo" = (
@@ -46174,6 +46186,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
 "cbO" = (
@@ -46181,6 +46194,7 @@
 /obj/item/reagent_containers/food/drinks/trophy{
 	pixel_y = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
 "cbP" = (
@@ -46337,15 +46351,15 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
 "ccF" = (
 /obj/effect/landmark/start/chaplain,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/chapel/main/monastery)
@@ -53016,8 +53030,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dpc" = (
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/sand,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/chapel/asteroid/monastery)
 "dps" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -53382,12 +53398,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "eit" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/chapel/main/monastery)
 "eiV" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -53405,10 +53418,6 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
 /area/lawoffice)
-"epg" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "epj" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -53684,12 +53693,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"eVT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "eWi" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -54613,14 +54616,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"gTy" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gUb" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -56405,12 +56400,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"kVy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "kWQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -56878,11 +56867,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mgU" = (
-/obj/effect/landmark/carpspawn,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "mhl" = (
 /obj/machinery/power/emitter,
 /obj/machinery/light{
@@ -57185,14 +57169,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"mSY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/chapel/dock)
 "mTS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57202,12 +57178,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"mVD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57289,12 +57259,6 @@
 /obj/item/chair/stool,
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
-"nho" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "nih" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/costume,
@@ -58380,17 +58344,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"ppY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/chapel/dock)
 "prQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -59875,22 +59828,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"tbF" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"tbY" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "tcY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60509,10 +60446,6 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uxI" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "uxP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -60717,10 +60650,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"vaB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "vco" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -60931,12 +60860,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vxZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "vzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -61374,9 +61297,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "wDe" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
@@ -61563,10 +61484,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"wUc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "wUf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -61601,25 +61518,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"wYJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "wYK" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"wZs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/hallway/secondary/entry)
 "xah" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61678,10 +61580,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
-"xeN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "xgh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -79230,26 +79128,26 @@ bIW
 bKc
 bOy
 bMt
-bLn
-bOy
-bPo
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
-bQg
+bLs
 bWX
-bXJ
-bZo
-bZo
-bZo
-bZo
-bZo
-bZo
+bPo
+dpc
+dpc
+dpc
+dpc
+dpc
+dpc
+dpc
+dpc
+dpc
+cek
+cdx
+eit
+eit
+eit
+eit
+eit
+eit
 cbO
 ccF
 cdx
@@ -80252,11 +80150,11 @@ aaa
 aaa
 aaa
 aaa
-koE
+aht
 aqG
 bGE
 bKf
-mSY
+bKf
 bMw
 bNy
 bNw
@@ -80508,12 +80406,12 @@ aaa
 aaa
 aaa
 aaa
-koE
-koE
+aht
+aht
 aqG
 bGE
 bKf
-mSY
+bKf
 bMx
 bNz
 bHM
@@ -80764,13 +80662,13 @@ aaa
 aaa
 aaa
 aaa
-koE
-koE
-koE
+aaa
+aaa
+aaa
 aqG
 bGE
 wDe
-ppY
+bHM
 bHM
 bNA
 bHM
@@ -81014,21 +80912,21 @@ aZx
 aaa
 aaa
 aaa
-mZE
-bVp
-bVp
-bVp
-bVp
-bVp
-eit
-gTy
-eit
-eit
-tbF
-aZx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bIY
-bLs
-aZx
+bIY
+aht
+aht
 bNB
 bMy
 abI
@@ -81271,21 +81169,21 @@ aZx
 aaa
 aaa
 aaa
-bGI
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-bIY
-wZs
-aZx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
 amC
 aaa
 aht
@@ -81528,21 +81426,21 @@ aZx
 aaa
 aaa
 aaa
-bGI
-aZx
-tbY
-wYJ
-xeN
-xeN
-xeN
-wYJ
-xeN
-eVT
-dpc
-vxZ
-bIY
-nho
-aZx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 amB
 aht
 aht
@@ -81785,21 +81683,21 @@ aZx
 aaa
 aaa
 aaa
-bGI
-aZx
-mVD
-dpc
-dpc
-dpc
-wUc
-vaB
-vaB
-vaB
-vaB
-vaB
-vaB
-kVy
-aZx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 amC
 aaa
 aht
@@ -82042,21 +81940,21 @@ aZx
 aaa
 aaa
 aaa
-bGI
-aZx
-mVD
-dpc
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 amB
 aht
 aht
@@ -82299,21 +82197,21 @@ aZx
 aaa
 aaa
 aaa
-aqG
-aZx
-mVD
-dpc
-aZx
-koE
-koE
-koE
-koE
-koE
-koE
-koE
-koE
-koE
-koE
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 amD
 aaa
 aht
@@ -82556,11 +82454,11 @@ aZx
 aaa
 aaa
 koE
-aqG
-aZx
-mVD
-dpc
-aZx
+aaa
+aaa
+aaa
+aaa
+aaa
 bBV
 bDf
 bDf
@@ -82815,12 +82713,12 @@ aZx
 aZx
 aZx
 aZx
-mVD
-uxI
+aaa
+aaa
 bAI
-epg
 abI
-koE
+abI
+aht
 abI
 aaa
 bva
@@ -83123,7 +83021,7 @@ cfN
 cfN
 xYV
 cjm
-koE
+aht
 aaa
 aaa
 aaa
@@ -83381,7 +83279,7 @@ cfN
 qWo
 cjm
 cjm
-koE
+aht
 aaa
 aaa
 aaa
@@ -84136,8 +84034,8 @@ bva
 bNK
 bva
 bva
-koE
-mgU
+aht
+aht
 kSb
 kSb
 aht
@@ -84395,7 +84293,7 @@ bQl
 cqX
 xNx
 ctS
-aaa
+cFB
 aaa
 aaa
 aaa
@@ -84407,8 +84305,8 @@ aaa
 aaa
 kSb
 kSb
-koE
-koE
+aht
+aht
 nKo
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -33839,7 +33839,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bAJ" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
@@ -34509,6 +34509,7 @@
 /area/science/xenobiology)
 "bBV" = (
 /obj/structure/transit_tube/curved,
+/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
 "bBW" = (
@@ -39725,13 +39726,19 @@
 	},
 /area/chapel/dock)
 "bMy" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/chapel/dock)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -44378,19 +44385,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "bWX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/sand,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/chapel/dock)
+/turf/open/floor/plasteel,
+/area/chapel/asteroid/monastery)
 "bWZ" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -53025,10 +53023,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "dpc" = (
-/obj/effect/turf_decal/sand,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/chapel/asteroid/monastery)
+/turf/open/floor/carpet,
+/area/chapel/main/monastery)
 "dps" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -53392,10 +53389,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"eit" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/chapel/main/monastery)
 "eiV" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -56049,10 +56042,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"koE" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -79111,25 +79100,25 @@ bKc
 bOy
 bMt
 bLs
-bWX
+bMy
 bPo
-dpc
-dpc
-dpc
-dpc
-dpc
-dpc
-dpc
-dpc
-dpc
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
+bWX
 cek
 cdx
-eit
-eit
-eit
-eit
-eit
-eit
+dpc
+dpc
+dpc
+dpc
+dpc
+dpc
 cbO
 ccF
 cdx
@@ -79621,7 +79610,7 @@ aaa
 bGI
 bHM
 bHM
-bHM
+bNw
 bLq
 bMv
 bNw
@@ -80910,7 +80899,7 @@ bIY
 aht
 aht
 bNB
-bMy
+abI
 abI
 aby
 abI
@@ -81679,7 +81668,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aht
 amC
 aaa
 aht
@@ -81935,8 +81924,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aht
+aht
 amB
 aht
 aht
@@ -82185,10 +82174,10 @@ aaa
 aaa
 aaa
 aht
-aht
-aht
-aht
-aht
+aaa
+aaa
+aaa
+aaa
 aht
 aht
 aht
@@ -82435,12 +82424,12 @@ bon
 aZx
 aaa
 aaa
-koE
 aaa
 aaa
 aaa
 aaa
 aaa
+aht
 bBV
 bDf
 bDf
@@ -82696,7 +82685,7 @@ aZx
 aZx
 aZx
 aaa
-aaa
+aht
 bAI
 abI
 abI


### PR DESCRIPTION
## About The Pull Request

Removes the northern hallway leading to the pubbystation's monastery.
Also some super miner nearstation stuff and moving where the carp spawn, since I saw it needed an update.

## Why It's Good For The Game

It's an ugly bright hallway that completely ruins the interesting part of the monastery, the fact that you need a shuttle or the transit tube to get in. 
I'm totally happy to remove the southern maint tunnel into the monastery as well, but this has always been the more egregious edition.

## Changelog
:cl:
del: Removes northern tunnel to the monastery on Pubby
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
