### PR TITLE
PDA Uplinks Can Now Siphon Pens

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1027,6 +1027,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	else if(is_type_in_list(C, contained_item)) //Checks if there is a pen
 		if(inserted_item)
 			to_chat(user, "<span class='warning'>There is already \a [inserted_item] in \the [src]!</span>")
+			return ..()
 		else
 			if(!user.transferItemToLoc(C, src))
 				return


### PR DESCRIPTION
## About The Pull Request
see title
![image](https://user-images.githubusercontent.com/31829017/89725247-1876ff00-d9d3-11ea-8863-3e9996286ba7.png)

## Why It's Good For The Game
if i beat the shit out of a guy for his uplink and i steal it i want to be able to steal his funny antagbucks god damn it
## Changelog
:cl:
fix: PDA uplinks can now steal from pens. Properly. Just make sure to have a pen in your PDA, first.
/:cl: