### PR TITLE
You Can No Longer Remove The Inferno Part Of Disco Inferno (tgstation/tgstation#52823)

### DIFF
--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -94,7 +94,7 @@
 /turf/open/floor/light/colour_cycle,
 /area/shuttle/escape)
 "r" = (
-/turf/open/floor/mineral/plasma,
+/turf/open/floor/mineral/plasma/disco,
 /area/shuttle/escape)
 "s" = (
 /turf/open/floor/mineral/silver,
@@ -112,7 +112,7 @@
 	resistance_flags = 2
 	},
 /obj/structure/fans/tiny,
-/turf/open/floor/mineral/plasma,
+/turf/open/floor/mineral/plasma/disco,
 /area/shuttle/escape)
 "v" = (
 /obj/machinery/jukebox/disco/indestructible,

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -60,6 +60,8 @@
 
 // Plasma floor that can't be removed, for disco
 
+/turf/open/floor/material/plasma/disco
+	name = "disco floor"
 /turf/open/floor/material/plasma/disco/crowbar_act(mob/living/user, obj/item/I)
 	return
 

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -58,6 +58,10 @@
 	if(exposed_temperature > 300)
 		PlasmaBurn(exposed_temperature)
 
+// Plasma floor that can't be removed, for disco
+
+/turf/open/floor/material/plasma/disco/crowbar_act(mob/living/user, obj/item/I)
+	return
 
 //GOLD
 

--- a/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -60,9 +60,9 @@
 
 // Plasma floor that can't be removed, for disco
 
-/turf/open/floor/material/plasma/disco
+/turf/open/floor/mineral/plasma/disco
 	name = "disco floor"
-/turf/open/floor/material/plasma/disco/crowbar_act(mob/living/user, obj/item/I)
+/turf/open/floor/mineral/plasma/disco/crowbar_act(mob/living/user, obj/item/I)
 	return
 
 //GOLD


### PR DESCRIPTION

## About The Pull Request
makes the plasma floors on disco a special uncrowbarrable version
port of https://github.com/tgstation/tgstation/pull/52823
## Why It's Good For The Game

you can no longer defeat the entire point of a shuttle with something everyone has in their backpack

## Changelog
:cl:
add: uncrowbarrable plasma floors
tweak:disco inferno's plasma floors can no longer be crowbarred.
/:cl:
