### PR TITLE
adds three t1 donator items

### DIFF
--- a/code/__HELPERS/donator_groupings.dm
+++ b/code/__HELPERS/donator_groupings.dm
@@ -17,9 +17,9 @@ For fast lookups, this is generated using regenerate_donator_grouping_list()
 /proc/regenerate_donator_grouping_list()
 	GLOB.donators_by_group = list()			//reinit everything
 	var/list/donator_list = GLOB.donators_by_group		//cache
-	var/list/tier_1 = TIER_1_DONATORS
-	donator_list[DONATOR_GROUP_TIER_1] = tier_1.Copy()		//The .Copy() is to "decouple"/make a new list, rather than letting the global list impact the config list.
-	var/list/tier_2 = tier_1 + TIER_2_DONATORS				//Using + on lists implies making new lists, so we don't need to manually Copy().
+	var/list/tier_3 = TIER_3_DONATORS
+	donator_list[DONATOR_GROUP_TIER_3] = tier_3.Copy()		//The .Copy() is to "decouple"/make a new list, rather than letting the global list impact the config list.
+	var/list/tier_2 = tier_3 + TIER_2_DONATORS				//Using + on lists implies making new lists, so we don't need to manually Copy().
 	donator_list[DONATOR_GROUP_TIER_2] = tier_2
-	var/list/tier_3 = tier_2 + TIER_3_DONATORS
-	donator_list[DONATOR_GROUP_TIER_3] = tier_3
+	var/list/tier_1 = tier_2 + TIER_1_DONATORS
+	donator_list[DONATOR_GROUP_TIER_1] = tier_1

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -187,7 +187,7 @@
 	new_choice.pass_flags = PASSTABLE | PASSMOB //your pet is not a bullet/person shield
 	new_choice.density = FALSE
 	new_choice.blood_volume = 0 //your pet cannot be used to drain blood from for a bloodsucker
-	new_choice.desc = "A pet [new_choice], owned by [owner]!"
+	new_choice.desc = "A pet [initial(choice.name)], owned by [owner]!"
 	if(pet_name)
 		new_choice.name = pet_name
 		new_choice.unique_name = TRUE

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -47,11 +47,11 @@
 	spawn_option(stored_options[choice],M)
 	qdel(src)
 
-/obj/item/choice_beacon/proc/create_choice_atom(atom/choice)
+/obj/item/choice_beacon/proc/create_choice_atom(atom/choice, mob/owner)
 	return new choice()
 
 /obj/item/choice_beacon/proc/spawn_option(atom/choice,mob/living/M)
-	var/obj/new_item = create_choice_atom(choice)
+	var/obj/new_item = create_choice_atom(choice, M)
 	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
 	pod.explosionSize = list(0,0,0,0)
 	new_item.forceMove(pod)
@@ -178,12 +178,16 @@
 /obj/item/choice_beacon/pet/generate_display_names()
 	return pets
 
-/obj/item/choice_beacon/pet/create_choice_atom(atom/choice)
+/obj/item/choice_beacon/pet/create_choice_atom(atom/choice, mob/owner)
 	var/mob/living/simple_animal/new_choice = new choice()
 	new_choice.butcher_results = null //please don't eat your pet, chef
 	var/obj/item/pet_carrier/donator/carrier = new() //a donator pet carrier is just a carrier that can't be shoved in an autolathe for metal
 	carrier.add_occupant(new_choice)
 	new_choice.mob_size = MOB_SIZE_TINY //yeah we're not letting you use this roundstart pet to hurt people / knock them down
+	new_choice.pass_flags = PASSTABLE | PASSMOB //your pet is not a bullet/person shield
+	new_choice.density = FALSE
+	new_choice.blood_volume = 0 //your pet cannot be used to drain blood from for a bloodsucker
+	new_choice.desc = "A pet [new_choice], owned by [owner]!"
 	if(pet_name)
 		new_choice.name = pet_name
 		new_choice.unique_name = TRUE

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -188,6 +188,7 @@
 	new_choice.density = FALSE
 	new_choice.blood_volume = 0 //your pet cannot be used to drain blood from for a bloodsucker
 	new_choice.desc = "A pet [initial(choice.name)], owned by [owner]!"
+	new_choice.can_have_ai = FALSE //no it cant be sentient damnit
 	if(pet_name)
 		new_choice.name = pet_name
 		new_choice.unique_name = TRUE

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -186,6 +186,7 @@
 	new_choice.mob_size = MOB_SIZE_TINY //yeah we're not letting you use this roundstart pet to hurt people / knock them down
 	if(pet_name)
 		new_choice.name = pet_name
+		new_choice.unique_name = TRUE
 	return carrier
 
 /obj/item/choice_beacon/pet/spawn_option(atom/choice,mob/living/M)

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -47,8 +47,11 @@
 	spawn_option(stored_options[choice],M)
 	qdel(src)
 
-/obj/item/choice_beacon/proc/spawn_option(obj/choice,mob/living/M)
-	var/obj/new_item = new choice()
+/obj/item/choice_beacon/proc/create_choice_atom(atom/choice)
+	return new choice()
+
+/obj/item/choice_beacon/proc/spawn_option(atom/choice,mob/living/M)
+	var/obj/new_item = create_choice_atom(choice)
 	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
 	pod.explosionSize = list(0,0,0,0)
 	new_item.forceMove(pod)
@@ -152,10 +155,44 @@
 			augment_list[initial(A.name)] = A
 	return augment_list
 
-/obj/item/choice_beacon/augments/spawn_option(obj/choice,mob/living/M)
+/obj/item/choice_beacon/augments/spawn_option(atom/choice,mob/living/M)
 	new choice(get_turf(M))
 	to_chat(M, "<span class='hear'>You hear something crackle from the beacon for a moment before a voice speaks. \"Please stand by for a message from S.E.L.F. Message as follows: <b>Item request received. Your package has been transported, use the autosurgeon supplied to apply the upgrade.</b> Message ends.\"</span>")
 
+/obj/item/choice_beacon/pet //donator beacon that summons a small friendly animal
+	name = "pet beacon"
+	desc = "Straight from the outerspace pet shop to your feet."
+	var/static/list/pets = list("Crab" = /mob/living/simple_animal/crab,
+		"Cat" = /mob/living/simple_animal/pet/cat,
+		"Space cat" = /mob/living/simple_animal/pet/cat/space,
+		"Kitten" = /mob/living/simple_animal/pet/cat/kitten,
+		"Dog" = /mob/living/simple_animal/pet/dog,
+		"Corgi" = /mob/living/simple_animal/pet/dog/corgi,
+		"Pug" = /mob/living/simple_animal/pet/dog/pug,
+		"Exotic Corgi" = /mob/living/simple_animal/pet/dog/corgi/exoticcorgi,
+		"Fox" = /mob/living/simple_animal/pet/fox,
+		"Red Panda" = /mob/living/simple_animal/pet/redpanda,
+		"Possum" = /mob/living/simple_animal/opossum)
+	var/pet_name
+
+/obj/item/choice_beacon/pet/generate_display_names()
+	return pets
+
+/obj/item/choice_beacon/pet/create_choice_atom(atom/choice)
+	var/mob/living/simple_animal/new_choice = new choice()
+	new_choice.butcher_results = null //please don't eat your pet, chef
+	var/obj/item/pet_carrier/donator/carrier = new() //a donator pet carrier is just a carrier that can't be shoved in an autolathe for metal
+	new_choice.forceMove(carrier)
+	new_choice.mob_size = MOB_SIZE_TINY //yeah we're not letting you use this roundstart pet to hurt people / knock them down
+	if(pet_name)
+		new_choice.name = pet_name
+	return carrier
+
+/obj/item/choice_beacon/pet/spawn_option(atom/choice,mob/living/M)
+	pet_name = input(M, "What would you like to name the pet? (leave blank for default name)", "Pet Name")
+	..()
+
+//choice boxes (they just open in your hand instead of making a pod)
 /obj/item/choice_beacon/box
 	name = "choice box (default)"
 	desc = "Think really hard about what you want, and then rip it open!"
@@ -163,21 +200,17 @@
 	icon_state = "deliverypackage3"
 	item_state = "deliverypackage3"
 
-/obj/item/choice_beacon/box/spawn_option(obj/choice,mob/living/M)
-	to_chat(M, "<span class='hear'>The box opens, revealing the [choice]!</span>")
+/obj/item/choice_beacon/box/spawn_option(atom/choice,mob/living/M)
+	var/choice_text = choice
+	if(ispath(choice_text))
+		choice_text = initial(choice.name)
+	to_chat(M, "<span class='hear'>The box opens, revealing the [choice_text]!</span>")
 	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
 	M.temporarilyRemoveItemFromInventory(src, TRUE)
 	M.put_in_hands(new choice)
 	qdel(src)
 
-/obj/item/choice_beacon/box/plushie
-	name = "choice box (plushie)"
-	desc = "Using the power of quantum entanglement, this box contains every plush, until the moment it is opened!"
-	icon = 'icons/obj/plushes.dmi'
-	icon_state = "box"
-	item_state = "box"
-
-/obj/item/choice_beacon/box/spawn_option(choice,mob/living/M)
+/obj/item/choice_beacon/box/plushie/spawn_option(choice,mob/living/M)
 	if(ispath(choice, /obj/item/toy/plush))
 		..() //regular plush, spawn it naturally
 	else
@@ -187,6 +220,31 @@
 		M.temporarilyRemoveItemFromInventory(src, TRUE)
 		M.put_in_hands(new choice)
 		qdel(src)
+
+/obj/item/choice_beacon/box/carpet //donator carpet beacon
+	name = "choice box (carpet)"
+	desc = "Contains 50 of a selected carpet inside!"
+	var/static/list/carpet_list = list(/obj/item/stack/tile/carpet/black/fifty = "Black Carpet",
+		"Black & Red Carpet" = /obj/item/stack/tile/carpet/blackred/fifty,
+		"Monochrome Carpet" = /obj/item/stack/tile/carpet/monochrome/fifty,
+		"Blue Carpet" = /obj/item/stack/tile/carpet/blue/fifty,
+		"Cyan Carpet" = /obj/item/stack/tile/carpet/cyan/fifty,
+		"Green Carpet" = /obj/item/stack/tile/carpet/green/fifty,
+		"Orange Carpet" = /obj/item/stack/tile/carpet/orange/fifty,
+		"Purple Carpet" = /obj/item/stack/tile/carpet/purple/fifty,
+		"Red Carpet" = /obj/item/stack/tile/carpet/red/fifty,
+		"Royal Black Carpet" = /obj/item/stack/tile/carpet/royalblack/fifty,
+		"Royal Blue Carpet" = /obj/item/stack/tile/carpet/royalblue/fifty)
+
+/obj/item/choice_beacon/box/carpet/generate_display_names()
+	return carpet_list
+
+/obj/item/choice_beacon/box/plushie
+	name = "choice box (plushie)"
+	desc = "Using the power of quantum entanglement, this box contains every plush, until the moment it is opened!"
+	icon = 'icons/obj/plushes.dmi'
+	icon_state = "box"
+	item_state = "box"
 
 /obj/item/choice_beacon/box/plushie/generate_display_names()
 	var/list/plushie_list = list()

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -182,7 +182,7 @@
 	var/mob/living/simple_animal/new_choice = new choice()
 	new_choice.butcher_results = null //please don't eat your pet, chef
 	var/obj/item/pet_carrier/donator/carrier = new() //a donator pet carrier is just a carrier that can't be shoved in an autolathe for metal
-	new_choice.forceMove(carrier)
+	carrier.add_occupant(new_choice)
 	new_choice.mob_size = MOB_SIZE_TINY //yeah we're not letting you use this roundstart pet to hurt people / knock them down
 	if(pet_name)
 		new_choice.name = pet_name

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -29,6 +29,9 @@
 	var/has_lock_sprites = TRUE //whether to load the lock overlays or not
 	var/allows_hostiles = FALSE //does the pet carrier allow hostile entities to be held within it?
 
+/obj/item/pet_carrier/donator
+	custom_materials = null //you cant just use the loadout item to get free metal!
+
 /obj/item/pet_carrier/Destroy()
 	if(occupants.len)
 		for(var/V in occupants)

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -243,10 +243,24 @@ LINEN BINS
 
 /obj/item/bedsheet/random/Initialize()
 	..()
-	var/type = pick(typesof(/obj/item/bedsheet) - /obj/item/bedsheet/random)
+	var/type = pick(typesof(/obj/item/bedsheet) - list(/obj/item/bedsheet/random, /obj/item/bedsheet/chameleon))
 	new type(loc)
 	return INITIALIZE_HINT_QDEL
 
+/obj/item/bedsheet/chameleon //donator chameleon bedsheet
+	name = "chameleon bedsheet"
+	desc = "Bedsheet technology has truly gone too far."
+	var/datum/action/item_action/chameleon/change/chameleon_action
+
+/obj/item/bedsheet/chameleon/New()
+	..()
+	chameleon_action = new(src)
+	chameleon_action.chameleon_type = /obj/item/bedsheet
+	chameleon_action.chameleon_name = "Bedsheet"
+	chameleon_action.chameleon_blacklist = typecacheof(list(/obj/item/bedsheet/chameleon, /obj/item/bedsheet/random), only_root_path = TRUE)
+	chameleon_action.initialize_disguises()
+
+//bedsheet bin
 /obj/structure/bedsheetbin
 	name = "linen bin"
 	desc = "It looks rather cosy."

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -791,9 +791,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				dat += "</b></center></td></tr>"
 				dat += "<tr><td colspan=4><hr></td></tr>"
-				
+
 				dat += "<tr><td colspan=4><center><b>"
-				
+
 				if(!length(GLOB.loadout_categories[gear_category]))
 					dat += "No subcategories detected. Something is horribly wrong!"
 				else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -801,7 +801,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(!subcategories.Find(gear_subcategory))
 						gear_subcategory = subcategories[1]
 
-					var/firstsubcat = FALSE
+					var/firstsubcat = TRUE
 					for(var/subcategory in subcategories)
 						if(firstsubcat)
 							firstsubcat = FALSE

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -7,6 +7,27 @@
 	category = LOADOUT_CATEGORY_DONATOR
 	ckeywhitelist = list("This entry should never appear with this variable set.") //If it does, then that means somebody fucked up the whitelist system pretty hard
 
+/datum/gear/donator/pet
+	name = "Pet Beacon"
+	slot = SLOT_IN_BACKPACK
+	path = /obj/item/choice_beacon/pet
+	ckeywhitelist = list()
+	donator_group_id = DONATOR_GROUP_TIER_1 // can be accessed by all donators
+
+/datum/gear/donator/carpet
+	name = "Carpet Beacon"
+	slot = SLOT_IN_BACKPACK
+	path = /obj/item/choice_beacon/box/carpet
+	ckeywhitelist = list()
+	donator_group_id = DONATOR_GROUP_TIER_1
+
+/datum/gear/donator/chameleon_bedsheet
+	name = "Chameleon Bedsheet"
+	slot = SLOT_NECK
+	path = /obj/item/bedsheet/chameleon
+	ckeywhitelist = list()
+	donator_group_id = DONATOR_GROUP_TIER_1
+
 /datum/gear/donator/donortestingbikehorn
 	name = "Donor item testing bikehorn"
 	slot = SLOT_IN_BACKPACK


### PR DESCRIPTION
## About The Pull Request
adds three more items to the loadout in the donator category accessible by anyone who has donated to the server (once added to the config to be recognised as such)

i have no clue if the config has been setup for tiers
me hopes it has been

the items are as follows:
chameleon bedsheet, self explanatory

carpet beacon, choice beacon that grants 50 carpet of a chosen type

pet beacon, choice beacon that grants a pet of a chosen type, it's set to tiny size so it can't knock people over if thrown, and its butcher contents is set to null, comes in a pet carrier that can't be turned into metal at a lathe, can't be drained by bloodsuckers, bullets go over it, people go over it, etc

they all cost 1 point

i have tried to make sure none of these items can be abused nor do they give a mechanical advantage, which is how loadout items should be, if there's any flaws in this, please say so

## Why It's Good For The Game
uhhh something something donator incentive

## Changelog
:cl:
add: three new items are in the loadout for all donators
/:cl:
