### PR TITLE
Electrocute Act no longer uses stun

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -244,7 +244,7 @@
 	//Stun
 	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
 	if(should_stun)
-		Stun(40)
+		DefaultCombatKnockdown(100) //Same as a hunters trap
 	//Jitter and other fluff.
 	jitteriness += 1000
 	do_jitter_animation(jitteriness)


### PR DESCRIPTION

## About The Pull Request

Replaces the stun(40) in eletrocute act to DefaultCombatKnockdown(100) same as a hunters trap

## Why It's Good For The Game
This might have been an understight when moving from stun based combat, simple error now corrected. Sorry to - Grill stun locking, tesla armor/gun stun locking, Lady Tesla stun locking (as if you ever survived one)

## Changelog
:cl:
fix: Electrocute Act no longer uses stun
/:cl:
