### PR TITLE
Proto-Kinetic Glaives Phase 2 - Parrying

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -188,7 +188,7 @@
 	//ideas: altclick that lets you pummel people with the handguard/handle?
 	//parrying functionality?
 
-/datum/block_parry_data/crusherglaive
+/datum/block_parry_data/crusherglaive // it's like quickparry, without the damage multiplier
 	parry_time_windup = 0
 	parry_time_active = 5
 	parry_time_spindown = 0

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -183,9 +183,38 @@
 	attack_verb = list("stabbed", "diced", "sliced", "cleaved", "chopped", "lacerated", "cut", "jabbed", "punctured")
 	icon_state = "crusher-glaive"
 	item_state = "crusher0-glaive"
+	item_flags = ITEM_CAN_PARRY
+	block_parry_data = /datum/block_parry_data/crusherglaive
 	//ideas: altclick that lets you pummel people with the handguard/handle?
 	//parrying functionality?
 
+/datum/block_parry_data/crusherglaive
+	parry_time_windup = 0
+	parry_time_active = 5
+	parry_time_spindown = 0
+	parry_time_perfect = 1.5
+	parry_time_perfect_leeway = 0.5
+	parry_imperfect_falloff_percent = 30
+	parry_efficiency_perfect = 100
+	parry_failed_stagger_duration = 1 SECONDS
+	parry_failed_clickcd_duration = 1 SECONDS
+
+/obj/item/kinetic_crusher/glaive/on_active_parry(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/block_return, parry_efficiency, parry_time) // if you're dumb enough to go for a parry...
+	var/turf/proj_turf = owner.loc // destabilizer bolt, ignoring cooldown
+	if(!isturf(proj_turf))
+		return
+	var/obj/item/projectile/destabilizer/D = new /obj/item/projectile/destabilizer(proj_turf)
+	for(var/t in trophies)
+		var/obj/item/crusher_trophy/T = t
+		T.on_projectile_fire(D, owner)
+	D.preparePixelProjectile(attacker, owner)
+	D.firer = owner
+	D.hammer_synced = src
+	playsound(owner, 'sound/weapons/plasma_cutter.ogg', 100, 1)
+	D.fire()
+	if((!attacker.anchored || ismegafauna(attacker))) // free backstab, if you perfect parry
+		attacker.dir = get_dir(owner,attacker)
+ 
 /obj/item/kinetic_crusher/glaive/update_icon_state()
 	item_state = "crusher[wielded]-glaive" // this is not icon_state and not supported by 2hcomponent
 


### PR DESCRIPTION
## About The Pull Request
Glaives can parry. Bonus points if you yell something dramatic before popping it.
Successful parries fire a destabilizing bolt (regardless of cooldown) and turn the attacker around.
Perfect parries capitalize on the above two points by giving you a free mark-detonating backstab. (Because of the fired bolt and turned-around attacker).
Numbers subject to change.
## Why It's Good For The Game
pressing G with the funny stick now has a purpose
## Changelog
:cl:
add: Proto-kinetic glaives (not crushers) can parry now.
/:cl: