### PR TITLE
vehicle rider headshots

### DIFF
--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -170,6 +170,6 @@
 
 /obj/vehicle/bullet_act(obj/item/projectile/Proj) //wrapper
 	if (!enclosed && occupants && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit drivers
-		occupants.bullet_act(Proj) //i'm sure that ATV will protect you against a dink, idiot
+		occupants[1].bullet_act(Proj) // driver dinkage
 		return BULLET_ACT_HIT
 	. = ..()

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -168,8 +168,8 @@
 		var/dir_to_move = get_dir(trailer.loc, newloc)
 		step(trailer, dir_to_move)
 
-/obj/vehicle/bullet_act(obj/projectile/Proj) //wrapper
-	if (!enclosed && occupant && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit drivers
-		occupant.bullet_act(Proj) //i'm sure that ATV will protect you against a dink, idiot
+/obj/vehicle/bullet_act(obj/item/projectile/Proj) //wrapper
+	if (!enclosed && occupants && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit drivers
+		occupants.bullet_act(Proj) //i'm sure that ATV will protect you against a dink, idiot
 		return BULLET_ACT_HIT
 	. = ..()

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -18,6 +18,7 @@
 	var/canmove = TRUE
 	var/emulate_door_bumps = TRUE	//when bumping a door try to make occupants bump them to open them.
 	var/default_driver_move = TRUE	//handle driver movement instead of letting something else do it like riding datums.
+	var/enclosed = FALSE	// is the rider protected from bullets? assume no
 	var/list/autogrant_actions_passenger	//plain list of typepaths
 	var/list/autogrant_actions_controller	//assoc list "[bitflag]" = list(typepaths)
 	var/list/mob/occupant_actions			//assoc list mob = list(type = action datum assigned to mob)
@@ -166,3 +167,9 @@
 	if(trailer && .)
 		var/dir_to_move = get_dir(trailer.loc, newloc)
 		step(trailer, dir_to_move)
+
+/obj/vehicle/bullet_act(obj/projectile/Proj) //wrapper
+	if (!enclosed && occupant && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit drivers
+		occupant.bullet_act(Proj) //i'm sure that ATV will protect you against a dink, idiot
+		return BULLET_ACT_HIT
+	. = ..()

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -169,7 +169,7 @@
 		step(trailer, dir_to_move)
 
 /obj/vehicle/bullet_act(obj/item/projectile/Proj) //wrapper
-	if (!enclosed && occupants && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit drivers
+	if (!enclosed && length(occupants) && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit drivers
 		occupants[1].bullet_act(Proj) // driver dinkage
 		return BULLET_ACT_HIT
 	. = ..()

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -1,4 +1,5 @@
 /obj/vehicle/sealed
+	enclosed = TRUE // you're in a sealed vehicle dont get dinked idiot
 	var/enter_delay = 20
 	flags_1 = BLOCK_FACE_ATOM_1
 


### PR DESCRIPTION
## About The Pull Request
vehicles (secways, ATVs, etc) now default to dinking occupant(s) in the face with bullets if you're aiming for head/chest
## Why It's Good For The Game
nice bullet deflect idiot
## Changelog
:cl:
balance: Vehicle riders can now, by default, get shot in the face and/or chest.
/:cl: