### PR TITLE
too many COOKS IN THE KITCEN WHY THE FUCK IS THERE MORE THAN 1 COOK SLOT

### DIFF
--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -4,7 +4,7 @@
 	department_head = list("Head of Personnel")
 	department_flag = CIVILIAN
 	faction = "Station"
-	total_positions = 2
+	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
@@ -48,4 +48,3 @@
 		return
 	var/datum/martial_art/cqc/under_siege/justacook = new
 	justacook.teach(H)
-


### PR DESCRIPTION
nerfs whetstone avilability

## Changelog
:cl:
tweak: chef slots 2 >> 1
/:cl:

