### PR TITLE
increases the cost of the brainwash surgery, reduces its success chance

### DIFF
--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -25,7 +25,7 @@
 	return TRUE
 /datum/surgery_step/brainwash
 	name = "brainwash"
-	implements = list(TOOL_HEMOSTAT = 85, TOOL_WIRECUTTER = 50, /obj/item/stack/packageWrap = 35, /obj/item/stack/cable_coil = 15)
+	implements = list(TOOL_HEMOSTAT = 60, TOOL_WIRECUTTER = 30, /obj/item/stack/packageWrap = 15, /obj/item/stack/cable_coil = 5)
 	time = 200
 	var/objective
 /datum/surgery_step/brainwash/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -46,7 +46,7 @@
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
 	restricted_roles = list("Medical Doctor", "Roboticist")
-	cost = 5
+	cost = 8
 
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -46,7 +46,7 @@
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
 	restricted_roles = list("Medical Doctor", "Roboticist")
-	cost = 8
+	cost = 10
 
 /datum/uplink_item/role_restricted/clown_bomb
 	name = "Clown Bomb"


### PR DESCRIPTION
## About The Pull Request
cost: 5 tc -> 10 tc
success rate: 85% with hemostat -> 65% (also reduced the ghetto methods by a fair amount too)
closes #12974

## Why It's Good For The Game
too cheap / easy to perform, alien tech requires it to be actually researched first whereas this doesn't and it literally turns traitor into a conversion mode in the right hands

provides an alternative to outright removing it by actually attempting to nerf it a bit because content removal is bad, especially on an underused item that is basically never an issue

## Changelog
:cl:
tweak: brainwashing disks now cost 10 tc in the uplink instead of 5, and have a lower success chance when performed
/:cl:
