### PR TITLE
atmos microoptimizations 

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -249,7 +249,7 @@
 //////////////////////////SPACEWIND/////////////////////////////
 
 /turf/open/proc/consider_pressure_difference(turf/T, difference)
-	SSair.high_pressure_delta |= src
+	SSair.high_pressure_delta[src] = TRUE
 	if(difference > pressure_difference)
 		pressure_direction = get_dir(src, T)
 		pressure_difference = difference
@@ -436,7 +436,8 @@
 	if(!thermal_conductivity)
 		return FALSE
 
-	SSair.active_super_conductivity |= src
+	SSair.active_super_conductivity[src] = TRUE
+
 	return TRUE
 
 /turf/open/consider_superconductivity(starting)


### PR DESCRIPTION
makes two commonly ran procs do [] which is faster than |= (which is going to try to Find() it which is bad)