### PR TITLE
wrestling rotation fix

### DIFF
--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -223,9 +223,9 @@
 		animate(D, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
 	sleep(15)
 	if (D)
-		animate(D, transform = null, time = 1, loop = 0)
 		if(transform_before && laying_before == D.lying) //animate calls sleep so this should be fine and stop a bug with transforms
 			D.transform = transform_before
+			animate(D, transform = null, time = 1, loop = 0)
 
 /datum/martial_art/wrestling/proc/slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D)
@@ -429,8 +429,8 @@
 			animate(A, transform = matrix(90, MATRIX_ROTATE), time = 1, loop = 0)
 		sleep(10)
 		if(A)
-			animate(A, transform = null, time = 1, loop = 0)
 			if(transform_before && laying_before == A.lying) //if they suddenly dropped to the floor between this period, don't revert their animation
+				animate(A, transform = null, time = 1, loop = 0)
 				A.transform = transform_before
 
 		A.forceMove(D.loc)

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -221,11 +221,9 @@
 		animate(D, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
 	sleep(15)
 	if (D)
-		if(transform_before)
-			sleep(10) //animate calls sleep apparently so this should be fine
+		animate(D, transform = null, time = 1, loop = 0)
+		if(transform_before) //animate calls sleep so this should be fine and stop a bug with transforms
 			D.transform = transform_before
-		else
-			animate(D, transform = null, time = 1, loop = 0)
 
 /datum/martial_art/wrestling/proc/slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D)
@@ -427,11 +425,9 @@
 			animate(A, transform = matrix(90, MATRIX_ROTATE), time = 1, loop = 0)
 		sleep(10)
 		if(A)
+			animate(A, transform = null, time = 1, loop = 0)
 			if(transform_before)
-				sleep(10)
 				A.transform = transform_before
-			else
-				animate(A, transform = null, time = 1, loop = 0)
 
 		A.forceMove(D.loc)
 

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -215,11 +215,17 @@
 
 /datum/martial_art/wrestling/proc/FlipAnimation(mob/living/carbon/human/D)
 	set waitfor = FALSE
+	var/transform_before
 	if (D)
+		transform_before = D.transform
 		animate(D, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
 	sleep(15)
 	if (D)
-		animate(D, transform = matrix(-180, MATRIX_ROTATE), time = 1, loop = 0)
+		if(transform_before)
+			sleep(10) //animate calls sleep apparently so this should be fine
+			D.transform = transform_before
+		else
+			animate(D, transform = null, time = 1, loop = 0)
 
 /datum/martial_art/wrestling/proc/slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D)
@@ -415,11 +421,17 @@
 			to_chat(A, "You can't drop onto [D] from here!")
 			return FALSE
 
+		var/transform_before
 		if(A)
+			transform_before = A.transform
 			animate(A, transform = matrix(90, MATRIX_ROTATE), time = 1, loop = 0)
 		sleep(10)
 		if(A)
-			animate(A, transform = matrix(-90, MATRIX_ROTATE), time = 1, loop = 0)
+			if(transform_before)
+				sleep(10)
+				A.transform = transform_before
+			else
+				animate(A, transform = null, time = 1, loop = 0)
 
 		A.forceMove(D.loc)
 

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -216,13 +216,15 @@
 /datum/martial_art/wrestling/proc/FlipAnimation(mob/living/carbon/human/D)
 	set waitfor = FALSE
 	var/transform_before
+	var/laying_before
 	if (D)
 		transform_before = D.transform
+		laying_before = D.lying
 		animate(D, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
 	sleep(15)
 	if (D)
 		animate(D, transform = null, time = 1, loop = 0)
-		if(transform_before) //animate calls sleep so this should be fine and stop a bug with transforms
+		if(transform_before && laying_before == D.lying) //animate calls sleep so this should be fine and stop a bug with transforms
 			D.transform = transform_before
 
 /datum/martial_art/wrestling/proc/slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -420,13 +422,15 @@
 			return FALSE
 
 		var/transform_before
+		var/laying_before
 		if(A)
 			transform_before = A.transform
+			laying_before = A.lying
 			animate(A, transform = matrix(90, MATRIX_ROTATE), time = 1, loop = 0)
 		sleep(10)
 		if(A)
 			animate(A, transform = null, time = 1, loop = 0)
-			if(transform_before)
+			if(transform_before && laying_before == A.lying) //if they suddenly dropped to the floor between this period, don't revert their animation
 				A.transform = transform_before
 
 		A.forceMove(D.loc)

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -219,7 +219,7 @@
 		animate(D, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
 	sleep(15)
 	if (D)
-		animate(D, transform = null, time = 1, loop = 0)
+		animate(D, transform = matrix(-180, MATRIX_ROTATE), time = 1, loop = 0)
 
 /datum/martial_art/wrestling/proc/slam(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!D)
@@ -419,7 +419,7 @@
 			animate(A, transform = matrix(90, MATRIX_ROTATE), time = 1, loop = 0)
 		sleep(10)
 		if(A)
-			animate(A, transform = null, time = 1, loop = 0)
+			animate(A, transform = matrix(-90, MATRIX_ROTATE), time = 1, loop = 0)
 
 		A.forceMove(D.loc)
 


### PR DESCRIPTION
## About The Pull Request
fixes dumb wrestling bug by reverting your transform matrix after animate is called on 2 wrestling moves, but only if you haven't changed your laying down status in-between

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: wrestling should no longer have the ability to permanently rotate people
/:cl:
