### PR TITLE
vore no longer breaks preferences

### DIFF
--- a/code/modules/vore/eating/bellymodes.dm
+++ b/code/modules/vore/eating/bellymodes.dm
@@ -76,7 +76,7 @@
 					play_sound = pick(pred_digest)
 
 				//Pref protection!
-				if (!M.vore_flags & DIGESTABLE || M.vore_flags & ABSORBED)
+				if (!CHECK_BITFIELD(M.vore_flags, DIGESTABLE) || M.vore_flags & ABSORBED)
 					continue
 
 				//Person just died in guts!

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -116,7 +116,7 @@
 		testing("[user] attempted to feed [prey] to [pred], via [lowertext(belly.name)] but it went wrong.")
 		return
 
-	if (!prey.vore_flags & DEVOURABLE)
+	if (!CHECK_BITFIELD(prey.vore_flags, DEVOURABLE))
 		to_chat(user, "This can't be eaten!")
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
oh my god

## Changelog
:cl:
fix: you can no longer vore and digest people regardless of vore preferences
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
