### PR TITLE
lizards no longer break their spines ~~roundstart~~ EVER AGAIN I FUCKING FIXED THE DOUBLE SET_SPECIES LIZARD BUG

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -567,7 +567,6 @@
 
 		client.prefs.scars_list["[cur_scar_index]"] = valid_scars
 		client.prefs.save_character()
-
 	client.prefs.copy_to(H)
 	H.dna.update_dna_identity()
 	if(mind)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -557,7 +557,6 @@
 	if(frn)
 		client.prefs.random_character()
 		client.prefs.real_name = client.prefs.pref_species.random_name(gender,1)
-	client.prefs.copy_to(H)
 	var/cur_scar_index = client.prefs.scars_index
 	if(client.prefs.persistent_scars && client.prefs.scars_list["[cur_scar_index]"])
 		var/scar_string = client.prefs.scars_list["[cur_scar_index]"]

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -47,6 +47,5 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 		return
 	var/mob/living/carbon/human/dummy/D = GLOB.human_dummy_list[slotnumber]
 	if(istype(D))
-		D.set_species(/datum/species/human,icon_update = TRUE, pref_load = TRUE) //for some fucking reason, if you don't change the species every time, some species will dafault certain things when it's their own species on the mannequin two times in a row, like lizards losing spines and tails setting to smooth. If you can find a fix for this that isn't this, good on you
 		D.wipe_state()
 		D.in_use = FALSE

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -45,7 +45,7 @@
 /obj/item/organ/tail/lizard/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
 	..()
 	if(istype(H))
-		// Checks here are necessary so it wouldn't overwrite the tail of a lizard it spawned in //yes, the if checks may cause snowflakes so that you can't insert another person's tail (haven't actually tested it but I assume that's the result of my addition) but it makes it so never again will lizards break their spine if set_species is called twice in a row
+		// Checks here are necessary so it wouldn't overwrite the tail of a lizard it spawned in //yes, the if checks may cause snowflakes so that you can't insert another person's tail (haven't actually tested it but I assume that's the result of my addition) but it makes it so never again will lizards break their spine if set_species is called twice in a row (hopefully)
 		if(!H.dna.species.mutant_bodyparts["tail_lizard"])
 			if (!H.dna.features["tail_lizard"])
 				H.dna.features["tail_lizard"] = tail_type

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -45,14 +45,20 @@
 /obj/item/organ/tail/lizard/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
 	..()
 	if(istype(H))
-		// Checks here are necessary so it wouldn't overwrite the tail of a lizard it spawned in
+		// Checks here are necessary so it wouldn't overwrite the tail of a lizard it spawned in //yes, the if checks may cause snowflakes so that you can't insert another person's tail (haven't actually tested it but I assume that's the result of my addition) but it makes it so never again will lizards break their spine if set_species is called twice in a row
 		if(!H.dna.species.mutant_bodyparts["tail_lizard"])
-			H.dna.features["tail_lizard"] = tail_type
-			H.dna.species.mutant_bodyparts["tail_lizard"] = tail_type
+			if (!H.dna.features["tail_lizard"])
+				H.dna.features["tail_lizard"] = tail_type
+				H.dna.species.mutant_bodyparts["tail_lizard"] = tail_type
+			else
+				H.dna.species.mutant_bodyparts["tail_lizard"] = H.dna.features["tail_lizard"]
 
 		if(!H.dna.species.mutant_bodyparts["spines"])
-			H.dna.features["spines"] = spines
-			H.dna.species.mutant_bodyparts["spines"] = spines
+			if (!H.dna.features["spines"])
+				H.dna.features["spines"] = spines
+				H.dna.species.mutant_bodyparts["spines"] = spines
+			else
+				H.dna.species.mutant_bodyparts["spines"] = H.dna.features["spines"]
 		H.update_body()
 
 /obj/item/organ/tail/lizard/Remove(special = FALSE)


### PR DESCRIPTION
## About The Pull Request

lizards have their spines and markings roundstart

### YOU CAN'T CALL SET_SPECIES TWICE FUCKING GODDAMN THIS IS THE SECOND TIME I'VE HAD TO FIX THIS

edit:

# I FIXED THE SPINE BREAKING TAIL SMOOTHING LIZARD BUG. FINALLY!!

It only took me a fucking hour *sob*

## Why It's Good For The Game

reee

## Changelog
:cl:
fix: lizard spines
/:cl: