### PR TITLE
experimental change (testmerge this!): going from a higher slowdown to a lower slowdown will immediately allow you to move at the lower slowdown 

### DIFF
--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -203,8 +203,9 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 	// your delay decreases, "give" the delay back to the client
 	cached_multiplicative_slowdown = .
 	var/diff = old - cached_multiplicative_slowdown
-	if(diff > 0)
-		client.move_delay -= diff
+	if((diff > 0) && client)
+		if(client.move_delay > world.time + 1.5)
+			client.move_delay -= diff
 
 /// Get the move speed modifiers list of the mob
 /mob/proc/get_movespeed_modifiers()

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -199,7 +199,12 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 			else
 				continue
 		. += amt
+	var/old = cached_multiplicative_slowdown		// CITAEDL EDIT - To make things a bit less jarring, when in situations where
+	// your delay decreases, "give" the delay back to the client
 	cached_multiplicative_slowdown = .
+	var/diff = old - cached_multiplicative_slowdown
+	if(diff > 0)
+		client.move_delay -= diff
 
 /// Get the move speed modifiers list of the mob
 /mob/proc/get_movespeed_modifiers()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Y'know how you're rooted in place for a moment after moving diagonally while down but you shove yourself up?
This aims to solve that.
When you have your movespeed upped your client's move delay is set accordingly if necessary to ensure that you are able to move at the new speed immediately rather than waiting for the cooldown from the old speed.
There's a check so that if you are already at 6.66 tiles per second speed this doesn't make you even faster (move delay has to be above world.time + 1.5)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes shoving up not root you in place and other kinds of weirdness.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
experimental: Going from a higher slowdown to a lower slowdown will immediately update your client to speed you up
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
