### PR TITLE
buffs bokkens stamina damage by 2

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -272,7 +272,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
-	force = 9
+	force = 7 //how much harm mode damage we do
+	var/stamina_damage_increment = 4 //how much extra damage do we do when in non-harm mode
 	throwforce = 10
 	damtype = STAMINA
 	attack_verb = list("whacked", "smacked", "struck")
@@ -323,6 +324,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/melee/bokken/Initialize()
 	. = ..()
 	AddElement(/datum/element/sword_point)
+	if(!harm) //if initialised in non-harm mode, setup force accordingly
+		force = force + stamina_damage_increment
 
 /obj/item/melee/bokken/attack_self(mob/user)
 	harm = !harm

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -327,13 +327,13 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/melee/bokken/attack_self(mob/user)
 	harm = !harm
 	if(harm)
-		force -= 2
+		force -= 4
 		damtype = BRUTE
 		attack_verb = list("bashed", "smashed", "attacked")
 		bare_wound_bonus = 15 // having your leg smacked by a wooden stick is probably not great for it if it's naked
 		wound_bonus = 0
 	else
-		force += 2
+		force += 4
 		damtype = STAMINA
 		attack_verb = list("whacked", "smacked", "struck")
 		bare_wound_bonus = 0

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -330,13 +330,13 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/melee/bokken/attack_self(mob/user)
 	harm = !harm
 	if(harm)
-		force -= 4
+		force -= stamina_damage_increment
 		damtype = BRUTE
 		attack_verb = list("bashed", "smashed", "attacked")
 		bare_wound_bonus = 15 // having your leg smacked by a wooden stick is probably not great for it if it's naked
 		wound_bonus = 0
 	else
-		force += 4
+		force += stamina_damage_increment
 		damtype = STAMINA
 		attack_verb = list("whacked", "smacked", "struck")
 		bare_wound_bonus = 0


### PR DESCRIPTION
## About The Pull Request
baseball bats do more damage than fists
bokken do less stamina damage than fists and less harm than a baseball bat
they're a _weapon_ they should be at least as strong as having no weapon
also rewrites it slightly so it looks better

## Why It's Good For The Game
why do we have this as a weak improvised weapon if its literally weaker than fists
stam damage on it was previously 9 now its 11
for reference: boxing gloves literally do more than this


## Changelog
:cl:
tweak: bokken do two more stamina damage now
/:cl:
