### PR TITLE
More Active Turf Fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/arcade.dmm
+++ b/_maps/RandomRuins/SpaceRuins/arcade.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/powered)
 "c" = (
 /turf/closed/mineral/random/high_chance,
@@ -135,7 +135,7 @@
 /area/ruin/powered)
 "F" = (
 /obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/powered)
 "G" = (
 /obj/structure/chair/sofa/right,

--- a/_maps/RandomRuins/SpaceRuins/augmentationfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/augmentationfacility.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "b" = (
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/powered)
 "c" = (
 /turf/closed/mineral/random/high_chance,
@@ -176,8 +176,8 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/autosurgeon{
-	name = "rusted autosurgeon";
 	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert an organ of implant. But this rusted version looks like it could only manage one implant....";
+	name = "rusted autosurgeon";
 	uses = 1
 	},
 /turf/open/floor/plasteel,
@@ -205,7 +205,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plating/asteroid,
+/turf/open/floor/plating/asteroid/airless,
 /area/ruin/powered)
 "K" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{

--- a/_maps/RandomRuins/SpaceRuinsStation/roid6.dmm
+++ b/_maps/RandomRuins/SpaceRuinsStation/roid6.dmm
@@ -80,7 +80,7 @@
 /obj/item/shard{
 	icon_state = "medium"
 	},
-/turf/open/floor/plating/airless{
+/turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
 /area/ruin/space/has_grav)

--- a/_maps/RandomZLevels/VR/murderdome.dmm
+++ b/_maps/RandomZLevels/VR/murderdome.dmm
@@ -232,7 +232,9 @@
 /area/awaymission/vr/murderdome)
 "H" = (
 /obj/machinery/telecomms/allinone,
-/turf/open/indestructible,
+/turf/open/indestructible{
+	initial_gas_mix = "TEMP=2.7"
+	},
 /area/awaymission/vr/murderdome)
 "R" = (
 /obj/effect/spawner/structure/window/reinforced/indestructable,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -334,8 +334,8 @@
 /area/crew_quarters/fitness/pool)
 "aaM" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
-	icon_state = "yellowcornersiding";
-	dir = 8
+	dir = 8;
+	icon_state = "yellowcornersiding"
 	},
 /area/crew_quarters/fitness/pool)
 "aaN" = (
@@ -354,8 +354,8 @@
 /area/crew_quarters/fitness/pool)
 "aaP" = (
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 8
+	dir = 8;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "aaQ" = (
@@ -433,8 +433,8 @@
 /area/crew_quarters/fitness/pool)
 "aaW" = (
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "aaX" = (
@@ -550,8 +550,8 @@
 "abm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abn" = (
@@ -580,8 +580,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abr" = (
@@ -595,8 +595,8 @@
 "abt" = (
 /obj/structure/pool/Rboard,
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 8
+	dir = 8;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abu" = (
@@ -659,8 +659,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/yellowsiding/corner{
-	icon_state = "yellowcornersiding";
-	dir = 4
+	dir = 4;
+	icon_state = "yellowcornersiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abB" = (
@@ -670,21 +670,21 @@
 	pixel_y = -27
 	},
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abC" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/yellowsiding{
-	icon_state = "yellowsiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowsiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abD" = (
 /turf/open/floor/plasteel/yellowsiding/corner{
-	icon_state = "yellowcornersiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowcornersiding"
 	},
 /area/crew_quarters/fitness/pool)
 "abE" = (
@@ -47273,7 +47273,7 @@
 "ceT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "ceU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -55663,12 +55663,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
-"izF" = (
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
-	},
-/area/maintenance/department/science)
 "iAx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57738,10 +57732,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "nAs" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -57904,7 +57895,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "nOY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -58008,7 +57999,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
 	luminosity = 2
 	},
 /area/maintenance/department/science)
@@ -59531,15 +59521,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"ros" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
-	},
-/area/maintenance/department/science)
 "rrb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60667,10 +60648,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "uos" = (
 /obj/machinery/computer/camera_advanced/base_construction,
@@ -61099,13 +61077,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"vpz" = (
-/obj/structure/girder,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
-	},
-/area/maintenance/department/science)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -62038,10 +62009,7 @@
 /area/maintenance/department/science)
 "xsO" = (
 /obj/item/ectoplasm,
-/turf/open/floor/plating{
-	initial_gas_mix = "o2=0.01;n2=0.01";
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "xuv" = (
 /obj/item/broken_bottle,
@@ -107723,7 +107691,7 @@ aht
 bwm
 ikB
 iVJ
-izF
+lWy
 typ
 bwm
 aht
@@ -108233,7 +108201,7 @@ bwm
 svN
 bIQ
 uek
-izF
+lWy
 bwm
 qnT
 lJr
@@ -108488,9 +108456,9 @@ dMO
 lWy
 rxQ
 lWy
-ros
-izF
-izF
+bIQ
+lWy
+lWy
 mES
 lWy
 lWy
@@ -108747,7 +108715,7 @@ bwm
 nzD
 uoj
 bwm
-izF
+lWy
 bwm
 dMI
 lWy
@@ -109001,7 +108969,7 @@ bkF
 bwm
 bwm
 bwm
-ros
+bIQ
 bwm
 bwm
 bwm
@@ -109258,8 +109226,8 @@ bkF
 qIO
 jXA
 bwm
-ros
-vpz
+bIQ
+hXt
 bwm
 aht
 bwm

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6313,48 +6313,11 @@
 "aoz" = (
 /turf/closed/wall,
 /area/maintenance/fore)
-"aoA" = (
-/obj/machinery/gateway{
-	dir = 9
-	},
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
 "aoB" = (
-/obj/machinery/gateway{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"aoC" = (
-/obj/machinery/gateway{
-	dir = 5
-	},
-/obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6692,42 +6655,8 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"apq" = (
-/obj/machinery/gateway{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
 "apr" = (
 /obj/machinery/gateway/centerstation,
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"aps" = (
-/obj/machinery/gateway{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "apt" = (
@@ -6916,9 +6845,6 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
 "apU" = (
-/obj/machinery/gateway{
-	dir = 10
-	},
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6933,7 +6859,6 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "apV" = (
-/obj/machinery/gateway,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -6948,9 +6873,6 @@
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "apW" = (
-/obj/machinery/gateway{
-	dir = 6
-	},
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -7876,32 +7798,7 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "arY" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
+/obj/machinery/computer/gateway_control,
 /turf/open/floor/plasteel,
 /area/gateway)
 "arZ" = (
@@ -8904,6 +8801,32 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/flashlight,
 /turf/open/floor/plasteel,
 /area/gateway)
 "auh" = (
@@ -97852,8 +97775,8 @@ aaa
 aaa
 aaa
 lcZ
-aoA
-apq
+apW
+apV
 apU
 aqQ
 arX
@@ -98366,8 +98289,8 @@ aiT
 aiS
 aaa
 lcZ
-aoC
-aps
+apU
+apV
 apW
 aqS
 arZ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -52911,7 +52911,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "cCT" = (
-/obj/machinery/rnd/production/protolathe/department/cargo,
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cCU" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -50326,10 +50326,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"cqW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/mineral,
-/area/chapel/asteroid/monastery)
 "cqX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
@@ -57921,9 +57917,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/plating{
-	luminosity = 2
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "odM" = (
 /obj/effect/landmark/barthpot,
@@ -75757,8 +75751,8 @@ aaa
 bGI
 bNs
 cfN
-cqW
-cqW
+cfN
+cfN
 cfN
 cfN
 bZY
@@ -76270,7 +76264,7 @@ aaa
 aaa
 bGI
 bNs
-cqW
+cfN
 bOw
 cfN
 bOw

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -38965,7 +38965,6 @@
 /area/chapel/dock)
 "bKe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
@@ -39999,12 +39998,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
@@ -50326,6 +50319,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"cqW" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "cqX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
@@ -55582,6 +55581,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"izF" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "iAx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59438,6 +59443,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ros" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "rrb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61508,12 +61521,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wDe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/chapel/dock)
 "wDl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/corner,
@@ -80362,7 +80369,7 @@ aaa
 aht
 aqG
 bGE
-bKf
+cqW
 bKf
 bMw
 bNy
@@ -80619,8 +80626,8 @@ aht
 aht
 aqG
 bGE
-bKf
-bKf
+izF
+ros
 bMx
 bNz
 bHM
@@ -80876,7 +80883,7 @@ aaa
 aaa
 aqG
 bGE
-wDe
+bGE
 bHM
 bHM
 bNA


### PR DESCRIPTION
## About The Pull Request

More active turf fixes, once again.

## Why It's Good For The Game

Active turfs make the game take more seconds to load.

## Changelog
:cl:
fix: fixed active tufs on some space ruins, murderdome VR, and a few on pubby, changed cargo autolathe to techfab, messed with pipe room leading to monastery.
/:cl: