### PR TITLE
You Thought I Was Done Fucking With Box BUT YOU WERE WRONG!

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
@@ -340,7 +340,7 @@
 /area/ruin/unpowered/xenonest)
 "bm" = (
 /obj/structure/stone_tile/slab/cracked,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bn" = (
 /obj/structure/stone_tile/block{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
@@ -227,7 +227,7 @@
 /area/ruin/unpowered/xenonest)
 "ba" = (
 /obj/structure/stone_tile/slab,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bb" = (
 /obj/structure/stone_tile/cracked{
@@ -241,7 +241,7 @@
 	dir = 8
 	},
 /obj/item/flashlight/lantern,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bc" = (
 /obj/structure/stone_tile/block,
@@ -251,7 +251,7 @@
 /obj/structure/stone_tile{
 	dir = 4
 	},
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bd" = (
 /obj/structure/stone_tile/block,
@@ -262,7 +262,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/xeno,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "be" = (
 /obj/structure/stone_tile/block,
@@ -272,7 +272,7 @@
 /obj/structure/stone_tile{
 	dir = 1
 	},
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bf" = (
 /obj/structure/stone_tile,
@@ -286,7 +286,7 @@
 	dir = 4
 	},
 /obj/item/flashlight/lantern,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bg" = (
 /obj/structure/alien/weeds,
@@ -303,7 +303,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bi" = (
 /obj/structure/alien/weeds,
@@ -336,7 +336,7 @@
 	dir = 1
 	},
 /obj/structure/stone_tile,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bm" = (
 /obj/structure/stone_tile/slab/cracked,
@@ -352,7 +352,7 @@
 /obj/structure/stone_tile{
 	dir = 4
 	},
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bo" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -383,7 +383,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/xeno,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bs" = (
 /obj/structure/stone_tile/block{
@@ -416,7 +416,7 @@
 	dir = 1
 	},
 /obj/structure/stone_tile/cracked,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bw" = (
 /obj/structure/stone_tile/cracked{
@@ -430,7 +430,7 @@
 	dir = 8
 	},
 /obj/item/flashlight/lantern,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bx" = (
 /obj/structure/stone_tile/block{
@@ -441,7 +441,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/xeno,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "by" = (
 /obj/structure/stone_tile/block{
@@ -451,7 +451,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 8
 	},
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bz" = (
 /obj/structure/stone_tile/block/cracked{
@@ -461,7 +461,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bA" = (
 /obj/structure/stone_tile/cracked{
@@ -475,7 +475,7 @@
 	},
 /obj/structure/stone_tile,
 /obj/item/flashlight/lantern,
-/turf/open/indestructible/boss/air,
+/turf/open/indestructible/boss,
 /area/ruin/unpowered/xenonest)
 "bB" = (
 /obj/structure/alien/weeds,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -58111,7 +58111,7 @@
 	dir = 5
 	},
 /obj/machinery/camera{
-	c_tag = "Bar Backroom"
+	c_tag = "Gravity Generator - Fore"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5103,7 +5103,7 @@
 /area/security/main)
 "ajv" = (
 /obj/machinery/computer/med_data{
-	dir = 3
+	dir = 4
 	},
 /obj/structure/sign/poster/official/medical_green_cross{
 	pixel_x = -32
@@ -30888,7 +30888,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bvH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -53679,9 +53679,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"dVU" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "dXq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -53734,7 +53731,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "egt" = (
 /obj/effect/turf_decal/tile/bar,
@@ -54363,7 +54360,7 @@
 "fIs" = (
 /obj/structure/grille,
 /obj/structure/lattice,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/space/nearstation)
 "fJY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54521,19 +54518,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
-"ghq" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 3;
-	name = "Docking Beacon";
-	picked_color = "Burgundy"
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
 "ghD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -54690,7 +54674,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "gJi" = (
 /obj/structure/lattice/catwalk,
@@ -54926,7 +54910,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hxn" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -57288,7 +57272,7 @@
 /area/crew_quarters/theatre)
 "oyN" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oyX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -58410,7 +58394,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
@@ -58667,9 +58651,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
-"sQX" = (
-/turf/open/floor/plating,
-/area/space)
 "sRH" = (
 /obj/machinery/autolathe/secure{
 	name = "public autolathe"
@@ -58786,7 +58767,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "trb" = (
 /obj/machinery/light{
@@ -59009,7 +58990,7 @@
 /area/hallway/primary/central)
 "uaw" = (
 /obj/machinery/power/apc{
-	areastring = "/area/storage/art";
+	areastring = "/area/maintenance/bar";
 	dir = 1;
 	name = "Maint bar";
 	pixel_y = 24
@@ -59422,7 +59403,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "vbi" = (
 /obj/structure/table,
@@ -60521,7 +60502,7 @@
 	name = "Docking Beacon";
 	picked_color = "Burgundy"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xOx" = (
 /obj/structure/chair/comfy/brown{
@@ -66754,11 +66735,11 @@ aaa
 aaa
 aaa
 aaa
-ghq
+xLX
 aaa
 aaa
 aaa
-ghq
+xLX
 aaa
 aaa
 aaa
@@ -67005,13 +66986,9 @@ aaa
 aaa
 aaa
 aaa
-ghq
+xLX
 aaa
-ghq
-aaa
-aaa
-aaa
-gXs
+xLX
 aaa
 aaa
 aaa
@@ -67019,9 +66996,13 @@ gXs
 aaa
 aaa
 aaa
-ghq
+gXs
 aaa
-ghq
+aaa
+aaa
+xLX
+aaa
+xLX
 aaa
 aaa
 aaa
@@ -76570,7 +76551,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -76827,7 +76808,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -77084,7 +77065,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -77341,7 +77322,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -77598,7 +77579,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -77855,7 +77836,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -78112,7 +78093,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aoV
 bZm
@@ -78369,13 +78350,13 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aoV
 bVz
 aaf
 aaf
-sQX
+aoV
 aaa
 aaS
 aaf
@@ -78626,7 +78607,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aag
 bVz
@@ -78883,7 +78864,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+gJi
 aaa
 aaf
 bVz
@@ -79140,7 +79121,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+gJi
 aaa
 aaf
 bVz
@@ -84190,7 +84171,7 @@ aaa
 aaa
 gXs
 gXs
-dVU
+aaH
 abc
 abu
 abu


### PR DESCRIPTION
## About The Pull Request

Fixed active turfs from plating that sat in space, removed random catwalk to nowhere, turned the medical console in the sleeper room to not face a window, FIXED MAINTENANCE BAR APC NOT ACTUALLY BEING FOR THE MAINTENANCE BAR. As well as fixed the xeno hive ruin on lavaland from having active turfs.

## Why It's Good For The Game

Active turf man still bad and APC's should actually power the rooms they're supposed to power.

## Changelog
:cl:
fix: active turfs on box and xenohive, maintenance bar APC not being stringed correctly, turned a monitor to face a direction that makes sense, changed tag of camera in gravgen being misnamed
/:cl: