### PR TITLE
load_delay var for /obj/item/ammo_box, nerfs shotgun stripper clips (hatter why'd you pr them)

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -80,17 +80,16 @@
 	if(!can_load(user))
 		return
 	if(istype(A, /obj/item/ammo_box))
-		if(load_delay)
-			if(!do_after(user, load_delay, target = src))
-				return
+
 		var/obj/item/ammo_box/AM = A
 		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
-			var/did_load = give_round(AC, replace_spent)
-			if(did_load)
-				AM.stored_ammo -= AC
-				num_loaded++
-			if(!did_load || !multiload)
-				break
+			if(load_delay && do_after(user, load_delay, target = src))
+				var/did_load = give_round(AC, replace_spent)
+				if(did_load)
+					AM.stored_ammo -= AC
+					num_loaded++
+				if(!did_load || !multiload)
+					break
 	if(istype(A, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/AC = A
 		if(give_round(AC, replace_spent))

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -20,6 +20,7 @@
 	var/caliber
 	var/multiload = 1
 	var/start_empty = 0
+	var/load_delay = 0 //how long do we take to load (deciseconds)
 	var/list/bullet_cost
 	var/list/base_cost// override this one as well if you override bullet_cost
 
@@ -79,6 +80,9 @@
 	if(!can_load(user))
 		return
 	if(istype(A, /obj/item/ammo_box))
+		if(load_delay)
+			if(!do_after(user, load_delay, target = src))
+				return
 		var/obj/item/ammo_box/AM = A
 		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
 			var/did_load = give_round(AC, replace_spent)

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -76,11 +76,12 @@
 	return 1
 
 /obj/item/ammo_box/attackby(obj/item/A, mob/user, params, silent = FALSE, replace_spent = 0)
+	if(INTERACTING_WITH(user, A))
+		return FALSE
 	var/num_loaded = 0
 	if(!can_load(user))
 		return
 	if(istype(A, /obj/item/ammo_box))
-
 		var/obj/item/ammo_box/AM = A
 		for(var/obj/item/ammo_casing/AC in AM.stored_ammo)
 			if(load_delay && do_after(user, load_delay, target = src))

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -148,6 +148,8 @@
 	max_ammo = 4
 	var/pixeloffsetx = 4
 	start_empty = TRUE
+	multiload = FALSE
+	load_delay = 2 //2ds
 
 /obj/item/ammo_box/shotgun/update_overlays()
 	. = ..()

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -149,7 +149,7 @@
 	var/pixeloffsetx = 4
 	start_empty = TRUE
 	multiload = FALSE
-	load_delay = 2 //2ds
+	load_delay = 6 //6ds
 
 /obj/item/ammo_box/shotgun/update_overlays()
 	. = ..()


### PR DESCRIPTION
allows you to set a `load_delay` var for `/obj/item/ammo_box`. on hitting a magazine (or gun with internal magazine) with a `/obj/item/ammo_box` with `load_delay`, it'll run a do_after for `load_delay` seconds.

shotgun stripper clips now have a load_delay of 0.6 seconds

shotgun stripper clips now only load one shot at a time- as far as i'm aware we don't have shotguns with internal box magazines, so you're either
1. loading a doublebarrel with a 4-round stripper clip. 
2. loading a triplebarrel with a 4-round stripper clip 
3. loading a tube magazine with a stripper clip. use a speedtube idiot.

all of these are fucking stupid and you should be fumbling around with them.

## Changelog
:cl:
balance: shotgun stripper clip nerf. ammoboxes can now accept a load_delay that happens when they attack a magazine, internal or external.
/:cl:

