### PR TITLE
aliens can remove embeds now

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -57,8 +57,17 @@
 
 /mob/living/carbon/alien/humanoid/Topic(href, href_list)
 	..()
-	//strip panel
+	//strip panel & embeds
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
+		if(href_list["embedded_object"])
+			var/obj/item/bodypart/L = locate(href_list["embedded_limb"]) in bodyparts
+			if(!L)
+				return
+			var/obj/item/I = locate(href_list["embedded_object"]) in L.embedded_objects
+			if(!I || I.loc != src) //no item, no limb, or item is not in limb or in the alien anymore
+				return
+			SEND_SIGNAL(src, COMSIG_CARBON_EMBED_RIP, I, L)
+			return
 		if(href_list["pouches"])
 			visible_message("<span class='danger'>[usr] tries to empty [src]'s pouches.</span>", \
 							"<span class='userdanger'>[usr] tries to empty [src]'s pouches.</span>")


### PR DESCRIPTION
## About The Pull Request
aliens can remove embeds now / fixes a bug
this was localtested and I removed an embed from myself as an alien, cool
closes #12833 

## Why It's Good For The Game
any item with 0 fall chance would just stick in an alien until they died and that was awful

## Changelog
:cl:
fix: aliens can remove embeds now
/:cl:
