### PR TITLE
""fixes"" an ""issue"" with vendors

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -576,7 +576,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		"<span class='notice'>You right [src].")
 
 	unbuckle_all_mobs(TRUE)
-
+	anchored = FALSE //so you can push it back into position
 	tilted = FALSE
 	layer = initial(layer)
 


### PR DESCRIPTION
this is more a tweak than anything but vendors are now unanchored when tipped so you can't get trapped or something

oversight maybe? idk

closes #12971 
## Changelog
:cl:
fix: vendors are now unanchored when tipped. it just fell over it's not bolted to the ground anymore.
/:cl:

