### PR TITLE
gravity now immediately updates on entering/exiting areas with different gravity and space meaning no more slow for 4 seconds while in a hardsuit and then fast with jetpack

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -516,7 +516,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 			used_environ += amount
 
 
-/area/Entered(atom/movable/M)
+/area/Entered(atom/movable/M, atom/OldLoc)
 	set waitfor = FALSE
 	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, M)
 	SEND_SIGNAL(M, COMSIG_ENTER_AREA, src) //The atom that enters the area
@@ -524,6 +524,11 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		return
 
 	var/mob/living/L = M
+	var/turf/oldTurf = get_turf(OldLoc)
+	var/area/A = oldTurf?.loc
+	if(A && (A.has_gravity != has_gravity))
+		L.update_gravity(L.mob_has_gravity())
+
 	if(!L.ckey)
 		return
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -134,9 +134,7 @@
 			to_chat(user, "<span class='warning'>The plating is going to need some support! Place metal rods first.</span>")
 
 /turf/open/space/Entered(atom/movable/A, atom/OldLoc)
-	..()
-	if ((!(A) || src != A.loc))
-		return
+	. = ..()
 	
 	var/turf/old = get_turf(OldLoc)
 	if(!isspaceturf(old) && ismob(A))
@@ -175,6 +173,12 @@
 		stoplag()//Let a diagonal move finish, if necessary
 		A.newtonian_move(A.inertia_dir)
 
+/turf/open/space/Exited(atom/movable/AM, atom/OldLoc)
+	. = ..()
+	var/turf/old = get_turf(OldLoc)
+	if(!isspaceturf(old) && ismob(AM))
+		var/mob/M = AM
+		M.update_gravity(M.mob_has_gravity())
 
 /turf/open/space/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)
 	return

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -133,10 +133,15 @@
 		else
 			to_chat(user, "<span class='warning'>The plating is going to need some support! Place metal rods first.</span>")
 
-/turf/open/space/Entered(atom/movable/A)
+/turf/open/space/Entered(atom/movable/A, atom/OldLoc)
 	..()
 	if ((!(A) || src != A.loc))
 		return
+	
+	var/turf/old = get_turf(OldLoc)
+	if(!isspaceturf(old) && ismob(A))
+		var/mob/M = A
+		M.update_gravity(M.mob_has_gravity())
 
 	if(destination_z && destination_x && destination_y && !(A.pulledby || !A.can_be_z_moved))
 		var/tx = destination_x


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
fix: gravity should update for mobs a fair bit faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
