### PR TITLE
truncates sdql2 output to 2500 objects instead of 20000 because it's a real epic gamer moment when admins crash their clients doing SELECT /datum/gas_mixture

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -666,8 +666,8 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/SDQL2_VV_all, new(null
 			obj_count_finished = select_refs
 			var/n = 0
 			for(var/i in found)
-				if(++n == 20000)
-					text_list += "<br><font color='red'><b>TRUNCATED - 20000 OBJECT LIMIT HIT</b></font>"
+				if(++n == 2500)
+					text_list += "<br><font color='red'><b>TRUNCATED - 2500 OBJECT LIMIT HIT</b></font>"
 				SDQL_print(i, text_list, print_nulls)
 				select_refs[REF(i)] = TRUE
 				SDQL2_TICK_CHECK


### PR DESCRIPTION
goddamnit byond