### PR TITLE
squeaking objects including air horns and clockwork boots now have a default 1 second cooldown. squeaking objects crossing each other will on average only allow 3 squeaks to occur, because if byond is literally running out of sound channels you know the fun has went too far

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -452,6 +452,9 @@
 	#define COMPONENT_TWOHANDED_BLOCK_WIELD 1
 #define COMSIG_TWOHANDED_UNWIELD "twohanded_unwield"					//from base of datum/component/two_handed/proc/unwield(mob/living/carbon/user): (/mob/user)
 
+// /datum/component/squeak signals
+#define COMSIG_CROSS_SQUEAKED "cross_squeaked"							// sent when a squeak component squeaks from crossing something, to delay anything else crossing that might squeak to prevent ear hurt.
+
 // /datum/action signals
 #define COMSIG_ACTION_TRIGGER "action_trigger"						//from base of datum/action/proc/Trigger(): (datum/action)
 	#define COMPONENT_ACTION_BLOCK_TRIGGER 1

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -11,6 +11,13 @@
 	// This is to stop squeak spam from inhand usage
 	var/last_use = 0
 	var/use_delay = 20
+	
+	// squeak cooldowns
+	var/last_squeak = 0
+	var/squeak_delay = 10
+	
+	/// chance we'll be stopped from squeaking by cooldown when something crossing us squeaks
+	var/cross_squeak_delay_chance = 33		// about 3 things can squeak at a time
 
 /datum/component/squeak/Initialize(custom_sounds, volume_override, chance_override, step_delay_override, use_delay_override)
 	if(!isatom(parent))
@@ -19,6 +26,7 @@
 	if(ismovable(parent))
 		RegisterSignal(parent, list(COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_IMPACT), .proc/play_squeak)
 		RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ITEM_WEARERCROSSED), .proc/play_squeak_crossed)
+		RegisterSignal(parent, COMSIG_CROSS_SQUEAKED, .proc/delay_squeak)
 		RegisterSignal(parent, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react)
 		if(isitem(parent))
 			RegisterSignal(parent, list(COMSIG_ITEM_ATTACK, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_HIT_REACT), .proc/play_squeak)
@@ -39,6 +47,9 @@
 		use_delay = use_delay_override
 
 /datum/component/squeak/proc/play_squeak()
+	if(last_squeak + squeak_delay < world.time)
+		return
+	last_squeak = world.time
 	if(prob(squeak_chance))
 		if(!override_squeak_sounds)
 			playsound(parent, pickweight(default_squeak_sounds), volume, 1, -1)
@@ -52,7 +63,7 @@
 	else
 		steps++
 
-/datum/component/squeak/proc/play_squeak_crossed(atom/movable/AM)
+/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/AM)
 	if(isitem(AM))
 		var/obj/item/I = AM
 		if(I.item_flags & ABSTRACT)
@@ -64,11 +75,16 @@
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))
 		play_squeak()
+		SEND_SIGNAL(AM, COMSIG_CROSS_SQUEAKED)
 
 /datum/component/squeak/proc/use_squeak()
 	if(last_use + use_delay < world.time)
 		last_use = world.time
 		play_squeak()
+
+/datum/component/squeak/proc/delay_squeak()
+	if(prob(cross_squeak_delay_chance))
+		last_squeak = world.time
 
 /datum/component/squeak/proc/on_equip(datum/source, mob/equipper, slot)
 	RegisterSignal(equipper, COMSIG_MOVABLE_DISPOSING, .proc/disposing_react, TRUE)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -50,15 +50,16 @@
 	do_play_squeak()
 
 /datum/component/squeak/proc/do_play_squeak(bypass_cooldown = FALSE)
-	if(!bypass_cooldown)
-		last_squeak + squeak_delay < world.time)
-			return
-		last_squeak = world.time
+	if(!bypass_cooldown && ((last_squeak + squeak_delay) < world.time))
+		return FALSE
 	if(prob(squeak_chance))
 		if(!override_squeak_sounds)
 			playsound(parent, pickweight(default_squeak_sounds), volume, 1, -1)
 		else
 			playsound(parent, pickweight(override_squeak_sounds), volume, 1, -1)
+		last_squeak = world.time
+		return TRUE
+	return FALSE
 
 /datum/component/squeak/proc/step_squeak()
 	if(steps > step_delay)
@@ -78,8 +79,8 @@
 				return
 	var/atom/current_parent = parent
 	if(isturf(current_parent.loc))
-		play_squeak()
-		SEND_SIGNAL(AM, COMSIG_CROSS_SQUEAKED)
+		if(do_play_squeak())
+			SEND_SIGNAL(AM, COMSIG_CROSS_SQUEAKED)
 
 /datum/component/squeak/proc/use_squeak()
 	if(last_use + use_delay < world.time)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -50,7 +50,7 @@
 	do_play_squeak()
 
 /datum/component/squeak/proc/do_play_squeak(bypass_cooldown = FALSE)
-	if(!bypass_cooldown && ((last_squeak + squeak_delay) < world.time))
+	if(!bypass_cooldown && ((last_squeak + squeak_delay) >= world.time))
 		return FALSE
 	if(prob(squeak_chance))
 		if(!override_squeak_sounds)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -14,7 +14,7 @@
 	
 	// squeak cooldowns
 	var/last_squeak = 0
-	var/squeak_delay = 10
+	var/squeak_delay = 5
 	
 	/// chance we'll be stopped from squeaking by cooldown when something crossing us squeaks
 	var/cross_squeak_delay_chance = 33		// about 3 things can squeak at a time
@@ -47,9 +47,13 @@
 		use_delay = use_delay_override
 
 /datum/component/squeak/proc/play_squeak()
-	if(last_squeak + squeak_delay < world.time)
-		return
-	last_squeak = world.time
+	do_play_squeak()
+
+/datum/component/squeak/proc/do_play_squeak(bypass_cooldown = FALSE)
+	if(!bypass_cooldown)
+		last_squeak + squeak_delay < world.time)
+			return
+		last_squeak = world.time
 	if(prob(squeak_chance))
 		if(!override_squeak_sounds)
 			playsound(parent, pickweight(default_squeak_sounds), volume, 1, -1)
@@ -58,7 +62,7 @@
 
 /datum/component/squeak/proc/step_squeak()
 	if(steps > step_delay)
-		play_squeak()
+		do_play_squeak(TRUE)
 		steps = 0
 	else
 		steps++

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -298,7 +298,7 @@
 
 /obj/item/clothing/shoes/bronze/Initialize()
 	. = ..()
-	AddComponent(/datum/component/squeak, list('sound/machines/clockcult/integration_cog_install.ogg' = 1, 'sound/magic/clockwork/fellowship_armory.ogg' = 1), 50, footstep_only = TRUE)
+	AddComponent(/datum/component/squeak, list('sound/machines/clockcult/integration_cog_install.ogg' = 1, 'sound/magic/clockwork/fellowship_armory.ogg' = 1), 50)
 
 /obj/item/clothing/shoes/wheelys
 	name = "Wheely-Heels"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -298,7 +298,7 @@
 
 /obj/item/clothing/shoes/bronze/Initialize()
 	. = ..()
-	AddComponent(/datum/component/squeak, list('sound/machines/clockcult/integration_cog_install.ogg' = 1, 'sound/magic/clockwork/fellowship_armory.ogg' = 1), 50)
+	AddComponent(/datum/component/squeak, list('sound/machines/clockcult/integration_cog_install.ogg' = 1, 'sound/magic/clockwork/fellowship_armory.ogg' = 1), 50, footstep_only = TRUE)
 
 /obj/item/clothing/shoes/wheelys
 	name = "Wheely-Heels"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

less ear-fuck

byond is literally out of sound channels, cease and desist.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
del: fun removal: squeaking objects now have an 1 second cooldown between squeaks, and will have a 33% chance of interrupting any other squeaking object when Cross()ing, meaning no more ear-fuck conveyor belts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
