### PR TITLE
funny timestop katana is less funny and more gameplay oriented

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -252,6 +252,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/katana/timestop
 	name = "temporal katana"
 	desc = "Delicately balanced, this finely-crafted blade hums with barely-restrained potential."
+	block_chance = 0 // oops
+	force = 27.5 // oops
 	item_flags = ITEM_CAN_PARRY
 	block_parry_data = /datum/block_parry_data/bokken/quick_parry/proj
 
@@ -259,7 +261,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	if(ishuman(owner))
 		var/mob/living/carbon/human/flynn = owner
 		flynn.emote("smirk")
-	new /obj/effect/timestop(get_turf(owner), 2, 50, list(owner))
+	new /obj/effect/timestop/magic(get_turf(owner), 1, 50, list(owner)) // null roddies counter
 
 /obj/item/melee/bokken // parrying stick
 	name = "bokken"


### PR DESCRIPTION
## About The Pull Request
nerfs the funny timestop katana:
- timestop radius is now 3x3 centered on user
- force dropped to 27.5 (*2.5 = 68.75 force on parry)
- timestop now respects antimagic
- the fucking rng blockchance that was there?? gone
- you still autosmirk on parry though no biggie
## Why It's Good For The Game
holy shit i cant believe i let this get merged lmao
## Changelog
:cl:
balance: The temporal katana is now slightly more worthy of the 2 spell point cost, with a smaller, antimagic respecting timestop, less force, and no random blockchance. Society has progressed past the need for blockchance.
/:cl: