### PR TITLE
replaces box whiteship tbaton with truncheon

### DIFF
--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -2690,7 +2690,6 @@
 /obj/structure/rack,
 /obj/item/storage/box/zipties,
 /obj/item/assembly/flash/handheld,
-/obj/item/melee/classic_baton/telescopic,
 /obj/machinery/light/small/built{
 	dir = 8
 	},

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -2690,6 +2690,7 @@
 /obj/structure/rack,
 /obj/item/storage/box/zipties,
 /obj/item/assembly/flash/handheld,
+/obj/item/melee/classic_baton,
 /obj/machinery/light/small/built{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
removes telebaton from box whiteship loot, replaced with truncheon
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
quirky baton should strictly be kept uniquely to heads as a defensive weapon, imo
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: replaces box whiteship tbaton with truncheon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
