### PR TITLE
makes it so you can craft armwraps roundstart again.

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -46,6 +46,7 @@
 	time = 60
 	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/stack/sheet/cloth = 4,
+				/obj/item/stack/sticky_tape = 2,
 				/obj/item/stack/sheet/leather = 2)
 	category = CAT_CLOTHING
 

--- a/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -46,7 +46,6 @@
 	time = 60
 	tools = list(TOOL_WIRECUTTER)
 	reqs = list(/obj/item/stack/sheet/cloth = 4,
-				/obj/item/stack/sheet/durathread = 2,
 				/obj/item/stack/sheet/leather = 2)
 	category = CAT_CLOTHING
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

regular armwraps no longer require durathread.

## Why It's Good For The Game

why would you go through all that trouble for a trait that buffs punches slightly and also makes it so you can't use guns.

## Changelog
:cl:
tweak: removed durathread from armwraps recipe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
