### PR TITLE
Gives ashwalkers night vision eyeballs

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -52,6 +52,7 @@
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
 	inherent_traits = list(TRAIT_CHUNKYFINGERS)
 	mutantlungs = /obj/item/organ/lungs/ashwalker
+	mutanteyes = /obj/item/organ/eyes/night_vision
 	burnmod = 0.9
 	brutemod = 0.9
 	species_language_holder = /datum/language_holder/lizard/ash


### PR DESCRIPTION
## About The Pull Request

Gives ashwalkers the same eyeballs as nightmares, letting them see in the dark better.

## Why It's Good For The Game

A race born in the dark ashes of a planet covered in a dull lava, bred to kill or be killed in a hostile environment, hunting foreign skywalkers who are stripping the land of cover and materials. Also they have tiny lamps because they're sad :((

It's a small buff, but it helps out ashwalkers immensely by letting them decide when to go down certain areas, they can better setup traps than miners, and know where the fauna are easier.

## Changelog
:cl:
add: Gives ashwalkers nightvision
/:cl: