### PR TITLE
removes firedoor autoopen on touch

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -74,12 +74,6 @@
 /obj/machinery/door/firedoor/Bumped(atom/movable/AM)
 	if(panel_open || operating || welded)
 		return
-	if(ismob(AM))
-		var/mob/user = AM
-		if(density && !welded && !operating && !(stat & NOPOWER) && (!density || allow_hand_open(user)))
-			add_fingerprint(user)
-			open()
-			return TRUE
 	return FALSE
 
 /obj/machinery/door/firedoor/power_change()
@@ -90,14 +84,6 @@
 		stat |= NOPOWER
 
 /obj/machinery/door/firedoor/on_attack_hand(mob/user, act_intent = user.a_intent, unarmed_attack_flags)
-	if(!welded && !operating && !(stat & NOPOWER) && (!density || allow_hand_open(user)))
-		add_fingerprint(user)
-		if(density)
-			emergency_close_timer = world.time + 30 // prevent it from instaclosing again if in space
-			open()
-		else
-			close()
-		return TRUE
 	if(operating || !density)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it was pretty nice when you could actually use firedoors to pose an obstacle rather than having them be worthless outside of an actual fire.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: firedoors no longer automatically open on touch when there's no pressure differences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
