### PR TITLE
rebalances shotgun shell stripper clips since no one else wants to

### DIFF
--- a/code/__DEFINES/storage/volumetrics.dm
+++ b/code/__DEFINES/storage/volumetrics.dm
@@ -24,7 +24,10 @@ GLOBAL_LIST_INIT(default_weight_class_to_volume, list(
 // Let's keep all of this in one place. given what we put above anyways..
 
 // volume amount for items
+/// volume for a data disk
 #define ITEM_VOLUME_DISK					1
+/// volume for a shotgun stripper clip holding 4 shells
+#define ITEM_VOLUME_STRIPPER_CLIP			(DEFAULT_VOLUME_NORMAL * 0.5)
 
 // #define SAMPLE_VOLUME_AMOUNT 2
 

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -144,6 +144,9 @@
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "shotgunclip"
 	caliber = "shotgun" // slapped in to allow shell mix n match
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKET
+	w_class = WEIGHT_CLASS_NORMAL
+	w_volume = ITEM_VOLUME_STRIPPER_CLIP
 	ammo_type = /obj/item/ammo_casing/shotgun
 	max_ammo = 4
 	var/pixeloffsetx = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

stripper clips are now normal sized items, taking up half the space of a box. yes, you can cram one more shell for the same space with these now, not 21 more shells. in a box. they fit in pockets, so if you are fine with sparing those slots i suppose you have won the (power)game.

no use time nerf yet mostly because i am too lazy to code a whlie(shells_left) do_after() loop but if someone else pr's it i will accept it .
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

i'm not srue who decided taking away the one disadvantage of "i used the shotgun" is a good idea but it's not
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:silicons
balance: no more shotgun stripper clips in boxes. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
