### PR TITLE
Adds another light to pubby next to the kitchen

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -22136,6 +22136,9 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYZ" = (


### PR DESCRIPTION
## About The Pull Request

Adds a light to pubby just above and to the right where the kitchen counter is.
Suggested by Tifastits#4430 aka Carl on the discord.

## Why It's Good For The Game

It dark, but not too dark for full light, but smol light.

## Changelog
:cl:
add: Adds a small light next to the kitchen counter
/:cl: