### PR TITLE
Demodularization + making certain sprite overlays less hilariously jank

### DIFF
--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -232,23 +232,6 @@
 /obj/item/organ/genital/proc/get_features(mob/living/carbon/human/H)
 	return
 
-
-//procs to handle sprite overlays being applied to humans
-
-/mob/living/carbon/human/equip_to_slot(obj/item/I, slot)
-	. = ..()
-	if(!. && I && slot && !(slot in GLOB.no_genitals_update_slots)) //the item was successfully equipped, and the chosen slot wasn't merely storage, hands or cuffs.
-		update_genitals()
-
-/mob/living/carbon/human/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE)
-	var/no_update = FALSE
-	if(!I || I == l_store || I == r_store || I == s_store || I == handcuffed || I == legcuffed || get_held_index_of_item(I)) //stops storages, cuffs and held items from triggering it.
-		no_update = TRUE
-	. = ..()
-	if(!. || no_update)
-		return
-	update_genitals()
-
 /mob/living/carbon/human/proc/update_genitals()
 	if(QDELETED(src))
 		return

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -169,7 +169,7 @@
 	//Item is handled and in slot, valid to call callback, for this proc should always be true
 	if(!not_handled)
 		I.equipped(src, slot)
-
+	update_genitals()
 	return not_handled //For future deeper overrides
 
 /mob/living/carbon/human/equipped_speed_mods()
@@ -257,6 +257,7 @@
 		s_store = null
 		if(!QDELETED(src))
 			update_inv_s_store()
+	update_genitals()
 
 /mob/living/carbon/human/wear_mask_update(obj/item/clothing/C, toggle_off = 1)
 	if((C.flags_inv & (HIDEHAIR|HIDEFACIALHAIR)) || (initial(C.flags_inv) & (HIDEHAIR|HIDEFACIALHAIR)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Enter the game as a character with parts.
2. Expose those parts by changing clothes.
3. Actually, they're not exposed, sprite-wise. What?
4. Take off your shoes.
5. Now they're exposed. What?
6. Put your jumpsuit back on.
7. The sprites are still there. What?

Fixes that. Fixes #12730.

## Why It's Good For The Game

That's a dumb situation.

You might wonder: hey, won't calling the update function every single time someone's inventory changes slow down the game? And the answer is: no. No, it won't. Premature optimization is the root of all evil. This updating takes pretty much zero time. Just don't think about it.

**Due to Chesterton's Fence, this should be tested before merging.**

## Changelog
:cl:
fix: a whole lot of jank regarding funny part sprite display.
/:cl: