### PR TITLE
Dynamic: tweaks and fixes: the reckoning

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_storytellers.dm
+++ b/code/game/gamemodes/dynamic/dynamic_storytellers.dm
@@ -50,10 +50,6 @@ Property weights are:
 	for(var/r in SSevents.running)
 		var/datum/round_event/R = r
 		threat += R.threat()
-	for(var/mob/living/simple_animal/hostile/H in GLOB.mob_living_list)
-		var/turf/T = get_turf(H)
-		if(H.stat != DEAD && is_station_level(T.z) && !("Station" in H.faction))
-			threat += H.threat()
 	for(var/obj/item/phylactery/P in GLOB.poi_list)
 		threat += 25 // can't be giving them too much of a break
 	for (var/mob/M in mode.current_players[CURRENT_LIVING_PLAYERS])
@@ -91,6 +87,8 @@ Property weights are:
 							mean += 2.5
 						if(CHAOS_MAX)
 							mean += 5
+				else
+					voters += 0.5
 			if(voters)
 				GLOB.dynamic_curve_centre += (mean/voters)
 		if(flags & USE_PREV_ROUND_WEIGHTS)
@@ -128,7 +126,8 @@ Property weights are:
 				for(var/property in property_weights)
 					if(property in rule.property_weights) // just treat it as 0 if it's not in there
 						property_weight += rule.property_weights[property] * property_weights[property]
-				drafted_rules[rule] = (rule.get_weight() * property_weight)*rule.weight_mult
+				if(property_weight > 0)
+					drafted_rules[rule] = rule.get_weight() * property_weight * rule.weight_mult
 	return drafted_rules
 
 /datum/dynamic_storyteller/proc/midround_draft()
@@ -140,25 +139,26 @@ Property weights are:
 			if (GLOB.dynamic_classic_secret && !((rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)))
 				continue
 			rule.trim_candidates()
-			var/threat_weight = 1
-			if(!(rule.flags & MINOR_RULESET)) // makes the traitor rulesets always possible anyway
-				var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
-				/*	Basically, the closer the cost is to the current threat-level-away-from-threat, the more likely it is to
-					pick this particular ruleset.
-					Let's use a toy example: there's 60 threat level and 10 threat spent.
-					We want to pick a ruleset that's close to that, so we run the below equation, on two rulesets.
-					Ruleset 1 has 30 cost, ruleset 2 has 5 cost.
-					When we do the math, ruleset 1's threat_weight is 0.538, and ruleset 2's is 0.238, meaning ruleset 1
-					is 2.26 times as likely to be picked, all other things considered.
-					Of course, we don't want it to GUARANTEE the closest, that's no fun, so it's just a weight.
-				*/
-				threat_weight = abs(1-abs(1-LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
 			if (rule.ready())
 				var/property_weight = 0
 				for(var/property in property_weights)
-					if(property in rule.property_weights)
+					if(property in rule.property_weights) // just treat it as 0 if it's not in there
 						property_weight += rule.property_weights[property] * property_weights[property]
-				drafted_rules[rule] = round(((rule.get_weight() * property_weight)*rule.weight_mult*threat_weight)*1000,1)
+				if(property_weight > 0)
+					var/threat_weight = 1
+					if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)) // makes the traitor rulesets always possible anyway
+						var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
+						/*	Basically, the closer the cost is to the current threat-level-away-from-threat, the more likely it is to
+							pick this particular ruleset.
+							Let's use a toy example: there's 60 threat level and 10 threat spent.
+							We want to pick a ruleset that's close to that, so we run the below equation, on two rulesets.
+							Ruleset 1 has 30 cost, ruleset 2 has 5 cost.
+							When we do the math, ruleset 1's threat_weight is 0.538, and ruleset 2's is 0.238, meaning ruleset 1
+							is 2.26 times as likely to be picked, all other things considered.
+							Of course, we don't want it to GUARANTEE the closest, that's no fun, so it's just a weight.
+						*/
+						threat_weight = abs(1-abs(1-LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
+					drafted_rules[rule] = rule.get_weight() * property_weight * rule.weight_mult * threat_weight
 	return drafted_rules
 
 /datum/dynamic_storyteller/proc/latejoin_draft(mob/living/carbon/human/newPlayer)
@@ -175,28 +175,29 @@ Property weights are:
 
 			rule.candidates = list(newPlayer)
 			rule.trim_candidates()
-			var/threat_weight = 1
-			if(!(rule.flags & MINOR_RULESET))
-				var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
-				threat_weight = 1-abs(1-(LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
 			if (rule.ready())
 				var/property_weight = 0
 				for(var/property in property_weights)
 					if(property in rule.property_weights)
 						property_weight += rule.property_weights[property] * property_weights[property]
-				drafted_rules[rule] = round(((rule.get_weight() * property_weight)*rule.weight_mult*threat_weight)*1000,1)
+				if(property_weight > 0)
+					var/threat_weight = 1
+					if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET))
+						var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
+						threat_weight = 1-abs(1-(LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
+					drafted_rules[rule] = rule.get_weight() * property_weight * rule.weight_mult * threat_weight
 	return drafted_rules
 
 /datum/dynamic_storyteller/proc/event_draft()
 	var/list/drafted_rules = list()
 	for(var/datum/dynamic_ruleset/event/rule in mode.events)
-		if(rule.acceptable(mode.current_players[CURRENT_LIVING_PLAYERS].len, mode.threat_level) && (mode.threat_level - mode.threat) >= rule.cost)
-			if(rule.ready())
-				var/property_weight = 0
-				for(var/property in property_weights)
-					if(property in rule.property_weights)
-						property_weight += rule.property_weights[property] * property_weights[property]
-				drafted_rules[rule] = (rule.get_weight() + property_weight)*rule.weight_mult
+		if(rule.acceptable(mode.current_players[CURRENT_LIVING_PLAYERS].len, mode.threat_level) && (mode.threat_level + 20 - mode.threat) >= rule.cost && rule.ready())
+			var/property_weight = 0
+			for(var/property in property_weights)
+				if(property in rule.property_weights)
+					property_weight += rule.property_weights[property] * property_weights[property]
+			if(property_weight > 0)
+				drafted_rules[rule] = rule.get_weight() + property_weight * rule.weight_mult
 	return drafted_rules
 
 
@@ -313,9 +314,8 @@ Property weights are:
 /datum/dynamic_storyteller/random/event_draft()
 	var/list/drafted_rules = list()
 	for(var/datum/dynamic_ruleset/event/rule in mode.events)
-		if(rule.acceptable(mode.current_players[CURRENT_LIVING_PLAYERS].len, mode.threat_level))
-			if(rule.ready())
-				drafted_rules[rule] = 1
+		if(rule.acceptable(mode.current_players[CURRENT_LIVING_PLAYERS].len, mode.threat_level) && rule.ready())
+			drafted_rules[rule] = 1
 	return drafted_rules
 
 /datum/dynamic_storyteller/story
@@ -330,7 +330,7 @@ Property weights are:
 
 /datum/dynamic_storyteller/story/calculate_threat()
 	var/current_time = (world.time / SSautotransfer.targettime)*180
-	mode.threat_level = round(mode.initial_threat_level*(sin(current_time)+0.25),0.1)
+	mode.threat_level = round((mode.initial_threat_level*(sin(current_time)/2)+0.75),0.1)
 	return ..()
 
 /datum/dynamic_storyteller/classic

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -268,7 +268,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	. = CONFIG_GET(keyed_list/antag_threat)[lowertext(name)]
 	if(. == null)
 		return threat
-	return threat
 
 //This one is created by admin tools for custom objectives
 /datum/antagonist/custom

--- a/code/modules/antagonists/blob/blob.dm
+++ b/code/modules/antagonists/blob/blob.dm
@@ -4,10 +4,16 @@
 	antagpanel_category = "Blob"
 	show_to_ghosts = TRUE
 	job_rank = ROLE_BLOB
-	threat = 20
+	threat = 50
 	var/datum/action/innate/blobpop/pop_action
 	var/starting_points_human_blob = 60
 	var/point_rate_human_blob = 2
+
+/datum/antagonist/blob/threat()
+	. = ..()
+	if(isovermind(owner.current))
+		var/mob/camera/blob/overmind = owner.current
+		. *= (overmind.blobs_legit.len / overmind.max_count)
 
 /datum/antagonist/blob/roundend_report()
 	var/basic_report = ..()

--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -75,7 +75,6 @@
 	desc = "A floating, fragile spore."
 	icon_state = "blobpod"
 	icon_living = "blobpod"
-	threat = 0.2
 	health = 30
 	maxHealth = 30
 	verb_say = "psychically pulses"

--- a/code/modules/antagonists/clockcult/clock_mobs.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs.dm
@@ -6,7 +6,6 @@
 	unique_name = 1
 	minbodytemp = 0
 	unsuitable_atmos_damage = 0
-	threat = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0) //Robotic
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	healable = FALSE

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -9,7 +9,6 @@
 	desc = "The stalwart apparition of a soldier, blazing with crimson flames. It's armed with a gladius and shield."
 	icon_state = "clockwork_marauder"
 	mob_biotypes = MOB_HUMANOID
-	threat = 3
 	health = 120
 	maxHealth = 120
 	force_threshold = 8

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -70,7 +70,6 @@
 	icon_living = "swarmer"
 	icon_dead = "swarmer_unactivated"
 	icon_gib = null
-	threat = 0.5
 	wander = 0
 	harm_intent_damage = 5
 	minbodytemp = 0

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -16,6 +16,18 @@
 	var/datum/team/xeno/xeno_team
 	threat = 3
 
+/datum/antagonist/xeno/threat()
+	. = 1
+	if(isalienhunter(owner))
+		. = 2
+	else if(isaliensentinel(owner))
+		. = 4
+	else if(isalienroyal(owner))
+		if(isalienqueen(owner))
+			. = 8
+		else
+			. = 6
+
 /datum/antagonist/xeno/create_team(datum/team/xeno/new_team)
 	if(!new_team)
 		for(var/datum/antagonist/xeno/X in GLOB.antagonists)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -27,7 +27,6 @@
 									 "How do I vore people?",
 									 "ERP?",
 									 "Not epic bros...")
-	threat = 5
 
 
 /datum/round_event/brand_intelligence/announce(fake)

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -30,7 +30,6 @@
 	icon_dead = "magicarp_dead"
 	icon_gib = "magicarp_gib"
 	ranged = 1
-	threat = 4
 	retreat_distance = 2
 	minimum_distance = 0 //Between shots they can and will close in to nash
 	projectiletype = /obj/item/projectile/magic
@@ -52,7 +51,6 @@
 	color = "#00FFFF"
 	maxHealth = 75
 	health = 75
-	threat = 7
 
 /mob/living/simple_animal/hostile/carp/ranged/chaos/Shoot()
 	projectiletype = pick(allowed_projectile_types)

--- a/code/modules/holiday/halloween/halloween.dm
+++ b/code/modules/holiday/halloween/halloween.dm
@@ -190,7 +190,6 @@
 	icon_dead = "scary_clown"
 	icon_gib = "scary_clown"
 	speak = list("...", ". . .")
-	threat = 3
 	maxHealth = 120
 	health = 120
 	emote_see = list("silently stares")

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -11,7 +11,6 @@
 	response_disarm_simple = "flail at"
 	response_harm_continuous = "punches"
 	response_harm_simple = "punch"
-	threat = 1
 	speak_chance = 1
 	icon = 'icons/mob/mob.dmi'
 	speed = 0
@@ -122,7 +121,6 @@
 	desc = "A massive, armored construct built to spearhead attacks and soak up enemy fire."
 	icon_state = "behemoth"
 	icon_living = "behemoth"
-	threat = 3
 	maxHealth = 150
 	health = 150
 	response_harm_continuous = "harmlessly punches"
@@ -187,7 +185,6 @@
 	desc = "A wicked, clawed shell constructed to assassinate enemies and sow chaos behind enemy lines."
 	icon_state = "floating"
 	icon_living = "floating"
-	threat = 3
 	maxHealth = 65
 	health = 65
 	melee_damage_lower = 20

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -8,7 +8,6 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	name = "Guardian Spirit"
 	real_name = "Guardian Spirit"
 	desc = "A mysterious being that stands by its charge, ever vigilant."
-	threat = 5
 	speak_emote = list("hisses")
 	gender = NEUTER
 	mob_biotypes = NONE

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -7,7 +7,6 @@
 	icon_dead = "alienh_dead"
 	icon_gib = "syndicate_gib"
 	gender = FEMALE
-	threat = 1
 	response_help_continuous = "pokes"
 	response_help_simple = "poke"
 	response_disarm_continuous = "shoves"
@@ -69,7 +68,6 @@
 	icon_state = "aliens"
 	icon_living = "aliens"
 	icon_dead = "aliens_dead"
-	threat = 3
 	health = 150
 	maxHealth = 150
 	melee_damage_lower = 15
@@ -87,7 +85,6 @@
 	icon_living = "alienq"
 	icon_dead = "alienq_dead"
 	pixel_x = -16
-	threat = 8
 	health = 250
 	maxHealth = 250
 	melee_damage_lower = 15
@@ -167,7 +164,6 @@
 	name = "lusty xenomorph maid"
 	melee_damage_lower = 0
 	melee_damage_upper = 0
-	threat = -1
 	a_intent = INTENT_HELP
 	friendly_verb_continuous = "caresses"
 	friendly_verb_simple = "caress"

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -2,7 +2,6 @@
 /mob/living/simple_animal/hostile/bear
 	name = "space bear"
 	desc = "You don't need to be faster than a space bear, you just need to outrun your crewmates."
-	threat = 1
 	icon_state = "bear"
 	icon_living = "bear"
 	icon_dead = "bear_dead"

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -16,7 +16,6 @@
 	icon_state = ""
 	icon_living = ""
 	icon = 'icons/mob/bees.dmi'
-	threat = 0.3
 	gender = FEMALE
 	speak_emote = list("buzzes")
 	emote_hear = list("buzzes")

--- a/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
@@ -1,7 +1,6 @@
 /mob/living/simple_animal/hostile/boss
 	name = "A Perfectly Generic Boss Placeholder"
 	desc = ""
-	threat = 10
 	robust_searching = TRUE
 	stat_attack = UNCONSCIOUS
 	status_flags = NONE

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -7,7 +7,6 @@
 	icon_living = "carp"
 	icon_dead = "carp_dead"
 	icon_gib = "carp_gib"
-	threat = 0.1
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	speak_chance = 0
 	turns_per_move = 5
@@ -74,7 +73,6 @@
 	icon_living = "megacarp"
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
-	threat = 3
 	regen_amount = 6
 
 	maxHealth = 30
@@ -98,7 +96,6 @@
 	name = "Cayenne"
 	desc = "A failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
 	gender = FEMALE
-	threat = 5
 	regen_amount = 8
 
 	speak_emote = list("squeaks")

--- a/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
@@ -1,7 +1,6 @@
 /mob/living/simple_animal/hostile/dark_wizard
 	name = "Dark Wizard"
 	desc = "Killing amateurs since the dawn of times."
-	threat = 3
 	icon = 'icons/mob/simple_human.dmi'
 	icon_state = "dark_wizard"
 	icon_living = "dark_wizard"

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -4,7 +4,6 @@
 	icon_state = "faithless"
 	icon_living = "faithless"
 	icon_dead = "faithless_dead"
-	threat = 1
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	gender = MALE
 	speak_chance = 0

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -17,7 +17,6 @@
 
 //basic spider mob, these generally guard nests
 /mob/living/simple_animal/hostile/poison/giant_spider
-	threat = 1
 	name = "giant spider"
 	desc = "Furry and black, it makes you shudder to look at it. This one has deep red eyes."
 	icon_state = "guard"

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -9,7 +9,6 @@
 	icon_state = "crawling"
 	icon_living = "crawling"
 	icon_dead = "dead"
-	threat = 0.5
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 80
 	maxHealth = 220

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -6,7 +6,6 @@
 	icon_state = "headcrab"
 	icon_living = "headcrab"
 	icon_dead = "headcrab_dead"
-	threat = 1
 	gender = NEUTER
 	health = 50
 	maxHealth = 50

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -3,7 +3,6 @@
 	stop_automated_movement_when_pulled = 0
 	obj_damage = 40
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES //Bitflags. Set to ENVIRONMENT_SMASH_STRUCTURES to break closets,tables,racks, etc; ENVIRONMENT_SMASH_WALLS for walls; ENVIRONMENT_SMASH_RWALLS for rwalls
-	var/threat = 0 // for dynamic
 	var/atom/target
 	var/ranged = FALSE
 	var/rapid = 0 //How many shots per volley.
@@ -600,6 +599,3 @@ mob/living/simple_animal/hostile/proc/DestroySurroundings() // for use with mega
 				. += M
 			else if (M.loc.type in hostile_machines)
 				. += M.loc
-
-/mob/living/simple_animal/hostile/proc/threat()
-	return threat

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -11,7 +11,6 @@
 	icon_living = "leaper"
 	icon_dead = "leaper_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	threat = 2
 	maxHealth = 300
 	health = 300
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
@@ -8,7 +8,6 @@
 	icon_living = "arachnid"
 	icon_dead = "arachnid_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_BUG
-	threat = 2
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 	maxHealth = 300

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
@@ -14,7 +14,6 @@
 	icon_living = "mook"
 	icon_dead = "mook_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	threat = 0.5
 	pixel_x = -16
 	maxHealth = 45
 	health = 45

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -13,7 +13,6 @@
 	icon_state = "seedling"
 	icon_living = "seedling"
 	icon_dead = "seedling_dead"
-	threat = 0.5
 	maxHealth = 100
 	health = 100
 	melee_damage_lower = 30

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -5,7 +5,6 @@
 	icon_living = "tomato"
 	icon_dead = "tomato_dead"
 	gender = NEUTER
-	threat = 0.3
 	speak_chance = 0
 	turns_per_move = 5
 	maxHealth = 30

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -23,7 +23,6 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/blood_drunk_miner
 	name = "blood-drunk miner"
 	desc = "A miner destined to wander forever, engaged in an endless hunt."
-	threat = 15
 	health = 900
 	maxHealth = 900
 	icon_state = "miner"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -26,7 +26,6 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum
 	name = "bubblegum"
 	desc = "In what passes for a hierarchy among slaughter demons, this one is king."
-	threat = 35
 	health = 2500
 	maxHealth = 2500
 	attack_verb_continuous = "rends"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -24,7 +24,6 @@ Difficulty: Very Hard
 /mob/living/simple_animal/hostile/megafauna/colossus
 	name = "colossus"
 	desc = "A monstrous creature protected by heavy shielding."
-	threat = 40
 	health = 2500
 	maxHealth = 2500
 	attack_verb_continuous = "judges"
@@ -603,7 +602,6 @@ Difficulty: Very Hard
 	icon_state = "lightgeist"
 	icon_living = "lightgeist"
 	icon_dead = "butterfly_dead"
-	threat = -0.7
 	turns_per_move = 1
 	response_help_continuous = "waves away"
 	response_help_simple = "wave away"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -38,7 +38,6 @@ Difficulty: Medium
 /mob/living/simple_animal/hostile/megafauna/dragon
 	name = "ash drake"
 	desc = "Guardians of the necropolis."
-	threat = 30
 	health = 2500
 	maxHealth = 2500
 	spacewalk = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -37,7 +37,6 @@ Difficulty: Normal
 /mob/living/simple_animal/hostile/megafauna/hierophant
 	name = "hierophant"
 	desc = "A massive metal club that hangs in the air as though waiting. It'll make you dance to its beat."
-	threat = 30
 	health = 2500
 	maxHealth = 2500
 	attack_verb_continuous = "clubs"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -18,7 +18,6 @@ Difficulty: Medium
 
 /mob/living/simple_animal/hostile/megafauna/legion
 	name = "Legion"
-	threat = 30
 	health = 800
 	maxHealth = 800
 	spacewalk = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -8,7 +8,6 @@
 	icon_aggro = "Basilisk_alert"
 	icon_dead = "Basilisk_dead"
 	icon_gib = "syndicate_gib"
-	threat = 4
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	move_to_delay = 20
 	projectiletype = /obj/item/projectile/temp/basilisk

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
@@ -10,7 +10,6 @@
 	move_to_delay = 5
 	vision_range = 20
 	aggro_vision_range = 20
-	threat = 1
 	maxHealth = 40 //easy to kill, but oh, will you be seeing a lot of them.
 	health = 40
 	melee_damage_lower = 10

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -11,7 +11,6 @@
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
 	ranged = TRUE
-	threat = 5
 	obj_damage = 5
 	vision_range = 6
 	aggro_vision_range = 18

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -25,7 +25,6 @@
 	icon_aggro = "broodmother"
 	icon_dead = "egg_sac"
 	icon_gib = "syndicate_gib"
-	threat = 10
 	maxHealth = 800
 	health = 800
 	melee_damage_lower = 30

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -24,7 +24,6 @@
 	icon_aggro = "herald"
 	icon_dead = "herald_dying"
 	icon_gib = "syndicate_gib"
-	threat = 10
 	maxHealth = 800
 	health = 800
 	melee_damage_lower = 20

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -24,7 +24,6 @@
 	icon_aggro = "legionnaire"
 	icon_dead = "legionnaire_dead"
 	icon_gib = "syndicate_gib"
-	threat = 10
 	maxHealth = 800
 	health = 800
 	melee_damage_lower = 30

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -24,7 +24,6 @@
 	icon_aggro = "pandora"
 	icon_dead = "pandora_dead"
 	icon_gib = "syndicate_gib"
-	threat = 10
 	maxHealth = 800
 	health = 800
 	melee_damage_lower = 15

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -8,7 +8,6 @@
 	icon_aggro = "Goldgrub_alert"
 	icon_dead = "Goldgrub_dead"
 	icon_gib = "syndicate_gib"
-	threat = 0.2
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	vision_range = 2
 	aggro_vision_range = 9

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -10,7 +10,6 @@
 	icon_gib = "syndicate_gib"
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	threat = 2
 	move_to_delay = 10
 	ranged = 1
 	ranged_cooldown_time = 60

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -9,7 +9,6 @@
 	icon_gib = "syndicate_gib"
 	mob_biotypes = MOB_ORGANIC
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	threat = 4
 	move_to_delay = 14
 	ranged = 1
 	vision_range = 4
@@ -241,7 +240,6 @@
 	icon_state = "legion"
 	icon_living = "legion"
 	icon_dead = "legion"
-	threat = 5
 	health = 450
 	maxHealth = 450
 	melee_damage_lower = 20

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -10,7 +10,6 @@
 	obj_damage = 100
 	melee_damage_lower = 25
 	melee_damage_upper = 50
-	threat = 2
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -10,7 +10,6 @@
 	turns_per_move = 5
 	response_help_continuous = "pushes"
 	response_help_simple = "push"
-	threat = 3
 	speed = 0
 	maxHealth = 115
 	health = 115

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -10,7 +10,6 @@
 	speak_chance = 0
 	turns_per_move = 5
 	speed = 0
-	threat = 1
 	maxHealth = 100
 	health = 100
 	harm_intent_damage = 5

--- a/code/modules/mob/living/simple_animal/hostile/sharks.dm
+++ b/code/modules/mob/living/simple_animal/hostile/sharks.dm
@@ -19,7 +19,6 @@
 	response_harm_continuous = "kicks"
 	response_harm_simple = "kick"
 	speed = 0
-	threat = 1
 	maxHealth = 75
 	health = 75
 	harm_intent_damage = 18

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -11,7 +11,6 @@
 	speak_emote = list("rattles")
 	emote_see = list("rattles")
 	a_intent = INTENT_HARM
-	threat = 0.5
 	maxHealth = 40
 	blood_volume = 0
 	health = 40
@@ -64,7 +63,6 @@
 	icon_state = "templar"
 	icon_living = "templar"
 	icon_dead = "templar_dead"
-	threat = 1.5
 	maxHealth = 150
 	health = 150
 	weather_immunities = list("snow")
@@ -98,7 +96,6 @@
 	icon_state = "plasma_miner"
 	icon_living = "plasma_miner"
 	icon_dead = "plasma_miner"
-	threat = 2
 	maxHealth = 150
 	health = 150
 	harm_intent_damage = 10
@@ -116,7 +113,6 @@
 	icon_state = "plasma_miner_tool"
 	icon_living = "plasma_miner_tool"
 	icon_dead = "plasma_miner_tool"
-	threat = 3
 	maxHealth = 185
 	health = 185
 	harm_intent_damage = 15

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -10,7 +10,6 @@
 	gender = NEUTER
 	a_intent = INTENT_HARM
 	mob_biotypes = MOB_HUMANOID
-	threat = 3
 	response_help_continuous = "touches"
 	response_help_simple = "touch"
 	response_disarm_continuous = "pushes"

--- a/code/modules/mob/living/simple_animal/hostile/stickman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stickman.dm
@@ -5,7 +5,6 @@
 	icon_living = "stickman"
 	icon_dead = "stickman_dead"
 	icon_gib = "syndicate_gib"
-	threat = 0.5
 	mob_biotypes = MOB_HUMANOID
 	gender = MALE
 	speak_chance = 0

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -25,7 +25,6 @@
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
 	turns_per_move = 5
-	threat = 1
 	speed = 0
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -7,7 +7,6 @@
 	icon_dead = "pine_1"
 	icon_gib = "pine_1"
 	gender = NEUTER
-	threat = 1
 	speak_chance = 0
 	turns_per_move = 5
 	response_help_continuous = "brushes"

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -8,7 +8,6 @@
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
 	turns_per_move = 3
-	threat = 3
 	speed = 0
 	maxHealth = 100
 	health = 100

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -11,7 +11,6 @@
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	mouse_opacity = MOUSE_OPACITY_ICON
 	move_to_delay = 5
-	threat = 1
 	friendly_verb_continuous = "floats near"
 	friendly_verb_simple = "float near"
 	speak_emote = list("puffs")

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -7,7 +7,6 @@
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	speak_chance = 0
 	stat_attack = UNCONSCIOUS //braains
-	threat = 1
 	maxHealth = 100
 	health = 100
 	harm_intent_damage = 5

--- a/code/modules/ruins/spaceruin_code/clericsden.dm
+++ b/code/modules/ruins/spaceruin_code/clericsden.dm
@@ -21,7 +21,6 @@
 	desc = "A weaker construct meant to scour ruins for objects of Nar'Sie's affection. Those barbed claws are no joke."
 	icon_state = "proteon"
 	icon_living = "proteon"
-	threat = 0.4
 	maxHealth = 35
 	health = 35
 	melee_damage_lower = 8


### PR DESCRIPTION
## About The Pull Request

Removed simplemobs counting for dynamic at all. Carp migration causing threat to go up was getting super old.

Made the "story" storyteller's curve half as tall. The minimum is now twice what it was, maximum is the same.

To make up for no longer counting inherently to threat, xeno antag now has threat scale with xeno type.

Blob threat now scales with blob coverage; instead of a flat 20, it's now 0-50, where 0 is "dead" and 50 is "will win the game next process".

Preferences are now half-counted "neutral" for individuals with no pref set.

Rulesets are now filtered out if they have negative weight, before pickweight is ever called on them. This will probably fix the "no roundstart antags" thing.

## Why It's Good For The Game

i kinda really do want dynamic to work y'know

## Changelog
:cl:
balance: Simplemobs no longer count in dynamic.
balance: "Story" storyteller no longer starts at a ludicrously low threat, always.
balance: Blob threat now scales with coverage.
tweak: One person with their pref on no longer overpowers 40 people who might not even know there is one.
fix: Negative-weight rulesets are no longer put into the list.
/:cl: