### PR TITLE
Nerfs Changeling Adrenaline

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -13,5 +13,5 @@
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
-	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list(/datum/reagent/medicine/epinephrine = 3, /datum/reagent/drug/methamphetamine/changeling = 10, /datum/reagent/medicine/changelingadrenaline = 5), "<span class='notice'>Energy rushes through us.</span>", 0, 0.75, 0)
+	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list(/datum/reagent/medicine/epinephrine = 3, /datum/reagent/medicine/changelingadrenaline = 5), "<span class='notice'>Energy rushes through us.</span>", 0, 0.75, 0)
 	return TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1356,22 +1356,14 @@
 	name = "Changeling Adrenaline"
 	description = "Reduces the duration of unconciousness, knockdown and stuns. Restores stamina, but deals toxin damage when overdosed."
 	color = "#918e53"
-	overdose_threshold = 30
+	overdose_threshold = 5
 	value = REAGENT_VALUE_VERY_RARE
 
-/datum/reagent/medicine/changelingadrenaline/on_mob_metabolize(mob/living/L)
-	..()
-	ADD_TRAIT(L, TRAIT_TASED_RESISTANCE, type)
-
-/datum/reagent/medicine/changelingadrenaline/on_mob_end_metabolize(mob/living/L)
-	REMOVE_TRAIT(L, TRAIT_TASED_RESISTANCE, type)
-	..()
-
 /datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/M as mob)
-	M.AdjustUnconscious(-20, 0)
-	M.AdjustAllImmobility(-20, 0)
-	M.AdjustSleeping(-20, 0)
-	M.adjustStaminaLoss(-30, 0)
+	M.AdjustUnconscious(-15, 0)
+	M.AdjustAllImmobility(-15, 0)
+	M.AdjustSleeping(-15, 0)
+	M.adjustStaminaLoss(-22, 0)
 	..()
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

- Adrenaline Glands no longer produce changeling meth.
- Changeling Adrenaline is now ~25% less effective.
- It is now physically possible to reach the OD threshold of Changeling Adrenaline.
- Changeling Adrenaline no longer makes the user immune to the tased status effect.

Where to start? Changeling was disabled due to the problematic way it interacted with stamina combat (namely, its various abilities allowed it to effectively ignore stamina combat altogether), which made it an undisputed combat powerhouse. Changeling has a long list of unique powers and you wouldn't know it, because for the longest time, the only combination anyone used was adrenals + strained muscles.

Now that Changeling has returned after its long hiatus... that's still the case. Adrenals is such a safe and powerful pick that it utterly dominates the gamemode. Changeling balance is synonymous with adrenals balance. This PR aims to rectify this by heavily reducing the power of adrenals so that we might see a little more variety out of this particular antagonist, rather than the metagolem of adrenals and EMP round after round after round after...

## Why It's Good For The Game

... round after round after round after round after...

## Changelog
:cl:
balance: Changeling adrenaline has been nerfed. Try some of the many other abilities in the Genetic Emporium!
/:cl:
