### PR TITLE
Made traitor reroll reroll to MI13 only.

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_bundles.dm
+++ b/code/modules/uplink/uplink_items/uplink_bundles.dm
@@ -173,8 +173,7 @@
 /datum/uplink_item/bundles_TC/reroll/purchase(mob/user, datum/component/uplink/U)
 	var/datum/antagonist/traitor/T = user?.mind?.has_antag_datum(/datum/antagonist/traitor)
 	if(istype(T))
-		var/new_traitor_kind = get_random_traitor_kind(list(T.traitor_kind.type))
-		T.set_traitor_kind(new_traitor_kind)
+		T.set_traitor_kind(/datum/traitor_class/human/subterfuge)
 	else
 		to_chat(user,"Invalid user for contract renegotiation.")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rerolling traitor goals will now ONLY give you "proper" objectives.

## Why It's Good For The Game

Anyone who is rerolling is probably doing it cause they don't want freeform anyway.

## Changelog
:cl:
tweak: Rerolling your traitor goals will ONLY give you "proper" objectives.
/:cl:
