### PR TITLE
makes survivalists pseudoantags again and limits summon guns/magic to one use

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -845,6 +845,37 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/destroy/internal
 	var/stolen = FALSE 		//Have we already eliminated this target?
 
+/datum/objective/steal_five_of_type
+	name = "steal five of"
+	explanation_text = "Steal at least five items!"
+	var/list/wanted_items = list(/obj/item)
+
+/datum/objective/steal_five_of_type/New()
+	..()
+	wanted_items = typecacheof(wanted_items)
+
+/datum/objective/steal_five_of_type/summon_guns
+	name = "steal guns"
+	explanation_text = "Steal at least five guns!"
+	wanted_items = list(/obj/item/gun)
+
+/datum/objective/steal_five_of_type/summon_magic
+	name = "steal magic"
+	explanation_text = "Steal at least five magical artefacts!"
+	wanted_items = list(/obj/item/spellbook, /obj/item/gun/magic, /obj/item/clothing/suit/space/hardsuit/wizard, /obj/item/scrying, /obj/item/antag_spawner/contract, /obj/item/necromantic_stone)
+
+/datum/objective/steal_five_of_type/check_completion()
+	var/list/datum/mind/owners = get_owners()
+	var/stolen_count = 0
+	for(var/datum/mind/M in owners)
+		if(!isliving(M.current))
+			continue
+		var/list/all_items = M.current.GetAllContents()	//this should get things in cheesewheels, books, etc.
+		for(var/obj/I in all_items) //Check for wanted items
+			if(is_type_in_typecache(I, wanted_items))
+				stolen_count++
+	return stolen_count >= 5
+
 //Created by admin tools
 /datum/objective/custom
 	name = "custom"

--- a/code/modules/antagonists/survivalist/survivalist.dm
+++ b/code/modules/antagonists/survivalist/survivalist.dm
@@ -23,6 +23,18 @@
 /datum/antagonist/survivalist/guns
 	greet_message = "Your own safety matters above all else, and the only way to ensure your safety is to stockpile weapons! Grab as many guns as possible, and don't let anyone take them!"
 
+/datum/antagonist/survivalist/guns/forge_objectives()
+	var/datum/objective/steal_five_of_type/summon_guns/guns = new
+	guns.owner = owner
+	objectives += guns
+	..()
+
 /datum/antagonist/survivalist/magic
 	name = "Amateur Magician"
 	greet_message = "This magic stuff is... so powerful. You want more. More! They want your power. They can't have it! Don't let them have it!"
+
+/datum/antagonist/survivalist/magic/forge_objectives()
+	var/datum/objective/steal_five_of_type/summon_magic/magic = new
+	magic.owner = owner
+	objectives += magic
+	..()

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -503,6 +503,7 @@
 	name = "Summon Guns"
 	desc = "Nothing could possibly go wrong with arming a crew of lunatics just itching for an excuse to kill you. Just be careful not to stand still too long!"
 	dynamic_requirement = 60
+	limit = 1
 
 /datum/spellbook_entry/summon/guns/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map
@@ -521,6 +522,7 @@
 	name = "Summon Magic"
 	desc = "Share the wonders of magic with the crew and show them why they aren't to be trusted with it at the same time."
 	dynamic_requirement = 60
+	limit = 1
 
 /datum/spellbook_entry/summon/magic/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gives them their steal objectives back 
summon guns/magic can now be only done once each
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

survivalists are supposed to make antagonists no one ever follows the flavortext to go crazy so here have their objectivse back
summon guns/magic x5 is shitty especially now that wizard is the only one who is able to delay the round. 

also reduced summon guns/magic to 1 point each. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
tweak: survivalists (from summon guns/magic) are proper objective'd pseudoantagonists again
tweak: summon guns/magic can only be used once each
tweak: summon guns/magic now only cost one point each
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
