### PR TITLE
wizard timestop parrying katana

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -250,6 +250,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	return(BRUTELOSS)
 
 /obj/item/katana/timestop
+	name = "temporal katana"
+	desc = "Delicately balanced, this finely-crafted blade hums with barely-restrained potential."
 	item_flags = ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/bokken/quick_parry/proj
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -249,6 +249,16 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	playsound(src, 'sound/weapons/bladeslice.ogg', 50, 1)
 	return(BRUTELOSS)
 
+/obj/item/katana/timestop
+	item_flags = ITEM_CAN_PARRY
+	block_parry_data = /datum/block_parry_data/bokken/quick_parry/proj
+
+/obj/item/katana/timestop/on_active_parry(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/block_return, parry_efficiency, parry_time)
+	if(ishuman(owner))
+		var/mob/living/carbon/human/flynn = owner
+		flynn.emote("me",1,"smirks.",FALSE)
+	new /obj/effect/timestop(get_turf(owner), 2, 50, list(owner))
+
 /obj/item/melee/bokken // parrying stick
 	name = "bokken"
 	desc = "A space-Japanese training sword made of wood and shaped like a katana."
@@ -300,6 +310,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	parry_failed_stagger_duration = 1 SECONDS
 	parry_failed_clickcd_duration = 1 SECONDS // more forgiving punishments for missed parries
 	// still, don't fucking miss your parries or you're down stamina and staggered to shit
+
+/datum/block_parry_data/bokken/quick_parry/proj
+	parry_efficiency_perfect_override = list()
 
 /obj/item/melee/bokken/Initialize()
 	. = ..()

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -258,7 +258,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/katana/timestop/on_active_parry(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/block_return, parry_efficiency, parry_time)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/flynn = owner
-		flynn.emote("me",1,"smirks.",FALSE)
+		flynn.emote("smirk")
 	new /obj/effect/timestop(get_turf(owner), 2, 50, list(owner))
 
 /obj/item/melee/bokken // parrying stick

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -294,6 +294,11 @@
 		dat += "[surplus] left.<br>"
 	return dat
 
+/datum/spellbook_entry/item/timestop_katana
+	name = "Temporal Katana"
+	desc = "An oddly-weighted katana, reinforced to allow parrying, with a temporal anomaly magically shoved into it. Successful ripostes prove devastating to those unprepared."
+	item_path = /obj/item/katana/timestop
+
 /datum/spellbook_entry/item/staffchange
 	name = "Staff of Change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -326,6 +326,11 @@
 	key_third_person = "smiles"
 	message = "smiles."
 
+/datum/emote/living/smirk
+	key = "smirk"
+	key_third_person = "smirks"
+	message = "smirks."
+
 /datum/emote/living/sneeze
 	key = "sneeze"
 	key_third_person = "sneezes"


### PR DESCRIPTION
## About The Pull Request
what the fuck do you think this is
## Why It's Good For The Game
pressing G for a timestop can't have repercussions if it's an adminbus-only object
(you also have to get hit by something while parrying)
## Changelog
:cl:
add: New item: Temporal Katana. 2 points for wizards, timestops upon successful parry, bokken quickparry stats (100 force on melee counter!).
add: Also you can *smirk. This has no mechanical effect, other than being smug.
/:cl: