### PR TITLE
Drinkable and Sell-able Telecrystals 

### DIFF
--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -4,6 +4,7 @@
 	singular_name = "telecrystal"
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "telecrystal"
+	grind_results = list(/datum/reagent/telecrystal = 20)
 	w_class = WEIGHT_CLASS_TINY
 	max_amount = 50
 	item_flags = NOBLUDGEON

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -155,3 +155,10 @@
 	cost = 30
 	message = "of paperframes"
 	export_types = list(/obj/item/stack/sheet/paperframes)
+
+/datum/export/stack/telecrystal
+	unit_name = "raw"
+	cost = 1000
+	message = "telecrystals"
+	export_types = list(/obj/item/stack/telecrystal)
+

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1154,6 +1154,13 @@
 /mob/living/proc/bluespace_shuffle()
 	do_teleport(src, get_turf(src), 5, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
 
+/datum/reagent/telecrystal
+	name = "Telecrystal Dust"
+	description = "A blood-red dust comprised of something that was much more useful when it was intact."
+	reagent_state = SOLID
+	color = "#660000" // rgb: 102, 0, 0.
+	taste_description = "contraband"
+
 /datum/reagent/aluminium
 	name = "Aluminium"
 	description = "A silvery white and ductile member of the boron group of chemical elements."


### PR DESCRIPTION

## About The Pull Request

Adds "Telecrystal Dust", which is a useless, red waste of syndicate resources that can be obtained by grinding raw Telecrystals in a blender. 

You can now also sell Telecrystals at cargo for 1000 points each, which is considerably less than if you just traded them for cash in your uplink.

I only did this for a (hopefully) harmless learning experience on how to use Dream Maker and submit a PR.

## Why It's Good For The Game

As a syndicate operative being able to grind your TC into a useless liquid will allow you to reach far greater levels of autism during your gameplay that were previously thought unobtainable. 

For the crew, the ability to send the TC to Centcom for points gives them at least something to do with any TC they happen across.

## Changelog
:cl:
add: Added Telecrystal Dust
tweak: Telecrystals can be sold at cargo
/:cl:

