### PR TITLE
increases space levels to 4

### DIFF
--- a/code/modules/mapping/map_config.dm
+++ b/code/modules/mapping/map_config.dm
@@ -1,4 +1,4 @@
-w//used for holding information about unique properties of maps
+//used for holding information about unique properties of maps
 //feed it json files that match the datum layout
 //defaults to box
 //  -Cyberboss

--- a/code/modules/mapping/map_config.dm
+++ b/code/modules/mapping/map_config.dm
@@ -1,4 +1,4 @@
-//used for holding information about unique properties of maps
+w//used for holding information about unique properties of maps
 //feed it json files that match the datum layout
 //defaults to box
 //  -Cyberboss
@@ -20,7 +20,7 @@
 	var/map_file = "BoxStation.dmm"
 
 	var/traits = null
-	var/space_ruin_levels = 2
+	var/space_ruin_levels = 4
 	var/space_empty_levels = 1
 	var/station_ruin_budget = -1 // can be set to manually override the station ruins budget on maps that don't support station ruins, stopping the error from being unable to place the ruins.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

reduces the amount of packing.
we have better memory optimization now, although maybe testmerge this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
tweak: default space levels is 4 again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
