### PR TITLE
ipcs make fake electrical sparks when they blush or cry

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -63,3 +63,23 @@
 
 /datum/effect_system/lightning_spread
 	effect_type = /obj/effect/particle_effect/sparks/electricity
+
+//fake sparks, not subtyped because we don't want light/heat, nor checks inside an often used proc for a rare subcase for saving like 10 lines of code
+/obj/effect/particle_effect/fake_sparks
+	name = "lightning"
+	icon_state = "electricity"
+
+/obj/effect/particle_effect/fake_sparks/Initialize()
+	. = ..()
+	flick(icon_state, src) // replay the animation
+	playsound(src, "sparks", 100, TRUE)
+	QDEL_IN(src, 20)
+
+/datum/effect_system/fake_spark_spread
+	effect_type = /obj/effect/particle_effect/fake_sparks
+
+/proc/do_fake_sparks(n, c, source)
+	var/datum/effect_system/fake_spark_spread/sparks = new
+	sparks.set_up(n, c, source)
+	sparks.autocleanup = TRUE
+	sparks.start()

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -7,6 +7,11 @@
 	message = "cries."
 	emote_type = EMOTE_AUDIBLE
 
+/datum/emote/living/carbon/human/cry/run_emote(mob/user, params)
+	. = ..()
+	if(. && isipcperson(user))
+		do_fake_sparks(5,FALSE,user)
+
 /datum/emote/living/carbon/human/dap
 	key = "dap"
 	key_third_person = "daps"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -9,6 +9,11 @@
 	key_third_person = "blushes"
 	message = "blushes."
 
+/datum/emote/living/blush/run_emote(mob/user, params)
+	. = ..()
+	if(. && isipcperson(user))
+		do_fake_sparks(5,FALSE,user)
+
 /datum/emote/living/bow
 	key = "bow"
 	key_third_person = "bows"


### PR DESCRIPTION
## About The Pull Request
ipcs make fake electrical sparks when they blush or cry
electrical sparks are the kind that don't fly around

they're fake sparks so they make no light or heat
honestly id rather they could make heat/light but id probably be yelled at for making ipcs portable igniters

## Why It's Good For The Game
it's funny

## Changelog
:cl:
tweak: I.P.Cs now short their circuits when expressing emotion, causing sparks to appear around them.
/:cl:
