### PR TITLE
Improves zombies, the gimped threat

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -327,6 +327,7 @@
 	new /obj/item/reagent_containers/glass/bottle/romerol(src)
 	new /obj/item/reagent_containers/syringe(src)
 	new /obj/item/reagent_containers/dropper(src)
+	new /obj/item/paper/guides/antag/romerol_instructions(src)
 
 /obj/item/storage/box/syndie_kit/ez_clean/PopulateContents()
 	for(var/i in 1 to 3)

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -32,6 +32,7 @@
 	name = "Infectious Zombie"
 	id = "memezombies"
 	limbs_id = "zombie"
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_NOBREATH,TRAIT_NODEATH,TRAIT_NOSOFTCRIT, TRAIT_FAKEDEATH)
 	mutanthands = /obj/item/zombie_hand
 	armor = 20 // 120 damage to KO a zombie, which kills it
 	speedmod = 1.6 // they're very slow
@@ -89,8 +90,8 @@
 		infection = new()
 		infection.Insert(C)
 
-	//make their bodyparts stamina-resistant
-	var/incoming_stam_mult = 0.7
+	//make their bodyparts stamina-immune, its a corpse.
+	var/incoming_stam_mult = 0
 	for(var/obj/item/bodypart/part in C.bodyparts)
 		part.incoming_stam_mult = incoming_stam_mult
 		//todo: add negative wound resistance to all parts when wounds is merged (zombies are physically weak in terms of limbs)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -81,3 +81,14 @@
 		user.updatehealth()
 		user.adjustOrganLoss(ORGAN_SLOT_BRAIN, -hp_gained) // Zom Bee gibbers "BRAAAAISNSs!1!"
 		user.adjust_nutrition(hp_gained, NUTRITION_LEVEL_FULL)
+
+/obj/item/paper/guides/antag/romerol_instructions
+	info = "How to do necromancy with chemicals:<br>\
+	<ul>\
+	<li>Use a dropper or syringe (provided) to inject the Romerol (provided) into a target (not provided)</li>\
+	<li>Wait for said target to die, or speed the process up by doing it yourself</li>\
+	<li>Run away from the target, as they will be hostile when rising back up</li>\
+	<li>Optionally: Inject chemical into foods and drinks to further spread possible infection</li>\
+	<li>???</li>\
+	<li>Complete assigned objectives amidst the chaos</li>\
+	</ul>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes zombies take no stamina damage due to being a reanimated corpse, makes zombies not enter softcrit (but still hardcrit for the fake death thing), gives the romerol kit a guide on proper usage of the chem.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Zombies are easy as fuck to deal with, why don't we make them worth the 25 TC cost to create them
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a guide for romerol usage
balance: made infectious zombies not enter softcrit and take no stamina damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
