### PR TITLE
Map Edits Three: The Mappening

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wizard.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wizard.dmm
@@ -90,11 +90,11 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "l" = (
 /obj/structure/stone_tile/block/cracked,
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "m" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
@@ -105,7 +105,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
 	},
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "n" = (
 /obj/structure/stone_tile/block/cracked{
@@ -136,14 +136,14 @@
 	},
 /obj/structure/table/bronze,
 /obj/item/disk/design_disk/adv/knight_gear,
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "q" = (
 /obj/structure/table/bronze,
 /obj/item/stack/sheet/mineral/runite{
 	amount = 5
 	},
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "r" = (
 /obj/structure/stone_tile/block{
@@ -153,7 +153,7 @@
 /obj/item/stack/sheet/mineral/runite{
 	amount = 5
 	},
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "s" = (
 /obj/structure/stone_tile/block{
@@ -186,13 +186,13 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "v" = (
 /obj/structure/stone_tile/block{
 	dir = 1
 	},
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "w" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -205,7 +205,7 @@
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
 	},
-/turf/open/indestructible/necropolis,
+/turf/open/indestructible/necropolis/air,
 /area/lavaland/surface/outdoors)
 "x" = (
 /obj/structure/stone_tile/block{

--- a/_maps/RandomRuins/SpaceRuins/spacehermit.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehermit.dmm
@@ -5,9 +5,6 @@
 "ab" = (
 /turf/closed/mineral/random/low_chance,
 /area/ruin/unpowered)
-"ac" = (
-/turf/open/floor/plating/asteroid,
-/area/ruin/unpowered)
 "ad" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/plating/asteroid,
@@ -327,9 +324,6 @@
 /obj/item/flashlight/lamp/bananalamp,
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
-"bt" = (
-/turf/closed/mineral/random/low_chance/earth_like,
-/area/ruin/unpowered)
 "bC" = (
 /obj/item/pickaxe/titanium,
 /turf/open/floor/plating/asteroid,
@@ -396,7 +390,7 @@ aa
 aa
 aa
 aa
-ac
+aA
 aO
 aA
 aA
@@ -2648,7 +2642,7 @@ aa
 aa
 aa
 aa
-ac
+aA
 aa
 aa
 aa
@@ -2699,9 +2693,9 @@ aa
 aa
 aa
 aa
-ac
+aA
 ab
-ac
+aA
 aa
 aa
 "}
@@ -2855,9 +2849,9 @@ aa
 aa
 aa
 aa
-ac
+aA
 ab
-ac
+aA
 aa
 aa
 "}
@@ -2907,7 +2901,7 @@ aa
 aa
 aa
 aa
-ac
+aA
 aa
 aa
 aa
@@ -2959,7 +2953,7 @@ aa
 aa
 aa
 aa
-bt
+ab
 aa
 aa
 aa

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -288,6 +288,15 @@
 	dir = 4
 	},
 /obj/item/toy/poolnoodle/red,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/fitness/pool";
+	dir = 1;
+	name = "Pool APC";
+	pixel_y = 24
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/pool)
 "aaH" = (
@@ -492,8 +501,8 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellowsiding/corner{
-	icon_state = "yellowcornersiding";
-	dir = 8
+	dir = 8;
+	icon_state = "yellowcornersiding"
 	},
 /area/crew_quarters/fitness/pool)
 "aba" = (
@@ -510,8 +519,8 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abb" = (
@@ -604,8 +613,8 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 8
+	dir = 8;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abn" = (
@@ -619,8 +628,8 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abo" = (
@@ -704,8 +713,8 @@
 	name = "pool camera"
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abv" = (
@@ -724,8 +733,8 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 8
+	dir = 8;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "aby" = (
@@ -765,8 +774,8 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abC" = (
@@ -904,8 +913,8 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abP" = (
@@ -972,8 +981,8 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/yellowsiding/corner{
-	icon_state = "yellowcornersiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowcornersiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abW" = (
@@ -982,8 +991,8 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abX" = (
@@ -995,8 +1004,8 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/yellowsiding/corner{
-	icon_state = "yellowcornersiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowcornersiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abY" = (
@@ -31107,6 +31116,11 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics";
+	name = "Hydroponics APC";
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -64485,8 +64499,8 @@
 /area/library)
 "cel" = (
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
-	dir = 8
+	dir = 8;
+	icon_state = "sofaend_right"
 	},
 /obj/structure/sign/painting/library{
 	pixel_x = 32
@@ -92830,6 +92844,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "dad" = (
@@ -101793,6 +101810,13 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/structure/cable/white,
+/obj/machinery/power/apc{
+	areastring = "/area/science/misc_lab";
+	dir = 4;
+	name = "Science Lounge APC";
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
@@ -113343,6 +113367,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "dKg" = (
@@ -125579,6 +125604,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"ePP" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Pool"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/pool)
 "eTv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -127072,6 +127111,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research/abandoned)
+"pQQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness/pool)
 "pWb" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/window/reinforced{
@@ -127298,6 +127356,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"tqP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/crew_quarters/fitness/recreation)
 "twt" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/neutral{
@@ -127768,8 +127844,8 @@
 /area/science/mixing)
 "xER" = (
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
-	dir = 8
+	dir = 8;
+	icon_state = "sofaend_left"
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -127849,6 +127925,22 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
+"yfK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "yiv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -181500,10 +181592,10 @@ cCl
 cWD
 cAz
 dac
-cxy
-aav
-aaz
-aaH
+yfK
+tqP
+ePP
+pQQ
 aaV
 aaN
 aaN


### PR DESCRIPTION
## About The Pull Request

Fixes active turfs in wizard ruin that spawns in lavaland and ones on the space hermit asteroid. Fixes delta missing APC's for botany, the pool, and the little lounge area before the circuitry lab. And a light to the server room so it's not pitch black in there.

## Why It's Good For The Game

Active turfs man bad.

## Changelog
:cl:
fix: fixed active turfs on wizard ruin and space hermit, fixed missing APC's and added a light on Delta
/:cl: