### PR TITLE
fixes a dumb bug to do with material crafting

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -233,7 +233,7 @@
 				return
 			T.PlaceOnTop(R.result_type, flags = CHANGETURF_INHERIT_AIR)
 		else
-			O = new R.result_type(get_turf(usr.drop_location))
+			O = new R.result_type(get_turf(usr))
 		if(O)
 			O.setDir(usr.dir)
 			log_craft("[O] crafted by [usr] at [loc_name(O.loc)]")

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -233,7 +233,7 @@
 				return
 			T.PlaceOnTop(R.result_type, flags = CHANGETURF_INHERIT_AIR)
 		else
-			O = new R.result_type(usr.drop_location())
+			O = new R.result_type(get_turf(usr.drop_location))
 		if(O)
 			O.setDir(usr.dir)
 			log_craft("[O] crafted by [usr] at [loc_name(O.loc)]")


### PR DESCRIPTION
## About The Pull Request
the place you put down structures crafted with stacks like windows, is now your turf, instead of your drop location, because sometimes your drop location isn't your turf, and this causes you to be able to continually craft items onto the same spot which is bad when you have 50 plasma statues on one turf and set one on fire

## Why It's Good For The Game
i too like not having an entire hallway turn to dust because someone used a bug to build 50 plasma statues on one spot and shoot them

## Changelog
:cl:
fix: slight tweak to how material crafting works
/:cl:
