### PR TITLE
pickles don't die until their contents is released

### DIFF
--- a/code/modules/mob/living/simple_animal/pickle.dm
+++ b/code/modules/mob/living/simple_animal/pickle.dm
@@ -20,12 +20,12 @@
 		laugher.emote("laugh")
 
 /mob/living/simple_animal/pickle/death()
-	..()
 	if(original_body)
 		original_body.adjustOrganLoss(ORGAN_SLOT_BRAIN, 200) //to be fair, you have to have a very high iq to understand-
 		original_body.forceMove(get_turf(src))
 		if(mind)
 			mind.transfer_to(original_body)
+	..()
 
 /mob/living/simple_animal/pickle/wabbajack_act() //restore users name before its used on the new mob
 	if(original_body)


### PR DESCRIPTION
## About The Pull Request
pickles don't call ..() on death until their contents is released if they have a contents, as deletion on death is set to true, oversight i forgot about when making the last pr for pickles

## Why It's Good For The Game
i like my pickle people to not be qdel'd

## Changelog
:cl:
fix: modern pickle technology now allows people who have been turned into pickles, to be retrieved through the medical course of dying
/:cl:

