### PR TITLE
the station charter rename now disallows any name with characters above a single byte in length unless an admin edits it to allow unicode

### DIFF
--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -49,7 +49,7 @@
 
 	if(!new_name)
 		return
-	if(!unicode_allowed && (length(new_name) != length_char(new_name)))
+	if(!allow_unicode && (length(new_name) != length_char(new_name)))
 		to_chat(user, "Unicode is not allowed. Adminhelp if you want to use it so badly.")
 		return
 	log_game("[key_name(user)] has proposed to name the station as \

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -13,6 +13,7 @@
 	var/ignores_timeout = FALSE
 	var/response_timer_id = null
 	var/approval_time = 600
+	var/allow_unicode = FALSE
 
 	var/static/regex/standard_station_regex
 
@@ -47,6 +48,9 @@
 		return
 
 	if(!new_name)
+		return
+	if(!unicode_allowed && (length(new_name) != length_char(new_name)))
+		to_chat(user, "Unicode is not allowed. Adminhelp if you want to use it so badly.")
 		return
 	log_game("[key_name(user)] has proposed to name the station as \
 		[new_name]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes fun
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

i'm going to go absolutely bananas if people don't stop naming the station things that will get us put on a watchlist
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: silicons
admin: stations can no longer be renamed unicode names unless an admin varedits the charter to allow_unicode = 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
