### PR TITLE
Adds spaceman's trumpet seeds to the exotic seeds crate

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -361,6 +361,7 @@
 					/obj/item/seeds/reishi,
 					/obj/item/seeds/banana,
 					/obj/item/seeds/eggplant/eggy,
+					/obj/item/seeds/poppy/lily/trumpet,
 					/obj/item/seeds/random,
 					/obj/item/seeds/random)
 	crate_name = "exotic seeds crate"


### PR DESCRIPTION
## About The Pull Request

As it says on the tin. These are exceptionally irritating to cultivate, particularly on Citadel because we've added an additional mutation to lilies. This gives botanists a compelling reason to engage with Cargo, a department that is famously unnecessary nine rounds out of ten.

## Why It's Good For The Game

Gives cargo sumthing2do. 

## Changelog
:cl:
tweak: Exotic seed crates now contain a spaceman's trumpet seed packet.
/:cl: