### PR TITLE
Heavily nerfs the TEG.

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -42,6 +42,7 @@
 
 
 #define GENRATE 800		// generator output coefficient from Q
+#define LOGISTIC_FUNCTION(L,k,x,x_0) (L/(1+(NUM_E**(-k*(x-x_0)))))
 
 /obj/machinery/power/generator/process_atmos()
 
@@ -66,7 +67,7 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				lastgen += energy_transfer*(efficiency-0.41)
+				lastgen += LOGISTIC_FUNCTION(1000000,0.0034,delta_temperature,2000)
 
 				hot_air.set_temperature(hot_air.return_temperature() - energy_transfer/hot_air_heat_capacity)
 				cold_air.set_temperature(cold_air.return_temperature() + heat/cold_air_heat_capacity)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -66,7 +66,7 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				lastgen += energy_transfer*efficiency
+				lastgen += energy_transfer*(efficiency-0.41)
 
 				hot_air.set_temperature(hot_air.return_temperature() - energy_transfer/hot_air_heat_capacity)
 				cold_air.set_temperature(cold_air.return_temperature() + heat/cold_air_heat_capacity)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -42,7 +42,6 @@
 
 
 #define GENRATE 800		// generator output coefficient from Q
-#define LOGISTIC_FUNCTION(L,k,x,x_0) (L/(1+(NUM_E**(-k*(x-x_0)))))
 
 /obj/machinery/power/generator/process_atmos()
 


### PR DESCRIPTION
## About The Pull Request

Nerfs the TEG's power generation heavily.

## Why It's Good For The Game

Before, it was way to easy to generate multiple MW of power with the TEG, especially with cheap setups.
This tweaks the power generation to be still powerful, so as to not make it completely worthless. Could still go further.
This is just initial testing, I guess. It's roughly 1/9 as powerful as before.

EDIT:
This changes the way that the TEG's power generation is calculated to be LOGISTICAL rather than LINEAR. You can expect to create about 100kW with a 3x3 build now, but that power generation increases rapidly as you increase the heat past the heat difference that a heater/freezer setup can create.
This is a much better handling of the TEG's power generation, thank you for the suggestions whoever suggested things

https://cdn.discordapp.com/attachments/161574200581029888/689392827545026564/unknown.png

## Changelog
:cl:
tweak: Thermoelectric Generator power output
/:cl:
