### PR TITLE
Adds a second shutter to the hopline on boxstation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4879,6 +4879,10 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hopqueue";
+	name = "HoP Queue Shutters"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aiW" = (


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin, it's on the top end because that's what was missing.

## Why It's Good For The Game

I think someone accidentally deleted it, just a quick fix.

## Changelog
:cl:
add: Adds a second shutter on the top of the hop line
/:cl:
