### PR TITLE
Minor Fixes to Box

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13347,7 +13347,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /obj/machinery/button/door{
@@ -14233,7 +14232,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /obj/machinery/button/door{
@@ -53437,6 +53435,7 @@
 "dfh" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/circuit";
+	dir = 4;
 	name = "Circuitry Lab APC";
 	pixel_x = 30
 	},
@@ -57075,6 +57074,7 @@
 	dir = 4;
 	pixel_y = 5
 	},
+/obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oby" = (
@@ -57847,7 +57847,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57907,7 +57907,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /obj/machinery/light/small{

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -54385,6 +54385,7 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fMp" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21716,7 +21716,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /obj/machinery/button/door{
@@ -54775,7 +54774,6 @@
 	dir = 8
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /obj/structure/mirror{
@@ -57198,7 +57196,6 @@
 	dir = 8
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /obj/structure/mirror{
@@ -60672,7 +60669,6 @@
 	pixel_y = 32
 	},
 /obj/structure/sink{
-	dir = 1;
 	pixel_y = 25
 	},
 /obj/machinery/button/door{


### PR DESCRIPTION
## About The Pull Request

Fixes a couple issues I've noticed about box. Namely backwards sinks, no cakehat, a missing third atmostech spawn, and the APC in circuits being goofy.

## Why It's Good For The Game

We play on this map all the time, it should at least make sense

## Changelog
:cl:
tweak: added cake hat to bar, adds another atmostech spawn
fix: sinks point in the right direction, APC won't spawn off the wall in circuits
/:cl: