### PR TITLE
Makes Ethereal hair their mutcolor instead of white

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -27,7 +27,7 @@
 	// Cold temperatures hurt faster as it is harder to move with out the heat energy
 	bodytemp_cold_damage_limit = (T20C - 10) // about 10c
 	*/
-	hair_color = "fixedmutcolor"
+	hair_color = "mutcolor"
 	hair_alpha = 140
 	var/current_color
 	var/EMPeffect = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ethereal hair was white on accident because it's "fixedmutcolor" on tg, and this was accidentally left in the porting. We don't have whatever the fuck fixedmutcolor is, so I just made it mutcolor like the splitter slimepeople have, which should make ethereal hair the same color as their body as God intended. This was a webedit and I didn't test this because I didn't feel like bothering to download the code as my computer is a lovely piece of trash these days and might lock up if I tried. It's a one line fix so who cares anyways.

I was roughly considering making it so that their hair color is customizable. this is marginally harder and would likely require testing so I will only do it if enough people actually care enough for me to do so

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Ethereal hair is now their body color instead of accidentally white
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
