### PR TITLE
Fixes the 'Naked' outfit

### DIFF
--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -282,6 +282,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	..()
 
 /datum/outfit/artifact_dealer
+	name = "Artifact Dealer"
 	uniform = /obj/item/clothing/under/suit/black_really
 	shoes = /obj/item/clothing/shoes/combat
 	head = /obj/item/clothing/head/that
@@ -323,6 +324,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	reward.insert_organ(new_implant)
 
 /datum/outfit/otherworldly_surgeon
+	name = "Otherworldly Surgeon"
 	uniform = /obj/item/clothing/under/pants/white
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	gloves = /obj/item/clothing/gloves/color/latex


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In the travelling-trader PR, the outfits added didn't actually have names, so they defaulted to "Naked" as name, which lead to one always ending up with the otherworldly surgeon outfit if one selected 'Naked'. This fixes that and gives the two added outfits actual names.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The 'Naked' outfit is no longer broken.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
