### PR TITLE
CentCom Galactic Ban DB

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -470,3 +470,5 @@
 
 /datum/config_entry/flag/minimaps_enabled
 	config_entry_value = TRUE
+
+/datum/config_entry/string/centcom_ban_db	// URL for the CentCom Galactic Ban DB API

--- a/code/datums/http.dm
+++ b/code/datums/http.dm
@@ -1,0 +1,74 @@
+/datum/http_request
+	var/id
+	var/in_progress = FALSE
+
+	var/method
+	var/body
+	var/headers
+	var/url
+
+	var/_raw_response
+
+/datum/http_request/proc/prepare(method, url, body = "", list/headers)
+	if (!length(headers))
+		headers = ""
+	else
+		headers = json_encode(headers)
+
+	src.method = method
+	src.url = url
+	src.body = body
+	src.headers = headers
+
+/datum/http_request/proc/execute_blocking()
+	_raw_response = rustg_http_request_blocking(method, url, body, headers)
+
+/datum/http_request/proc/begin_async()
+	if (in_progress)
+		CRASH("Attempted to re-use a request object.")
+
+	id = rustg_http_request_async(method, url, body, headers)
+
+	if (isnull(text2num(id)))
+		stack_trace("Proc error: [id]")
+		_raw_response = "Proc error: [id]"
+	else
+		in_progress = TRUE
+
+/datum/http_request/proc/is_complete()
+	if (isnull(id))
+		return TRUE
+
+	if (!in_progress)
+		return TRUE
+
+	var/r = rustg_http_check_request(id)
+
+	if (r == RUSTG_JOB_NO_RESULTS_YET)
+		return FALSE
+	else
+		_raw_response = r
+		in_progress = FALSE
+		return TRUE
+
+/datum/http_request/proc/into_response()
+	var/datum/http_response/R = new()
+
+	try
+		var/list/L = json_decode(_raw_response)
+		R.status_code = L["status_code"]
+		R.headers = L["headers"]
+		R.body = L["body"]
+	catch
+		R.errored = TRUE
+		R.error = _raw_response
+
+	return R
+
+/datum/http_response
+	var/status_code
+	var/body
+	var/list/headers
+
+	var/errored = FALSE
+	var/error

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -40,6 +40,11 @@
 
 	if(M.client)
 		body += "<br>\[<b>First Seen:</b> [M.client.player_join_date]\]\[<b>Byond account registered on:</b> [M.client.account_join_date]\]"
+		body += "<br><br><b>CentCom Galactic Ban DB: </b> "
+		if(CONFIG_GET(string/centcom_ban_db))
+			body += "<a href='?_src_=holder;[HrefToken()];centcomlookup=[M.client.ckey]'>Search</a>"
+		else
+			body += "<i>Disabled</i>"
 		body += "<br><br><b>Show related accounts by:</b> "
 		body += "\[ <a href='?_src_=holder;[HrefToken()];showrelatedacc=cid;client=[REF(M.client)]'>CID</a> | "
 		body += "<a href='?_src_=holder;[HrefToken()];showrelatedacc=ip;client=[REF(M.client)]'>IP</a> \]"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2834,6 +2834,60 @@
 
 		usr << browse(dat.Join("<br>"), "window=related_[C];size=420x300")
 
+	else if(href_list["centcomlookup"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		if(!CONFIG_GET(string/centcom_ban_db))
+			to_chat(usr, "<span class='warning'>Centcom Galactic Ban DB is disabled!</span>")
+			return
+
+		var/ckey = href_list["centcomlookup"]
+
+		// Make the request
+		var/datum/http_request/request = new()
+		request.prepare(RUSTG_HTTP_METHOD_GET, "[CONFIG_GET(string/centcom_ban_db)]/[ckey]", "", "")
+		request.begin_async()
+		UNTIL(request.is_complete() || !usr)
+		if (!usr)
+			return
+		var/datum/http_response/response = request.into_response()
+
+		var/list/bans
+
+		var/list/dat = list("<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><body>")
+
+		if(response.errored)
+			dat += "<br>Failed to connect to CentCom."
+		else if(response.status_code != 200)
+			dat += "<br>Failed to connect to CentCom. Status code: [response.status_code]"
+		else
+			if(response.body == "[]")
+				dat += "<center><b>0 bans detected for [ckey]</b></center>"
+			else
+				bans = json_decode(response["body"])
+				dat += "<center><b>[bans.len] ban\s detected for [ckey]</b></center>"
+				for(var/list/ban in bans)
+					dat += "<b>Server: </b> [sanitize(ban["sourceName"])]<br>"
+					dat += "<b>RP Level: </b> [sanitize(ban["sourceRoleplayLevel"])]<br>"
+					dat += "<b>Type: </b> [sanitize(ban["type"])]<br>"
+					dat += "<b>Banned By: </b> [sanitize(ban["bannedBy"])]<br>"
+					dat += "<b>Reason: </b> [sanitize(ban["reason"])]<br>"
+					dat += "<b>Datetime: </b> [sanitize(ban["bannedOn"])]<br>"
+					var/expiration = ban["expires"]
+					dat += "<b>Expires: </b> [expiration ? "[sanitize(expiration)]" : "Permanent"]<br>"
+					if(ban["type"] == "job")
+						dat += "<b>Jobs: </b> "
+						var/list/jobs = ban["jobs"]
+						dat += sanitize(jobs.Join(", "))
+						dat += "<br>"
+					dat += "<hr>"
+
+		dat += "<br></body>"
+		var/datum/browser/popup = new(usr, "centcomlookup-[ckey]", "<div align='center'>Central Command Galactic Ban Database</div>", 700, 600)
+		popup.set_content(dat.Join())
+		popup.open(0)
+
 	else if(href_list["modantagrep"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/config/config.txt
+++ b/config/config.txt
@@ -525,3 +525,7 @@ FAIL2TOPIC_RULE_NAME _dd_fail2topic
 
 ## Enable automatic profiling - Byond 513.1506 and newer only.
 #AUTO_PROFILE
+
+## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
+## More API details can be found here: https://centcom.melonmesa.com
+CENTCOM_BAN_DB https://centcom.melonmesa.com/ban/search

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -377,6 +377,7 @@
 #include "code\datums\explosion.dm"
 #include "code\datums\forced_movement.dm"
 #include "code\datums\holocall.dm"
+#include "code\datums\http.dm"
 #include "code\datums\hud.dm"
 #include "code\datums\mind.dm"
 #include "code\datums\mutable_appearance.dm"


### PR DESCRIPTION
Ports https://github.com/BeeStation/BeeStation-Hornet/pull/2207

Admins will now be able to look up a player's bans from several other servers via the player panel.

My hope is that porting this to as many servers as possible will encourage more servers to make their bans publicly viewable so they can be included in this system. Direct access to a server's database is not required (or even supported).

Supported servers: 
* BeeStation 
* /vg/station
* OracleStation
* FTL13

Planned support that bobbah is working on:
* World Server
* Yogstation
* Halo: SSE
* Any other server willing to make their bans publicly visible.

API: https://centcom.melonmesa.com
Source: https://github.com/bobbahbrown/CentCom

## Changelog
:cl: ike709 and bobbahbrown
add: Admins can now see your bans on (some) other servers.
/:cl:
