### PR TITLE
Removal of mop upgrade module, Service borg gains a bucket in response

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -127,5 +127,3 @@
 		STOP_PROCESSING(SSobj, src)
 	return ..()
 
-/obj/item/mop/advanced/cyborg
-	insertable = FALSE

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -228,33 +228,6 @@
 		R.module.basic_modules += TB
 		R.module.add_module(TB, FALSE, TRUE)
 
-/obj/item/borg/upgrade/amop
-	name = "janitor cyborg advanced mop"
-	desc = "An advanced mop replacement for the janiborg's standard mop."
-	icon_state = "cyborg_upgrade3"
-	require_module = 1
-	module_type = list(/obj/item/robot_module/butler)
-
-/obj/item/borg/upgrade/amop/action(mob/living/silicon/robot/R)
-	. = ..()
-	if(.)
-		for(var/obj/item/mop/cyborg/M in R.module.modules)
-			R.module.remove_module(M, TRUE)
-
-	var/obj/item/mop/advanced/cyborg/A = new /obj/item/mop/advanced/cyborg(R.module)
-	R.module.basic_modules += A
-	R.module.add_module(A, FALSE, TRUE)
-
-/obj/item/borg/upgrade/amop/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-		for(var/obj/item/mop/advanced/cyborg/A in R.module.modules)
-			R.module.remove_module(A, TRUE)
-
-		var/obj/item/mop/cyborg/M = new (R.module)
-		R.module.basic_modules += M
-		R.module.add_module(M, FALSE, TRUE)
-
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -793,6 +793,7 @@
 		/obj/item/soap/nanotrasen,
 		/obj/item/storage/bag/trash/cyborg,
 		/obj/item/mop/cyborg,
+		/obj/item/reagent_containers/glass/bucket/cyborg,
 		/obj/item/lightreplacer/cyborg,
 		/obj/item/holosign_creator,
 		/obj/item/reagent_containers/spray/cyborg_drying)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -355,6 +355,8 @@
 	slot_flags = NONE
 	item_flags = NO_MAT_REDEMPTION
 
+/obj/item/reagent_containers/glass/bucket/cyborg
+
 /obj/item/reagent_containers/glass/beaker/waterbottle
 	name = "bottle of water"
 	desc = "A bottle of water filled at an old Earth bottling facility."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -787,15 +787,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_advancedmop
-	name = "Cyborg Upgrade (Advanced Mop)"
-	id = "borg_upgrade_advancedmop"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/amop
-	materials = list(/datum/material/iron=10000, /datum/material/glass=200, /datum/material/titanium=1000)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 /datum/design/borg_upgrade_expand
 	name = "Cyborg Upgrade (Expand)"
 	id = "borg_upgrade_expand"

--- a/code/modules/research/techweb/nodes/robotics_nodes.dm
+++ b/code/modules/research/techweb/nodes/robotics_nodes.dm
@@ -28,7 +28,7 @@
 	display_name = "Advanced Robotics Research"
 	description = "It can even do the dishes!"
 	prereq_ids = list("robotics")
-	design_ids = list("borg_upgrade_diamonddrill", "borg_upgrade_advancedmop", "borg_upgrade_advcutter")
+	design_ids = list("borg_upgrade_diamonddrill", "borg_upgrade_advcutter")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 
 /datum/techweb_node/neural_programming


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Puts an end to the exploit where you could add an adv mop to any borg module without even expending the upgrade.
- Adds a bucket to the service borg default loadout.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
exploit man bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: removes borg mop upgrade module
add: gives service borg a bucket
fix: removes exploit of infinite mop upgrades
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
