### PR TITLE
Made IC issue wording less salt-assuming

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -371,8 +371,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		return
 
 	var/msg = "<font color='red' size='4'><b>- AdminHelp marked as IC issue by [usr?.client?.holder?.fakekey? usr.client.holder.fakekey : "an administrator"]! -</b></font><br>"
-	msg += "<font color='red'><b>Losing is part of the game!</b></font><br>"
-	msg += "<font color='red'>It is also possible that your ahelp is unable to be answered properly, due to events occurring in the round.</font>"
+	msg += "<font color='red'>Your ahelp is unable to be answered properly due to events occurring in the round. Your question probably has an IC answer, which means you should deal with it IC!</font>"
 	if(initiator)
 		to_chat(initiator, msg)
 


### PR DESCRIPTION
## About The Pull Request

When administrators mark something an IC issue, it makes sure to say **Losing is part of the game!**, even though salt tickets are not just a minority of IC issue tickets, but not really something we want to discourage. The wording has been changed to make it more clear as to what "IC issue" means: "this is an issue for your character, not for administration, to take care of."

## Why It's Good For The Game

Less hostility in the dang automated systems seems nice.

## Changelog
:cl:
tweak: Tweaked wording for marking tickets IC issue.
/:cl: