### PR TITLE
make tongue preference pass through cloning

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2796,6 +2796,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if(custom_tongue != "default")
 		var/new_tongue = GLOB.roundstart_tongues[custom_tongue]
 		if(new_tongue)
+			character.dna.species.mutanttongue = new_tongue //this means we get our tongue when we clone
 			var/obj/item/organ/tongue/T = character.getorganslot(ORGAN_SLOT_TONGUE)
 			if(T)
 				qdel(T)


### PR DESCRIPTION
## About The Pull Request
giving yourself a custom tongue updates your species mutanttongue var so that when being cloned, it gets copied over

## Why It's Good For The Game
i like giving people the ability to hiss who don't want to specifically play lizards

## Changelog
:cl:
tweak: the custom tongue preference now passes through cloning so you spawn with your selected tongue
/:cl: