### PR TITLE
Minor paramed edit

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 		if("Medical Doctor")
 			heirloom_type = /obj/item/healthanalyzer/advanced
 		if("Paramedic")
-			heirloom_type = pick(/obj/item/clothing/neck/stethoscope, /obj/item/bodybag)
+			heirloom_type = /obj/item/lighter
 		if("Station Engineer")
 			heirloom_type = /obj/item/wirecutters/brass
 		if("Atmospheric Technician")


### PR DESCRIPTION
In muh vg canon, paramedics smoke, to the point where they spawn with a cig in their mouth. Also stephoscope bad, forcing someone to have a normal sized item to lug around when you have shit like officers and medals having no downsides.

:cl:
tweak: Paramedic heirloom is now a zippo
/:cl: