### PR TITLE
makes the thing that ensures explosives in bags hit everything in said bag only work if it's actually in the bag (no more pda bombs erase your entire inventory)

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -198,8 +198,8 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		if((T == epicenter) && !QDELETED(explosion_source) && (get_turf(explosion_source) == T)) // Ensures explosives detonating from bags trigger other explosives in that bag
 			var/list/atoms = list()
-			var/turf/T = get_turf(explosion_source)		// yeah this is two get turfs but this should only happen once
-			for(var/atom/A in T)
+			var/turf/the_source_turf = get_turf(explosion_source)		// yeah this is two get turfs but this should only happen once
+			for(var/atom/A in the_source_turf)
 				atoms += A
 			for(var/i in atoms)
 				var/atom/A = i

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -196,10 +196,9 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		//------- EX_ACT AND TURF FIRES -------
 
-		if((T == epicenter) && !QDELETED(explosion_source) && (get_turf(explosion_source) == T)) // Ensures explosives detonating from bags trigger other explosives in that bag
+		if((T == epicenter) && !QDELETED(explosion_source) && ismovable(explosion_source) && (get_turf(explosion_source) == T)) // Ensures explosives detonating from bags trigger other explosives in that bag
 			var/list/atoms = list()
-			var/turf/the_source_turf = get_turf(explosion_source)		// yeah this is two get turfs but this should only happen once
-			for(var/atom/A in the_source_turf)
+			for(var/atom/A in explosion_source.loc)		// the ismovableatom check 2 lines above makes sure we don't nuke an /area
 				atoms += A
 			for(var/i in atoms)
 				var/atom/A = i

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -198,7 +198,8 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		if((T == epicenter) && !QDELETED(explosion_source) && (get_turf(explosion_source) == T)) // Ensures explosives detonating from bags trigger other explosives in that bag
 			var/list/atoms = list()
-			for(var/atom/A in explosion_source.loc)
+			var/turf/T = get_turf(explosion_source)		// yeah this is two get turfs but this should only happen once
+			for(var/atom/A in T)
 				atoms += A
 			for(var/i in atoms)
 				var/atom/A = i

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		//------- EX_ACT AND TURF FIRES -------
 
-		if((T == epicenter) && !QDELETED(explosion_source) && (explosion_source.loc == T)) // Ensures explosives detonating from bags trigger other explosives in that bag
+		if((T == epicenter) && !QDELETED(explosion_source) && (get_turf(explosion_source) == T)) // Ensures explosives detonating from bags trigger other explosives in that bag
 			var/list/atoms = list()
 			for(var/atom/A in explosion_source.loc)
 				atoms += A

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -196,14 +196,12 @@ GLOBAL_LIST_EMPTY(explosions)
 
 		//------- EX_ACT AND TURF FIRES -------
 
-		if(T == epicenter) // Ensures explosives detonating from bags trigger other explosives in that bag
-			var/list/items = list()
-			for(var/I in T)
-				var/atom/A = I
-				if (!(A.flags_1 & PREVENT_CONTENTS_EXPLOSION_1)) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
-					items += A.GetAllContents()
-			for(var/O in items)
-				var/atom/A = O
+		if((T == epicenter) && !QDELETED(explosion_source) && (explosion_source.loc == T)) // Ensures explosives detonating from bags trigger other explosives in that bag
+			var/list/atoms = list()
+			for(var/atom/A in explosion_source.loc)
+				atoms += A
+			for(var/i in atoms)
+				var/atom/A = i
 				if(!QDELETED(A))
 					A.ex_act(dist)
 


### PR DESCRIPTION
explosion recursion as a whole needs to be looked at but hey ok.

## why it's good for the game

this feature that's supposed to make in bag grenades detonate everything in said bag is instead just shredding everyone's things.