### PR TITLE
active blocking now also considers a stamina damaging projectile's stamina damage to be .. damage

### DIFF
--- a/code/modules/mob/living/living_active_block.dm
+++ b/code/modules/mob/living/living_active_block.dm
@@ -181,9 +181,9 @@
 /// Apply the stamina damage to our user, notice how damage argument is stamina_amount.
 /obj/item/proc/active_block_do_stamina_damage(mob/living/owner, atom/object, stamina_amount, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 	if(istype(object, /obj/item/projectile))
-		var/obj/item/projectile/P = O
+		var/obj/item/projectile/P = object
 		if(P.stamina)
-			var/blocked = active_block_calculate_final_damage(owner, object, stamina, attack_text, attack_type, armour_penetration, attacker, def_zone, final_block_chance, block_return)
+			var/blocked = active_block_calculate_final_damage(owner, object, P.stamina, attack_text, attack_type, armour_penetration, attacker, def_zone, final_block_chance, block_return)
 			var/stam = active_block_stamina_cost(owner, object, blocked, attack_text, ATTACK_TYPE_PROJECTILE, armour_penetration, attacker, def_zone, final_block_chance, block_return)
 			stamina_amount += stam
 	var/datum/block_parry_data/data = get_block_parry_data()

--- a/code/modules/mob/living/living_active_block.dm
+++ b/code/modules/mob/living/living_active_block.dm
@@ -13,7 +13,7 @@
 	DelayNextAction(data.block_end_click_cd_add)
 	return TRUE
 
-/mob/living/proc/ACTIVE_BLOCK_START(obj/item/I)
+/mob/living/proc/active_block_start(obj/item/I)
 	if(combat_flags & (COMBAT_FLAG_ACTIVE_BLOCK_STARTING | COMBAT_FLAG_ACTIVE_BLOCKING))
 		return FALSE
 	if(!(I in held_items))
@@ -109,7 +109,7 @@
 		animate(src, pixel_x = get_standard_pixel_x_offset(), pixel_y = get_standard_pixel_y_offset(), time = 2.5, FALSE, SINE_EASING | EASE_IN, ANIMATION_END_NOW)
 		return
 	combat_flags &= ~(COMBAT_FLAG_ACTIVE_BLOCK_STARTING)
-	ACTIVE_BLOCK_START(I)
+	active_block_start(I)
 
 /**
   * Gets the first item we can that can block, but if that fails, default to active held item.COMSIG_ENABLE_COMBAT_MODE
@@ -180,6 +180,12 @@
 
 /// Apply the stamina damage to our user, notice how damage argument is stamina_amount.
 /obj/item/proc/active_block_do_stamina_damage(mob/living/owner, atom/object, stamina_amount, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
+	if(istype(object, /obj/item/projectile))
+		var/obj/item/projectile/P = O
+		if(P.stamina)
+			var/blocked = active_block_calculate_final_damage(owner, object, stamina, attack_text, attack_type, armour_penetration, attacker, def_zone, final_block_chance, block_return)
+			var/stam = active_block_stamina_cost(owner, object, blocked, attack_text, ATTACK_TYPE_PROJECTILE, armour_penetration, attacker, def_zone, final_block_chance, block_return)
+			stamina_amount += stam
 	var/datum/block_parry_data/data = get_block_parry_data()
 	if(iscarbon(owner))
 		var/mob/living/carbon/C = owner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ok so story time

projectiles have a primary damage type, that can be STAMINA, in the case of things like disablers

but they also have a stamina variable that allows them to do additional stamina. this is bad right now because say you have a projectile that does 5 brute and 60 stam, and you have a shield blocking 75% of damage. this affects both since apply effects scans the return list for how efficient your block is but it isn't taken into account for stamina dealt to the user, so you're blocking all that damage for free
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

honestly i'm not sure if i should do this because it makes sense for shields to be good vs things that are meant to drain stamina vs outright damage, but gameplay-wise it's pretty terrible for some stamina-focused ballistics to be nearly useless on anyone with a shield. it'll still be bad with this just not nearly as bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
tweak: stamina draining projectiles without stamina for their primary damage type now has their stamina damage taken into account for shield blocking, rather than the block being done for free for that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
