### PR TITLE
Expanding airlocks for the majority of stations

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5033,7 +5033,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/solar/port/fore)
+/area/maintenance/solars/port/fore)
 "ajr" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45035,7 +45035,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/atmos)
 "cez" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
@@ -54806,10 +54806,6 @@
 	dir = 8
 	},
 /area/medical/sleeper)
-"haL" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "haM" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -57159,10 +57155,6 @@
 /obj/item/bedsheet/green,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"okM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "old" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -58892,7 +58884,7 @@
 	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
-/area/solar/port/aft)
+/area/maintenance/solars/port/aft)
 "tHh" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/red,
@@ -59066,10 +59058,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ucr" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "udT" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/plasteel,
@@ -67580,7 +67568,7 @@ gXs
 gXs
 gJi
 gJi
-haL
+gXs
 aag
 gJi
 aaa
@@ -68334,7 +68322,7 @@ aaa
 aaa
 aaa
 aae
-ktS
+aaa
 gXs
 aaa
 aaa
@@ -68591,7 +68579,7 @@ aaa
 aaa
 aaa
 aaa
-ktS
+aaa
 gXs
 aaa
 aaa
@@ -68848,7 +68836,7 @@ aaa
 aaa
 aaa
 aaa
-ktS
+aaa
 gXs
 aaa
 aaa
@@ -69105,7 +69093,7 @@ aaa
 aaa
 aaa
 aaa
-ktS
+aaa
 gXs
 aaa
 cqq
@@ -69362,7 +69350,7 @@ aaf
 aaf
 aaf
 aaa
-ktS
+aaa
 arB
 asE
 cyb
@@ -78687,9 +78675,9 @@ aaf
 aaa
 aaf
 aaa
-ucr
+aaf
 hrF
-ucr
+aaf
 aaa
 aaf
 aaa
@@ -78944,9 +78932,9 @@ aaf
 aaf
 aaf
 aaf
-okM
+cfx
 tEK
-okM
+cfx
 aaf
 aaf
 aaf
@@ -79450,8 +79438,8 @@ caf
 aoV
 aag
 aaf
-haL
-haL
+gXs
+gXs
 aaf
 aaa
 aaa
@@ -90244,7 +90232,7 @@ bUE
 bWM
 bXJ
 bMK
-bMK
+bYH
 bYH
 bYH
 bVg
@@ -92560,10 +92548,10 @@ bWQ
 bWQ
 caD
 bWQ
-ccw
-ccw
+bLK
+bLK
 cey
-ccw
+bLK
 ccw
 ccw
 ccw

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1258,6 +1258,16 @@
 /area/maintenance/fore/secondary)
 "acV" = (
 /obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/fore)
+"acW" = (
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar{
@@ -1265,11 +1275,6 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/fore)
-"acW" = (
-/obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
 /area/solar/port/fore)
 "acX" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1489,7 +1494,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/fore)
-"adu" = (
+"adw" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/fore)
+"adx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -1498,30 +1508,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
-"adv" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
-"adw" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
-"adx" = (
-/obj/structure/cable{
-	icon_state = "0-4"
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
@@ -1530,28 +1516,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
-"adz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/fore)
 "adA" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "auxsolareast";
+	name = "Port Auxiliary Solar Array"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "adB" = (
 /obj/structure/cable{
@@ -1817,12 +1788,11 @@
 /turf/open/space,
 /area/solar/starboard/fore)
 "adZ" = (
-/obj/structure/cable,
-/obj/machinery/power/solar{
-	id = "auxsolareast";
-	name = "Port Auxiliary Solar Array"
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
 /area/solar/port/fore)
 "aea" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -5054,11 +5024,15 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ajq" = (
-/obj/structure/lattice/catwalk,
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/space,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
 /area/solar/port/fore)
 "ajr" = (
 /obj/structure/table/wood,
@@ -5417,16 +5391,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ajW" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-4"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/fore)
 "ajX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -6668,15 +6638,17 @@
 /area/security/courtroom)
 "amv" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/fore)
 "amw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8572,13 +8544,15 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aqJ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/fore)
 "aqK" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -42345,15 +42319,9 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "bXv" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/item/stack/rods,
+/turf/open/space,
+/area/space)
 "bXw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -45521,9 +45489,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cfK" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/space,
+/area/solar/port/fore)
 "cfL" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -46323,18 +46294,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "chO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/area/maintenance/fore/secondary)
 "chP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49352,15 +49316,16 @@
 /turf/open/space,
 /area/maintenance/aft)
 "csg" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
+/area/maintenance/solars/starboard/fore)
 "csi" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 1
@@ -51153,13 +51118,10 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "cxW" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space/nearstation)
 "cxY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Escape Pod 1";
@@ -51258,14 +51220,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cyC" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
+	name = "External Access";
 	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/port/fore)
 "cyD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -51287,15 +51248,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cyG" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	req_access_txt = "24"
+	name = "External Access";
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/maintenance/starboard/fore)
 "cyK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51341,18 +51300,14 @@
 /turf/open/space/basic,
 /area/space)
 "cyU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
+	req_access_txt = "13"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard/aft)
+/area/maintenance/starboard)
 "czg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -52258,10 +52213,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "cCS" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "cCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -52328,12 +52282,15 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "cDY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53612,6 +53569,11 @@
 	dir = 8
 	},
 /area/crew_quarters/fitness/pool)
+"dCt" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "dCV" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -54280,6 +54242,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
+"fty" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "ftE" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -55122,6 +55090,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"imk" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "imH" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -55417,6 +55392,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"jiK" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/engine/engineering)
 "jjC" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
@@ -56729,6 +56708,19 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"mQp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "mQS" = (
 /obj/machinery/light{
 	dir = 8;
@@ -57167,6 +57159,10 @@
 /obj/item/bedsheet/green,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"okM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "old" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -58858,14 +58854,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "tAH" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tCa" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar{
@@ -58888,6 +58880,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tEK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/turf/open/floor/plating,
+/area/solar/port/aft)
 "tHh" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/red,
@@ -59061,6 +59066,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ucr" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "udT" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/plasteel,
@@ -59258,7 +59267,7 @@
 "uDO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-2"
 	},
 /turf/open/space,
 /area/solar/port/fore)
@@ -60002,6 +60011,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"wmu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "woR" = (
 /obj/machinery/cryopod{
 	dir = 1
@@ -60161,6 +60180,16 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"wWi" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "wWT" = (
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel/white,
@@ -73695,8 +73724,8 @@ aaa
 aae
 aaa
 aaa
-aaa
 aag
+alU
 alU
 alU
 alU
@@ -73952,9 +73981,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
-aqJ
+cyC
+amC
 amC
 gLH
 ase
@@ -74209,7 +74238,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gJi
 alU
 alU
 alU
@@ -74958,7 +74987,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaS
 aaS
@@ -74974,6 +75002,7 @@ aaS
 aba
 aaS
 aaS
+aaf
 aaf
 aaf
 aaf
@@ -75215,7 +75244,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 abY
 aaa
 aaf
@@ -75228,9 +75256,10 @@ acy
 aaa
 aaf
 aaa
-aiS
+bXv
 aaa
 aaS
+aaa
 aaa
 aaa
 aaa
@@ -75472,22 +75501,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
 abY
 aaa
+acW
 acV
-adv
-adZ
+adA
 aaa
+acW
 acV
-adv
-adZ
+adA
 aaa
+acW
 acV
-adv
-adZ
+adA
 aaa
 aaS
+aaf
 aaf
 aaf
 aaf
@@ -75726,25 +75755,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aae
 aaa
 aaa
 abY
 aaf
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
 aaf
 aaf
+aaa
 aaa
 aaa
 aaa
@@ -75986,22 +76015,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
 abY
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
 aaf
-acV
-adu
-adZ
+acW
+adx
+adA
 aaf
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
 aaf
+aaa
 aaa
 aaa
 aaa
@@ -76243,20 +76272,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
+aaf
 aaf
 aaf
 aaf
@@ -76497,25 +76526,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaS
 aaS
 aaf
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
-acV
-adu
-adZ
+acW
+adx
+adA
 aaa
 aaf
+aaa
 aaa
 ajV
 alR
@@ -76754,24 +76783,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaa
 aaf
 aaa
 aaa
 aaa
-adw
+adZ
 aaa
 aaa
 aaa
-adw
+adZ
 aaa
 aaa
 aaa
-adw
+adZ
 aaa
 aaa
+ajV
 ajV
 ajV
 ajV
@@ -77011,13 +77040,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaf
 abs
 abZ
 abZ
-acW
+adw
 ady
 ady
 ady
@@ -77027,9 +77055,10 @@ ady
 ady
 ady
 ady
+cfK
 uDO
 ajq
-ajW
+akB
 akB
 alh
 alT
@@ -77268,24 +77297,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaa
 aaf
 aaa
 aaa
 aaa
-adx
+ajW
 aaa
 aaa
 aaa
-adx
+ajW
 aaa
 aaa
 aaa
-adx
+ajW
 aaa
 aaa
+ajV
 ajV
 ajV
 ajV
@@ -77525,25 +77554,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aba
 aaS
 aaf
 aaa
-acV
-adz
-adZ
+acW
+amv
+adA
 aaa
-acV
-adz
-adZ
+acW
+amv
+adA
 aaa
-acV
-adz
-adZ
+acW
+amv
+adA
 aaa
 aaf
+aaa
 aaa
 ajV
 alR
@@ -77785,22 +77814,22 @@ aaa
 aaa
 aaa
 aaa
+aaf
+aaf
+acW
+amv
+adA
 aaa
-aaf
-aaf
-acV
-adz
-adZ
+acW
+amv
+adA
 aaa
-acV
-adz
-adZ
+acW
+amv
+adA
+aaf
+aaf
 aaa
-acV
-adz
-adZ
-aaf
-aaf
 aaa
 aaa
 aaa
@@ -78042,21 +78071,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaa
-acV
-adz
-adZ
+acW
+amv
+adA
 aaf
-acV
-adz
-adZ
+acW
+amv
+adA
 aaf
-acV
-adz
-adZ
+acW
+amv
+adA
 aaa
+aaf
 aaf
 aaf
 aaf
@@ -78299,22 +78328,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaf
-acV
-adz
-adZ
+acW
+amv
+adA
 aaa
-acV
-adz
-adZ
+acW
+amv
+adA
 aaa
-acV
-adz
-adZ
+acW
+amv
+adA
 aaf
 aaf
+aaa
 aaa
 aaa
 aaa
@@ -78556,22 +78585,22 @@ aaa
 aaa
 aaa
 aaa
+aaS
+aaa
+acW
+aqJ
+adA
+aaa
+acW
+aqJ
+adA
+aaa
+acW
+aqJ
+adA
 aaa
 aaS
 aaa
-acV
-adA
-adZ
-aaa
-acV
-adA
-adZ
-aaa
-acV
-adA
-adZ
-aaa
-aaS
 aaa
 aaa
 aaa
@@ -78658,9 +78687,9 @@ aaf
 aaa
 aaf
 aaa
-aaa
+ucr
 hrF
-aaa
+ucr
 aaa
 aaf
 aaa
@@ -78813,7 +78842,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaa
 aaf
@@ -78829,6 +78857,7 @@ aaa
 aaf
 aaa
 aaS
+aaf
 aaf
 aaf
 gXs
@@ -78915,9 +78944,9 @@ aaf
 aaf
 aaf
 aaf
-aaf
-hrF
-aaf
+okM
+tEK
+okM
 aaf
 aaf
 aaf
@@ -79070,7 +79099,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaS
 aaS
 aaS
@@ -79086,6 +79114,7 @@ aaS
 aaS
 aaS
 aaS
+aaa
 aaa
 aaa
 aaa
@@ -79173,7 +79202,7 @@ aaf
 aaa
 aaa
 cfx
-chO
+chN
 cfx
 aaa
 aaf
@@ -79421,8 +79450,8 @@ caf
 aoV
 aag
 aaf
-aaa
-aaa
+haL
+haL
 aaf
 aaa
 aaa
@@ -79675,9 +79704,9 @@ bLv
 bCq
 aoV
 cbj
-aoV
-aag
-aaf
+bLv
+cDY
+bLv
 aaf
 bCq
 bCq
@@ -79933,7 +79962,7 @@ bCq
 bCq
 cbj
 bLv
-bXv
+bHE
 bLv
 aaf
 bCq
@@ -79949,7 +79978,7 @@ ciQ
 cfw
 aaa
 aaa
-aaa
+gXs
 aaf
 aaf
 aaa
@@ -80204,9 +80233,9 @@ cgC
 chR
 ciS
 cfw
-aaa
-aaa
-aaa
+aag
+aag
+aag
 aaa
 aaf
 aaf
@@ -80461,9 +80490,9 @@ cgB
 chQ
 ciR
 cfw
-aag
-aag
-aag
+bCq
+cDY
+bCq
 aaa
 aaa
 aaf
@@ -80719,7 +80748,7 @@ chS
 cfw
 cfw
 bCq
-bXv
+bHE
 bCq
 aaa
 aaa
@@ -92810,9 +92839,9 @@ ckF
 cpE
 cjR
 crW
-csg
+ciZ
+wmu
 aag
-aaa
 aaa
 aaa
 aaa
@@ -93067,9 +93096,9 @@ crw
 cjO
 ccw
 crX
-cfK
+ciZ
+jiK
 aag
-aaa
 aaa
 aaa
 aaa
@@ -93325,7 +93354,7 @@ cjm
 ccw
 ccw
 cig
-aag
+cig
 aag
 aag
 aag
@@ -95003,8 +95032,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
 acw
+abp
 abp
 abp
 adR
@@ -95259,10 +95288,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aag
 acU
+anF
 adr
 sXy
 aeC
@@ -95517,8 +95546,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aag
+abp
 abp
 abp
 abp
@@ -96045,7 +96074,7 @@ aaa
 ahn
 ahn
 ahn
-tAH
+anF
 ahn
 eMs
 anG
@@ -96301,8 +96330,8 @@ aaa
 aaa
 aaa
 aaa
-gJi
-gJi
+ahn
+chO
 ahn
 ahn
 khB
@@ -96390,10 +96419,10 @@ bQA
 bPj
 bOh
 cCQ
-bLK
-cyG
-bLK
-aoV
+cCS
+chg
+cCS
+aaf
 aoV
 aoV
 aaf
@@ -96558,8 +96587,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gJi
+gJi
 dFX
 wWW
 dqb
@@ -96646,21 +96675,21 @@ cbI
 ccC
 cdD
 bOh
-cCG
+cCQ
 cCS
+wWi
 cCS
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cDY
+aaa
+aaa
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cCQ
 aaf
 aaf
 aaf
@@ -96903,21 +96932,21 @@ cbH
 ccB
 cbH
 bOh
-aaf
-aaa
-aoV
-aaf
-aoV
-aoV
-aoV
-aaf
-aoV
-aoV
-aoV
-aoV
-aoV
-aoV
-gXs
+cCG
+tAH
+dCt
+fty
+dCt
+dCt
+dCt
+fty
+dCt
+dCt
+dCt
+dCt
+dCt
+dCt
+imk
 aoV
 aaa
 aaa
@@ -97161,11 +97190,11 @@ ccD
 cbH
 bOh
 aaf
-aaf
-aaf
-aaf
-aaf
-aoV
+aaa
+aaa
+aaa
+aaa
+aaa
 aoV
 aaf
 aoV
@@ -100424,7 +100453,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 aaf
 aaf
 alO
@@ -100680,8 +100709,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aag
+gJi
+alO
 alO
 arp
 alO
@@ -100937,9 +100966,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aag
-cxW
+gJi
+cyG
+anf
 anf
 aqv
 ayf
@@ -101194,9 +101223,9 @@ aaf
 aaf
 aaf
 aaf
-aaf
-aag
+cxW
 alO
+anf
 anf
 alO
 mAH
@@ -101703,7 +101732,7 @@ aaa
 aaa
 aaf
 aaa
-aaa
+amw
 amw
 amw
 amw
@@ -101960,8 +101989,8 @@ eaR
 jIs
 jIs
 jIs
-acx
-amv
+csg
+ane
 ane
 cxN
 aog
@@ -102217,7 +102246,7 @@ aaa
 aaa
 aaf
 aaa
-aaa
+amw
 amw
 amw
 amw
@@ -110535,7 +110564,7 @@ cmw
 cnj
 cnj
 cnj
-aaa
+cnj
 aaa
 aaf
 aaa
@@ -110742,7 +110771,7 @@ aaf
 aaf
 aaf
 bky
-cyC
+btp
 bns
 boF
 bqe
@@ -110791,8 +110820,8 @@ clx
 cmv
 cnk
 cnK
-cyU
-cpi
+cnK
+mQp
 cpi
 cpi
 cqJ
@@ -110997,9 +111026,9 @@ aQE
 aNa
 aaa
 aaf
-aaa
-aaf
-aaa
+gXs
+bky
+cyU
 bns
 boF
 bqe
@@ -111049,7 +111078,7 @@ cmx
 cnj
 cnj
 cnj
-aaa
+cnj
 aaa
 aaf
 aaa
@@ -111254,7 +111283,7 @@ afE
 aNa
 aaa
 aaa
-aaa
+gXs
 aaf
 aaa
 bns
@@ -112836,7 +112865,7 @@ aaa
 aaa
 aaf
 cNW
-cPI
+cOe
 cNW
 aaf
 aaf
@@ -113092,9 +113121,9 @@ aaa
 aaa
 aaa
 aaf
-aag
-aag
-aag
+cNW
+cPI
+cNW
 aaf
 aaa
 aaa
@@ -113348,11 +113377,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
 aag
-aaa
-aaa
+aag
+aag
+gXs
 aaa
 aaa
 aaa
@@ -113607,7 +113636,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aag
 aaa
 aaa
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1464,19 +1464,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Solar Access";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/fore)
 "acQ" = (
@@ -17256,19 +17244,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Solar Access";
-	req_one_access_txt = "13; 24; 10"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
 "aIk" = (
@@ -25107,14 +25083,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "aUK" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/security/prison)
@@ -43327,21 +43297,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bzd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/construction/mining/aux_base)
 "bze" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bzf" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -44447,122 +44412,83 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bAI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
-"bAJ" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
-"bAK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bAL" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/gravity_generator";
-	dir = 1;
-	name = "Gravity Generator APC";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bAM" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bAN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bAO" = (
-/turf/closed/wall,
-/area/engine/gravity_generator)
-"bAP" = (
-/obj/machinery/door/firedoor,
+/area/construction/mining/aux_base)
+"bAJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/construction/mining/aux_base)
+"bAK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+	name = "External Solar Access";
+	req_access_txt = "10; 13"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/starboard/fore)
+"bAL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space,
+/area/solar/port/fore)
+"bAM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Solar Access";
+	req_one_access_txt = "13; 24; 10"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/port/fore)
+"bAN" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "63"
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/turf/open/floor/plating,
+/area/security/prison)
+"bAO" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bAP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bAQ" = (
@@ -45609,7 +45535,7 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"bCw" = (
+"bCx" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45623,37 +45549,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"bCx" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
-"bCy" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "bCz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -45668,26 +45566,91 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bCA" = (
-/obj/structure/cable/white,
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "bCB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bCC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/gravity_generator";
+	dir = 1;
+	name = "Gravity Generator APC";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bCD" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bCE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bCF" = (
+/obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -45698,80 +45661,26 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bCD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bCE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bCF" = (
-/obj/structure/sign/warning/radiation,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"bCG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Gravity Generator Foyer";
-	dir = 4;
-	name = "engineering camera"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bCH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bCI" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/engine/gravity_generator)
 "bCJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45784,9 +45693,6 @@
 	icon_state = "0-4"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/engine/break_room)
 "bCL" = (
@@ -45801,12 +45707,12 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -47193,11 +47099,8 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "bEn" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/sign/warning/radiation{
-	pixel_x = -32
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47212,112 +47115,124 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bEo" = (
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
-"bEp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "Gravity Generator Chamber";
-	req_access_txt = "19; 61"
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bEq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEr" = (
-/obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/cable/white{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bEu" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Room";
-	req_access_txt = "19;23"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bEv" = (
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bEw" = (
-/obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bEx" = (
+"bEu" = (
+/obj/structure/sign/warning/radiation,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"bEv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Gravity Generator Foyer";
+	dir = 4;
+	name = "engineering camera"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bEw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bEx" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bEy" = (
@@ -47330,9 +47245,6 @@
 	req_access_txt = "10"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -47342,17 +47254,20 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bEz" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -47363,13 +47278,12 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -47377,12 +47291,12 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -47393,23 +47307,23 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bED" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48446,22 +48360,15 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bFW" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green,
 /area/engine/gravity_generator)
 "bFX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/warning/radiation{
+	pixel_x = -32
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -48475,87 +48382,87 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "bFY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bFZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bGa" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bGb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bGc" = (
-/obj/structure/sign/warning/radiation,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"bGd" = (
 /obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bGe" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bGf" = (
-/obj/structure/closet/radiation,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+"bGc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room";
+	req_access_txt = "19;23"
 	},
-/obj/machinery/light/small,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bGd" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bGe" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bGf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bGg" = (
@@ -48565,6 +48472,9 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bGh" = (
@@ -48579,6 +48489,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/break_room)
 "bGi" = (
@@ -48586,13 +48499,14 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/break_room)
 "bGj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -49624,9 +49538,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "bHN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -49641,68 +49553,50 @@
 /area/engine/gravity_generator)
 "bHO" = (
 /obj/structure/cable/white,
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "bHP" = (
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Gravity Generator";
-	dir = 1;
-	name = "engineering camera"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHR" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHS" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/wrench,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -49710,27 +49604,23 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Door"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bHU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/preopen{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Door"
+/obj/machinery/status_display/evac{
+	pixel_x = 32;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -51017,27 +50907,30 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Transit Tube Access";
-	req_one_access_txt = "32;19"
+/obj/machinery/door/poddoor/preopen{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "bJP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/preopen{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Door"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/transit_tube)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "bJQ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -52186,49 +52079,53 @@
 /turf/closed/wall/r_wall,
 /area/engine/transit_tube)
 "bLG" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "Gravity Generator Chamber";
+	req_access_txt = "19; 61"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
-"bLH" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/engine/transit_tube)
-"bLI" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/transit_tube";
-	dir = 1;
-	name = "Transit Tube Access APC";
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /obj/structure/cable/white{
-	icon_state = "0-4"
+	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"bLH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/break_room)
+"bLI" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/area/engine/gravity_generator)
 "bLJ" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Transit Tube Access";
+	req_one_access_txt = "32;19"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -52241,35 +52138,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bLK" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/button/door{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Control";
-	pixel_y = 26;
-	req_access_txt = "39; 19"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall/r_wall,
 /area/engine/transit_tube)
 "bLL" = (
 /obj/item/kirbyplants/random,
@@ -53595,29 +53468,14 @@
 /turf/open/space,
 /area/space/nearstation)
 "bNH" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/white{
-	icon_state = "2-4"
+/obj/structure/sign/warning/radiation,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
 "bNI" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Exterior Access";
-	req_one_access_txt = "32;19"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -53631,12 +53489,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNJ" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -53647,39 +53499,21 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNK" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Exterior Access";
-	req_one_access_txt = "32;19"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
 /area/engine/transit_tube)
 "bNL" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/transit_tube";
+	dir = 1;
+	name = "Transit Tube Access APC";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -53689,16 +53523,17 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNM" = (
 /obj/structure/cable/white{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -53709,11 +53544,22 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bNN" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/item/kirbyplants/random,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/button/door{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Control";
+	pixel_y = 26;
+	req_access_txt = "39; 19"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -54901,9 +54747,38 @@
 /turf/open/space,
 /area/space/nearstation)
 "bPL" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/machinery/light/small,
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
+"bPM" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Exterior Access";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54917,20 +54792,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
-"bPM" = (
-/turf/closed/wall,
-/area/engine/transit_tube)
 "bPN" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -26;
-	pixel_y = -26
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -54944,6 +54810,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bPO" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -54954,15 +54823,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bPP" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = -10
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -56192,13 +56062,15 @@
 /turf/open/space,
 /area/space/nearstation)
 "bRV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/transit_tube)
-"bRW" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Transit Tube Access";
-	req_one_access_txt = "32;19"
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = -26;
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -56212,10 +56084,38 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
+"bRW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "bRX" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/machinery/light_switch{
+	pixel_x = 22;
+	pixel_y = -10
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bRY" = (
 /obj/machinery/keycard_auth{
@@ -57376,22 +57276,9 @@
 /turf/open/space,
 /area/space/nearstation)
 "bTL" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "AI Satellite - Transit Tube";
-	name = "ai camera";
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/item/clipboard,
-/obj/item/folder/blue,
-/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -57403,30 +57290,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/transit_tube)
+/area/engine/gravity_generator)
 "bTM" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engine/transit_tube)
 "bTN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Transit Tube Access";
+	req_one_access_txt = "32;19"
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -57437,22 +57310,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bTO" = (
-/obj/item/kirbyplants/random,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/engine/transit_tube)
 "bTP" = (
 /obj/machinery/computer/station_alert{
@@ -59145,9 +59009,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bWc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -59156,12 +59017,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bWd" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -59171,6 +59037,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
@@ -60846,6 +60718,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
@@ -72264,7 +72139,7 @@
 	pixel_y = 32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "crE" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -83035,22 +82910,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cJI" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/structure/cable/white,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "cJJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -108364,19 +108233,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Solar Access";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/starboard/aft)
 "dBN" = (
@@ -115581,6 +115438,10 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "dOc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
+"dOd" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -115597,11 +115458,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
-"dOd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
 "dOe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -115610,6 +115466,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -122648,19 +122505,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Solar Access";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/aft)
 "ebE" = (
@@ -124004,14 +123849,16 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "edX" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "edY" = (
@@ -124731,16 +124578,6 @@
 /turf/open/floor/carpet,
 /area/chapel/office)
 "eft" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "efu" = (
@@ -125581,6 +125418,24 @@
 /obj/machinery/chem_dispenser/apothecary,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"eMb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/maintenance/port)
 "eMD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -125733,6 +125588,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"fMf" = (
+/turf/closed/wall,
+/area/engine/transit_tube)
 "fRK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -126016,6 +125874,24 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"ikq" = (
+/obj/machinery/light,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Gravity Generator";
+	dir = 1;
+	name = "engineering camera"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "imI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -126143,6 +126019,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"iUc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Solar Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/port/aft)
 "jdx" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -126344,6 +126239,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/science/mixing)
+"jUu" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "jYx" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -126736,6 +126634,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"mte" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light_switch{
+	pixel_y = -26
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/wrench,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -126877,6 +126789,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"nYv" = (
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "odz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -127171,6 +127095,25 @@
 	dir = 9
 	},
 /area/science/circuit)
+"qhB" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "qnx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input,
 /turf/open/floor/engine/vacuum,
@@ -127408,6 +127351,25 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/library)
+"tML" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Solar Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/solars/starboard/aft)
 "tNT" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -127653,6 +127615,32 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"vFT" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Exterior Access";
+	req_one_access_txt = "32;19"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/transit_tube)
 "vHN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -127688,6 +127676,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
+"vYo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "wei" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -127750,6 +127750,16 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"wFK" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/space,
+/area/space/nearstation)
 "wZT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -127972,6 +127982,23 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"yja" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "yjc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research/abandoned";
@@ -145314,10 +145341,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
 ajr
 ajr
 aad
-ajr
 ajr
 ajr
 aad
@@ -145571,11 +145598,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
 ajr
 aaa
 aaa
 aad
-aaa
 aad
 aaa
 aad
@@ -145828,11 +145855,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
 ajr
 aad
 ajr
 ajr
-aad
 ajr
 ajr
 ajr
@@ -146085,10 +146112,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
 ajr
 aaa
 ajr
-aad
 aad
 aad
 aad
@@ -146342,6 +146369,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aad
 aaa
 ajr
@@ -146352,12 +146380,11 @@ bxC
 bxC
 bxC
 bxC
-bxC
-aad
+jUu
 aad
 aad
 bNF
-aad
+qgU
 bVZ
 aad
 aad
@@ -146599,20 +146626,20 @@ aaa
 aaa
 aaa
 aaa
-ajr
-aad
-ajr
-aad
-bxC
-bAH
-bAH
-bEn
-bAH
-bAH
-bxC
-aad
-ajr
 aaa
+ajr
+aad
+ajr
+aad
+bxC
+bAH
+bAH
+bFX
+bAH
+bAH
+jUu
+aad
+ajr
 bNF
 aaa
 bVZ
@@ -146856,20 +146883,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
 ajr
 aaa
 aad
 aad
 bxC
 bAH
-bCw
 bCx
-bCy
+bEo
+bCF
 bAH
-bxC
+jUu
 aad
 ajr
-aaa
 bNF
 aaa
 bVZ
@@ -146896,8 +146923,8 @@ cdB
 cdB
 cdB
 car
-aad
-abj
+caE
+yja
 caE
 caE
 cOj
@@ -147090,7 +147117,7 @@ aAP
 aAP
 avY
 ask
-ask
+bAL
 aad
 abj
 abj
@@ -147099,6 +147126,7 @@ abj
 abj
 aad
 aad
+aaa
 aaa
 aaa
 aaa
@@ -147119,16 +147147,15 @@ ajr
 aad
 bxC
 bAH
-bCx
 bEo
 bFW
+bLI
 bAH
-bxC
-aad
+jUu
 aad
 aad
 bNF
-aad
+qgU
 bVY
 aad
 aad
@@ -147153,8 +147180,8 @@ car
 car
 car
 car
-caE
-cJI
+eMb
+cqI
 caE
 cme
 cOk
@@ -147346,9 +147373,9 @@ aad
 aad
 aad
 aad
-aad
-apK
-aad
+aFp
+bAM
+aFp
 aLb
 aad
 aaa
@@ -147370,20 +147397,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aad
 aaa
 ajr
 aad
 bxC
 bAH
-bCy
+bCF
+bEo
 bCx
-bCw
 bAH
-bxC
+jUu
 aad
 ajr
-aaa
 bNF
 aaa
 bVZ
@@ -147628,19 +147655,19 @@ ajr
 ajr
 aad
 ajr
+ajr
 aad
 ajr
 aad
 bxC
-bAI
 bCz
+bEn
 bAH
-bFX
 bHN
-bxC
+bTL
+jUu
 aad
 aad
-aaa
 bNF
 aaa
 bVZ
@@ -147888,18 +147915,18 @@ aad
 aaa
 aaa
 aad
+aad
 bxC
-bAJ
-bCA
-bEp
 bCA
 bHO
-bxC
+bLG
+bHO
+cJI
+jUu
 aad
-bNH
-bPK
+wFK
 bRU
-aad
+qgU
 bVZ
 aad
 car
@@ -148145,18 +148172,18 @@ ajr
 ajr
 aad
 aad
+aad
 bxC
-bAK
 bCB
 bEq
 bFY
 bHP
-bxC
-aad
-bNF
-aad
-aad
-aad
+ikq
+bLF
+bLF
+vFT
+bLF
+qgU
 bVZ
 aad
 car
@@ -148402,18 +148429,18 @@ aad
 aad
 aad
 aad
+aad
 bxC
-bAL
 bCC
 bEr
 bFZ
 bHQ
-bxC
+vYo
 bLF
 bNI
+qhB
 bLF
-bLF
-aad
+qgU
 bVZ
 aad
 car
@@ -148659,18 +148686,18 @@ aRF
 aRF
 aad
 aad
+aad
 bxC
-bAM
 bCD
 bEs
 bGa
 bHR
-bxC
-bLG
+nYv
+bLF
 bNJ
 bPL
 bLF
-bTK
+qgU
 bWa
 bTK
 car
@@ -148916,18 +148943,18 @@ bpO
 aRF
 aad
 aad
+aad
 bxC
-bAN
 bCE
 bEt
 bGb
 bHS
-bxC
-bLH
+mte
+bLF
 bNK
 bPM
+fMf
 bLF
-bTL
 bWb
 bYn
 car
@@ -149172,15 +149199,15 @@ bpO
 btK
 aRF
 aad
+qgU
+qgU
 bxC
 bxC
-bxC
-bCF
 bEu
 bGc
+bNH
 bxC
-bxC
-bLI
+bLF
 bNL
 bPN
 bRV
@@ -149430,9 +149457,9 @@ btL
 aRF
 abj
 bxC
-bzd
-bAO
-bCG
+bxC
+bxC
+bCI
 bEv
 bGd
 bHT
@@ -150203,9 +150230,9 @@ aMG
 bxE
 bzg
 bzg
-bCJ
-bEy
 bzg
+bEy
+bLH
 bHV
 bJQ
 bLL
@@ -154660,7 +154687,7 @@ aaa
 aad
 aad
 aad
-ajr
+qgU
 aad
 ebC
 aad
@@ -154918,9 +154945,9 @@ ajr
 aad
 aad
 aad
-aad
-ebC
-aad
+eak
+iUc
+eak
 aad
 aaa
 aac
@@ -169915,8 +169942,8 @@ aaa
 aaa
 aaa
 aad
-aad
 abi
+bAI
 abR
 abi
 acp
@@ -170172,8 +170199,8 @@ aaa
 aaa
 aaa
 abj
-abj
 abH
+abS
 abS
 acd
 acq
@@ -170428,9 +170455,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aad
+qgU
 abi
+bAJ
 abT
 abi
 acr
@@ -170684,9 +170711,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aac
+jdx
 aad
+bzd
 abi
 abi
 ace
@@ -170941,8 +170968,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aac
+jdx
+aad
 aad
 aad
 aad
@@ -171198,7 +171225,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aac
 aac
 aac
 aad
@@ -172489,9 +172516,9 @@ aac
 aaa
 aad
 aad
-aad
-acQ
-aad
+acf
+bAK
+acf
 aad
 aaa
 abi
@@ -172745,7 +172772,7 @@ aaa
 aac
 aac
 aad
-aac
+aad
 aad
 aaj
 aad
@@ -182646,9 +182673,9 @@ aaA
 aaa
 aaa
 aad
-aaa
-dBN
-aad
+dyV
+tML
+dyV
 aad
 aaa
 aad
@@ -182902,9 +182929,9 @@ aci
 aaA
 aaa
 aaa
-ajr
-aad
-dBO
+qgU
+qgU
+dBN
 aad
 aaa
 dFy
@@ -184873,7 +184900,7 @@ aaa
 ajr
 ajr
 ajr
-aaa
+qgU
 aKZ
 aKZ
 aKZ
@@ -185130,9 +185157,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+qgU
 abj
+bAN
 aUK
 aWs
 aXT
@@ -185388,8 +185415,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aad
+aKV
 aKV
 aKV
 aKV

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2134,14 +2134,11 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "adM" = (
-/obj/machinery/door/airlock/external{
-	name = "Abandoned External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/maintenance/fore)
 "adN" = (
 /obj/effect/turf_decal/loading_area{
@@ -2160,11 +2157,16 @@
 /turf/open/floor/engine,
 /area/ai_monitored/storage/satellite)
 "adO" = (
+/obj/machinery/door/airlock/external{
+	name = "Satellite External Airlock";
+	req_one_access_txt = "32;19"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "adP" = (
 /obj/machinery/status_display/ai,
@@ -2513,6 +2515,9 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "aeD" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -2598,13 +2603,20 @@
 	},
 /obj/machinery/light/small,
 /turf/open/floor/plating/airless,
-/area/maintenance/starboard/fore)
+/area/space/nearstation)
 "aeL" = (
+/obj/machinery/door/airlock/external{
+	name = "Abandoned External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "aeM" = (
 /obj/machinery/photocopier,
@@ -5704,13 +5716,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ajI" = (
-/obj/machinery/door/airlock/external{
-	name = "Abandoned External Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6935,7 +6940,6 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset/anchored,
-/obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -9658,12 +9662,19 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/genetics)
 "aqp" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/solar/port/fore)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "aqq" = (
 /obj/machinery/status_display/ai{
 	pixel_x = -32
@@ -12462,12 +12473,18 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "auN" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/solar/starboard/fore)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/fore)
 "auO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -64779,11 +64796,15 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "bZG" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/machinery/door/airlock/external{
+	name = "Abandoned External Airlock"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/fore)
 "bZH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -64902,9 +64923,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bZP" = (
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	name = "Prison External Airlock";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "bZQ" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/structure/window/reinforced,
@@ -67690,11 +67720,6 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "ceA" = (
-/obj/machinery/door/airlock/external{
-	name = "Satellite External Airlock";
-	req_one_access_txt = "32;19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69610,15 +69635,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chO" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "chP" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
+/obj/structure/sign/warning/vacuum/external,
+/turf/closed/wall,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "chQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -69697,12 +69719,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chU" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/solar/port/aft)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "chW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -71343,15 +71372,8 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ckJ" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -71763,15 +71785,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "clx" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -74873,6 +74888,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -74941,6 +74959,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal)
@@ -76410,14 +76431,12 @@
 /turf/open/floor/plating/airless,
 /area/solar/starboard/aft)
 "ctO" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/disposal)
 "ctP" = (
 /obj/structure/cable{
@@ -76438,15 +76457,8 @@
 /turf/open/floor/plating/airless,
 /area/solar/starboard/aft)
 "ctS" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -77673,12 +77685,18 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cwb" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/solar/starboard/aft)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "cwc" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/airlock_sensor/incinerator_atmos{
@@ -77774,9 +77792,9 @@
 /area/maintenance/starboard/aft)
 "cwk" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plating/asteroid/airless,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cwl" = (
 /obj/structure/cable{
@@ -77954,13 +77972,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cwD" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard)
 "cwE" = (
@@ -78131,6 +78142,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cwQ" = (
@@ -78244,6 +78258,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -78301,6 +78318,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cxh" = (
@@ -78340,6 +78360,9 @@
 /area/maintenance/disposal)
 "cxj" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -78387,17 +78410,21 @@
 	},
 /area/maintenance/port/fore)
 "cxp" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "cxq" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/maintenance/fore)
 "cxr" = (
 /obj/structure/sign/poster/contraband/clown,
 /turf/closed/wall/rust,
@@ -83810,15 +83837,8 @@
 	},
 /area/maintenance/starboard)
 "cMH" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -84487,13 +84507,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cUD" = (
-/obj/machinery/door/airlock/external{
-	name = "Prison External Airlock";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -84511,6 +84524,10 @@
 	icon_state = "wood-broken"
 	},
 /area/security/vacantoffice)
+"dky" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dlg" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -84661,6 +84678,12 @@
 "fyr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/mineral/random/labormineral,
+/area/space/nearstation)
+"fAn" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "fXq" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -85114,6 +85137,16 @@
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
+"lqz" = (
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard)
 "lKu" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
@@ -85171,6 +85204,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"mKj" = (
+/turf/closed/wall/rust,
+/area/security/execution/education)
 "mKp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -85537,6 +85573,12 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/port/fore)
+"yaV" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ydo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -99350,9 +99392,9 @@ bTK
 bVs
 hNk
 bXG
+abp
 cZm
-bZG
-aeU
+fAn
 aeU
 aeU
 aeU
@@ -99609,7 +99651,7 @@ cTF
 bXH
 cUD
 bZP
-aeU
+dky
 coy
 aeU
 aeU
@@ -99862,19 +99904,19 @@ aaG
 aez
 cIj
 aeB
-cZm
+mKj
 aez
 aez
+aez
 cko
 cko
-cko
 aeU
 aeU
 aeU
 aeU
-aeU
+cnS
 chU
-aeU
+cnS
 aUz
 aeU
 aeu
@@ -100317,9 +100359,9 @@ aeu
 aeU
 aeU
 aeU
-aeU
+ctH
 aqp
-aeU
+ctH
 aeu
 aeu
 aeu
@@ -112391,7 +112433,7 @@ aaa
 aaa
 aeU
 aUz
-aeu
+adH
 adH
 adH
 adH
@@ -112648,8 +112690,8 @@ aaa
 aaa
 acm
 aeU
-aeU
 adQ
+cxq
 alN
 chj
 aoc
@@ -112905,7 +112947,7 @@ aeR
 aeR
 aes
 aes
-aes
+bZG
 adM
 alO
 amL
@@ -113162,7 +113204,7 @@ aaa
 aaa
 acm
 aaa
-aaa
+adH
 adH
 adH
 adQ
@@ -120603,8 +120645,8 @@ aaa
 aaa
 aaa
 aaa
-aeU
 aeK
+baH
 baH
 afb
 baH
@@ -124312,8 +124354,8 @@ cpb
 crf
 cnu
 cnu
+cnu
 cko
-aeu
 aeu
 aaa
 aaa
@@ -124570,7 +124612,7 @@ cxg
 cxj
 ctO
 cxp
-aeU
+yaV
 ciQ
 aeU
 aaa
@@ -124826,7 +124868,7 @@ cnu
 cnd
 cnu
 cnu
-cxq
+cnu
 cwk
 cxu
 aeU
@@ -126360,9 +126402,9 @@ bzG
 bzG
 aeu
 aeu
-aeU
+ckz
 cwb
-aeU
+ckz
 aeU
 aUz
 aeU
@@ -129382,9 +129424,9 @@ aaQ
 aeo
 aeo
 acm
-acm
-acK
-acm
+bkd
+lqz
+bkd
 aaa
 aaa
 aaa
@@ -129617,9 +129659,9 @@ aeu
 aeu
 aeu
 aeu
-aeU
+cLM
 auN
-aeU
+cLM
 aeu
 aeu
 aeu

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -793,10 +793,16 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "abN" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
 	},
-/area/security/prison)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "abO" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -954,6 +960,9 @@
 /area/security/prison)
 "acg" = (
 /obj/machinery/light/small,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -962,18 +971,22 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/prison)
-"aci" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
 	req_access_txt = "1"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/security/prison)
+"aci" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/door/airlock/external{
+	req_one_access_txt = "13,8"
+	},
+/turf/open/space,
+/area/maintenance/starboard/fore)
 "acj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2047,14 +2060,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aef" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aeg" = (
@@ -2309,9 +2320,6 @@
 "aeG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -7007,14 +7015,8 @@
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "amG" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/space)
 "amH" = (
 /obj/machinery/door/airlock/external{
 	req_one_access_txt = "13,8"
@@ -11553,18 +11555,14 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "avJ" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/starboard/fore)
 "avK" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -37959,12 +37957,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bwl" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Space Access Airlock";
-	req_one_access_txt = "32;19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
@@ -38523,9 +38517,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
@@ -44779,7 +44770,7 @@
 	dir = 8
 	},
 /turf/open/space,
-/area/aisat)
+/area/space/nearstation)
 "bKR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46796,14 +46787,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "bOY" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/space/nearstation)
 "bOZ" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
@@ -53609,9 +53600,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ccY" = (
@@ -54894,17 +54882,12 @@
 /turf/open/space,
 /area/solar/port/aft)
 "cfA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "cfB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
@@ -63173,12 +63156,9 @@
 /turf/open/space,
 /area/solar/port/aft)
 "cvj" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/engine/break_room)
 "cvk" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar/red,
@@ -63664,7 +63644,10 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "cwc" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Escape Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cwd" = (
@@ -63693,9 +63676,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cwh" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -70269,7 +70257,7 @@
 	pixel_x = -32
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "cIz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -70553,17 +70541,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cJf" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/space/nearstation)
 "cJg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -71813,6 +71803,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cLA" = (
@@ -72157,15 +72148,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMk" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/maintenance/aft";
-	name = "Aft Maintenance APC";
-	pixel_y = -24
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
 	},
-/obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/space,
+/area/space)
 "cMl" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty{
@@ -72750,10 +72738,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cNe" = (
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Escape Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cNf" = (
@@ -76630,9 +76614,6 @@
 "dbQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -81313,6 +81294,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gsT" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/solar/starboard/aft)
 "gEk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -81350,9 +81344,7 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "gNe" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "gRS" = (
@@ -81393,6 +81385,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hKW" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/maintenance/aft)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -81526,13 +81522,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "jAj" = (
@@ -81656,17 +81645,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "kDM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Space Access Airlock";
+	req_one_access_txt = "32;19"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/dark,
+/area/engine/break_room)
 "kJW" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -81775,14 +81762,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lNZ" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/lattice/catwalk,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lOi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -81902,6 +81884,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mSd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -82477,8 +82465,9 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "sdw" = (
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/window/reinforced,
+/turf/open/space,
+/area/space)
 "siF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -82576,6 +82565,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"sUM" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sZN" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -82662,6 +82657,13 @@
 /obj/machinery/cryopod,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"uim" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space/nearstation)
 "uku" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
@@ -82832,6 +82834,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"wkz" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "wlH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82853,12 +82859,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wxc" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -82869,10 +82871,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
 "wFH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/maintenance/aft";
+	name = "Aft Maintenance APC";
+	pixel_y = -24
 	},
-/obj/effect/landmark/blobstart,
+/obj/structure/cable/yellow,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wKo" = (
@@ -82880,8 +82885,15 @@
 /turf/closed/wall,
 /area/science/circuit)
 "wOE" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/engine/atmos)
 "wOY" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -82940,15 +82952,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xse" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -83056,6 +83064,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"yfW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "ygk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -95238,9 +95259,9 @@ anS
 anS
 aaf
 aaf
-aqB
-anS
-aaf
+dne
+cfA
+dne
 aaf
 aaf
 aaf
@@ -95496,7 +95517,7 @@ aaa
 aaa
 aaf
 dne
-avJ
+avL
 dne
 aaf
 aaa
@@ -96581,7 +96602,7 @@ bXt
 bYC
 bYC
 bYC
-aaa
+bYC
 aaa
 aaf
 aaa
@@ -96838,8 +96859,8 @@ bXu
 bYD
 bZN
 jyQ
+yfW
 cda
-cej
 cfz
 cED
 chY
@@ -97095,7 +97116,7 @@ bXv
 bYC
 bYC
 bYC
-aaa
+bYC
 aaa
 aaf
 aaa
@@ -99168,7 +99189,7 @@ ckN
 aaa
 aaf
 aaf
-aaa
+lMJ
 aaa
 aaf
 aaa
@@ -99423,7 +99444,7 @@ ckQ
 cjt
 ckN
 aaf
-aaf
+ack
 cwf
 ack
 aaf
@@ -99680,10 +99701,10 @@ cjt
 diJ
 dux
 dux
-ack
+dux
 cwg
-ack
-ack
+dux
+dux
 aaf
 aaa
 aaa
@@ -99937,9 +99958,9 @@ crh
 dxv
 ctn
 dux
-dux
-cfA
-dux
+sUM
+cwh
+dyw
 dux
 aaf
 aaf
@@ -100194,8 +100215,8 @@ dvt
 csf
 cto
 dux
-cvj
-cwh
+cfF
+mSd
 cxb
 dux
 aaa
@@ -101647,7 +101668,7 @@ aaa
 aaa
 acT
 aaa
-aaf
+aee
 aee
 aee
 aee
@@ -101904,7 +101925,7 @@ aaf
 aaf
 acU
 aak
-aak
+abN
 aef
 aeG
 afE
@@ -102161,7 +102182,7 @@ aaa
 aaa
 aaf
 aaa
-aaf
+aee
 aee
 aee
 aee
@@ -108580,7 +108601,7 @@ aaa
 aaa
 aaa
 wOY
-abN
+abe
 ach
 aax
 acN
@@ -108838,7 +108859,7 @@ urv
 abe
 abe
 abe
-aci
+abL
 aax
 acO
 adh
@@ -112806,7 +112827,7 @@ cFh
 cKH
 cLz
 wFH
-cMk
+bTs
 bTs
 bTs
 bTs
@@ -113063,8 +113084,8 @@ cJN
 cCq
 cgN
 cMl
-wOE
 bTs
+hKW
 aaf
 aaf
 aaf
@@ -113321,7 +113342,7 @@ cCq
 cLA
 bTs
 bTs
-bTs
+hKW
 aaf
 aaa
 aaa
@@ -119485,7 +119506,7 @@ aaf
 aaa
 aaf
 dvY
-kDM
+cJd
 dvY
 aaa
 dbN
@@ -119741,13 +119762,13 @@ cEA
 aaf
 aaa
 aaa
-ack
+blx
 cJf
-ack
+blx
 aaa
-aaf
-dbR
-aaa
+dbN
+gsT
+dbN
 aaa
 aaa
 aaa
@@ -119893,7 +119914,7 @@ aaf
 aaa
 aaa
 aaa
-sdw
+aaa
 aaa
 acP
 acP
@@ -119998,9 +120019,9 @@ blx
 aaa
 aaa
 aaa
-aaa
-aaf
-aaa
+wkz
+uim
+wkz
 aaa
 aaf
 dbR
@@ -121523,7 +121544,7 @@ cpK
 ciL
 csc
 dvY
-vLD
+lMJ
 krD
 jyv
 ohj
@@ -121780,7 +121801,7 @@ cpL
 crb
 csd
 dvY
-vLD
+lMJ
 krD
 krD
 noG
@@ -123501,7 +123522,7 @@ aaa
 aaa
 aaf
 dni
-amG
+asB
 amH
 anN
 dnS
@@ -123758,7 +123779,7 @@ aaf
 aaf
 aaf
 dnh
-amH
+avG
 dnh
 apd
 dnS
@@ -124014,8 +124035,8 @@ aaa
 aaf
 aaa
 aaf
-aaa
-ack
+dnh
+aci
 dnh
 ape
 dnS
@@ -127140,8 +127161,8 @@ aaa
 aaf
 bpw
 aaf
-aaf
-ack
+cvj
+kDM
 bxc
 bzg
 bAP
@@ -127398,7 +127419,7 @@ aaf
 bpw
 aaa
 aaf
-aaf
+ack
 bxc
 bzh
 bAQ
@@ -128190,9 +128211,9 @@ gJs
 bFZ
 bAR
 aaf
-bxc
+lNZ
 wxc
-bxc
+lNZ
 aaf
 aaa
 aaf
@@ -128447,9 +128468,9 @@ bVN
 bXr
 bAR
 aaf
-aMr
-ccY
-bBb
+lNZ
+wOE
+lNZ
 aaf
 aaa
 aaf
@@ -128704,7 +128725,7 @@ bVO
 bUJ
 bAR
 aaf
-aMq
+sdw
 ccY
 bgo
 aTQ
@@ -129161,8 +129182,8 @@ aaa
 ack
 ack
 atn
-bOY
-avG
+anN
+dnS
 dqT
 aaf
 aaa
@@ -129218,7 +129239,7 @@ bAR
 bAR
 bAR
 aaf
-aMq
+sdw
 ccY
 aVk
 aNC
@@ -129418,8 +129439,8 @@ aaf
 aaf
 aaf
 dnh
-dnh
-lNZ
+avJ
+avG
 dqT
 aaf
 aaa
@@ -129674,9 +129695,9 @@ aaa
 aaa
 aaf
 aaa
-aaa
-aaf
-ack
+amG
+blx
+bOY
 dqT
 aaf
 anT
@@ -135878,7 +135899,7 @@ blA
 bnu
 bpH
 brU
-aOV
+cMk
 aaa
 aMq
 bzm
@@ -136120,7 +136141,7 @@ aOU
 aOY
 aOY
 aOY
-aTT
+aNC
 aaa
 aaa
 aaa
@@ -136138,7 +136159,7 @@ brV
 aRy
 aaa
 aaa
-aTT
+aNC
 aOY
 aOY
 aOY
@@ -136377,7 +136398,7 @@ aOV
 aaa
 aaa
 aaa
-aTU
+aaf
 aaa
 aRy
 aRy
@@ -136402,7 +136423,7 @@ aaa
 aaa
 aaa
 aaa
-aTU
+aaf
 aaa
 aaa
 aaa
@@ -139461,7 +139482,7 @@ aOV
 aaa
 aaa
 aaa
-aTU
+aaf
 aaa
 aRy
 aRy
@@ -139479,14 +139500,14 @@ bsh
 aRy
 bvt
 aaa
-aTU
+aaf
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aTU
+aaf
 aaa
 aaa
 aaa
@@ -139718,7 +139739,7 @@ aOX
 aNw
 aNw
 aNw
-aTY
+bJl
 aaa
 aaa
 aaa
@@ -139736,14 +139757,14 @@ bsi
 aRy
 aaa
 aaa
-aTY
+bJl
 aNw
 aNw
 aNw
 aNw
 aNw
 aNw
-aTY
+bJl
 aNw
 aNw
 aNw

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1244,15 +1244,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "abM" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "abN" = (
@@ -23608,21 +23600,8 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aKB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
@@ -23645,14 +23624,23 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aKF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/sign/warning/vacuum{
-	pixel_x = -32;
-	pixel_y = 32
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
 	},
-/turf/open/floor/plating,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "aKG" = (
 /obj/structure/cable/white{
@@ -39608,9 +39596,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "edA" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/starboard/fore)
 "eew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -42876,9 +42872,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/rust,
 /area/maintenance/starboard)
-"sIO" = (
-/turf/open/space/basic,
-/area/space/nearstation)
 "sIP" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/bot,
@@ -71461,7 +71454,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+sdX
 uhz
 uhz
 oxn
@@ -71718,7 +71711,7 @@ aac
 aac
 aac
 aac
-aaa
+sdX
 uhz
 iye
 mJP
@@ -91220,7 +91213,7 @@ aaa
 aae
 aaa
 aaa
-aac
+bxZ
 abL
 bxZ
 swz
@@ -91477,7 +91470,7 @@ aaa
 aae
 aad
 aac
-bvg
+edA
 abM
 acu
 adt
@@ -91734,7 +91727,7 @@ aad
 aah
 aad
 aad
-aad
+bxZ
 bxZ
 adq
 bxZ
@@ -93059,7 +93052,7 @@ aRz
 sIc
 sIv
 sFs
-sIO
+aaa
 sIU
 sJe
 sIU
@@ -98477,9 +98470,9 @@ aac
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aac
 aac
 aac
@@ -98734,9 +98727,9 @@ aac
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aac
 aaa
@@ -98991,9 +98984,9 @@ aaa
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -99248,9 +99241,9 @@ aaa
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -99505,9 +99498,9 @@ aaa
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -99762,9 +99755,9 @@ aaa
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -100019,9 +100012,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -100276,9 +100269,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -100533,9 +100526,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -100790,9 +100783,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -101047,9 +101040,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -101304,9 +101297,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -101561,9 +101554,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -101818,9 +101811,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -102075,9 +102068,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -102332,9 +102325,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -102589,9 +102582,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -102846,9 +102839,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -103103,9 +103096,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -103360,9 +103353,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -103617,9 +103610,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -103874,9 +103867,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -104131,9 +104124,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -104388,9 +104381,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -104645,9 +104638,9 @@ jFP
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -104902,9 +104895,9 @@ aaa
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -105159,9 +105152,9 @@ aaa
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa
@@ -105416,9 +105409,9 @@ aaa
 aaa
 aaa
 aaa
-edA
+sdX
 aaa
-edA
+sdX
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1846,7 +1846,7 @@
 	network = list("minisat")
 	},
 /turf/open/space,
-/area/ai_monitored/turret_protected/AIsatextAS)
+/area/ai_monitored/turret_protected/AIsatextAP)
 "aeA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -2623,9 +2623,6 @@
 	dir = 8
 	},
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
@@ -2744,12 +2741,8 @@
 /turf/open/floor/plating,
 /area/security/main)
 "agR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65"
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -2821,11 +2814,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahh" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/showcase/cyborg/old{
-	pixel_y = 20
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/turf/open/space,
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_access_txt = "65"
+	},
+/turf/open/floor/plating,
 /area/space/nearstation)
 "ahi" = (
 /obj/structure/lattice/catwalk,
@@ -2927,13 +2923,8 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "ahr" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Entrance";
-	network = list("minisat")
-	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/space)
 "ahs" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube,
@@ -4690,8 +4681,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "alb" = (
-/turf/open/floor/wood,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/structure/lattice/catwalk,
+/obj/structure/showcase/cyborg/old{
+	pixel_y = 20
+	},
+/turf/open/space,
+/area/space)
 "alc" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigars,
@@ -8703,13 +8698,9 @@
 /turf/closed/wall,
 /area/bridge)
 "atZ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Bridge External Access";
-	req_access_txt = "10;13"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "aua" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -9123,9 +9114,6 @@
 /obj/structure/closet/emcloset/anchored,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /turf/open/floor/plating,
 /area/bridge)
@@ -13689,14 +13677,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "aFj" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "MiniSat Entrance";
+	network = list("minisat")
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/turf/open/space,
+/area/space/nearstation)
 "aFk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/lootdrop/minor/bowler_or_that,
@@ -22864,11 +22851,13 @@
 /turf/closed/wall,
 /area/maintenance/solars/starboard)
 "baH" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/multitool,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Bridge External Access";
+	req_access_txt = "10;13"
+	},
 /turf/open/floor/plating,
-/area/maintenance/solars/starboard)
+/area/ai_monitored/turret_protected/aisat_interior)
 "baI" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -23315,13 +23304,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bbL" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bbM" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -23333,17 +23315,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"bbO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
+"bbM" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/multitool,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "bbP" = (
@@ -23758,16 +23733,6 @@
 /area/maintenance/department/cargo)
 "bcJ" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Solar Access";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard)
-"bcK" = (
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
@@ -23775,24 +23740,38 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"bcL" = (
+"bcK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"bcN" = (
-/obj/machinery/power/solar_control{
-	dir = 8;
-	id = "starboardsolar";
-	name = "Starboard Solar Control"
+"bcL" = (
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"bcN" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/bridge)
 "bcO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -24156,17 +24135,17 @@
 	},
 /area/maintenance/department/cargo)
 "bdR" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Starboard Solar APC";
-	pixel_x = -24
-	},
+/obj/structure/chair/stool,
+/obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "bdS" = (
-/obj/structure/chair/stool,
-/obj/item/cigbutt/cigarbutt,
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "starboardsolar";
+	name = "Starboard Solar Control"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "bdU" = (
@@ -27986,7 +27965,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/storage/emergency/port)
+/area/medical/medbay/zone3)
 "bny" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
@@ -28005,7 +27984,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/storage/emergency/port)
+/area/medical/medbay/zone3)
 "bnz" = (
 /obj/structure/table,
 /obj/item/folder/white,
@@ -43266,7 +43245,7 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/break_room)
 "bTR" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -43455,7 +43434,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/break_room)
 "bUp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
@@ -43848,7 +43827,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/break_room)
 "bVd" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -45016,10 +44995,6 @@
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
 "bXN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
 "bXS" = (
@@ -45926,12 +45901,21 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 8
 	},
+/obj/machinery/air_sensor/atmos/incinerator_tank{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "bZV" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bZY" = (
 /turf/closed/wall,
 /area/chapel/office)
@@ -46149,13 +46133,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/igniter/incinerator_atmos,
-/obj/machinery/air_sensor/atmos/incinerator_tank{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "caP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
+"caQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -46167,13 +46153,9 @@
 	dir = 8;
 	luminosity = 2
 	},
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	network = list("turbine")
-	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"caQ" = (
+"caR" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -46182,10 +46164,6 @@
 	luminosity = 2
 	},
 /turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
-"caR" = (
-/obj/machinery/door/poddoor/incinerator_atmos_main,
-/turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "caS" = (
 /turf/closed/wall,
@@ -46611,9 +46589,9 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccs" = (
-/obj/machinery/door/poddoor/incinerator_atmos_aux,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/department/cargo)
 "ccu" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/plating/asteroid,
@@ -46786,13 +46764,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cdl" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics External Access";
-	req_access_txt = "24"
-	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cdm" = (
@@ -47328,6 +47299,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfu" = (
@@ -47446,14 +47420,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfQ" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "cfS" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/emergency_oxygen/engi,
@@ -47579,13 +47551,11 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cgs" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "61"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -47678,9 +47648,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cgQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
@@ -49453,7 +49420,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/AIsatextAS)
+/area/ai_monitored/turret_protected/AIsatextAP)
 "cnJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/wardrobe/sec_wardrobe,
@@ -50434,20 +50401,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "crB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"crC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"crC" = (
-/obj/machinery/light/small{
-	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53207,6 +53174,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"dhS" = (
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -53580,13 +53551,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dWp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "61"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dYe" = (
 /obj/structure/cable{
@@ -53958,6 +53931,9 @@
 "eVy" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -54360,6 +54336,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fRr" = (
+/turf/open/floor/engine/vacuum,
+/area/maintenance/disposal/incinerator)
 "fRs" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hor)
@@ -54572,6 +54551,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"gmZ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics External Access";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal/incinerator)
 "gna" = (
 /turf/open/floor/plasteel/stairs/medium,
 /area/maintenance/department/crew_quarters/dorms)
@@ -54932,6 +54921,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hbl" = (
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/turf/open/floor/engine/vacuum,
+/area/space)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -55279,14 +55272,15 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "hSM" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Solar Access";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/science)
+/area/maintenance/solars/starboard)
 "hTl" = (
 /obj/structure/sink{
 	dir = 4;
@@ -55395,6 +55389,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"igB" = (
+/obj/machinery/camera{
+	c_tag = "Turbine Chamber";
+	network = list("turbine")
+	},
+/turf/open/floor/engine,
+/area/maintenance/disposal/incinerator)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -55667,7 +55668,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
-/area/storage/emergency/port)
+/area/medical/medbay/zone3)
 "iJi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -57269,6 +57270,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"mvm" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Starboard Solar APC";
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard)
 "mwg" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -57459,6 +57469,10 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nbu" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/space)
 "ncm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -58035,6 +58049,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"ore" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "ost" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -58146,13 +58164,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "oDP" = (
@@ -58221,6 +58232,12 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
+"oGw" = (
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/disposal/incinerator)
 "oHa" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
@@ -59255,6 +59272,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"qVk" = (
+/obj/machinery/door/poddoor/incinerator_atmos_aux,
+/turf/open/space/basic,
+/area/maintenance/disposal/incinerator)
 "qVP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59563,6 +59584,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"rzF" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "rBh" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -60878,10 +60906,14 @@
 /area/science/xenobiology)
 "uXH" = (
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
@@ -61180,6 +61212,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"vHf" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "vIc" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -62245,7 +62286,9 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 
@@ -77500,9 +77543,9 @@ rLi
 tlc
 aiu
 aht
-aaa
-azH
-aaa
+axB
+rKr
+axB
 aaa
 aaa
 aaa
@@ -77760,7 +77803,7 @@ axC
 axB
 rKr
 axB
-axC
+aaa
 aaa
 aaa
 aaa
@@ -78017,7 +78060,7 @@ axC
 ayz
 azN
 axB
-axC
+aaa
 aaa
 aaa
 aaa
@@ -81853,7 +81896,7 @@ ahB
 ahZ
 aiB
 ajc
-agy
+ajM
 akB
 alq
 alZ
@@ -82110,7 +82153,7 @@ ahC
 aia
 aiC
 ajc
-agy
+ajM
 akC
 alr
 ama
@@ -82367,7 +82410,7 @@ ahD
 aib
 aiD
 ajc
-agy
+ajM
 akD
 als
 amb
@@ -82458,9 +82501,9 @@ aht
 aaa
 aaa
 abI
-aaa
-bSZ
-ahi
+dhS
+cqS
+rzF
 bNs
 bOw
 bOw
@@ -82624,7 +82667,7 @@ ahB
 aic
 aiE
 agy
-agy
+ajM
 akE
 alt
 amc
@@ -82716,7 +82759,7 @@ abI
 abI
 abI
 aaa
-aht
+bSZ
 ahi
 bNs
 bNs
@@ -84536,8 +84579,8 @@ aaa
 aaa
 aaa
 aaa
-kSb
-kSb
+fon
+fon
 aht
 aht
 nKo
@@ -88120,7 +88163,7 @@ bDi
 bDi
 bDi
 bIZ
-mZE
+aaa
 aaa
 aaa
 aaa
@@ -88377,8 +88420,8 @@ wNq
 bva
 gMO
 bBX
-mZE
-mZE
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88635,7 +88678,7 @@ bBX
 fdS
 bBX
 bBX
-mZE
+aaa
 aaa
 aaa
 aaa
@@ -90436,7 +90479,7 @@ gnq
 bXk
 ceU
 eVy
-cfP
+bXk
 bXk
 bXk
 bXk
@@ -90950,8 +90993,8 @@ cdM
 bXq
 xmE
 ymb
-cfQ
 bXk
+ore
 qWG
 bXk
 paU
@@ -94698,7 +94741,7 @@ ags
 adX
 adX
 adX
-aaa
+ahr
 aaa
 aaa
 aaa
@@ -94954,8 +94997,8 @@ cnC
 adX
 adX
 adX
-ahh
-aaa
+shH
+alb
 aaa
 aaa
 aaa
@@ -94970,9 +95013,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 ahi
 atY
+bcN
 auU
 atY
 lQQ
@@ -95211,8 +95254,8 @@ bIK
 agt
 agD
 agR
-ahi
-aaa
+ahh
+atZ
 aaa
 aaa
 aaa
@@ -95227,9 +95270,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 ahi
-atZ
+baH
+auV
 auV
 awc
 axg
@@ -95468,8 +95511,8 @@ agg
 adX
 adX
 adX
-ahh
-aaa
+shH
+alb
 aaa
 aaa
 aaa
@@ -95484,8 +95527,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
 ahi
+atY
 atY
 atY
 atY
@@ -95726,8 +95769,8 @@ ags
 adX
 adX
 adX
-ahr
-aht
+shH
+aFj
 aht
 aht
 aht
@@ -98814,7 +98857,7 @@ iqc
 ngp
 cBr
 cBs
-alb
+tap
 gna
 klV
 xbJ
@@ -99584,7 +99627,7 @@ aju
 ajt
 alQ
 mnG
-alb
+tap
 tap
 aiS
 anY
@@ -99842,7 +99885,7 @@ alc
 alR
 amF
 pzF
-alb
+tap
 anm
 ajv
 ajv
@@ -101740,7 +101783,7 @@ caN
 bZT
 bYw
 cdl
-bYw
+oGw
 bYw
 aaa
 mau
@@ -101995,9 +102038,9 @@ bYw
 bZU
 caO
 cbF
-ccs
-cdm
-cdm
+bYw
+gmZ
+bYw
 bYw
 aht
 fon
@@ -102249,13 +102292,13 @@ bVo
 bJP
 aht
 bYw
-bYw
+igB
 caP
+fRr
+qVk
+cdm
+cdm
 bYw
-bYw
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -102505,11 +102548,11 @@ bWg
 bVo
 bJP
 aaa
-aaa
+bYw
 bYw
 caQ
 bYw
-aaa
+bYw
 aaa
 aaa
 aaa
@@ -102762,10 +102805,10 @@ bJP
 bJP
 bJP
 abI
-abI
-bZV
+aaa
+bYw
 caR
-bZV
+bYw
 aaa
 aaa
 aaa
@@ -103019,10 +103062,10 @@ aaa
 aaa
 abI
 aaa
-aaa
-aaa
-aaa
-aaa
+abI
+nbu
+hbl
+nbu
 aaa
 aaa
 aaa
@@ -106822,7 +106865,7 @@ aEl
 aEj
 aEj
 aht
-aht
+ccs
 aEj
 aEl
 aEl
@@ -107079,9 +107122,9 @@ aTu
 aUB
 aEl
 aaa
-aaa
-aEl
+aEj
 aZv
+aUC
 aUC
 bcH
 aUC
@@ -107337,8 +107380,8 @@ aGO
 aEj
 aEj
 aEj
-aEj
 aTx
+aFi
 aGO
 bcI
 aFi
@@ -107574,10 +107617,10 @@ aaa
 aaa
 aaa
 aaa
+aEl
+aFi
 aEj
-aFj
-aEj
-aEj
+aaa
 aEj
 aEl
 aEj
@@ -107594,12 +107637,12 @@ aUC
 aVE
 aUC
 aUC
-aUC
 aZw
-aFi
-bcI
-aFi
-aFi
+aEj
+aEj
+hSM
+aEj
+aEj
 kIo
 bfN
 aEj
@@ -107831,9 +107874,9 @@ aaa
 aaa
 aaa
 aaa
-ahi
-ahi
-ahi
+aEj
+bZV
+aEj
 aaa
 aaa
 aaa
@@ -107853,9 +107896,9 @@ aEj
 aEj
 aYC
 baG
-baG
+cfQ
 bcJ
-baG
+mvm
 baG
 aEj
 aEj
@@ -108088,9 +108131,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+ahi
+ahi
+ahi
 aaa
 aaa
 aaa
@@ -108624,9 +108667,9 @@ aFi
 aFi
 aYD
 baG
-baH
+rWE
 uXH
-bcN
+rWE
 baG
 eZA
 tDn
@@ -108882,7 +108925,7 @@ aXC
 aYE
 baG
 rWE
-bbO
+oCX
 rWE
 baG
 vzT
@@ -109902,7 +109945,7 @@ aaa
 aaa
 aaa
 aaa
-mZE
+aaa
 aaa
 aaa
 aaa
@@ -112504,7 +112547,7 @@ qcH
 bnd
 nNN
 bwm
-hSM
+lWy
 bwm
 bwm
 aaa
@@ -112760,10 +112803,10 @@ riW
 jtf
 bnd
 aht
-ahi
-ahi
-ahi
-aht
+bwm
+vHf
+bwm
+aaa
 aht
 aby
 aht
@@ -113017,9 +113060,9 @@ cOp
 lGS
 bnd
 aaa
-aaa
-aaa
-aaa
+ahi
+ahi
+ahi
 aht
 aaa
 aed


### PR DESCRIPTION
## About The Pull Request

Increases the majority of cycling airlocks from 1 wide, to 2 wide.
This does not include:
-Lambda and Snaxi, because those are actively being worked on at the moment
-BoxStation Engines, because there's a PR for one of the engines, and I'd rather do it all at once, then forget.
-Arrivals, departures, and all associated shuttles. I could be persuaded to make these adjustments, but, expanding arrivals can actually cause a nonzero amount of issues because it moves things around pretty significantly, and departures tends to have the extra space. Shuttle cycling airlocks aren't used to enter and exit the station basically ever.

## Why It's Good For The Game

With fastmos, carrying something into the station with a 1 tile wide movement, is actually just awful. 
Open the first airlock. It gets pushed out of your hand. Go back to grab it. Open the second airlock, more air pushes it out of your hand. Go back, and depending on the amount of air on that part of the station, wait for that to depressurize to bring the object it. While waiting, the first airlock closes, because it's a cycling airlock. Open the first one, the second airlock closes. Move forward to open the second airlock, and hopefully by this point the air doesn't push the object out of your hand again. Then move on with your day.
This fixes that.

## Changelog
:cl:
tweak: Increases the majority of airlocks by 1 tile.
/:cl: