### PR TITLE
do we want (probably) free memory savings trick question yes we do

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -152,11 +152,11 @@
 		var/list/po = A.priority_overlays;\
 		if(LAZYLEN(rm)){\
 			A.overlays -= rm;\
-			rm.Cut();\
+			rm = null;\
 		}\
 		if(LAZYLEN(ad)){\
 			A.overlays |= ad;\
-			ad.Cut();\
+			ad = null;\
 		}\
 		if(LAZYLEN(po)){\
 			A.overlays |= po;\

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -161,5 +161,8 @@
 		if(LAZYLEN(po)){\
 			A.overlays |= po;\
 		}\
+		else{\
+			A.priority_overlays = null;\
+		}\
 		A.flags_1 &= ~OVERLAY_QUEUED_1;\
 	}

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -152,11 +152,11 @@
 		var/list/po = A.priority_overlays;\
 		if(LAZYLEN(rm)){\
 			A.overlays -= rm;\
-			rm = null;\
+			A.remove_overlays = null;\
 		}\
 		if(LAZYLEN(ad)){\
 			A.overlays |= ad;\
-			ad = null;\
+			A.add_overlays = null;\
 		}\
 		if(LAZYLEN(po)){\
 			A.overlays |= po;\


### PR DESCRIPTION
clears remove/add overlays list after compiling instead of leaving it around and nulls priority overlays if it's empty
no reason to leave the list around in a lot of cases especially if something is only done as an one-off overlay change during init.