### PR TITLE
Buffs/hugboxes slaughter demons

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -538,7 +538,7 @@
 	name = "Slaughter Demon"
 	config_tag = "slaughter_demon"
 	antag_flag = ROLE_ALIEN
-	enemy_roles = list("Security Officer","Shaft Miner","Head of Security","Captain","Janitor","AI","Cyborg")
+	enemy_roles = list("Security Officer","Shaft Miner","Head of Security","Captain","Janitor","AI","Cyborg","Bartender")
 	required_enemies = list(3,2,2,2,2,1,1,1,1,0)
 	required_candidates = 1
 	weight = 4

--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -65,6 +65,10 @@
 	var/wound_bonus_per_hit = 5
 	// How much our wound_bonus hitstreak bonus caps at (peak demonry)
 	var/wound_bonus_hitstreak_max = 12
+	// Keep the people we eat
+	var/list/consumed_mobs = list()
+	//buffs only happen when hearts are eaten, so this needs to be kept track separately
+	var/consumed_buff = 0
 
 /mob/living/simple_animal/slaughter/Initialize()
 	..()
@@ -111,8 +115,44 @@
 /mob/living/simple_animal/slaughter/phasein()
 	. = ..()
 	add_movespeed_modifier(/datum/movespeed_modifier/slaughter)
-	addtimer(CALLBACK(src, .proc/remove_movespeed_modifier, /datum/movespeed_modifier/slaughter), 6 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	var/slowdown_time = 6 SECONDS + (0.5 * consumed_buff)
+	addtimer(CALLBACK(src, .proc/remove_movespeed_modifier, /datum/movespeed_modifier/slaughter), slowdown_time, TIMER_UNIQUE | TIMER_OVERRIDE)
 
+/mob/living/simple_animal/slaughter/Destroy()
+	release_victims()
+	. = ..()
+
+/mob/living/simple_animal/slaughter/proc/release_victims()
+	if(!consumed_mobs)
+		return
+
+	for(var/mob/living/M in consumed_mobs)
+		if(!M)
+			continue
+		var/turf/T = find_safe_turf()
+		if(!T)
+			T = get_turf(src)
+		M.forceMove(T)
+
+/mob/living/simple_animal/slaughter/proc/refresh_consumed_buff()
+	melee_damage_lower = 22.5 + (0.5 * consumed_buff)
+	melee_damage_upper = 22.5 + (1 * consumed_buff)
+
+/mob/living/simple_animal/slaughter/bloodcrawl_swallow(var/mob/living/victim)
+	if(consumed_mobs)
+		// Keep their corpse so rescue is possible
+		consumed_mobs += victim
+		victim.reagents?.add_reagent(/datum/reagent/preservahyde,3) // make it so that they don't decay in there
+		var/obj/item/organ/heart/heart = victim.getorganslot(ORGAN_SLOT_HEART)
+		if(heart)
+			qdel(heart)
+			consumed_buff++
+			refresh_consumed_buff()
+	else
+		// Be safe and just eject the corpse
+		victim.forceMove(get_turf(victim))
+		victim.exit_blood_effect()
+		victim.visible_message("[victim] falls out of the air, covered in blood, looking highly confused. And dead.")
 
 //The loot from killing a slaughter demon - can be consumed to allow the user to blood crawl
 /obj/item/organ/heart/demon
@@ -177,9 +217,6 @@
 		prison of hugs."
 	loot = list(/mob/living/simple_animal/pet/cat/kitten{name = "Laughter"})
 
-	// Keep the people we hug!
-	var/list/consumed_mobs = list()
-
 	playstyle_string = "<span class='big bold'>You are a laughter \
 	demon,</span><B> a wonderful creature from another realm. You have a single \
 	desire: <span class='clown'>To hug and tickle.</span><BR>\
@@ -194,10 +231,6 @@
 	released and fully healed, because in the end it's just a jape, \
 	sibling!</B>"
 
-/mob/living/simple_animal/slaughter/laughter/Destroy()
-	release_friends()
-	. = ..()
-
 /mob/living/simple_animal/slaughter/laughter/ex_act(severity)
 	switch(severity)
 		if(1)
@@ -207,7 +240,22 @@
 		if(3)
 			adjustBruteLoss(30)
 
-/mob/living/simple_animal/slaughter/laughter/proc/release_friends()
+/mob/living/simple_animal/slaughter/laughter/refresh_consumed_buff()
+	melee_damage_lower -= 0.5 // JAPES
+	melee_damage_upper += 1
+
+/mob/living/simple_animal/slaughter/laughter/bloodcrawl_swallow(var/mob/living/victim)
+	if(consumed_mobs)
+		// Keep their corpse so rescue is possible
+		consumed_mobs += victim
+		refresh_consumed_buff()
+	else
+		// Be safe and just eject the corpse
+		victim.forceMove(get_turf(victim))
+		victim.exit_blood_effect()
+		victim.visible_message("[victim] falls out of the air, covered in blood, looking highly confused. And dead.")
+
+/mob/living/simple_animal/slaughter/laughter/release_victims()
 	if(!consumed_mobs)
 		return
 
@@ -222,13 +270,3 @@
 			M.grab_ghost(force = TRUE)
 			playsound(T, feast_sound, 50, 1, -1)
 			to_chat(M, "<span class='clown'>You leave [src]'s warm embrace,	and feel ready to take on the world.</span>")
-
-/mob/living/simple_animal/slaughter/laughter/bloodcrawl_swallow(var/mob/living/victim)
-	if(consumed_mobs)
-		// Keep their corpse so rescue is possible
-		consumed_mobs += victim
-	else
-		// Be safe and just eject the corpse
-		victim.forceMove(get_turf(victim))
-		victim.exit_blood_effect()
-		victim.visible_message("[victim] falls out of the air, covered in blood, looking highly confused. And dead.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes slaughter demons gain damage and time-spent-moving-fast-when-leaving-bloodcrawl as they eat more people; also made it so that slaughter demons release all their victims on death, albeit with no hearts. They only get the buff if they eat stuff with hearts.

Laughter demons always get the buff, but the buff only increases the damage 1/3 as much, and in fact the laughter demon occasionally does *less* damage (though will, on average, do more). Japes.

## Why It's Good For The Game

Slaughter demon is too weak but also, if it actually kills you, removes you from the round with no hope of ever returning to it. This hopefully fixes the weakness, and definitely fixes the latter; a good medbay will be able to quickly revive all the killed individuals, as long as they prepare enough hearts.

## Changelog
:cl:
balance: Buffed slaughter demon: gets stronger as it eats people
balance: Nerfed slaughter demon: no longer permanently round-removes all who are eaten by it, instead releasing their now-heartless bodies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
