### PR TITLE
pda bomb buyonce

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -177,6 +177,7 @@
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
 	item = /obj/item/storage/box/syndie_kit/guardian
 	cost = 15
+	limited_stock = 1 // you can only have one holopara apparently?
 	refundable = TRUE
 	cant_discount = TRUE
 	surplus = 0

--- a/code/modules/uplink/uplink_items/uplink_explosives.dm
+++ b/code/modules/uplink/uplink_items/uplink_explosives.dm
@@ -80,6 +80,7 @@
 	item = /obj/item/cartridge/virus/syndicate
 	cost = 5
 	restricted = TRUE
+	limited_stock = 1
 
 /datum/uplink_item/explosives/emp
 	name = "EMP Grenades and Implanter Kit"


### PR DESCRIPTION
## About the Pull Request
see title (you can buy pda bombs once only now)
edit: extends to traitor holoparasite kits because you can apparently only have one implanted in yourself?
## Why It's Good For The Game
i too deeply enjoy the riveting gameplay of turning my fucking PDA off
also nitpicking
## Changelog
:cl:
tweak: Traitor holoparasites can now only be bought once, because apparently you can only have one active holopara.
balance: PDA bombs can now only be bought once per uplink.
/:cl: