### PR TITLE
fine, i'll do it myself (airlocks now only shock on pulse/wirecutters instead of tgui interaction attempt to prevent stunlocks) 

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -53,8 +53,6 @@
 
 /datum/wires/airlock/interactable(mob/user)
 	var/obj/machinery/door/airlock/A = holder
-	if(!A.hasSiliconAccessInArea(user) && A.isElectrified() && A.shock(user, 100))
-		return FALSE
 	if(A.panel_open)
 		return TRUE
 
@@ -73,6 +71,8 @@
 /datum/wires/airlock/on_pulse(wire)
 	set waitfor = FALSE
 	var/obj/machinery/door/airlock/A = holder
+	if(!A.hasSiliconAccessInArea(usr) && A.isElectrified() && A.shock(usr, 100))
+		return FALSE
 	switch(wire)
 		if(WIRE_POWER1, WIRE_POWER2) // Pulse to loose power.
 			A.loseMainPower()
@@ -127,6 +127,8 @@
 
 /datum/wires/airlock/on_cut(wire, mend)
 	var/obj/machinery/door/airlock/A = holder
+	if(!A.hasSiliconAccessInArea(usr) && A.isElectrified() && A.shock(usr, 100))
+		return FALSE
 	switch(wire)
 		if(WIRE_POWER1, WIRE_POWER2) // Cut to loose power, repair all to gain power.
 			if(mend && !is_cut(WIRE_POWER1) && !is_cut(WIRE_POWER2))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

the stunlock to death thing isn't funny
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: airlocks now only shock on pulse/wirecutters instead of on tgui panel open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
