### PR TITLE
the travelling trader midround event

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -58,10 +58,10 @@
 	name = "throwing fork"
 	desc = "A fork, sharpened to perfection, making it a great weapon for throwing."
 	throwforce = 15
-	throw_speed = 3
+	throw_speed = 4
 	throw_range = 6
 	embedding = list("pain_mult" = 2, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 15)
-	sharpness = IS_SHARP_ACCURATE
+	sharpness = IS_SHARP
 
 /obj/item/kitchen/knife
 	name = "kitchen knife"

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -58,7 +58,9 @@
 	name = "throwing fork"
 	desc = "A fork, sharpened to perfection, making it a great weapon for throwing."
 	throwforce = 15
-	embedding = list("pain_mult" = 2, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 100)
+	throw_speed = 3
+	throw_range = 6
+	embedding = list("pain_mult" = 2, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 15)
 	sharpness = IS_SHARP_ACCURATE
 
 /obj/item/kitchen/knife

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -54,6 +54,12 @@
 	else
 		return ..()
 
+/obj/item/kitchen/fork/throwing
+	name = "throwing fork"
+	desc = "A fork, sharpened to perfection, making it a great weapon for throwing."
+	throwforce = 15
+	embedding = list("pain_mult" = 2, "embed_chance" = 100, "fall_chance" = 0, "embed_chance_turf_mod" = 100)
+	sharpness = IS_SHARP_ACCURATE
 
 /obj/item/kitchen/knife
 	name = "kitchen knife"

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -106,7 +106,7 @@
 	if(user == target)
 		to_chat(user, "<span class='warning'>Why would you ever do that?</span>")
 		return
-	if(ishostile(target) && (!allows_hostiles || istype(target, /mob/living/simple_animal/hostile/carp/cayenne))) || target.move_resist < MOVE_FORCE_VERY_STRONG) //don't allow goliaths into pet carriers, but let cayenne in!
+	if(ishostile(target) && (!allows_hostiles || istype(target, /mob/living/simple_animal/hostile/carp/cayenne)) || target.move_resist < MOVE_FORCE_VERY_STRONG) //don't allow goliaths into pet carriers, but let cayenne in!
 		to_chat(user, "<span class='warning'>You have a feeling you shouldn't keep this as a pet.</span>")
 	load_occupant(user, target)
 

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -106,7 +106,7 @@
 	if(user == target)
 		to_chat(user, "<span class='warning'>Why would you ever do that?</span>")
 		return
-	if(ishostile(target) && !allows_hostiles && target.move_resist < MOVE_FORCE_VERY_STRONG) //don't allow goliaths into pet carriers
+	if(ishostile(target) && (!allows_hostiles || istype(target, /mob/living/simple_animal/hostile/carp/cayenne))) || target.move_resist < MOVE_FORCE_VERY_STRONG) //don't allow goliaths into pet carriers, but let cayenne in!
 		to_chat(user, "<span class='warning'>You have a feeling you shouldn't keep this as a pet.</span>")
 	load_occupant(user, target)
 
@@ -253,7 +253,8 @@
 		occupant_gas_supply = new
 	if(isanimal(occupant))
 		var/mob/living/simple_animal/animal = occupant
-		occupant_gas_supply.set_temperature(animal.minbodytemp) //simple animals only care about temperature when their turf isnt a location
+		occupant_gas_supply[/datum/gas/oxygen] = 0.0064 //make sure it has some gas in so it isn't depressurized
+		occupant_gas_supply.set_temperature(animal.minbodytemp) //simple animals only care about temperature/pressure when their turf isnt a location
 	else
 		if(ishuman(occupant)) //humans require resistance to cold/heat and living in no air while inside, and lose this when outside
 			ADD_TRAIT(occupant, TRAIT_RESISTCOLD, "bluespace_container_cold_resist")

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -15,6 +15,7 @@
 	var/list/conferred_embed = EMBED_HARMLESS
 	var/overwrite_existing = FALSE
 
+	var/endless = FALSE
 	var/apply_time = 30
 
 /obj/item/stack/sticky_tape/afterattack(obj/item/I, mob/living/user)
@@ -31,7 +32,7 @@
 		I.embedding = conferred_embed
 		I.updateEmbedding()
 		to_chat(user, "<span class='notice'>You finish wrapping [I] with [src].</span>")
-		if(max_amount > 0)
+		if(!endless)
 			use(1)
 		I.name = "[prefix] [I.name]"
 
@@ -42,7 +43,7 @@
 /obj/item/stack/sticky_tape/infinite //endless tape that applies far faster, for maximum honks
 	name = "endless sticky tape"
 	desc = "This roll of sticky tape somehow has no end."
-	max_amount = 0
+	endless = TRUE
 	apply_time = 10
 
 /obj/item/stack/sticky_tape/super

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -15,6 +15,8 @@
 	var/list/conferred_embed = EMBED_HARMLESS
 	var/overwrite_existing = FALSE
 
+	var/apply_time = 30
+
 /obj/item/stack/sticky_tape/afterattack(obj/item/I, mob/living/user)
 	if(!istype(I))
 		return
@@ -25,16 +27,23 @@
 
 	user.visible_message("<span class='notice'>[user] begins wrapping [I] with [src].</span>", "<span class='notice'>You begin wrapping [I] with [src].</span>")
 
-	if(do_after(user, 30, target=I))
+	if(do_after(user, apply_time, target=I))
 		I.embedding = conferred_embed
 		I.updateEmbedding()
 		to_chat(user, "<span class='notice'>You finish wrapping [I] with [src].</span>")
-		use(1)
+		if(max_amount > 0)
+			use(1)
 		I.name = "[prefix] [I.name]"
 
 		if(istype(I, /obj/item/grenade))
 			var/obj/item/grenade/sticky_bomb = I
 			sticky_bomb.sticky = TRUE
+
+/obj/item/stack/sticky_tape/infinite //endless tape that applies far faster, for maximum honks
+	name = "endless sticky tape"
+	desc = "This roll of sticky tape somehow has no end."
+	max_amount = 0
+	apply_time = 10
 
 /obj/item/stack/sticky_tape/super
 	name = "super sticky tape"

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1418,3 +1418,9 @@ obj/item/storage/box/stingbangs
 	new /obj/item/reagent_containers/glass/beaker/meta(src)
 	new /obj/item/reagent_containers/glass/beaker/noreact(src)
 	new /obj/item/reagent_containers/glass/beaker/bluespace(src)
+
+/obj/item/storage/box/strange_seeds_5pack
+
+/obj/item/storage/box/strange_seeds_5pack/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/seeds/random(src)

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -174,7 +174,7 @@
 		/mob/living/simple_animal/hostile/bear = 1,
 		/mob/living/simple_animal/hostile/retaliate/clown/fleshclown = 1,
 		/mob/living/simple_animal/hostile/tree = 1,
-		/mob/living/simple_animal/hostile/mimic = 1
+		/mob/living/simple_animal/hostile/mimic = 1,
 		/mob/living/simple_animal/hostile/shark/laser = 1
 		)
 
@@ -199,7 +199,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 /mob/living/carbon/human/dummy/travelling_trader/animal_hunter/give_reward(var/mob/giver) //the reward is actually given in a jar, because releasing it onto the station might be a bad idea
 	var/mob/living/animal = pickweight(possible_rewards)
 	if(giver && giver.tag)
-		animal.faction += "/[[giver.tag]/]"
+		animal.faction += "\[[giver.tag]\]"
 	var/obj/item/pet_carrier/bluespace/jar = new(get_turf(src))
 	jar.add_occupant(animal)
 	jar.name = "WARNING: [animal] INSIDE"
@@ -215,7 +215,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	possible_rewards = list(/obj/structure/reagent_dispensers/keg/neurotoxin = 1, //all kegs have 250u aside from neurotoxin/hearty punch which have 100u
 		/obj/structure/reagent_dispensers/keg/hearty_punch = 3,
 		/obj/structure/reagent_dispensers/keg/red_queen = 3,
-		/obj/structure/reagent_dispensers/keg/narsour = 3
+		/obj/structure/reagent_dispensers/keg/narsour = 3,
 		/obj/structure/reagent_dispensers/keg/quintuple_sec = 3)
 
 
@@ -252,17 +252,17 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 /mob/living/carbon/human/dummy/travelling_trader/artifact_dealer
 	trader_name = "Otherworldly Artifact Dealer"
 	trader_outfit = /datum/outfit/artifact_dealer //he's cool enough to get his own outfit
-	inital_speech = "I have come here due to sensing the existence of an object of great power and importance."
+	initial_speech = "I have come here due to sensing the existence of an object of great power and importance."
 	request_speech = "Give to me a requested_item and I shall make it worth your while, traveller."
 	acceptance_speech = "This is truly an artifact worthy of my collection, thank you."
 	refusal_speech = "A given_item? Hah! Worthless."
 	possible_wanted_items = list(/obj/item/pen/fountain/captain = 1, //various rare things and high risk but not useful things (i.e. champion belt, bedsheet, pen)
-		 /obj/item/storage/belt/champion = 1
-		 /obj/item/clothing/shoes/wheelys = 1
-		 /obj/item/relic = 1
-		 /obj/item/flashlight/lamp/bananalamp = 1
-		 /obj/item/storage/box/hug = 1
-		 /obj/item/clothing/gloves/color/yellow = 1
+		 /obj/item/storage/belt/champion = 1,
+		 /obj/item/clothing/shoes/wheelys = 1,
+		 /obj/item/relic = 1,
+		 /obj/item/flashlight/lamp/bananalamp = 1,
+		 /obj/item/storage/box/hug = 1,
+		 /obj/item/clothing/gloves/color/yellow = 1,
 		 /obj/item/instrument/saxophone = 1,
 		 /obj/item/bedsheet/captain = 1,
 		 /obj/item/slime_extract/green = 1,
@@ -274,7 +274,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 		/obj/item/clothing/suit/hooded/wintercoat/cosmic = 2)
 
 /mob/living/carbon/human/dummy/travelling_trader/artifact_dealer/Initialize()
-	possible_rewards[pick(subtypesof(/obj/item/clothing/head/collectable)) = 1] //this is slightly lower because it's absolutely useless
+	possible_rewards += list(pick(subtypesof(/obj/item/clothing/head/collectable)) = 1) //this is slightly lower because it's absolutely useless
 	..()
 
 /datum/outfit/artifact_dealer
@@ -291,7 +291,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	request_speech = "Find me a requested_item. I shall make sure it's worth your efforts."
 	acceptance_speech = "This shall do. Goodbye, meatbag."
 	refusal_speech = "That is not what I wish for. Give me a requested_item, or I shall take one by force."
-	possible_wanted_items = list(/obj/item/bodypart/l_arm = 4, //limbs are the most common, with brain/head being the least so, organs in the middle
+	possible_wanted_items = list(/obj/item/bodypart/l_arm = 4,
 		/obj/item/bodypart/r_arm = 4,
 		/obj/item/bodypart/l_leg = 4,
 		/obj/item/bodypart/r_leg = 4,
@@ -299,9 +299,23 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 		/obj/item/organ/liver = 2,
 		/obj/item/organ/lungs = 2,
 		/obj/item/organ/heart = 2,
-		/obj/item/bodypart/eyes = 1.
+		/obj/item/organ/eyes = 1,
 		/obj/item/organ/brain = 1,
 		/obj/item/bodypart/head = 1)
+	possible_rewards = list(/obj/item/organ/cyberimp/mouth/breathing_tube = 1,
+		/obj/item/organ/eyes/robotic/thermals = 1,
+		/obj/item/organ/cyberimp/arm/toolset = 1,
+		/obj/item/organ/cyberimp/arm/surgery = 1,
+		/obj/item/organ/cyberimp/arm/janitor = 1,
+		/obj/item/organ/cyberimp/arm/flash = 1,
+		/obj/item/organ/cyberimp/arm/shield = 1,
+		/obj/item/organ/cyberimp/eyes/hud/medical = 1,
+		/obj/item/organ/cyberimp/arm/baton = 1)
+
+/mob/living/carbon/human/dummy/travelling_trader/surgeon/give_reward()
+	var/obj/item/organ/implant = pickweight(possible_rewards)
+	var/obj/item/autosurgeon/reward = new(get_turf(src))
+	reward.insert_organ(implant)
 
 /datum/outfit/otherworldly_surgeon
 	uniform = /obj/item/clothing/under/pants/white

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -128,7 +128,10 @@
 
 /mob/living/carbon/human/dummy/travelling_trader/cook/Initialize()
 	//pick a random crafted food item as the requested item
-	requested_item = GLOB.crafting_recipes[pick(subtypesof( /datum/crafting_recipe/food))].result
+	var/recipe = pick(subtypesof(/datum/crafting_recipe/food))
+	var/datum/crafting_recipe/food/new_recipe = new recipe
+	requested_item = new_recipe.result
+	qdel(new_recipe) //we don't need it anymore
 	..()
 
 //botanist
@@ -136,7 +139,7 @@
 	trader_name = "Otherworldly Gardener"
 	trader_outfit = /datum/outfit/job/botanist
 	initial_speech = "I have come across this realm in search of rare plants and believe this station may be able to help me.."
-	request_speech = "Are you able to bring me a requested_item? I could see that you get some reward for this task."
+	request_speech = "Are you able to bring me the plant known to you as: 'requested_item'? I could see that you get some reward for this task."
 	acceptance_speech = "Amazing! Ill finally be able to make that salad. Goodbye for now!"
 	refusal_speech = "A given_item? Did nobody ever teach you the basics of gardening?"
 	possible_rewards = list(/obj/item/seeds/cherry/bomb = 1,
@@ -175,8 +178,9 @@
 		/mob/living/simple_animal/hostile/retaliate/clown/fleshclown = 1,
 		/mob/living/simple_animal/hostile/tree = 1,
 		/mob/living/simple_animal/hostile/mimic = 1,
-		/mob/living/simple_animal/hostile/shark/laser = 1
-		)
+		/mob/living/simple_animal/hostile/shark = 1,
+		/mob/living/simple_animal/hostile/netherworld/blankbody = 1,
+		/mob/living/simple_animal/hostile/retaliate/goose = 1)
 
 mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	acceptance_speech = pick(list("This lifeform shall make for a great stew, thank you.", "This lifeform shall be of a true use to our cause, thank you.", "The lifeform is adequate. Goodbye.", "This lifeform shall make a great addition to my collection."))
@@ -197,12 +201,13 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	return FALSE
 
 /mob/living/carbon/human/dummy/travelling_trader/animal_hunter/give_reward(var/mob/giver) //the reward is actually given in a jar, because releasing it onto the station might be a bad idea
-	var/mob/living/animal = pickweight(possible_rewards)
-	if(giver && giver.tag)
-		animal.faction += "\[[giver.tag]\]"
 	var/obj/item/pet_carrier/bluespace/jar = new(get_turf(src))
-	jar.add_occupant(animal)
-	jar.name = "WARNING: [animal] INSIDE"
+	var/chosen_animal = pickweight(possible_rewards)
+	var/mob/living/new_animal = new chosen_animal(jar)
+	if(giver && giver.tag)
+		new_animal.faction += "\[[giver.tag]\]"
+	jar.add_occupant(new_animal)
+	jar.name = "WARNING: [new_animal]"
 
 //bartender
 /mob/living/carbon/human/dummy/travelling_trader/bartender
@@ -217,7 +222,6 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 		/obj/structure/reagent_dispensers/keg/red_queen = 3,
 		/obj/structure/reagent_dispensers/keg/narsour = 3,
 		/obj/structure/reagent_dispensers/keg/quintuple_sec = 3)
-
 
 /mob/living/carbon/human/dummy/travelling_trader/bartender/Initialize() //pick a subtype of ethanol that isn't found in the default set of the booze dispensers reagents
 	requested_item = pick(subtypesof(/datum/reagent/consumable/ethanol) - list(/datum/reagent/consumable/ethanol/beer,
@@ -253,7 +257,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	trader_name = "Otherworldly Artifact Dealer"
 	trader_outfit = /datum/outfit/artifact_dealer //he's cool enough to get his own outfit
 	initial_speech = "I have come here due to sensing the existence of an object of great power and importance."
-	request_speech = "Give to me a requested_item and I shall make it worth your while, traveller."
+	request_speech = "Give to me the great object known as: requested_item and I shall make it worth your while, traveller."
 	acceptance_speech = "This is truly an artifact worthy of my collection, thank you."
 	refusal_speech = "A given_item? Hah! Worthless."
 	possible_wanted_items = list(/obj/item/pen/fountain/captain = 1, //various rare things and high risk but not useful things (i.e. champion belt, bedsheet, pen)
@@ -288,7 +292,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	trader_name = "Otherworldly Surgeon"
 	trader_outfit = /datum/outfit/otherworldly_surgeon
 	initial_speech = "Hello there, meatbag. You can provide me with something I want."
-	request_speech = "Find me a requested_item. I shall make sure it's worth your efforts."
+	request_speech = "Find me the appendage you call 'requested_item'. I shall make sure it's worth your efforts."
 	acceptance_speech = "This shall do. Goodbye, meatbag."
 	refusal_speech = "That is not what I wish for. Give me a requested_item, or I shall take one by force."
 	possible_wanted_items = list(/obj/item/bodypart/l_arm = 4,
@@ -313,9 +317,10 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 		/obj/item/organ/cyberimp/arm/baton = 1)
 
 /mob/living/carbon/human/dummy/travelling_trader/surgeon/give_reward()
-	var/obj/item/organ/implant = new pickweight(possible_rewards)
+	var/chosen_implant = pickweight(possible_rewards)
+	var/new_implant = new chosen_implant
 	var/obj/item/autosurgeon/reward = new(get_turf(src))
-	reward.insert_organ(implant)
+	reward.insert_organ(new_implant)
 
 /datum/outfit/otherworldly_surgeon
 	uniform = /obj/item/clothing/under/pants/white

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -130,7 +130,10 @@
 	//pick a random crafted food item as the requested item
 	var/recipe = pick(subtypesof(/datum/crafting_recipe/food))
 	var/datum/crafting_recipe/food/new_recipe = new recipe
-	requested_item = new_recipe.result
+	if(istype(new_recipe.result, /obj/item/reagent_containers/food)) //not all food recipes make food objects (like cak/butterbear)
+		requested_item = new_recipe.result
+	else
+		requested_item = /obj/item/reagent_containers/food/snacks/copypasta
 	qdel(new_recipe) //we don't need it anymore
 	..()
 

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -1,0 +1,115 @@
+/datum/round_event_control/travelling_trader
+	name = "Travelling Trader"
+	typepath = /datum/round_event/travelling_trader
+	weight = 10
+	max_occurrences = 3
+	earliest_start = 0 MINUTES
+
+/datum/round_event/travelling_trader
+	startWhen = 0
+	endWhen = 600 //you effectively have 10 minutes to complete the traders request, before they disappear
+	var/mob/living/carbon/human/dummy/travelling_trader/trader
+	var/atom/spawn_location //where the trader appears
+
+/datum/round_event/travelling_trader/setup()
+	//find position to place trader at, same as how jacq works for poofing
+	var/list/targets = list()
+	for(var/H in GLOB.network_holopads)
+		var/area/A = get_area(H)
+		if(!A || findtextEx(A.name, "AI") || !is_station_level(H))
+			continue
+		targets += H
+
+	if(!targets)
+		targets = GLOB.generic_event_spawns
+
+	spawn_location = pick(targets)
+
+/datum/round_event/travelling_trader/start()
+	//spawn a type of trader
+	trader = pick(subtypesof(/mob/living/carbon/human/dummy/travelling_trader))
+	var/datum/effect_system/smoke_spread/smoke = new
+	smoke.set_up(1, spawn_location)
+	smoke.start()
+	trader.visible_message("<b>[src]</b> suddenly appears in a puff of smoke!")
+
+/datum/round_event/travelling_trader/announce(fake)
+	priority_announce("A mysterious figure has been detected on sensors at [get_area(spawn_location)]", "Mysterious Figure")
+
+/datum/round_event/travelling_trader/end()
+	if(trader)
+		trader.visible_message("The <b>[src]</b> has given up on waiting!")
+		qdel(trader)
+
+//the actual trader mob
+/mob/living/carbon/human/dummy/travelling_trader //subtype of dummy because we want to be resource-efficient
+	real_name = "Debug Travelling Trader"
+	status_flags = GODMODE //avoid scenarios of people trying to kill the trader
+	move_resist = MOVE_FORCE_VERY_STRONG //you can't bluespace bodybag them!
+	var/datum/outfit/trader_outfit
+	var/list/possible_wanted_items //weighted list of possible things to request
+	var/list/possible_rewards //weighted list of possible things to give in return for the requested item
+	var/atom/requested_item //the thing they chose from possible_wanted_items
+	var/last_speech //last time someone tried interacting with them using their hand
+	var/last_refusal //last time they vocally refused an item given to them
+	var/initial_speech = "It looks like the coders did a mishap!" //first thing they say when interacted with, like a description
+	var/speech_verb = "says"
+	var/request_speech = "Please bring me a requested_item you shall be greatly rewarded!" //second thing they say when interacted with
+	var/acceptance_speech = "This is exactly what I wanted! I shall be on my way now, thank you.!"
+	var/refusal_speech = "A given_item? I wanted a requested_item!" //what they say when refusing an item
+	var/active = TRUE
+
+/mob/living/carbon/human/dummy/travelling_trader/proc/setup_speech(var/input_speech, var/obj/item/given_item)
+	if(requested_item)
+		input_speech = replacetext(input_speech, "requested_item", requested_item.name)
+	if(given_item)
+		input_speech = replacetext(input_speech, "given_item", given_item.name)
+	return input_speech
+
+/mob/living/carbon/human/dummy/travelling_trader/attack_hand(mob/living/carbon/human/H)
+	if(active && last_speech + 3 SECONDS < world.realtime) //can only talk once per 3 seconds, to avoid spam
+		last_speech = world.realtime
+		if(initial_speech)
+			visible_message("<b>[src]</b> [speech_verb] \"[setup_speech(initial_speech)]\"")
+			sleep(15)
+		if(active && request_speech) //they might not be active anymore because of the prior sleep!
+			visible_message("<b>[src]</b> [speech_verb] \"[setup_speech(request_speech)]\"")
+
+/mob/living/carbon/human/dummy/travelling_trader/attackby(obj/item/I, mob/user)
+	if(active)
+		if(check_item(I))
+			active = FALSE
+			visible_message("<b>[src]</b> [speech_verb] \"[setup_speech(acceptance_speech, I)]\"")
+			qdel(I)
+			sleep(20)
+			give_reward()
+			qdel(src)
+		else
+			if(last_refusal + 3 SECONDS < world.realtime)
+				last_refusal = world.realtime
+				visible_message("<b>[src]</b> [speech_verb] \"[setup_speech(refusal_speech, I)]\"")
+
+/mob/living/carbon/human/dummy/travelling_trader/proc/check_item(var/obj/item/supplied_item) //sometimes we might want to care about the properties of the item, etc
+	return istype(supplied_item, requested_item)
+
+/mob/living/carbon/human/dummy/travelling_trader/proc/give_reward()
+	var/reward = pickweight(possible_rewards)
+	new reward(get_turf(src))
+
+/mob/living/carbon/human/dummy/travelling_trader/Initialize()
+	ADD_TRAIT(src,TRAIT_PIERCEIMMUNE, "trader_pierce_immune") //don't let people take their blood
+	trader_outfit.equip(src, TRUE)
+	for(var/obj/item/item in src.get_equipped_items())
+		ADD_TRAIT(item, TRAIT_NODROP, "trader_no_drop") //don't let people steal the travellers clothes!
+		item.resistance_flags |= INDESTRUCTIBLE //don't let people burn their clothes off, either.
+	requested_item = pickweight(possible_wanted_items)
+	..()
+
+/mob/living/carbon/human/dummy/travelling_trader/Destroy()
+	var/datum/effect_system/smoke_spread/smoke = new
+	smoke.set_up(1, loc)
+	smoke.start()
+	visible_message("<b>[src]</b> disappears in a puff of smoke, leaving something on the ground!")
+	..()
+
+//travelling trader subtypes (the types that can actually spawn)

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -313,7 +313,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 		/obj/item/organ/cyberimp/arm/baton = 1)
 
 /mob/living/carbon/human/dummy/travelling_trader/surgeon/give_reward()
-	var/obj/item/organ/implant = pickweight(possible_rewards)
+	var/obj/item/organ/implant = new pickweight(possible_rewards)
 	var/obj/item/autosurgeon/reward = new(get_turf(src))
 	reward.insert_organ(implant)
 

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -201,8 +201,8 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	..()
 
 /mob/living/carbon/human/dummy/travelling_trader/bartender/check_item(var/obj/item/supplied_item) //you need to check its reagents
-	var/obj/item/reagent_container/container = supplied_item
-	if(container)
-		if(container.reagents.has_reagent(requested_item, 30))
+	var/obj/item/reagent_container/supplied_container = supplied_item
+	if(supplied_container)
+		if(supplied_container.reagents.has_reagent(requested_item, 30))
 			return TRUE
 	return FALSE

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -55,9 +55,7 @@
 
 /mob/living/carbon/human/dummy/travelling_trader/proc/setup_speech(var/input_speech, var/obj/item/given_item)
 	if(requested_item)
-		var/atom/temp_requested = new requested_item
-		input_speech = replacetext(input_speech, "requested_item", temp_requested.name)
-		qdel(temp_requested)
+		input_speech = replacetext(input_speech, "requested_item", initial(requested_item.name))
 	if(given_item)
 		input_speech = replacetext(input_speech, "given_item", given_item.name)
 	return input_speech
@@ -128,13 +126,12 @@
 
 /mob/living/carbon/human/dummy/travelling_trader/cook/Initialize()
 	//pick a random crafted food item as the requested item
-	var/recipe = pick(subtypesof(/datum/crafting_recipe/food))
-	var/datum/crafting_recipe/food/new_recipe = new recipe
-	if(istype(new_recipe.result, /obj/item/reagent_containers/food)) //not all food recipes make food objects (like cak/butterbear)
-		requested_item = new_recipe.result
+	var/datum/crafting_recipe/food_recipe = pick(subtypesof(/datum/crafting_recipe/food))
+	var/result = initial(food_recipe.result)
+	if(ispath(result, /obj/item/reagent_containers/food)) //not all food recipes make food objects (like cak/butterbear)
+		requested_item = result
 	else
 		requested_item = /obj/item/reagent_containers/food/snacks/copypasta
-	qdel(new_recipe) //we don't need it anymore
 	..()
 
 //botanist

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -25,3 +25,7 @@
 	new /obj/item/coin/gold(src)
 	new /obj/item/coin/gold(src)
 	new /obj/item/coin/adamantine(src)
+
+/obj/item/storage/bag/money/c5000/PopulateContents()
+	for(var/i = 0, i < 5, i++)
+		new /obj/item/stack/spacecash/c1000(src)

--- a/code/modules/mob/living/simple_animal/friendly/bumbles.dm
+++ b/code/modules/mob/living/simple_animal/friendly/bumbles.dm
@@ -30,6 +30,7 @@
 	verb_yell = "buzzes intensely"
 	emote_see = list("buzzes.", "makes a loud buzz.", "rolls several times.", "buzzes happily.")
 	speak_chance = 1
+	unique_name = TRUE
 
 /mob/living/simple_animal/pet/bumbles/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -199,7 +199,7 @@
 
 /mob/living/simple_animal/cow/random/Initialize()
 	milk_reagent = get_random_reagent_id() //this has a blacklist so don't worry about romerol cows, etc
-
+	..()
 
 //Wisdom cow, speaks and bestows great wisdoms
 /mob/living/simple_animal/cow/wisdom

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -192,6 +192,15 @@
 	else
 		..()
 
+//a cow that produces a random reagent in its udder
+/mob/living/simple_animal/cow/random
+	name = "strange cow"
+	desc = "Something seems off about the milk this cow is producing."
+
+/mob/living/simple_animal/cow/random/Initialize()
+	milk_reagent = get_random_reagent_id() //this has a blacklist so don't worry about romerol cows, etc
+
+
 //Wisdom cow, speaks and bestows great wisdoms
 /mob/living/simple_animal/cow/wisdom
 	name = "wisdom cow"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -247,3 +247,42 @@
 	icon_state = "bluekeg"
 	reagent_id = /datum/reagent/consumable/ethanol/gargle_blaster
 	tank_volume = 100
+
+//kegs given by the travelling trader's bartender subtype
+
+/obj/structure/reagent_dispensers/keg/quintuple_sec
+	name = "keg of quintuple sec"
+	desc = "A keg of pure justice."
+	icon_state = "redkeg"
+	reagent_id = /datum/reagent/consumable/ethanol/quintuple_sec
+	tank_volume = 250
+
+/obj/structure/reagent_dispensers/keg/narsour
+	name = "keg of narsour"
+	desc = "A keg of eldritch terrors."
+	icon_state = "redkeg"
+	reagent_id = /datum/reagent/consumable/ethanol/narsour
+	tank_volume = 250
+
+/obj/structure/reagent_dispensers/keg/red_queen
+	name = "keg of red queen"
+	desc = "A strange keg, filled with a kind of tea."
+	icon_state = "redkeg"
+	reagent_id = /datum/reagent/consumable/red_queen
+	tank_volume = 250
+
+/obj/structure/reagent_dispensers/keg/hearty_punch
+	name = "keg of hearty punch"
+	desc = "A keg that will get you right back on your feet."
+	icon_state = "redkeg"
+	reagent_id = /datum/reagent/consumable/hearty_punch
+	tank_volume = 100 //this usually has a 15:1 ratio when being made, so we provide less of it
+
+/obj/structure/reagent_dispensers/keg/neurotoxin
+	name = "keg of neurotoxin"
+	desc = "A keg of the sickly substance known as 'neurotoxin'."
+	icon_state = "bluekeg"
+	reagent_id = /datum/reagent/consumable/ethanol/neurotoxin
+	tank_volume = 100 //2.5x less than the other kegs because it's harder to get
+
+

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -275,7 +275,7 @@
 	name = "keg of hearty punch"
 	desc = "A keg that will get you right back on your feet."
 	icon_state = "redkeg"
-	reagent_id = /datum/reagent/consumable/hearty_punch
+	reagent_id = /datum/reagent/consumable/ethanol/hearty_punch
 	tank_volume = 100 //this usually has a 15:1 ratio when being made, so we provide less of it
 
 /obj/structure/reagent_dispensers/keg/neurotoxin

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1954,6 +1954,7 @@
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"
 #include "code\modules\events\stray_cargo.dm"
+#include "code\modules\events\travelling_trader.dm"
 #include "code\modules\events\vent_clog.dm"
 #include "code\modules\events\wisdomcow.dm"
 #include "code\modules\events\wormholes.dm"


### PR DESCRIPTION
## About The Pull Request
this adds a weight 10 midround event to the game that spawns a travelling trader mob who despawns after 15 minutes
they ask for one specific item out of a pool of possible items, based off the type of trader they are
upon giving them the requested item, they hand you a reward, also based off the type of trader they are

also fixes a small pet carrier bug (relevant because the rewards from the animal hunter all come inside a pet_carrier/bluespace (jar))

it also adds an embeddable fork, some kegs, and an infinite sticky tape roll into the game, as they're used for some of the reward pools

the subtypes so far:
cook - asks for a crafted food item
bartender - asks for a drink not found in the base dispenser reagents
animal hunter - asks for a station pet (if none happen to exist, asks for a monkey or a corgi, randomly)
surgeon - asks for a random body part/organ
botanist - asks for a random plant
artifact hunter - asks for something more unique or rare

also the animal hunter is special because their rewards consist of a (usually) hostile mob picked from a list, contained within a jar, and it's friendly specifically to the person who handed the item into the trader by adding their mob faction to its factions

## Why It's Good For The Game
we need more nice midrounds and this should be a pretty nice one for giving people something to do

## Changelog
:cl:
add: travelling traders from another dimension can now visit the station in search of something specific, and reward you for giving it to them
fix: small error with pet carrier logic fixed and also making sure simple mobs are catered for properly inside bluespace jars
/:cl:
