### PR TITLE
chaplain nullrod nerf

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -342,8 +342,8 @@
 	name = "divine lightblade"
 	desc = "A giant blade of bright and holy light, said to cut down the wicked with ease."
 	force = 5
-	block_chance = 50
 	armour_penetration = 0
+	block_parry_data = /datum/block_parry_data/chair
 	var/chaplain_spawnable = TRUE
 	can_reflect = FALSE
 	obj_flags = UNIQUE_RENAME

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -343,10 +343,28 @@
 	desc = "A giant blade of bright and holy light, said to cut down the wicked with ease."
 	force = 5
 	armour_penetration = 0
-	block_parry_data = /datum/block_parry_data/chair
+	block_parry_data = /datum/block_parry_data/chaplain
 	var/chaplain_spawnable = TRUE
 	can_reflect = FALSE
 	obj_flags = UNIQUE_RENAME
+
+/datum/block_parry_data/chaplain
+	parry_stamina_cost = 12
+	parry_time_windup = 2
+	parry_time_active = 5
+	parry_time_spindown = 3
+	// parry_flags = PARRY_DEFAULT_HANDLE_FEEDBACK
+	parry_time_perfect = 1
+	parry_time_perfect_leeway = 1
+	parry_imperfect_falloff_percent = 7.5
+	parry_efficiency_to_counterattack = 100
+	parry_efficiency_considered_successful = 80
+	parry_efficiency_perfect = 120
+	parry_efficiency_perfect_override = list(
+		TEXT_ATTACK_TYPE_PROJECTILE = 30,
+	)
+	parry_failed_stagger_duration = 3 SECONDS
+	parry_failed_clickcd_duration = 2 SECONDS
 
 /obj/item/dualsaber/hypereutactic/chaplain/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

nerfs the chaplain's variant of hypereut because it inherited the parry data of deswords.
also removes the 50% block.

## Why It's Good For The Game

maybe hypereut having the parry data of a weapon that costs somewhere about 12-16 tc isn't a good idea, especially if it's a roundstart nullrod. removes the innate blockchance that it had as well, because rng block is bad.

## Changelog
:cl:
balance: nerfed hypereut chaplain weapon.
balance: 50% rng blockchance -> 0%
balance: parry made much worse because it's an actual weapon and a roundstart one at that.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
