### PR TITLE
fixes ashwalker languages

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -276,7 +276,8 @@ Key procs
 							/datum/language/draconic = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard/ash
-	selected_language = /datum/language/draconic
+	understood_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
 
 /datum/language_holder/monkey
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
tin

closes #12998 

## Changelog
:cl:
fix: The Tendril-Mother on Lavaland has remembered how to make ashwalkers who know how to speak Draconic again.
/:cl:


