### PR TITLE
Makes Public Autolathe Non Secure

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -58688,7 +58688,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
 "sRH" = (
-/obj/machinery/autolathe/secure{
+/obj/machinery/autolathe{
 	name = "public autolathe"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -31245,7 +31245,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/machinery/autolathe/secure{
+/obj/machinery/autolathe{
 	name = "public autolathe"
 	},
 /obj/effect/turf_decal/bot,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -35115,7 +35115,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/autolathe/secure{
+/obj/machinery/autolathe{
 	name = "public autolathe"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -32078,7 +32078,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/autolathe/secure{
+/obj/machinery/autolathe{
 	name = "public autolathe"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Snaxi/Snaxi.dmm
+++ b/_maps/map_files/Snaxi/Snaxi.dmm
@@ -9710,7 +9710,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/autolathe/secure{
+/obj/machinery/autolathe{
 	name = "public autolathe"
 	},
 /turf/open/floor/plasteel,


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I like a lot of things in the autolathe that aren't available in the secure lathe, and I don't like going to the public lathe just to realize I have to go to the autolathe inside of cargo to get what I want.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People don't have to break into cargo "AS" much.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed secure from public lathes
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
