### PR TITLE
Removes craftable shield impants

### DIFF
--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -87,7 +87,7 @@
 	display_name = "Combat Cybernetic Implants"
 	description = "Military grade combat implants to improve performance."
 	prereq_ids = list("adv_cyber_implants","weaponry","NVGtech","high_efficiency")
-	design_ids = list("ci-xray", "ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters", "ci-shield")
+	design_ids = list("ci-xray", "ci-thermals", "ci-antidrop", "ci-antistun", "ci-thrusters")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /////////////////////////Advanced Surgery/////////////////////////


### PR DESCRIPTION

## About The Pull Request

Shield implants are now admin only

## Why It's Good For The Game
Such a misstake, should been admin only a long time ago
## Changelog
:cl
balance: RnD has lost the blueprints to the shield implant for arms, leaving the only remaining copys in CC for their use.
/:cl:
