### PR TITLE
insidious combat gloves but they can tackle now

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -281,6 +281,7 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 		/obj/item/clothing/suit/armor/vest/infiltrator,
 		/obj/item/clothing/under/syndicate/bloodred,
 		/obj/item/clothing/gloves/color/latex/nitrile/infiltrator,
+		/obj/item/clothing/gloves/tackler/combat/insulated/infiltrator,
 		/obj/item/clothing/mask/infiltrator,
 		/obj/item/clothing/shoes/combat/sneakboots,
 		/obj/item/gun/ballistic/automatic/pistol,
@@ -292,7 +293,7 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	new /obj/item/clothing/head/helmet/infiltrator(src)
 	new /obj/item/clothing/suit/armor/vest/infiltrator(src)
 	new /obj/item/clothing/under/syndicate/bloodred(src)
-	new /obj/item/clothing/gloves/color/latex/nitrile/infiltrator(src)
+	new /obj/item/clothing/gloves/tackler/combat/insulated/infiltrator(src)
 	new /obj/item/clothing/mask/infiltrator(src)
 	new /obj/item/clothing/shoes/combat/sneakboots(src)
 

--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -72,6 +72,25 @@
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
 
+/obj/item/clothing/gloves/tackler/combat/insulated/infiltrator
+	name = "insidious guerrilla gloves"
+	desc = "Specialized combat gloves for carrying people around. Transfers tactical kidnapping and tackling knowledge to the user via the use of nanochips."
+	icon_state = "infiltrator"
+	item_state = "infiltrator"
+	siemens_coefficient = 0
+	permeability_coefficient = 0.05
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	var/carrytrait = TRAIT_QUICKER_CARRY
+
+/obj/item/clothing/gloves/tackler/combat/insulated/infiltrator/equipped(mob/user, slot)
+	. = ..()
+	if(slot == SLOT_GLOVES)
+		ADD_TRAIT(user, carrytrait, GLOVE_TRAIT)
+
+/obj/item/clothing/gloves/tackler/combat/insulated/infiltrator/dropped(mob/user)
+	. = ..()
+	REMOVE_TRAIT(user, carrytrait, GLOVE_TRAIT)
+
 /obj/item/clothing/gloves/tackler/rocket
 	name = "rocket gloves"
 	desc = "The ultimate in high risk, high reward, perfect for when you need to stop a criminal from fifty feet away or die trying. Banned in most Spinward gridiron football and rugby leagues."


### PR DESCRIPTION
## About The Pull Request
see title (adds a guerilla glove subtype that also confers the faster fireman carry trait and adds it to sneaksuit case)
## Why It's Good For The Game
heho tackling
## Changelog
:cl:
add: Insidious combat gloves have been replaced by insidious guerilla gloves. They're generally the same, except now you can tackle with them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
