### PR TITLE
since it's a little hard to fix the actual issue let's just make the projectile safety check that's causing stuff to freeze when something goes wrong more lenient so things don't freeze and people don't think anything is wrong

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -623,7 +623,7 @@
 				pixel_x = trajectory.return_px()
 				pixel_y = trajectory.return_py()
 		else if(T != loc)
-			var/safety = CEILING(pixel_increment_amount / world.icon_size, 1) * 2 + 1
+			var/safety = CEILING(pixel_increment_amount / world.icon_size, 1) * 5 + 1
 			while(T != loc)
 				if(!--safety)
 					CRASH("[type] took too long (allowed: [CEILING(pixel_increment_amount/world.icon_size,1)*2] moves) to get to its location.")


### PR DESCRIPTION
to be honest it isn't THAT necessary

maybe i'll just revert to pixel projectiles v7 instead of this at some point

it'll be fine.