### PR TITLE
Allows Photos to be Burned

### DIFF
--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -51,6 +51,8 @@
 	user.examinate(src)
 
 /obj/item/photo/attackby(obj/item/P, mob/user, params)
+	if(try_burn(P, user))
+		return
 	if(istype(P, /obj/item/pen) || istype(P, /obj/item/toy/crayon))
 		if(!user.is_literate())
 			to_chat(user, "<span class='notice'>You scribble illegibly on [src]!</span>")
@@ -59,6 +61,26 @@
 		if(txt && user.canUseTopic(src, BE_CLOSE))
 			scribble = txt
 	..()
+
+/obj/item/photo/proc/try_burn(obj/item/I, mob/living/user)
+	var/ignition_message = I.ignition_effect(src, user)
+	if(!ignition_message)
+		return
+	. = TRUE
+	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(10) && Adjacent(user))
+		user.visible_message("<span class='warning'>[user] accidentally ignites [user.p_them()]self!</span>", \
+							"<span class='userdanger'>You miss [src] and accidentally light yourself on fire!</span>")
+		if(user.is_holding(I)) //checking if they're holding it in case TK is involved
+			user.dropItemToGround(I)
+		user.adjust_fire_stacks(1)
+		user.IgniteMob()
+		return
+
+	if(user.is_holding(src)) //no TK shit here.
+		user.dropItemToGround(src)
+	user.visible_message(ignition_message)
+	add_fingerprint(user)
+	fire_act(I.get_temperature())
 
 /obj/item/photo/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Almost directly copy pastes burning paper code onto photos. I almost made a burnable component but decided against it since ignition_effect() seems to be the expected use, plus theres some other way stuff burns already in the game and I didn't want to confuse coders by having 2 things with the same name.

## Why It's Good For The Game

😳 

## Changelog
:cl:
add: You can now burn photos
/:cl:
