### PR TITLE
the very much needed zombie buffs

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -33,14 +33,13 @@
 	limbs_id = "zombie"
 	mutanthands = /obj/item/zombie_hand
 	armor = 20 // 120 damage to KO a zombie, which kills it
-	speedmod = 1.6
+	speedmod = 1.6 // they're very slow
 	mutanteyes = /obj/item/organ/eyes/night_vision/zombie
 	var/heal_rate = 1
 	var/regen_cooldown = 0
 
 /datum/species/zombie/infectious/check_roundstart_eligible()
 	return FALSE
-
 
 /datum/species/zombie/infectious/spec_stun(mob/living/carbon/human/H,amount)
 	. = min(20, amount)
@@ -85,6 +84,11 @@
 		infection = new()
 		infection.Insert(C)
 
+	//make their bodyparts stamina-resistant
+	var/incoming_stam_mult = 0.7
+	for(var/obj/item/bodypart/part in C.bodyparts)
+		part.incoming_stam_mult = incoming_stam_mult
+		//todo: add negative wound resistance to all parts when wounds is merged (zombies are physically weak in terms of limbs)
 
 // Your skin falls off
 /datum/species/krokodil_addict

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -11,7 +11,8 @@
 	var/icon_left = "bloodhand_left"
 	var/icon_right = "bloodhand_right"
 	hitsound = 'sound/hallucinations/growl1.ogg'
-	force = 21 // Just enough to break airlocks with melee attacks
+	force = 18
+	sharpness = IS_SHARP_ACCURATE //it's a claw, they're sharp.
 	damtype = "brute"
 	total_mass = TOTAL_MASS_HAND_REPLACEMENT
 
@@ -32,11 +33,15 @@
 	. = ..()
 	if(!proximity_flag)
 		return
-	else if(isliving(target))
-		if(ishuman(target))
-			try_to_zombie_infect(target)
+	else
+		if(istype(target, /obj/)) //do far more damage to non mobs so we can get through airlocks
+			var/obj/target_object = target
+			target_object.take_damage(force * 3, BRUTE, "melee", 0)
 		else
-			check_feast(target, user)
+			if(isliving(target) && ishuman(target))
+				try_to_zombie_infect(target)
+			else
+				check_feast(target, user)
 
 /proc/try_to_zombie_infect(mob/living/carbon/human/target)
 	CHECK_DNA_AND_SPECIES(target)
@@ -51,8 +56,6 @@
 	if(!infection)
 		infection = new()
 		infection.Insert(target)
-
-
 
 /obj/item/zombie_hand/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is ripping [user.p_their()] brains out! It looks like [user.p_theyre()] trying to commit suicide!</span>")


### PR DESCRIPTION
## About The Pull Request
this only concerns infectious zombies
claw damage: 21 -> 18
claws are now sharp, because it's a claw
the after-attack of claws does 3x damage to objects meaning it's 4x overall and they can kill an airlock in 10 hits
zombies now take 70% stamina damage although the fact they take stamina damage at all is crazy considering they're slow

## Why It's Good For The Game
zombies are horrendously weak and useless, this attempts to fix that by stopping stamina-combat and just closing an airlock on them being a hard counter

## Changelog
:cl:
tweak: zombie claws are now sharp and do less damage, but can destroy non-lifeforms far faster
tweak: zombies now take less stamina damage
/:cl:
