### PR TITLE
chemical reactions now have priority - "the first grenade helped with the revenant and the second blew up the evacuation shuttle"

### DIFF
--- a/code/__DEFINES/chemistry/reactions.dm
+++ b/code/__DEFINES/chemistry/reactions.dm
@@ -1,0 +1,4 @@
+// Reaction priorities, higher makes it checked first. Otherwise, it goes based on reaction temperature requirements.
+
+#define CHEMICAL_REACTION_PRIORITY_DEFAULT				100
+#define CHEMICAL_REACTION_PRIORITY_SMOKE				1000

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -125,3 +125,11 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 	if(A.ui_category == B.ui_category)
 		return sorttext(A.name, B.name)
 	return sorttext(A.ui_category, B.ui_category)
+
+/proc/cmp_chemical_reactions_default(datum/chemical_reaction/A, datum/chemical_reaction/B)
+	if(A.priority != B.priority)
+		return A.priority - B.priority
+	else if(A.is_cold_recipe)
+		return B.required_temp - A.required_temp		//return coldest
+	else
+		return A.required_temp - B.required_temp		//return hottest

--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -128,8 +128,8 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 
 /proc/cmp_chemical_reactions_default(datum/chemical_reaction/A, datum/chemical_reaction/B)
 	if(A.priority != B.priority)
-		return A.priority - B.priority
+		return B.priority - A.priority
 	else if(A.is_cold_recipe)
-		return B.required_temp - A.required_temp		//return coldest
+		return A.required_temp - B.required_temp		//return coldest
 	else
-		return A.required_temp - B.required_temp		//return hottest
+		return B.required_temp - A.required_temp		//return hottest

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -463,17 +463,10 @@
 				if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && matching_other && meets_temp_requirement && can_special_react)
 					possible_reactions  += C
 
+		sortTim(possible_reactions, /proc/cmp_chemical_reactions_default, FALSE)
+
 		if(possible_reactions.len)
 			var/datum/chemical_reaction/selected_reaction = possible_reactions[1]
-			//select the reaction with the most extreme temperature requirements
-			for(var/V in possible_reactions)
-				var/datum/chemical_reaction/competitor = V
-				if(selected_reaction.is_cold_recipe)
-					if(competitor.required_temp <= selected_reaction.required_temp)
-						selected_reaction = competitor
-				else
-					if(competitor.required_temp >= selected_reaction.required_temp) //will return with the hotter reacting first.
-						selected_reaction = competitor
 			var/list/cached_required_reagents = selected_reaction.required_reagents//update reagents list
 			var/list/cached_results = selected_reaction.results//resultant chemical list
 			var/special_react_result = selected_reaction.check_special_react(src)

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -5,6 +5,9 @@
 	var/list/required_reagents = new/list()
 	var/list/required_catalysts = new/list()
 
+	/// Higher is higher priority, determines which order reactions are checked.
+	var/priority = CHEMICAL_REACTION_PRIORITY_DEFAULT
+
 	// Both of these variables are mostly going to be used with slime cores - but if you want to, you can use them for other things
 	var/required_container = null // the exact container path required for the reaction to happen
 	var/required_other = 0 // an integer required for the reaction to happen

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -280,6 +280,7 @@
 /datum/chemical_reaction/smoke_powder
 	name = "smoke_powder"
 	id = /datum/reagent/smoke_powder
+	priority = CHEMICAL_REACTION_PRIORITY_SMOKE
 	results = list(/datum/reagent/smoke_powder = 3)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -123,6 +123,7 @@
 #include "code\__DEFINES\_flags\item_flags.dm"
 #include "code\__DEFINES\_flags\obj_flags.dm"
 #include "code\__DEFINES\admin\keybindings.dm"
+#include "code\__DEFINES\chemistry\reactions.dm"
 #include "code\__DEFINES\combat\attack_types.dm"
 #include "code\__DEFINES\combat\block.dm"
 #include "code\__DEFINES\combat\block_parry.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds priorities to chemical reactions

gives the smoke reaction a higher priority than most reactions
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

allows for dangerous chemical recipes without being basically random based on required temperature only

**SOMEONE GOOD WITH MATH/WHATEVER CHECK MY SORTING SYSTEM.**
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
add: chemical reactions now are sorted by priority first and temperature second.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
