### PR TITLE
makes explosions only recurse one level into storage at full power before dropping 1 level per storage object recursed

### DIFF
--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -19,8 +19,9 @@
 	return TRUE
 
 /obj/item/storage/contents_explosion(severity, target)
+	var/in_storage = istype(loc, /obj/item/storage)? (max(0, severity - 1)) : (severity)
 	for(var/atom/A in contents)
-		A.ex_act(severity, target)
+		A.ex_act(in_storage, target)
 		CHECK_TICK
 
 //Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

explosions shredding things is fine but i feel like storage should provide some protection to alleviate "backpack shredded syndrome"

note: maxcaps/similar should still shred all items.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
balance: explosions only recurse one level into storage before dropping 1 level per storage layer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
