### PR TITLE
Moved dice from pill_bottles to boxes on cogStation

### DIFF
--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -8607,7 +8607,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/box/dice,
 /obj/item/toy/cards/deck,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -16804,7 +16804,7 @@
 /area/bridge)
 "aKw" = (
 /obj/structure/table,
-/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/box/dice,
 /obj/item/toy/cards/deck,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31910,7 +31910,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/item/storage/pill_bottle/dice,
+/obj/item/storage/box/dice,
 /obj/item/toy/cards/deck,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1


### PR DESCRIPTION
## About The Pull Request

Following up on #12646
Changes dice typing so cogstation stops breaking.

## Why It's Good For The Game

Fixes CogStation dice.

## Changelog
:cl:
fix: Moves pill_bottles/dice to box/dice on CogStation.
/:cl: