### PR TITLE
Fixes / Buffs sentinels compromise to heal augmented bodyparts aswell.

### DIFF
--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -113,8 +113,7 @@
 		for(var/i in 1 to healseverity)
 			new /obj/effect/temp_visual/heal(targetturf, "#1E8CE1")
 		if(totaldamage)
-			L.adjustBruteLoss(-brutedamage)
-			L.adjustFireLoss(-burndamage)
+			L.heal_overall_damage(brutedamage, burndamage, only_organic = FALSE) //Maybe a machine god shouldn't murder augmented followers instead of healing them
 			L.adjustOxyLoss(-oxydamage)
 			L.adjustToxLoss(totaldamage * 0.5, TRUE, TRUE)
 			clockwork_say(ranged_ability_user, text2ratvar("[has_holy_water ? "Heal tainted" : "Mend wounded"] flesh!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously, sentinels compromise did not heal augmented bodyparts of cultists, though it took their damage into account for generating half of total damage as toxins. making it a pretty effective tool to instead kill fully augmented cultists.
This PR changes modifies it so that it, while taking their damage into account, also heals them as is fitting for a machine god.

Locally tested.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Taking augmented bodypart damage into account for the backlash but not healing it is pretty bad, so the two ways to go about that were 'make it not take augmented bodyparts into account' and 'heal augmented bodyparts too'
I chose the latter as it is more fitting with what Ratvar is, aswell as it being a bad mechanic to punish the followers of a machine cult for getting augmented.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Sentinels compromise now heals augmented bodyparts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
