### PR TITLE
set hierophant friendly fire check to on by default

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -1104,7 +1104,7 @@
 	var/blast_range = 13 //how long the cardinal blast's walls are
 	var/obj/effect/hierophant/beacon //the associated beacon we teleport to
 	var/teleporting = FALSE //if we ARE teleporting
-	var/friendly_fire_check = FALSE //if the blasts we make will consider our faction against the faction of hit targets
+	var/friendly_fire_check = TRUE //if the blasts we make will consider our faction against the faction of hit targets
 
 /obj/item/hierophant_club/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION


## About The Pull Request
Sets the hierophant's club to have friendly fire check by default, meaning you have to switch it intentionally to start murdering your friends with it. It still harms anyone who doesn't share your faction, obviously. (so pretty much all simplemobs)

## Why It's Good For The Game
Hugbox

## Changelog
:cl: Yakumo Chen
tweak: Hierophant club now checks for friendly fire by default.
/:cl:
