### PR TITLE
KC-G Phase 2.1 - Parry Tweaks

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -188,16 +188,16 @@
 	//ideas: altclick that lets you pummel people with the handguard/handle?
 	//parrying functionality?
 
-/datum/block_parry_data/crusherglaive // it's like quickparry, without the damage multiplier
+/datum/block_parry_data/crusherglaive // small perfect window, active for a fair while, time it right or use the Forbidden Technique
 	parry_time_windup = 0
 	parry_time_active = 8
 	parry_time_spindown = 0
-	parry_time_perfect = 0
-	parry_time_perfect_leeway = 3
+	parry_time_perfect = 1
+	parry_time_perfect_leeway = 2
 	parry_imperfect_falloff_percent = 20
-	parry_efficiency_to_counterattack = 120 // perfect parry or you're cringe
+	parry_efficiency_to_counterattack = 100 // perfect parry or you're cringe
 	parry_failed_stagger_duration = 1.5 SECONDS // a good time to reconsider your actions...
-	parry_failed_clickcd_duration = 2 SECONDS // or your failures
+	parry_failed_clickcd_duration = 1.5 SECONDS // or your failures
 
 /obj/item/kinetic_crusher/glaive/on_active_parry(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/block_return, parry_efficiency, parry_time) // if you're dumb enough to go for a parry...
 	var/turf/proj_turf = owner.loc // destabilizer bolt, ignoring cooldown
@@ -212,9 +212,11 @@
 	D.hammer_synced = src
 	playsound(owner, 'sound/weapons/plasma_cutter.ogg', 100, 1)
 	D.fire()
-	if((!attacker.anchored || ismegafauna(attacker))) // free backstab, if you perfect parry
+
+/obj/item/kinetic_crusher/glaive/active_parry_reflex_counter(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/return_list, parry_efficiency, list/effect_text)
+	if(owner.Adjacent(attacker) && (!attacker.anchored || ismegafauna(attacker))) // free backstab, if you perfect parry
 		attacker.dir = get_dir(owner,attacker)
- 
+
 /obj/item/kinetic_crusher/glaive/update_icon_state()
 	item_state = "crusher[wielded]-glaive" // this is not icon_state and not supported by 2hcomponent
 

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -190,14 +190,14 @@
 
 /datum/block_parry_data/crusherglaive // it's like quickparry, without the damage multiplier
 	parry_time_windup = 0
-	parry_time_active = 5
+	parry_time_active = 8
 	parry_time_spindown = 0
-	parry_time_perfect = 1.5
-	parry_time_perfect_leeway = 0.5
-	parry_imperfect_falloff_percent = 30
-	parry_efficiency_perfect = 100
-	parry_failed_stagger_duration = 1 SECONDS
-	parry_failed_clickcd_duration = 1 SECONDS
+	parry_time_perfect = 0
+	parry_time_perfect_leeway = 3
+	parry_imperfect_falloff_percent = 20
+	parry_efficiency_to_counterattack = 120 // perfect parry or you're cringe
+	parry_failed_stagger_duration = 1.5 SECONDS // a good time to reconsider your actions...
+	parry_failed_clickcd_duration = 2 SECONDS // or your failures
 
 /obj/item/kinetic_crusher/glaive/on_active_parry(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, list/block_return, parry_efficiency, parry_time) // if you're dumb enough to go for a parry...
 	var/turf/proj_turf = owner.loc // destabilizer bolt, ignoring cooldown

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -68,13 +68,13 @@
 		new /datum/data/mining_equipment("KA Adjustable Tracer Rounds",	/obj/item/borg/upgrade/modkit/tracer/adjustable,					150),
 		new /datum/data/mining_equipment("KA Super Chassis",			/obj/item/borg/upgrade/modkit/chassis_mod,							250),
 		new /datum/data/mining_equipment("KA Hyper Chassis",			/obj/item/borg/upgrade/modkit/chassis_mod/orange,					300),
-		new /datum/data/mining_equipment("Kinetic Glaive",				/obj/item/kinetic_crusher/glaive,									1500),
 		new /datum/data/mining_equipment("KA Range Increase",			/obj/item/borg/upgrade/modkit/range,								1000),
 		new /datum/data/mining_equipment("KA Damage Increase",			/obj/item/borg/upgrade/modkit/damage,								1000),
 		new /datum/data/mining_equipment("KA Cooldown Decrease",		/obj/item/borg/upgrade/modkit/cooldown,								1000),
 		new /datum/data/mining_equipment("KA AoE Damage",				/obj/item/borg/upgrade/modkit/aoe/mobs,								2000),
 		new /datum/data/mining_equipment("Miner Full Replacement",		/obj/item/storage/backpack/duffelbag/mining_cloned,					3000),
-		new /datum/data/mining_equipment("Premium Accelerator",			/obj/item/gun/energy/kinetic_accelerator/premiumka,					8000)
+		new /datum/data/mining_equipment("Premium Accelerator",			/obj/item/gun/energy/kinetic_accelerator/premiumka,					8000),
+		new /datum/data/mining_equipment("Kinetic Glaive",				/obj/item/kinetic_crusher/glaive,									2250),
 		)
 
 /datum/data/mining_equipment


### PR DESCRIPTION
## About The Pull Request
glaives are more expensive (1500 - 2250) because their parry might be good actually
stagger and click cooldown on failed parry to 1 sec -> 1.5 sec
perfect parry required for counterattack
parried targets only turn for the backstab if you're actually in melee range
## Why It's Good For The Game
i wasn't done pushing changes, parry might be a bit spicy (but maybe that price raise is a bit much)
## Changelog
:cl:
balance: Proto-kinetic glaives are more expensive, stagger/cooldown on failed parries increased slightly, perfect parries required for counterattack.
/:cl: