### PR TITLE
slaughter demons to MOB_SIZE_LARGE

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -16,6 +16,7 @@
 	icon_state = "daemon"
 	icon_living = "daemon"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	mob_size = MOB_SIZE_LARGE
 	speed = 1
 	a_intent = INTENT_HARM
 	stop_automated_movement = 1


### PR DESCRIPTION
## About The Pull Request
slaughter demons are now MOB_SIZE_LARGE, one of the more immediate effects being that they can be marked with crushers, dunno what else it would do
## Why It's Good For The Game
the dedicated counter to slaughter demons...hitting them with a Gun Axe
## Changelog
:cl:
balance: Slaughter demons (and laughter demons, being a subtype) are MOB_SIZE_LARGE, with one of the more immediate effects being able to mark them with a crusher and backstab them.
/:cl:
