### PR TITLE
qol: customization features appear in alphabetical order

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/alienpeople.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/alienpeople.dm
@@ -14,13 +14,13 @@
 	name = "Standard"
 	icon_state = "standard"
 
-/datum/sprite_accessory/xeno_dorsal/royal
-	name = "Royal"
-	icon_state = "royal"
-
 /datum/sprite_accessory/xeno_dorsal/down
 	name = "Dorsal Down"
 	icon_state = "down"
+
+/datum/sprite_accessory/xeno_dorsal/royal
+	name = "Royal"
+	icon_state = "royal"
 
 /******************************************
 ************* Xeno Tails ******************
@@ -57,13 +57,13 @@
 	name = "Standard"
 	icon_state = "standard"
 
-/datum/sprite_accessory/xeno_head/royal
-	name = "royal"
-	icon_state = "royal"
-
 /datum/sprite_accessory/xeno_head/hollywood
 	name = "hollywood"
 	icon_state = "hollywood"
+
+/datum/sprite_accessory/xeno_head/royal
+	name = "royal"
+	icon_state = "royal"
 
 /datum/sprite_accessory/xeno_head/warrior
 	name = "warrior"

--- a/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/body_markings.dm
@@ -16,6 +16,12 @@
 	icon_state = "dtiger"
 	gender_specific = 1
 
+/datum/sprite_accessory/body_markings/guilmon
+	name = "Guilmon"
+	icon_state = "guilmon"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/markings_notmammals.dmi'
+
 /datum/sprite_accessory/body_markings/ltiger
 	name = "Light Tiger Body"
 	icon_state = "ltiger"
@@ -49,11 +55,6 @@
 	icon = 'modular_citadel/icons/mob/markings_notmammals.dmi'
 	relevant_layers = null
 
-/datum/sprite_accessory/mam_body_markings/plain
-	name = "Plain"
-	icon_state = "plain"
-	icon = 'modular_citadel/icons/mob/markings_notmammals.dmi'
-
 /datum/sprite_accessory/mam_body_markings/redpanda
 	name = "Redpanda"
 	icon_state = "redpanda"
@@ -77,13 +78,13 @@
 	icon_state = "bellyslim"
 	icon = 'modular_citadel/icons/mob/markings_notmammals.dmi'
 
-/datum/sprite_accessory/mam_body_markings/corgi
-	name = "Corgi"
-	icon_state = "corgi"
-
 /datum/sprite_accessory/mam_body_markings/cow
 	name = "Bovine"
 	icon_state = "bovine"
+
+/datum/sprite_accessory/mam_body_markings/corgi
+	name = "Corgi"
+	icon_state = "corgi"
 
 /datum/sprite_accessory/mam_body_markings/corvid
 	name = "Corvid"
@@ -139,14 +140,18 @@
 	name = "Hyena"
 	icon_state = "hyena"
 
-/datum/sprite_accessory/mam_body_markings/lab
-	name = "Lab"
-	icon_state = "lab"
-
 /datum/sprite_accessory/mam_body_markings/insect
 	name = "Insect"
 	icon_state = "insect"
 	icon = 'modular_citadel/icons/mob/markings_notmammals.dmi'
+
+/datum/sprite_accessory/mam_body_markings/lab
+	name = "Lab"
+	icon_state = "lab"
+
+/datum/sprite_accessory/mam_body_markings/orca
+	name = "Orca"
+	icon_state = "orca"
 
 /datum/sprite_accessory/mam_body_markings/otie
 	name = "Otie"
@@ -156,13 +161,14 @@
 	name = "Otter"
 	icon_state = "otter"
 
-/datum/sprite_accessory/mam_body_markings/orca
-	name = "Orca"
-	icon_state = "orca"
-
 /datum/sprite_accessory/mam_body_markings/panther
 	name = "Panther"
 	icon_state = "panther"
+
+/datum/sprite_accessory/mam_body_markings/plain
+	name = "Plain"
+	icon_state = "plain"
+	icon = 'modular_citadel/icons/mob/markings_notmammals.dmi'
 
 /datum/sprite_accessory/mam_body_markings/possum
 	name = "Possum"
@@ -171,6 +177,10 @@
 /datum/sprite_accessory/mam_body_markings/raccoon
 	name = "Raccoon"
 	icon_state = "raccoon"
+
+/datum/sprite_accessory/mam_body_markings/sergal
+	name = "Sergal"
+	icon_state = "sergal"
 
 /datum/sprite_accessory/mam_body_markings/pede
 	name = "Scolipede"
@@ -181,17 +191,13 @@
 	name = "Shark"
 	icon_state = "shark"
 
-/datum/sprite_accessory/mam_body_markings/skunk
-	name = "Skunk"
-	icon_state = "skunk"
-
-/datum/sprite_accessory/mam_body_markings/sergal
-	name = "Sergal"
-	icon_state = "sergal"
-
 /datum/sprite_accessory/mam_body_markings/shepherd
 	name = "Shepherd"
 	icon_state = "shepherd"
+
+/datum/sprite_accessory/mam_body_markings/skunk
+	name = "Skunk"
+	icon_state = "skunk"
 
 /datum/sprite_accessory/mam_body_markings/tajaran
 	name = "Tajaran"
@@ -232,74 +238,9 @@
 	icon_state = "none"
 	relevant_layers = null
 
-/datum/sprite_accessory/insect_fluff/plain
-	name = "Plain"
-	icon_state = "plain"
-
-/datum/sprite_accessory/insect_fluff/reddish
-	name = "Reddish"
-	icon_state = "redish"
-
-/datum/sprite_accessory/insect_fluff/royal
-	name = "Royal"
-	icon_state = "royal"
-
-/datum/sprite_accessory/insect_fluff/gothic
-	name = "Gothic"
-	icon_state = "gothic"
-
-/datum/sprite_accessory/insect_fluff/lovers
-	name = "Lovers"
-	icon_state = "lovers"
-
-/datum/sprite_accessory/insect_fluff/whitefly
-	name = "White Fly"
-	icon_state = "whitefly"
-
 /datum/sprite_accessory/insect_fluff/punished
 	name = "Burnt Off"
 	icon_state = "punished"
-
-/datum/sprite_accessory/insect_fluff/firewatch
-	name = "Firewatch"
-	icon_state = "firewatch"
-
-/datum/sprite_accessory/insect_fluff/deathhead
-	name = "Deathshead"
-	icon_state = "deathhead"
-
-/datum/sprite_accessory/insect_fluff/poison
-	name = "Poison"
-	icon_state = "poison"
-
-/datum/sprite_accessory/insect_fluff/ragged
-	name = "Ragged"
-	icon_state = "ragged"
-
-/datum/sprite_accessory/insect_fluff/moonfly
-	name = "Moon Fly"
-	icon_state = "moonfly"
-
-/datum/sprite_accessory/insect_fluff/snow
-	name = "Snow"
-	icon_state = "snow"
-
-/datum/sprite_accessory/insect_fluff/oakworm
-	name = "Oak Worm"
-	icon_state = "oakworm"
-
-/datum/sprite_accessory/insect_fluff/jungle
-	name = "Jungle"
-	icon_state = "jungle"
-
-/datum/sprite_accessory/insect_fluff/witchwing
-	name = "Witch Wing"
-	icon_state = "witchwing"
-
-/datum/sprite_accessory/insect_fluff/colored
-	name = "Colored (Hair)"
-	icon_state = "snow"
-	color_src = HAIR
 
 /datum/sprite_accessory/insect_fluff/colored1
 	name = "Colored (Primary)"
@@ -315,3 +256,68 @@
 	name = "Colored (Tertiary)"
 	icon_state = "snow"
 	color_src = MUTCOLORS3
+
+/datum/sprite_accessory/insect_fluff/colored
+	name = "Colored (Hair)"
+	icon_state = "snow"
+	color_src = HAIR
+
+/datum/sprite_accessory/insect_fluff/deathhead
+	name = "Deathshead"
+	icon_state = "deathhead"
+
+/datum/sprite_accessory/insect_fluff/firewatch
+	name = "Firewatch"
+	icon_state = "firewatch"
+
+/datum/sprite_accessory/insect_fluff/gothic
+	name = "Gothic"
+	icon_state = "gothic"
+
+/datum/sprite_accessory/insect_fluff/jungle
+	name = "Jungle"
+	icon_state = "jungle"
+
+/datum/sprite_accessory/insect_fluff/lovers
+	name = "Lovers"
+	icon_state = "lovers"
+
+/datum/sprite_accessory/insect_fluff/moonfly
+	name = "Moon Fly"
+	icon_state = "moonfly"
+
+/datum/sprite_accessory/insect_fluff/oakworm
+	name = "Oak Worm"
+	icon_state = "oakworm"
+
+/datum/sprite_accessory/insect_fluff/plain
+	name = "Plain"
+	icon_state = "plain"
+
+/datum/sprite_accessory/insect_fluff/poison
+	name = "Poison"
+	icon_state = "poison"
+
+/datum/sprite_accessory/insect_fluff/ragged
+	name = "Ragged"
+	icon_state = "ragged"
+
+/datum/sprite_accessory/insect_fluff/reddish
+	name = "Reddish"
+	icon_state = "redish"
+
+/datum/sprite_accessory/insect_fluff/royal
+	name = "Royal"
+	icon_state = "royal"
+
+/datum/sprite_accessory/insect_fluff/snow
+	name = "Snow"
+	icon_state = "snow"
+
+/datum/sprite_accessory/insect_fluff/whitefly
+	name = "White Fly"
+	icon_state = "whitefly"
+
+/datum/sprite_accessory/insect_fluff/witchwing
+	name = "Witch Wing"
+	icon_state = "witchwing"

--- a/code/modules/mob/dead/new_player/sprite_accessories/ears.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/ears.dm
@@ -41,7 +41,7 @@
 	extra = TRUE
 	extra_color_src = NONE
 
-/datum/sprite_accessory/ears/human/bigwolfdark
+/datum/sprite_accessory/ears/human/bigwolfdark //ignore alphabetical sort here for ease-of-use
 	name = "Dark Big Wolf"
 	icon_state = "bigwolfdark"
 	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
@@ -54,6 +54,12 @@
 	color_src = MATRIXED
 	extra = TRUE
 	extra_color_src = NONE
+
+/datum/sprite_accessory/ears/bunny
+	name = "Bunny"
+	icon_state = "bunny"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
 
 /datum/sprite_accessory/ears/cat
 	name = "Cat"
@@ -73,6 +79,12 @@
 	icon_state = "horn1"
 	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
 	color_src = MUTCOLORS3
+
+/datum/sprite_accessory/ears/lab
+	name = "Dog, Floppy"
+	icon_state = "lab"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
 
 /datum/sprite_accessory/ears/human/eevee
 	name = "Eevee"
@@ -115,12 +127,6 @@
 	icon_state = "jellyfish"
 	color_src = HAIR
 
-/datum/sprite_accessory/ears/lab
-	name = "Dog, Floppy"
-	icon_state = "lab"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
-
 /datum/sprite_accessory/ears/murid
 	name = "Murid"
 	icon_state = "murid"
@@ -133,17 +139,17 @@
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
 
-/datum/sprite_accessory/ears/human/pede
-	name = "Scolipede"
-	icon_state = "pede"
-	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
-	color_src = MATRIXED
-
 /datum/sprite_accessory/ears/human/rabbit
 	name = "Rabbit"
 	icon_state = "rabbit"
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
+
+/datum/sprite_accessory/ears/human/pede
+	name = "Scolipede"
+	icon_state = "pede"
+	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
+	color_src = MATRIXED
 
 /datum/sprite_accessory/ears/human/sergal
 	name = "Sergal"
@@ -166,12 +172,6 @@
 /datum/sprite_accessory/ears/wolf
 	name = "Wolf"
 	icon_state = "wolf"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
-
-/datum/sprite_accessory/ears/bunny
-	name = "Bunny"
-	icon_state = "bunny"
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
 
@@ -216,7 +216,7 @@
 	extra = TRUE
 	extra_color_src = NONE
 
-/datum/sprite_accessory/ears/mam_ears/bigwolfdark
+/datum/sprite_accessory/ears/mam_ears/bigwolfdark //alphabetical sort ignored here for ease-of-use
 	name = "Dark Big Wolf"
 	icon_state = "bigwolfdark"
 
@@ -225,6 +225,10 @@
 	icon_state = "bigwolfinnerdark"
 	extra = TRUE
 	extra_color_src = NONE
+
+/datum/sprite_accessory/ears/mam_ears/bunny
+	name = "Bunny"
+	icon_state = "bunny"
 
 /datum/sprite_accessory/ears/mam_ears/cat
 	name = "Cat"
@@ -256,12 +260,10 @@
 	name = "Eevee"
 	icon_state = "eevee"
 
-
 /datum/sprite_accessory/ears/mam_ears/elf
 	name = "Elf"
 	icon_state = "elf"
 	color_src = MUTCOLORS3
-
 
 /datum/sprite_accessory/ears/mam_ears/elephant
 	name = "Elephant"
@@ -283,14 +285,14 @@
 	name = "Husky"
 	icon_state = "wolf"
 
-/datum/sprite_accessory/ears/mam_ears/kangaroo
-	name = "kangaroo"
-	icon_state = "kangaroo"
-
 /datum/sprite_accessory/ears/mam_ears/jellyfish
 	name = "Jellyfish"
 	icon_state = "jellyfish"
 	color_src = HAIR
+
+/datum/sprite_accessory/ears/mam_ears/kangaroo
+	name = "kangaroo"
+	icon_state = "kangaroo"
 
 /datum/sprite_accessory/ears/mam_ears/lab
 	name = "Dog, Long"
@@ -304,17 +306,13 @@
 	name = "Otusian"
 	icon_state = "otie"
 
-/datum/sprite_accessory/ears/mam_ears/squirrel
-	name = "Squirrel"
-	icon_state = "squirrel"
+/datum/sprite_accessory/ears/mam_ears/rabbit
+	name = "Rabbit"
+	icon_state = "rabbit"
 
 /datum/sprite_accessory/ears/mam_ears/pede
 	name = "Scolipede"
 	icon_state = "pede"
-
-/datum/sprite_accessory/ears/mam_ears/rabbit
-	name = "Rabbit"
-	icon_state = "rabbit"
 
 /datum/sprite_accessory/ears/mam_ears/sergal
 	name = "Sergal"
@@ -324,10 +322,10 @@
 	name = "skunk"
 	icon_state = "skunk"
 
+/datum/sprite_accessory/ears/mam_ears/squirrel
+	name = "Squirrel"
+	icon_state = "squirrel"
+
 /datum/sprite_accessory/ears/mam_ears/wolf
 	name = "Wolf"
 	icon_state = "wolf"
-
-/datum/sprite_accessory/ears/mam_ears/bunny
-	name = "Bunny"
-	icon_state = "bunny"

--- a/code/modules/mob/dead/new_player/sprite_accessories/frills.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/frills.dm
@@ -11,6 +11,10 @@
 	icon_state = "none"
 	relevant_layers = null
 
+/datum/sprite_accessory/frills/aquatic
+	name = "Aquatic"
+	icon_state = "aqua"
+
 /datum/sprite_accessory/frills/simple
 	name = "Simple"
 	icon_state = "simple"
@@ -18,7 +22,3 @@
 /datum/sprite_accessory/frills/short
 	name = "Short"
 	icon_state = "short"
-
-/datum/sprite_accessory/frills/aquatic
-	name = "Aquatic"
-	icon_state = "aqua"

--- a/code/modules/mob/dead/new_player/sprite_accessories/hair_face.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/hair_face.dm
@@ -6,6 +6,10 @@
 	gender = MALE // barf (unless you're a dorf, dorfs dig chix w/ beards :P)
 
 // please make sure they're sorted alphabetically and categorized
+/datum/sprite_accessory/facial_hair/shaved //this is exempt from the alphabetical sort
+	name = "Shaved"
+	icon_state = null
+	gender = NEUTER
 
 /datum/sprite_accessory/facial_hair/threeoclock
 	name = "Beard (3 o\'Clock)"
@@ -134,11 +138,6 @@
 /datum/sprite_accessory/facial_hair/muttonmus
 	name = "Mutton Chops with Moustache"
 	icon_state = "facial_muttonmus"
-
-/datum/sprite_accessory/facial_hair/shaved
-	name = "Shaved"
-	icon_state = null
-	gender = NEUTER
 
 /datum/sprite_accessory/facial_hair/sideburn
 	name = "Sideburns"

--- a/code/modules/mob/dead/new_player/sprite_accessories/hair_head.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/hair_head.dm
@@ -9,6 +9,10 @@
 	// try to spell
 	// you do not need to define _s or _l sub-states, game automatically does this for you
 
+/datum/sprite_accessory/hair/bald //this is exempt from the alphabetical sort
+	name = "Bald"
+	icon_state = "bald"
+
 /datum/sprite_accessory/hair/afro
 	name = "Afro"
 	icon_state = "hair_afro"
@@ -24,10 +28,6 @@
 /datum/sprite_accessory/hair/antenna
 	name = "Ahoge"
 	icon_state = "hair_antenna"
-
-/datum/sprite_accessory/hair/bald
-	name = "Bald"
-	icon_state = "bald"
 
 /datum/sprite_accessory/hair/balding
 	name = "Balding Hair"

--- a/code/modules/mob/dead/new_player/sprite_accessories/horns.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/horns.dm
@@ -12,21 +12,9 @@
 	icon_state = "none"
 	relevant_layers = null
 
-/datum/sprite_accessory/horns/simple
-	name = "Simple"
-	icon_state = "simple"
-
-/datum/sprite_accessory/horns/short
-	name = "Short"
-	icon_state = "short"
-
 /datum/sprite_accessory/horns/curled
 	name = "Curled"
 	icon_state = "curled"
-
-/datum/sprite_accessory/horns/ram
-	name = "Ram"
-	icon_state = "ram"
 
 /datum/sprite_accessory/horns/angler
 	name = "Angeler"
@@ -40,3 +28,15 @@
 /datum/sprite_accessory/horns/guilmon
 	name = "Guilmon"
 	icon_state = "guilmon"
+
+/datum/sprite_accessory/horns/ram
+	name = "Ram"
+	icon_state = "ram"
+
+/datum/sprite_accessory/horns/simple
+	name = "Simple"
+	icon_state = "simple"
+
+/datum/sprite_accessory/horns/short
+	name = "Short"
+	icon_state = "short"

--- a/code/modules/mob/dead/new_player/sprite_accessories/ipc_synths.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/ipc_synths.dm
@@ -11,95 +11,89 @@
 	name = "Blank"
 	icon_state = "blank"
 
-/datum/sprite_accessory/screen/pink
-	name = "Pink"
-	icon_state = "pink"
-
-/datum/sprite_accessory/screen/green
-	name = "Green"
-	icon_state = "green"
-
-/datum/sprite_accessory/screen/red
-	name = "Red"
-	icon_state = "red"
-
 /datum/sprite_accessory/screen/blue
 	name = "Blue"
 	icon_state = "blue"
-
-/datum/sprite_accessory/screen/yellow
-	name = "Yellow"
-	icon_state = "yellow"
-
-/datum/sprite_accessory/screen/shower
-	name = "Shower"
-	icon_state = "shower"
-
-/datum/sprite_accessory/screen/nature
-	name = "Nature"
-	icon_state = "nature"
-
-/datum/sprite_accessory/screen/eight
-	name = "Eight"
-	icon_state = "eight"
-
-/datum/sprite_accessory/screen/goggles
-	name = "Goggles"
-	icon_state = "goggles"
-
-/datum/sprite_accessory/screen/heart
-	name = "Heart"
-	icon_state = "heart"
-
-/datum/sprite_accessory/screen/monoeye
-	name = "Mono eye"
-	icon_state = "monoeye"
 
 /datum/sprite_accessory/screen/breakout
 	name = "Breakout"
 	icon_state = "breakout"
 
-/datum/sprite_accessory/screen/purple
-	name = "Purple"
-	icon_state = "purple"
-
-/datum/sprite_accessory/screen/scroll
-	name = "Scroll"
-	icon_state = "scroll"
+/datum/sprite_accessory/screen/bsod
+	name = "BSOD"
+	icon_state = "bsod"
 
 /datum/sprite_accessory/screen/console
 	name = "Console"
 	icon_state = "console"
 
-/datum/sprite_accessory/screen/rgb
-	name = "RGB"
-	icon_state = "rgb"
+/datum/sprite_accessory/screen/eight
+	name = "Eight"
+	icon_state = "eight"
+
+/datum/sprite_accessory/screen/eyes
+	name = "Eyes"
+	icon_state = "eyes"
+
+/datum/sprite_accessory/screen/ecgwave
+	name = "ECG wave"
+	icon_state = "ecgwave"
+
+/datum/sprite_accessory/screen/green
+	name = "Green"
+	icon_state = "green"
+
+/datum/sprite_accessory/screen/goggles
+	name = "Goggles"
+	icon_state = "goggles"
 
 /datum/sprite_accessory/screen/golglider
 	name = "Gol Glider"
 	icon_state = "golglider"
 
+/datum/sprite_accessory/screen/heart
+	name = "Heart"
+	icon_state = "heart"
+
+/datum/sprite_accessory/screen/pink
+	name = "Pink"
+	icon_state = "pink"
+
+/datum/sprite_accessory/screen/red
+	name = "Red"
+	icon_state = "red"
+
+/datum/sprite_accessory/screen/monoeye
+	name = "Mono eye"
+	icon_state = "monoeye"
+
+/datum/sprite_accessory/screen/nature
+	name = "Nature"
+	icon_state = "nature"
+
+/datum/sprite_accessory/screen/purple
+	name = "Purple"
+	icon_state = "purple"
+
 /datum/sprite_accessory/screen/rainbow
 	name = "Rainbow"
 	icon_state = "rainbow"
 
-/datum/sprite_accessory/screen/sunburst
-	name = "Sunburst"
-	icon_state = "sunburst"
-
-/datum/sprite_accessory/screen/static
-	name = "Static"
-	icon_state = "static"
-
-//Oracle Station sprites
-
-/datum/sprite_accessory/screen/bsod
-	name = "BSOD"
-	icon_state = "bsod"
-
 /datum/sprite_accessory/screen/redtext
 	name = "Red Text"
 	icon_state = "retext"
+
+/datum/sprite_accessory/screen/rgb
+	name = "RGB"
+	icon_state = "rgb"
+
+/datum/sprite_accessory/screen/scroll
+	name = "Scroll"
+	icon_state = "scroll"
+
+/datum/sprite_accessory/screen/shower
+	name = "Shower"
+	icon_state = "shower"
 
 /datum/sprite_accessory/screen/sinewave
 	name = "Sine wave"
@@ -109,22 +103,25 @@
 	name = "Square wave"
 	icon_state = "squarwave"
 
-/datum/sprite_accessory/screen/ecgwave
-	name = "ECG wave"
-	icon_state = "ecgwave"
+/datum/sprite_accessory/screen/stars
+	name = "Stars"
+	icon_state = "stars"
 
-/datum/sprite_accessory/screen/eyes
-	name = "Eyes"
-	icon_state = "eyes"
+/datum/sprite_accessory/screen/static
+	name = "Static"
+	icon_state = "static"
+
+/datum/sprite_accessory/screen/sunburst
+	name = "Sunburst"
+	icon_state = "sunburst"
 
 /datum/sprite_accessory/screen/textdrop
 	name = "Text drop"
 	icon_state = "textdrop"
 
-/datum/sprite_accessory/screen/stars
-	name = "Stars"
-	icon_state = "stars"
-
+/datum/sprite_accessory/screen/yellow
+	name = "Yellow"
+	icon_state = "yellow"
 
 /******************************************
 ************** IPC Antennas ***************
@@ -145,14 +142,6 @@
 	name = "Angled Antennae"
 	icon_state = "antennae"
 
-/datum/sprite_accessory/antenna/tvantennae
-	name = "TV Antennae"
-	icon_state = "tvantennae"
-
-/datum/sprite_accessory/antenna/cyberhead
-	name = "Cyberhead"
-	icon_state = "cyberhead"
-
 /datum/sprite_accessory/antenna/antlers
 	name = "Antlers"
 	icon_state = "antlers"
@@ -160,3 +149,11 @@
 /datum/sprite_accessory/antenna/crowned
 	name = "Crowned"
 	icon_state = "crowned"
+
+/datum/sprite_accessory/antenna/cyberhead
+	name = "Cyberhead"
+	icon_state = "cyberhead"
+
+/datum/sprite_accessory/antenna/tvantennae
+	name = "TV Antennae"
+	icon_state = "tvantennae"

--- a/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
@@ -49,6 +49,13 @@
 	relevant_layers = null
 	hide_legs = FALSE
 
+/datum/sprite_accessory/taur/canine
+	name = "Canine"
+	icon_state = "canine"
+	taur_mode = STYLE_PAW_TAURIC
+	color_src = MUTCOLORS
+	extra = TRUE
+
 /datum/sprite_accessory/taur/cow
 	name = "Cow"
 	icon_state = "cow"
@@ -95,6 +102,13 @@
 	color_src = MUTCOLORS
 	extra = TRUE
 
+/datum/sprite_accessory/taur/feline
+	name = "Feline"
+	icon_state = "feline"
+	taur_mode = STYLE_PAW_TAURIC
+	color_src = MUTCOLORS
+	extra = TRUE
+
 /datum/sprite_accessory/taur/horse
 	name = "Horse"
 	icon_state = "horse"
@@ -126,17 +140,3 @@
 	taur_mode = STYLE_SNEK_TAURIC
 	color_src = MUTCOLORS
 	hide_legs = USE_SNEK_CLIP_MASK
-
-/datum/sprite_accessory/taur/canine
-	name = "Canine"
-	icon_state = "canine"
-	taur_mode = STYLE_PAW_TAURIC
-	color_src = MUTCOLORS
-	extra = TRUE
-
-/datum/sprite_accessory/taur/feline
-	name = "Feline"
-	icon_state = "feline"
-	taur_mode = STYLE_PAW_TAURIC
-	color_src = MUTCOLORS
-	extra = TRUE

--- a/code/modules/mob/dead/new_player/sprite_accessories/snouts.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/snouts.dm
@@ -7,13 +7,18 @@
 	var/obj/item/bodypart/head/HD = H.get_bodypart(BODY_ZONE_HEAD)
 	return ((H.wear_mask && (H.wear_mask.flags_inv & HIDESNOUT)) || (H.head && (H.head.flags_inv & HIDESNOUT)) || !HD || HD.status == BODYPART_ROBOTIC)
 
-/datum/sprite_accessory/snouts/sharp
-	name = "Sharp"
-	icon_state = "sharp"
+/datum/sprite_accessory/snout/guilmon
+	name = "Guilmon"
+	icon_state = "guilmon"
+	color_src = MATRIXED
 
 /datum/sprite_accessory/snouts/round
 	name = "Round"
 	icon_state = "round"
+
+/datum/sprite_accessory/snouts/sharp
+	name = "Sharp"
+	icon_state = "sharp"
 
 /datum/sprite_accessory/snouts/sharplight
 	name = "Sharp + Light"
@@ -22,11 +27,6 @@
 /datum/sprite_accessory/snouts/roundlight
 	name = "Round + Light"
 	icon_state = "roundlight"
-
-/datum/sprite_accessory/snout/guilmon
-	name = "Guilmon"
-	icon_state = "guilmon"
-	color_src = MATRIXED
 
 //christ this was a mistake, but it's here just in case someone wants to selectively fix -- Pooj
 /************* Lizard compatable snoots ***********
@@ -192,11 +192,19 @@
 	extra = TRUE
 	extra_color_src = MUTCOLORS3
 
-/datum/sprite_accessory/snouts/mam_snouts/skulldog
-	name = "Skulldog"
-	icon_state = "skulldog"
+/datum/sprite_accessory/snouts/mam_snouts/husky
+	name = "Husky"
+	icon_state = "husky"
+
+/datum/sprite_accessory/snouts/mam_snouts/rhino
+	name = "Horn"
+	icon_state = "rhino"
 	extra = TRUE
-	extra_color_src = MATRIXED
+	extra = MUTCOLORS3
+
+/datum/sprite_accessory/snouts/mam_snouts/rodent
+	name = "Rodent"
+	icon_state = "rodent"
 
 /datum/sprite_accessory/snouts/mam_snouts/lcanid
 	name = "Mammal, Long"
@@ -226,31 +234,19 @@
 	name = "Mammal, Thick ALT"
 	icon_state = "wolfalt"
 
-/datum/sprite_accessory/snouts/mam_snouts/redpanda
-	name = "WahCoon"
-	icon_state = "wah"
-
-/datum/sprite_accessory/snouts/mam_snouts/redpandaalt
-	name = "WahCoon ALT"
-	icon_state = "wahalt"
-
-/datum/sprite_accessory/snouts/mam_snouts/rhino
-	name = "Horn"
-	icon_state = "rhino"
-	extra = TRUE
-	extra = MUTCOLORS3
-
-/datum/sprite_accessory/snouts/mam_snouts/rodent
-	name = "Rodent"
-	icon_state = "rodent"
-
-/datum/sprite_accessory/snouts/mam_snouts/husky
-	name = "Husky"
-	icon_state = "husky"
-
 /datum/sprite_accessory/snouts/mam_snouts/otie
 	name = "Otie"
 	icon_state = "otie"
+
+/datum/sprite_accessory/snouts/mam_snouts/round
+	name = "Round"
+	icon_state = "round"
+	color_src = MUTCOLORS
+
+/datum/sprite_accessory/snouts/mam_snouts/roundlight
+	name = "Round + Light"
+	icon_state = "roundlight"
+	color_src = MUTCOLORS
 
 /datum/sprite_accessory/snouts/mam_snouts/pede
 	name = "Scolipede"
@@ -268,18 +264,9 @@
 	name = "hShark"
 	icon_state = "hshark"
 
-/datum/sprite_accessory/snouts/mam_snouts/toucan
-	name = "Toucan"
-	icon_state = "toucan"
-
 /datum/sprite_accessory/snouts/mam_snouts/sharp
 	name = "Sharp"
 	icon_state = "sharp"
-	color_src = MUTCOLORS
-
-/datum/sprite_accessory/snouts/mam_snouts/round
-	name = "Round"
-	icon_state = "round"
 	color_src = MUTCOLORS
 
 /datum/sprite_accessory/snouts/mam_snouts/sharplight
@@ -287,11 +274,23 @@
 	icon_state = "sharplight"
 	color_src = MUTCOLORS
 
-/datum/sprite_accessory/snouts/mam_snouts/roundlight
-	name = "Round + Light"
-	icon_state = "roundlight"
-	color_src = MUTCOLORS
+/datum/sprite_accessory/snouts/mam_snouts/skulldog
+	name = "Skulldog"
+	icon_state = "skulldog"
+	extra = TRUE
+	extra_color_src = MATRIXED
 
+/datum/sprite_accessory/snouts/mam_snouts/toucan
+	name = "Toucan"
+	icon_state = "toucan"
+
+/datum/sprite_accessory/snouts/mam_snouts/redpanda
+	name = "WahCoon"
+	icon_state = "wah"
+
+/datum/sprite_accessory/snouts/mam_snouts/redpandaalt
+	name = "WahCoon ALT"
+	icon_state = "wahalt"
 
 /******************************************
 **************** Snouts *******************
@@ -317,6 +316,16 @@
 	icon_state = "felephant"
 	extra = TRUE
 	extra_color_src = MUTCOLORS3
+
+/datum/sprite_accessory/snouts/mam_snouts/frhino
+	name = "Horn (Top)"
+	icon_state = "frhino"
+	extra = TRUE
+	extra = MUTCOLORS3
+
+/datum/sprite_accessory/snouts/mam_snouts/fhusky
+	name = "Husky (Top)"
+	icon_state = "fhusky"
 
 /datum/sprite_accessory/snouts/mam_snouts/flcanid
 	name = "Mammal, Long (Top)"
@@ -346,27 +355,23 @@
 	name = "Mammal, Thick ALT (Top)"
 	icon_state = "fwolfalt"
 
-/datum/sprite_accessory/snouts/mam_snouts/fredpanda
-	name = "WahCoon (Top)"
-	icon_state = "fwah"
-
-/datum/sprite_accessory/snouts/mam_snouts/frhino
-	name = "Horn (Top)"
-	icon_state = "frhino"
-	extra = TRUE
-	extra = MUTCOLORS3
+/datum/sprite_accessory/snouts/mam_snouts/fotie
+	name = "Otie (Top)"
+	icon_state = "fotie"
 
 /datum/sprite_accessory/snouts/mam_snouts/frodent
 	name = "Rodent (Top)"
 	icon_state = "frodent"
 
-/datum/sprite_accessory/snouts/mam_snouts/fhusky
-	name = "Husky (Top)"
-	icon_state = "fhusky"
+/datum/sprite_accessory/snouts/mam_snouts/fround
+	name = "Round (Top)"
+	icon_state = "fround"
+	color_src = MUTCOLORS
 
-/datum/sprite_accessory/snouts/mam_snouts/fotie
-	name = "Otie (Top)"
-	icon_state = "fotie"
+/datum/sprite_accessory/snouts/mam_snouts/froundlight
+	name = "Round + Light (Top)"
+	icon_state = "froundlight"
+	color_src = MUTCOLORS
 
 /datum/sprite_accessory/snouts/mam_snouts/fpede
 	name = "Scolipede (Top)"
@@ -380,18 +385,9 @@
 	name = "Shark (Top)"
 	icon_state = "fshark"
 
-/datum/sprite_accessory/snouts/mam_snouts/ftoucan
-	name = "Toucan (Top)"
-	icon_state = "ftoucan"
-
 /datum/sprite_accessory/snouts/mam_snouts/fsharp
 	name = "Sharp (Top)"
 	icon_state = "fsharp"
-	color_src = MUTCOLORS
-
-/datum/sprite_accessory/snouts/mam_snouts/fround
-	name = "Round (Top)"
-	icon_state = "fround"
 	color_src = MUTCOLORS
 
 /datum/sprite_accessory/snouts/mam_snouts/fsharplight
@@ -399,7 +395,10 @@
 	icon_state = "fsharplight"
 	color_src = MUTCOLORS
 
-/datum/sprite_accessory/snouts/mam_snouts/froundlight
-	name = "Round + Light (Top)"
-	icon_state = "froundlight"
-	color_src = MUTCOLORS
+/datum/sprite_accessory/snouts/mam_snouts/ftoucan
+	name = "Toucan (Top)"
+	icon_state = "ftoucan"
+
+/datum/sprite_accessory/snouts/mam_snouts/fredpanda
+	name = "WahCoon (Top)"
+	icon_state = "fwah"

--- a/code/modules/mob/dead/new_player/sprite_accessories/socks.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/socks.dm
@@ -20,6 +20,10 @@
 	name = "Knee-high - Bee"
 	icon_state = "bee_knee"
 
+/datum/sprite_accessory/underwear/socks/christmas_knee
+	name = "Knee-High - Christmas"
+	icon_state = "christmas_knee"
+
 /datum/sprite_accessory/underwear/socks/commie_knee
 	name = "Knee-High - Commie"
 	icon_state = "commie_knee"
@@ -31,6 +35,14 @@
 /datum/sprite_accessory/underwear/socks/rainbow_knee
 	name = "Knee-high - Rainbow"
 	icon_state = "rainbow_knee"
+
+/datum/sprite_accessory/underwear/socks/candycaner_knee
+	name = "Knee-High - Red Candy Cane"
+	icon_state = "candycaner_knee"
+
+/datum/sprite_accessory/underwear/socks/candycaneg_knee //ignore alphabetisation for ease of use in scenarios like this
+	name = "Knee-High - Green Candy Cane"
+	icon_state = "candycaneg_knee"
 
 /datum/sprite_accessory/underwear/socks/striped_knee
 	name = "Knee-high - Striped"
@@ -45,18 +57,6 @@
 /datum/sprite_accessory/underwear/socks/uk_knee
 	name = "Knee-High - UK"
 	icon_state = "uk_knee"
-
-/datum/sprite_accessory/underwear/socks/christmas_knee
-	name = "Knee-High - Christmas"
-	icon_state = "christmas_knee"
-
-/datum/sprite_accessory/underwear/socks/candycaner_knee
-	name = "Knee-High - Red Candy Cane"
-	icon_state = "candycaner_knee"
-
-/datum/sprite_accessory/underwear/socks/candycaneg_knee
-	name = "Knee-High - Green Candy Cane"
-	icon_state = "candycaneg_knee"
 
 /datum/sprite_accessory/underwear/socks/socks_norm
 	name = "Normal"
@@ -129,21 +129,33 @@
 	name = "Thigh-high - Bee"
 	icon_state = "bee_thigh"
 
+/datum/sprite_accessory/underwear/socks/christmas_thigh
+	name = "Thigh-high - Christmas"
+	icon_state = "christmas_thigh"
+
 /datum/sprite_accessory/underwear/socks/commie_thigh
 	name = "Thigh-high - Commie"
 	icon_state = "commie_thigh"
-
-/datum/sprite_accessory/underwear/socks/usa_thigh
-	name = "Thigh-high - Freedom"
-	icon_state = "assblastusa_thigh"
 
 /datum/sprite_accessory/underwear/socks/fishnet
 	name = "Thigh-high - Fishnet"
 	icon_state = "fishnet"
 
+/datum/sprite_accessory/underwear/socks/usa_thigh
+	name = "Thigh-high - Freedom"
+	icon_state = "assblastusa_thigh"
+
 /datum/sprite_accessory/underwear/socks/rainbow_thigh
 	name = "Thigh-high - Rainbow"
 	icon_state = "rainbow_thigh"
+
+/datum/sprite_accessory/underwear/socks/candycaner_thigh
+	name = "Thigh-high - Red Candy Cane"
+	icon_state = "candycaner_thigh"
+
+/datum/sprite_accessory/underwear/socks/candycaneg_thigh
+	name = "Thigh-high - Green Candy Cane"
+	icon_state = "candycaneg_thigh"
 
 /datum/sprite_accessory/underwear/socks/striped_thigh
 	name = "Thigh-high - Striped"
@@ -158,15 +170,3 @@
 /datum/sprite_accessory/underwear/socks/uk_thigh
 	name = "Thigh-high - UK"
 	icon_state = "uk_thigh"
-
-/datum/sprite_accessory/underwear/socks/christmas_thigh
-	name = "Thigh-high - Christmas"
-	icon_state = "christmas_thigh"
-
-/datum/sprite_accessory/underwear/socks/candycaner_thigh
-	name = "Thigh-high - Red Candy Cane"
-	icon_state = "candycaner_thigh"
-
-/datum/sprite_accessory/underwear/socks/candycaneg_thigh
-	name = "Thigh-high - Green Candy Cane"
-	icon_state = "candycaneg_thigh"

--- a/code/modules/mob/dead/new_player/sprite_accessories/spines.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/spines.dm
@@ -21,21 +21,13 @@
 	name = "None"
 	icon_state = "none"
 
-/datum/sprite_accessory/spines/short
-	name = "Short"
-	icon_state = "short"
+/datum/sprite_accessory/spines/aqautic
+	name = "Aquatic"
+	icon_state = "aqua"
 
-/datum/sprite_accessory/spines_animated/short
-	name = "Short"
-	icon_state = "short"
-
-/datum/sprite_accessory/spines/shortmeme
-	name = "Short + Membrane"
-	icon_state = "shortmeme"
-
-/datum/sprite_accessory/spines_animated/shortmeme
-	name = "Short + Membrane"
-	icon_state = "shortmeme"
+/datum/sprite_accessory/spines_animated/aqautic
+	name = "Aquatic"
+	icon_state = "aqua"
 
 /datum/sprite_accessory/spines/long
 	name = "Long"
@@ -53,10 +45,18 @@
 	name = "Long + Membrane"
 	icon_state = "longmeme"
 
-/datum/sprite_accessory/spines/aqautic
-	name = "Aquatic"
-	icon_state = "aqua"
+/datum/sprite_accessory/spines/short
+	name = "Short"
+	icon_state = "short"
 
-/datum/sprite_accessory/spines_animated/aqautic
-	name = "Aquatic"
-	icon_state = "aqua"
+/datum/sprite_accessory/spines_animated/short
+	name = "Short"
+	icon_state = "short"
+
+/datum/sprite_accessory/spines/shortmeme
+	name = "Short + Membrane"
+	icon_state = "shortmeme"
+
+/datum/sprite_accessory/spines_animated/shortmeme
+	name = "Short + Membrane"
+	icon_state = "shortmeme"

--- a/code/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
@@ -25,12 +25,6 @@
 	icon_state = "synthliz_tertunder"
 
 //Synth body markings
-/datum/sprite_accessory/mam_body_markings/synthliz
-	recommended_species = list("synthliz")
-	icon = 'modular_citadel/icons/mob/synthliz_body_markings.dmi'
-	name = "Synthetic Lizard - Plates"
-	icon_state = "synthlizscutes"
-
 /datum/sprite_accessory/mam_body_markings/synthliz/synthliz_pecs
 	icon = 'modular_citadel/icons/mob/synthliz_body_markings.dmi'
 	name = "Synthetic Lizard - Pecs"
@@ -40,6 +34,12 @@
 	icon = 'modular_citadel/icons/mob/synthliz_body_markings.dmi'
 	name = "Synthetic Lizard - Pecs Light"
 	icon_state = "synthlizpecslight"
+
+/datum/sprite_accessory/mam_body_markings/synthliz
+	recommended_species = list("synthliz")
+	icon = 'modular_citadel/icons/mob/synthliz_body_markings.dmi'
+	name = "Synthetic Lizard - Plates"
+	icon_state = "synthlizscutes"
 
 //Synth tails
 /datum/sprite_accessory/tails/mam_tails/synthliz
@@ -70,17 +70,17 @@
 	name = "Synthetic Lizard - Curled"
 	icon_state = "synth_curled"
 
-/datum/sprite_accessory/antenna/synthliz/synthliz_thick
+/datum/sprite_accessory/antenna/synthliz/synth_horns
 	icon = 'modular_citadel/icons/mob/synthliz_antennas.dmi'
 	color_src = MUTCOLORS
-	name = "Synthetic Lizard - Thick"
-	icon_state = "synth_thick"
+	name = "Synthetic Lizard - Horns"
+	icon_state = "synth_horns"
 
-/datum/sprite_accessory/antenna/synthliz/synth_thicklight
+/datum/sprite_accessory/antenna/synthliz/synth_hornslight
 	icon = 'modular_citadel/icons/mob/synthliz_antennas.dmi'
 	color_src = MATRIXED
-	name = "Synthetic Lizard - Thick Light"
-	icon_state = "synth_thicklight"
+	name = "Synthetic Lizard - Horns Light"
+	icon_state = "synth_hornslight"
 
 /datum/sprite_accessory/antenna/synthliz/synth_short
 	icon = 'modular_citadel/icons/mob/synthliz_antennas.dmi'
@@ -100,17 +100,17 @@
 	name = "Synthetic Lizard - Sharp Light"
 	icon_state = "synth_sharplight"
 
-/datum/sprite_accessory/antenna/synthliz/synth_horns
+/datum/sprite_accessory/antenna/synthliz/synthliz_thick
 	icon = 'modular_citadel/icons/mob/synthliz_antennas.dmi'
 	color_src = MUTCOLORS
-	name = "Synthetic Lizard - Horns"
-	icon_state = "synth_horns"
+	name = "Synthetic Lizard - Thick"
+	icon_state = "synth_thick"
 
-/datum/sprite_accessory/antenna/synthliz/synth_hornslight
+/datum/sprite_accessory/antenna/synthliz/synth_thicklight
 	icon = 'modular_citadel/icons/mob/synthliz_antennas.dmi'
 	color_src = MATRIXED
-	name = "Synthetic Lizard - Horns Light"
-	icon_state = "synth_hornslight"
+	name = "Synthetic Lizard - Thick Light"
+	icon_state = "synth_thicklight"
 
 //Synth Taurs (Ported from Virgo)
 /datum/sprite_accessory/taur/synthliz

--- a/code/modules/mob/dead/new_player/sprite_accessories/tails.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/tails.dm
@@ -18,38 +18,7 @@
 /datum/sprite_accessory/tails_animated/lizard/is_not_visible(var/mob/living/carbon/human/H, var/tauric)
 	return (((H.wear_suit && (H.wear_suit.flags_inv & HIDETAUR)) || tauric) || H.dna.species.mutant_bodyparts["tail_lizard"])
 
-/datum/sprite_accessory/tails/lizard/smooth
-	name = "Smooth"
-	icon_state = "smooth"
-
-/datum/sprite_accessory/tails_animated/lizard/smooth
-	name = "Smooth"
-	icon_state = "smooth"
-
-/datum/sprite_accessory/tails/lizard/dtiger
-	name = "Dark Tiger"
-	icon_state = "dtiger"
-
-/datum/sprite_accessory/tails_animated/lizard/dtiger
-	name = "Dark Tiger"
-	icon_state = "dtiger"
-
-/datum/sprite_accessory/tails/lizard/ltiger
-	name = "Light Tiger"
-	icon_state = "ltiger"
-
-/datum/sprite_accessory/tails_animated/lizard/ltiger
-	name = "Light Tiger"
-	icon_state = "ltiger"
-
-/datum/sprite_accessory/tails/lizard/spikes
-	name = "Spikes"
-	icon_state = "spikes"
-
-/datum/sprite_accessory/tails_animated/lizard/spikes
-	name = "Spikes"
-	icon_state = "spikes"
-
+//this goes first regardless of alphabetical order
 /datum/sprite_accessory/tails/lizard/none
 	name = "None"
 	icon_state = "None"
@@ -72,11 +41,13 @@
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
-/datum/sprite_accessory/body_markings/guilmon
-	name = "Guilmon"
-	icon_state = "guilmon"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/markings_notmammals.dmi'
+/datum/sprite_accessory/tails/lizard/dtiger
+	name = "Dark Tiger"
+	icon_state = "dtiger"
+
+/datum/sprite_accessory/tails_animated/lizard/dtiger
+	name = "Dark Tiger"
+	icon_state = "dtiger"
 
 /datum/sprite_accessory/tails/lizard/guilmon
 	name = "Guilmon"
@@ -89,6 +60,30 @@
 	icon_state = "guilmon"
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+
+/datum/sprite_accessory/tails/lizard/ltiger
+	name = "Light Tiger"
+	icon_state = "ltiger"
+
+/datum/sprite_accessory/tails_animated/lizard/ltiger
+	name = "Light Tiger"
+	icon_state = "ltiger"
+
+/datum/sprite_accessory/tails/lizard/smooth
+	name = "Smooth"
+	icon_state = "smooth"
+
+/datum/sprite_accessory/tails_animated/lizard/smooth
+	name = "Smooth"
+	icon_state = "smooth"
+
+/datum/sprite_accessory/tails/lizard/spikes
+	name = "Spikes"
+	icon_state = "spikes"
+
+/datum/sprite_accessory/tails_animated/lizard/spikes
+	name = "Spikes"
+	icon_state = "spikes"
 
 /******************************************
 ************** Human Tails ****************
@@ -106,18 +101,6 @@
 
 /datum/sprite_accessory/tails_animated/human/is_not_visible(var/mob/living/carbon/human/H, var/tauric)
 	return (((H.wear_suit && (H.wear_suit.flags_inv & HIDETAUR)) || tauric)|| H.dna.species.mutant_bodyparts["tail_human"])
-
-/datum/sprite_accessory/tails/human/ailurus
-	name = "Red Panda"
-	icon_state = "wah"
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-	color_src = MATRIXED
-
-/datum/sprite_accessory/tails_animated/human/ailurus
-	name = "Red Panda"
-	icon_state = "wah"
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-	color_src = MATRIXED
 
 /datum/sprite_accessory/tails/human/axolotl
 	name = "Axolotl"
@@ -199,6 +182,14 @@
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 	color_src = MATRIXED
 
+/datum/sprite_accessory/tails/human/corvid
+	name = "Corvid"
+	icon_state = "crow"
+
+/datum/sprite_accessory/tails_animated/human/corvid
+	name = "Corvid"
+	icon_state = "crow"
+
 /datum/sprite_accessory/tails/human/cow
 	name = "Cow"
 	icon_state = "cow"
@@ -211,13 +202,25 @@
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 	color_src = MATRIXED
 
-/datum/sprite_accessory/tails/human/corvid
-	name = "Corvid"
-	icon_state = "crow"
+/datum/sprite_accessory/tails/human/dtiger
+	name = "Dark Tiger"
+	icon_state = "dtiger"
 
-/datum/sprite_accessory/tails_animated/human/corvid
-	name = "Corvid"
-	icon_state = "crow"
+/datum/sprite_accessory/tails_animated/human/dtiger
+	name = "Dark Tiger"
+	icon_state = "dtiger"
+
+/datum/sprite_accessory/tails/human/datashark
+	name = "datashark"
+	icon_state = "datashark"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+
+/datum/sprite_accessory/tails_animated/human/datashark
+	name = "datashark"
+	icon_state = "datashark"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
 /datum/sprite_accessory/tails/human/eevee
 	name = "Eevee"
@@ -298,7 +301,7 @@
 	color_src = MATRIXED
 
 /datum/sprite_accessory/tails_animated/human/insect
-	name = "insect"
+	name = "Insect"
 	icon_state = "insect"
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 	color_src = MATRIXED
@@ -315,6 +318,14 @@
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
+/datum/sprite_accessory/tails/human/ltiger
+	name = "Light Tiger"
+	icon_state = "ltiger"
+
+/datum/sprite_accessory/tails_animated/human/ltiger
+	name = "Light Tiger"
+	icon_state = "ltiger"
+
 /datum/sprite_accessory/tails/human/murid
 	name = "Murid"
 	icon_state = "murid"
@@ -324,18 +335,6 @@
 /datum/sprite_accessory/tails_animated/human/murid
 	name = "Murid"
 	icon_state = "murid"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-
-/datum/sprite_accessory/tails/human/otie
-	name = "Otusian"
-	icon_state = "otie"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-
-/datum/sprite_accessory/tails_animated/human/otie
-	name = "Otusian"
-	icon_state = "otie"
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
@@ -351,15 +350,15 @@
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
-/datum/sprite_accessory/tails/human/pede
-	name = "Scolipede"
-	icon_state = "pede"
+/datum/sprite_accessory/tails/human/otie
+	name = "Otusian"
+	icon_state = "otie"
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
-/datum/sprite_accessory/tails_animated/human/pede
-	name = "Scolipede"
-	icon_state = "pede"
+/datum/sprite_accessory/tails_animated/human/otie
+	name = "Otusian"
+	icon_state = "otie"
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
@@ -375,6 +374,30 @@
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
+/datum/sprite_accessory/tails/human/ailurus
+	name = "Red Panda"
+	icon_state = "wah"
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+	color_src = MATRIXED
+
+/datum/sprite_accessory/tails_animated/human/ailurus
+	name = "Red Panda"
+	icon_state = "wah"
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+	color_src = MATRIXED
+
+/datum/sprite_accessory/tails/human/pede
+	name = "Scolipede"
+	icon_state = "pede"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+
+/datum/sprite_accessory/tails_animated/human/pede
+	name = "Scolipede"
+	icon_state = "pede"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+
 /datum/sprite_accessory/tails/human/sergal
 	name = "Sergal"
 	icon_state = "sergal"
@@ -384,6 +407,18 @@
 /datum/sprite_accessory/tails_animated/human/sergal
 	name = "Sergal"
 	icon_state = "sergal"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+
+/datum/sprite_accessory/tails/human/shark
+	name = "Shark"
+	icon_state = "shark"
+	color_src = MATRIXED
+	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
+
+/datum/sprite_accessory/tails_animated/human/shark
+	name = "Shark"
+	icon_state = "shark"
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
@@ -414,30 +449,6 @@
 /datum/sprite_accessory/tails_animated/human/spikes
 	name = "Spikes"
 	icon_state = "spikes"
-
-/datum/sprite_accessory/tails/human/shark
-	name = "Shark"
-	icon_state = "shark"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-
-/datum/sprite_accessory/tails_animated/human/shark
-	name = "Shark"
-	icon_state = "shark"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-
-/datum/sprite_accessory/tails/human/datashark
-	name = "datashark"
-	icon_state = "datashark"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
-
-/datum/sprite_accessory/tails_animated/human/datashark
-	name = "datashark"
-	icon_state = "datashark"
-	color_src = MATRIXED
-	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
 /datum/sprite_accessory/tails/human/straighttail
 	name = "Straight Tail"
@@ -495,22 +506,6 @@
 	color_src = MATRIXED
 	icon = 'modular_citadel/icons/mob/mam_tails.dmi'
 
-/datum/sprite_accessory/tails/human/dtiger
-	name = "Dark Tiger"
-	icon_state = "dtiger"
-
-/datum/sprite_accessory/tails_animated/human/dtiger
-	name = "Dark Tiger"
-	icon_state = "dtiger"
-
-/datum/sprite_accessory/tails/human/ltiger
-	name = "Light Tiger"
-	icon_state = "ltiger"
-
-/datum/sprite_accessory/tails_animated/human/ltiger
-	name = "Light Tiger"
-	icon_state = "ltiger"
-
 /datum/sprite_accessory/tails/human/wolf
 	name = "Wolf"
 	icon_state = "wolf"
@@ -553,16 +548,6 @@
 	name = "None"
 	icon_state = "none"
 	relevant_layers = null
-
-/datum/sprite_accessory/tails/mam_tails/ailurus
-	name = "Red Panda"
-	icon_state = "wah"
-	extra = TRUE
-
-/datum/sprite_accessory/tails_animated/mam_tails_animated/ailurus
-	name = "Red Panda"
-	icon_state = "wah"
-	extra = TRUE
 
 /datum/sprite_accessory/tails/mam_tails/axolotl
 	name = "Axolotl"
@@ -637,6 +622,18 @@
 /datum/sprite_accessory/tails_animated/mam_tails_animated/cow
 	name = "Cow"
 	icon_state = "cow"
+
+/datum/sprite_accessory/tails/mam_tails/dtiger
+	name = "Dark Tiger"
+	icon_state = "dtiger"
+	color_src = MUTCOLORS
+	icon = 'icons/mob/mutant_bodyparts.dmi'
+
+/datum/sprite_accessory/tails_animated/mam_tails_animated/dtiger
+	name = "Dark Tiger"
+	icon_state = "dtiger"
+	color_src = MUTCOLORS
+	icon = 'icons/mob/mutant_bodyparts.dmi'
 
 /datum/sprite_accessory/tails/mam_tails/eevee
 	name = "Eevee"
@@ -728,6 +725,18 @@ datum/sprite_accessory/tails/mam_tails/insect
 	name = "Lab"
 	icon_state = "lab"
 
+/datum/sprite_accessory/tails/mam_tails/ltiger
+	name = "Light Tiger"
+	icon_state = "ltiger"
+	color_src = MUTCOLORS
+	icon = 'icons/mob/mutant_bodyparts.dmi'
+
+/datum/sprite_accessory/tails_animated/mam_tails_animated/ltiger
+	name = "Light Tiger"
+	icon_state = "ltiger"
+	color_src = MUTCOLORS
+	icon = 'icons/mob/mutant_bodyparts.dmi'
+
 /datum/sprite_accessory/tails/mam_tails/murid
 	name = "Murid"
 	icon_state = "murid"
@@ -735,14 +744,6 @@ datum/sprite_accessory/tails/mam_tails/insect
 /datum/sprite_accessory/tails_animated/mam_tails_animated/murid
 	name = "Murid"
 	icon_state = "murid"
-
-/datum/sprite_accessory/tails/mam_tails/otie
-	name = "Otusian"
-	icon_state = "otie"
-
-/datum/sprite_accessory/tails_animated/mam_tails_animated/otie
-	name = "Otusian"
-	icon_state = "otie"
 
 /datum/sprite_accessory/tails/mam_tails/orca
 	name = "Orca"
@@ -752,13 +753,13 @@ datum/sprite_accessory/tails/mam_tails/insect
 	name = "Orca"
 	icon_state = "orca"
 
-/datum/sprite_accessory/tails/mam_tails/pede
-	name = "Scolipede"
-	icon_state = "pede"
+/datum/sprite_accessory/tails/mam_tails/otie
+	name = "Otusian"
+	icon_state = "otie"
 
-/datum/sprite_accessory/tails_animated/mam_tails_animated/pede
-	name = "Scolipede"
-	icon_state = "pede"
+/datum/sprite_accessory/tails_animated/mam_tails_animated/otie
+	name = "Otusian"
+	icon_state = "otie"
 
 /datum/sprite_accessory/tails/mam_tails/rabbit
 	name = "Rabbit"
@@ -768,6 +769,24 @@ datum/sprite_accessory/tails/mam_tails/insect
 	name = "Rabbit"
 	icon_state = "rabbit"
 
+/datum/sprite_accessory/tails/mam_tails/ailurus
+	name = "Red Panda"
+	icon_state = "wah"
+	extra = TRUE
+
+/datum/sprite_accessory/tails_animated/mam_tails_animated/ailurus
+	name = "Red Panda"
+	icon_state = "wah"
+	extra = TRUE
+
+/datum/sprite_accessory/tails/mam_tails/pede
+	name = "Scolipede"
+	icon_state = "pede"
+
+/datum/sprite_accessory/tails_animated/mam_tails_animated/pede
+	name = "Scolipede"
+	icon_state = "pede"
+
 /datum/sprite_accessory/tails/mam_tails/sergal
 	name = "Sergal"
 	icon_state = "sergal"
@@ -775,6 +794,22 @@ datum/sprite_accessory/tails/mam_tails/insect
 /datum/sprite_accessory/tails_animated/mam_tails_animated/sergal
 	name = "Sergal"
 	icon_state = "sergal"
+
+/datum/sprite_accessory/tails/mam_tails/shark
+	name = "Shark"
+	icon_state = "shark"
+
+/datum/sprite_accessory/tails_animated/mam_tails_animated/shark
+	name = "Shark"
+	icon_state = "shark"
+
+/datum/sprite_accessory/tails/mam_tails/shepherd
+	name = "Shepherd"
+	icon_state = "shepherd"
+
+/datum/sprite_accessory/tails_animated/mam_tails_animated/shepherd
+	name = "Shepherd"
+	icon_state = "shepherd"
 
 /datum/sprite_accessory/tails/mam_tails/skunk
 	name = "Skunk"
@@ -807,22 +842,6 @@ datum/sprite_accessory/tails/mam_tails/insect
 	icon_state = "spikes"
 	color_src = MUTCOLORS
 	icon = 'icons/mob/mutant_bodyparts.dmi'
-
-/datum/sprite_accessory/tails/mam_tails/shark
-	name = "Shark"
-	icon_state = "shark"
-
-/datum/sprite_accessory/tails_animated/mam_tails_animated/shark
-	name = "Shark"
-	icon_state = "shark"
-
-/datum/sprite_accessory/tails/mam_tails/shepherd
-	name = "Shepherd"
-	icon_state = "shepherd"
-
-/datum/sprite_accessory/tails_animated/mam_tails_animated/shepherd
-	name = "Shepherd"
-	icon_state = "shepherd"
 
 /datum/sprite_accessory/tails/mam_tails/straighttail
 	name = "Straight Tail"
@@ -863,30 +882,6 @@ datum/sprite_accessory/tails/mam_tails/insect
 /datum/sprite_accessory/tails_animated/mam_tails_animated/tiger
 	name = "Tiger"
 	icon_state = "tiger"
-
-/datum/sprite_accessory/tails/mam_tails/dtiger
-	name = "Dark Tiger"
-	icon_state = "dtiger"
-	color_src = MUTCOLORS
-	icon = 'icons/mob/mutant_bodyparts.dmi'
-
-/datum/sprite_accessory/tails_animated/mam_tails_animated/dtiger
-	name = "Dark Tiger"
-	icon_state = "dtiger"
-	color_src = MUTCOLORS
-	icon = 'icons/mob/mutant_bodyparts.dmi'
-
-/datum/sprite_accessory/tails/mam_tails/ltiger
-	name = "Light Tiger"
-	icon_state = "ltiger"
-	color_src = MUTCOLORS
-	icon = 'icons/mob/mutant_bodyparts.dmi'
-
-/datum/sprite_accessory/tails_animated/mam_tails_animated/ltiger
-	name = "Light Tiger"
-	icon_state = "ltiger"
-	color_src = MUTCOLORS
-	icon = 'icons/mob/mutant_bodyparts.dmi'
 
 /datum/sprite_accessory/tails/mam_tails/wolf
 	name = "Wolf"

--- a/code/modules/mob/dead/new_player/sprite_accessories/undershirt.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/undershirt.dm
@@ -12,6 +12,38 @@
 
 // please make sure they're sorted alphabetically and categorized
 
+/datum/sprite_accessory/underwear/top/cowboyshirt
+	name = "Cowboy Shirt Black"
+	icon_state = "cowboyshirt"
+
+/datum/sprite_accessory/underwear/top/cowboyshirt/red
+	name = "Cowboy Shirt Red"
+	icon_state = "cowboyshirt_red"
+
+/datum/sprite_accessory/underwear/top/cowboyshirt/navy
+	name = "Cowboy Shirt Navy"
+	icon_state = "cowboyshirt_navy"
+
+/datum/sprite_accessory/underwear/top/cowboyshirt/white
+	name = "Cowboy Shirt White"
+	icon_state = "cowboyshirt_white"
+
+/datum/sprite_accessory/underwear/top/cowboyshirt/s
+	name = "Cowboy Shirt Shortsleeved Black"
+	icon_state = "cowboyshirt_s"
+
+/datum/sprite_accessory/underwear/top/cowboyshirt/red/s
+	name = "Cowboy Shirt Shortsleeved Red"
+	icon_state = "cowboyshirt_reds"
+
+/datum/sprite_accessory/underwear/top/cowboyshirt/navy/s
+	name = "Cowboy Shirt Shortsleeved Navy"
+	icon_state = "cowboyshirt_navys"
+
+/datum/sprite_accessory/underwear/top/cowboyshirt/white/s
+	name = "Cowboy Shirt Shortsleeved White"
+	icon_state = "cowboyshirt_whites"
+
 /datum/sprite_accessory/underwear/top/longjon
 	name = "Long John Shirt"
 	icon_state = "ljont"
@@ -30,36 +62,6 @@
 	icon_state = "undershirt"
 	has_color = TRUE
 
-/datum/sprite_accessory/underwear/top/bowlingw
-	name = "Shirt - Bowling"
-	icon_state = "bowlingw"
-	has_color = TRUE
-
-/datum/sprite_accessory/underwear/top/bowling
-	name = "Shirt, Bowling - Red"
-	icon_state = "bowling"
-
-/datum/sprite_accessory/underwear/top/bowlingp
-	name = "Shirt, Bowling - Pink"
-	icon_state = "bowlingp"
-
-/datum/sprite_accessory/underwear/top/bowlinga
-	name = "Shirt, Bowling - Aqua"
-	icon_state = "bowlinga"
-
-/datum/sprite_accessory/underwear/top/bluejersey
-	name = "Shirt, Jersey - Blue"
-	icon_state = "shirt_bluejersey"
-
-/datum/sprite_accessory/underwear/top/redjersey
-	name = "Shirt, Jersey - Red"
-	icon_state = "shirt_redjersey"
-
-/datum/sprite_accessory/underwear/top/polo
-	name = "Shirt - Polo"
-	icon_state = "polo"
-	has_color = TRUE
-
 /datum/sprite_accessory/underwear/top/alienshirt
 	name = "Shirt - Alien"
 	icon_state = "shirt_alien"
@@ -71,6 +73,23 @@
 /datum/sprite_accessory/underwear/top/shirt_bee
 	name = "Shirt - Bee"
 	icon_state = "bee_shirt"
+
+/datum/sprite_accessory/underwear/top/bowlingw
+	name = "Shirt - Bowling"
+	icon_state = "bowlingw"
+	has_color = TRUE
+
+/datum/sprite_accessory/underwear/top/bowlinga
+	name = "Shirt, Bowling - Aqua"
+	icon_state = "bowlinga"
+
+/datum/sprite_accessory/underwear/top/bowling
+	name = "Shirt, Bowling - Red"
+	icon_state = "bowling"
+
+/datum/sprite_accessory/underwear/top/bowlingp
+	name = "Shirt, Bowling - Pink"
+	icon_state = "bowlingp"
 
 /datum/sprite_accessory/underwear/top/clownshirt
 	name = "Shirt - Clown"
@@ -87,6 +106,14 @@
 /datum/sprite_accessory/underwear/top/ilovent
 	name = "Shirt - I Love NT"
 	icon_state = "ilovent"
+
+/datum/sprite_accessory/underwear/top/bluejersey
+	name = "Shirt, Jersey - Blue"
+	icon_state = "shirt_bluejersey"
+
+/datum/sprite_accessory/underwear/top/redjersey
+	name = "Shirt, Jersey - Red"
+	icon_state = "shirt_redjersey"
 
 /datum/sprite_accessory/underwear/top/lover
 	name = "Shirt - Lover"
@@ -112,6 +139,11 @@
 	name = "Shirt - Pogoman"
 	icon_state = "pogoman"
 
+/datum/sprite_accessory/underwear/top/polo
+	name = "Shirt - Polo"
+	icon_state = "polo"
+	has_color = TRUE
+
 /datum/sprite_accessory/underwear/top/question
 	name = "Shirt - Question"
 	icon_state = "shirt_question"
@@ -119,6 +151,23 @@
 /datum/sprite_accessory/underwear/top/skull
 	name = "Shirt - Skull"
 	icon_state = "shirt_skull"
+
+/datum/sprite_accessory/underwear/top/shortsleeve
+	name = "Shirt - Short Sleeved"
+	icon_state = "shortsleeve"
+	has_color = TRUE
+
+/datum/sprite_accessory/underwear/top/blueshirtsport
+	name = "Shirt, Sports - Blue"
+	icon_state = "blueshirtsport"
+
+/datum/sprite_accessory/underwear/top/greenshirtsport
+	name = "Shirt, Sports - Green"
+	icon_state = "greenshirtsport"
+
+/datum/sprite_accessory/underwear/top/redshirtsport
+	name = "Shirt, Sports - Red"
+	icon_state = "redshirtsport"
 
 /datum/sprite_accessory/underwear/top/ss13
 	name = "Shirt - SS13"
@@ -141,27 +190,6 @@
 	name = "Shirt - USA"
 	icon_state = "shirt_assblastusa"
 
-/datum/sprite_accessory/underwear/top/shortsleeve
-	name = "Shirt - Short Sleeved"
-	icon_state = "shortsleeve"
-	has_color = TRUE
-
-/datum/sprite_accessory/underwear/top/blueshirtsport
-	name = "Shirt, Sports - Blue"
-	icon_state = "blueshirtsport"
-
-/datum/sprite_accessory/underwear/top/greenshirtsport
-	name = "Shirt, Sports - Green"
-	icon_state = "greenshirtsport"
-
-/datum/sprite_accessory/underwear/top/redshirtsport
-	name = "Shirt, Sports - Red"
-	icon_state = "redshirtsport"
-
-/datum/sprite_accessory/underwear/top/tankfire
-	name = "Tank Top - Fire"
-	icon_state = "tank_fire"
-
 /datum/sprite_accessory/underwear/top/tanktop
 	name = "Tank Top"
 	icon_state = "tanktop"
@@ -171,6 +199,10 @@
 	name = "Tank Top - Alt"
 	icon_state = "tanktop_alt"
 	has_color = TRUE
+
+/datum/sprite_accessory/underwear/top/tankfire
+	name = "Tank Top - Fire"
+	icon_state = "tank_fire"
 
 /datum/sprite_accessory/underwear/top/tanktop_midriff
 	name = "Tank Top - Midriff"
@@ -192,6 +224,8 @@
 	name = "Tank top - Sun"
 	icon_state = "tank_sun"
 
+//feminine accessories from here on
+
 /datum/sprite_accessory/underwear/top/babydoll
 	name = "Baby-Doll"
 	icon_state = "babydoll"
@@ -210,15 +244,25 @@
 	has_color = TRUE
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/top/bra_thin
-	name = "Bra - Thin"
-	icon_state = "bra_thin"
-	has_color = TRUE
+/datum/sprite_accessory/underwear/top/bra_beekini
+	name = "Bra - Bee-kini"
+	icon_state = "bra_bee-kini"
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/top/bra_kinky
-	name = "Bra - Kinky Black"
-	icon_state = "bra_kinky"
+/datum/sprite_accessory/underwear/top/bra_binder
+	name = "Bra (binder)"
+	icon_state = "bra_binder"
+	has_color = TRUE
+
+/datum/sprite_accessory/underwear/top/bra_binder_strapless
+	name = "Bra (binder, strapless)"
+	icon_state = "bra_binder_strapless"
+	has_color = TRUE
+
+
+/datum/sprite_accessory/underwear/top/bra_commie
+	name = "Bra - Commie"
+	icon_state = "bra_commie"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/top/bra_freedom
@@ -226,31 +270,15 @@
 	icon_state = "bra_assblastusa"
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/top/bra_commie
-	name = "Bra - Commie"
-	icon_state = "bra_commie"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/top/bra_beekini
-	name = "Bra - Bee-kini"
-	icon_state = "bra_bee-kini"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/top/bra_uk
-	name = "Bra - UK"
-	icon_state = "bra_uk"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/top/bra_neko
-	name = "Bra - Neko"
-	icon_state = "bra_neko"
-	has_color = TRUE
-	gender = FEMALE
-
 /datum/sprite_accessory/underwear/top/halterneck_bra
 	name = "Bra - Halterneck"
 	icon_state = "halterneck_bra"
 	has_color = TRUE
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/top/bra_kinky
+	name = "Bra - Kinky Black"
+	icon_state = "bra_kinky"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/top/sports_bra
@@ -283,14 +311,31 @@
 	has_color = TRUE
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/top/fishnet_sleeves
-	name = "Fishnet - sleeves"
-	icon_state = "fishnet_sleeves"
+/datum/sprite_accessory/underwear/top/bra_thin
+	name = "Bra - Thin"
+	icon_state = "bra_thin"
+	has_color = TRUE
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/top/bra_neko
+	name = "Bra - Neko"
+	icon_state = "bra_neko"
+	has_color = TRUE
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/top/bra_uk
+	name = "Bra - UK"
+	icon_state = "bra_uk"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/top/fishnet_gloves
 	name = "Fishnet - gloves"
 	icon_state = "fishnet_gloves"
+	gender = FEMALE
+
+/datum/sprite_accessory/underwear/top/fishnet_sleeves
+	name = "Fishnet - sleeves"
+	icon_state = "fishnet_sleeves"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/top/fishnet_base
@@ -315,45 +360,3 @@
 	icon_state = "tubetop"
 	has_color = TRUE
 	gender = FEMALE
-
-/datum/sprite_accessory/underwear/top/cowboyshirt
-	name = "Cowboy Shirt Black"
-	icon_state = "cowboyshirt"
-
-/datum/sprite_accessory/underwear/top/cowboyshirt/s
-	name = "Cowboy Shirt Shortsleeved Black"
-	icon_state = "cowboyshirt_s"
-
-/datum/sprite_accessory/underwear/top/cowboyshirt/white
-	name = "Cowboy Shirt White"
-	icon_state = "cowboyshirt_white"
-
-/datum/sprite_accessory/underwear/top/cowboyshirt/white/s
-	name = "Cowboy Shirt Shortsleeved White"
-	icon_state = "cowboyshirt_whites"
-
-/datum/sprite_accessory/underwear/top/cowboyshirt/navy
-	name = "Cowboy Shirt Navy"
-	icon_state = "cowboyshirt_navy"
-
-/datum/sprite_accessory/underwear/top/cowboyshirt/navy/s
-	name = "Cowboy Shirt Shortsleeved Navy"
-	icon_state = "cowboyshirt_navys"
-
-/datum/sprite_accessory/underwear/top/cowboyshirt/red
-	name = "Cowboy Shirt Red"
-	icon_state = "cowboyshirt_red"
-
-/datum/sprite_accessory/underwear/top/cowboyshirt/red/s
-	name = "Cowboy Shirt Shortsleeved Red"
-	icon_state = "cowboyshirt_reds"
-
-/datum/sprite_accessory/underwear/top/bra_binder
-	name = "Bra (binder)"
-	icon_state = "bra_binder"
-	has_color = TRUE
-
-/datum/sprite_accessory/underwear/top/bra_binder_strapless
-	name = "Bra (binder, strapless)"
-	icon_state = "bra_binder_strapless"
-	has_color = TRUE

--- a/code/modules/mob/dead/new_player/sprite_accessories/underwear.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/underwear.dm
@@ -10,18 +10,6 @@
 	icon_state = null
 	covers_groin = FALSE
 
-/datum/sprite_accessory/underwear/bottom/mankini
-	name = "Mankini"
-	icon_state = "mankini"
-	has_color = TRUE
-	gender = MALE
-
-/datum/sprite_accessory/underwear/bottom/male_kinky
-	name = "Jockstrap"
-	icon_state = "jockstrap"
-	has_color = TRUE
-	gender = MALE
-
 /datum/sprite_accessory/underwear/bottom/briefs
 	name = "Briefs"
 	icon_state = "briefs"
@@ -77,6 +65,26 @@
 	has_digitigrade = TRUE
 	has_color = TRUE
 
+/datum/sprite_accessory/underwear/bottom/male_kinky
+	name = "Jockstrap"
+	icon_state = "jockstrap"
+	has_color = TRUE
+	gender = MALE
+
+/datum/sprite_accessory/underwear/bottom/longjon
+	name = "Long John Bottoms"
+	icon_state = "ljonb"
+	has_digitigrade = TRUE
+	has_color = TRUE
+
+/datum/sprite_accessory/underwear/bottom/mankini
+	name = "Mankini"
+	icon_state = "mankini"
+	has_color = TRUE
+	gender = MALE
+
+//feminine underwear from here on
+
 /datum/sprite_accessory/underwear/bottom/panties
 	name = "Panties"
 	icon_state = "panties"
@@ -89,11 +97,6 @@
 	has_color = TRUE
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/bottom/fishnet_lower
-	name = "Panties - Fishnet"
-	icon_state = "fishnet_lower"
-	gender = FEMALE
-
 /datum/sprite_accessory/underwear/bottom/female_beekini
 	name = "Panties - Bee-kini"
 	icon_state = "panties_bee-kini"
@@ -104,6 +107,11 @@
 	icon_state = "panties_commie"
 	gender = FEMALE
 
+/datum/sprite_accessory/underwear/bottom/fishnet_lower
+	name = "Panties - Fishnet"
+	icon_state = "fishnet_lower"
+	gender = FEMALE
+
 /datum/sprite_accessory/underwear/bottom/female_usastripe
 	name = "Panties - Freedom"
 	icon_state = "panties_assblastusa"
@@ -112,11 +120,6 @@
 /datum/sprite_accessory/underwear/bottom/female_kinky
 	name = "Panties - Kinky Black"
 	icon_state = "panties_kinky"
-	gender = FEMALE
-
-/datum/sprite_accessory/underwear/bottom/panties_uk
-	name = "Panties - UK"
-	icon_state = "panties_uk"
 	gender = FEMALE
 
 /datum/sprite_accessory/underwear/bottom/panties_neko
@@ -149,17 +152,10 @@
 	has_color = TRUE
 	gender = FEMALE
 
-/datum/sprite_accessory/underwear/bottom/longjon
-	name = "Long John Bottoms"
-	icon_state = "ljonb"
-	has_digitigrade = TRUE
-	has_color = TRUE
-
-/datum/sprite_accessory/underwear/bottom/swimsuit_red
-	name = "Swimsuit, One Piece - Red"
-	icon_state = "swimming_red"
+/datum/sprite_accessory/underwear/bottom/panties_uk
+	name = "Panties - UK"
+	icon_state = "panties_uk"
 	gender = FEMALE
-	covers_chest = TRUE
 
 /datum/sprite_accessory/underwear/bottom/swimsuit
 	name = "Swimsuit, One Piece - Black"
@@ -170,6 +166,12 @@
 /datum/sprite_accessory/underwear/bottom/swimsuit_blue
 	name = "Swimsuit, One Piece - Striped Blue"
 	icon_state = "swimming_blue"
+	gender = FEMALE
+	covers_chest = TRUE
+
+/datum/sprite_accessory/underwear/bottom/swimsuit_red
+	name = "Swimsuit, One Piece - Red"
+	icon_state = "swimming_red"
 	gender = FEMALE
 	covers_chest = TRUE
 
@@ -184,5 +186,3 @@
 	icon_state = "thong_babydoll"
 	has_color = TRUE
 	gender = FEMALE
-
-

--- a/code/modules/mob/dead/new_player/sprite_accessories/wings.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/wings.dm
@@ -58,6 +58,10 @@
 	dimension_y = 34
 	relevant_layers = list(BODY_BEHIND_LAYER, BODY_ADJ_LAYER, BODY_FRONT_LAYER)
 
+/datum/sprite_accessory/deco_wings/atlas
+	name = "Atlas"
+	icon_state = "atlas"
+
 /datum/sprite_accessory/deco_wings/bat
 	name = "Bat"
 	icon_state = "bat"
@@ -66,6 +70,10 @@
 	name = "Bee"
 	icon_state = "bee"
 
+/datum/sprite_accessory/deco_wings/deathhead
+	name = "Deathshead"
+	icon_state = "deathhead"
+
 /datum/sprite_accessory/deco_wings/fairy
 	name = "Fairy"
 	icon_state = "fairy"
@@ -73,14 +81,6 @@
 /datum/sprite_accessory/deco_wings/feathery
 	name = "Feathery"
 	icon_state = "feathery"
-
-/datum/sprite_accessory/deco_wings/atlas
-	name = "Atlas"
-	icon_state = "atlas"
-
-/datum/sprite_accessory/deco_wings/deathhead
-	name = "Deathshead"
-	icon_state = "deathhead"
 
 /datum/sprite_accessory/deco_wings/firewatch
 	name = "Firewatch"
@@ -150,6 +150,10 @@
 	icon_state = "none"
 	relevant_layers = null
 
+/datum/sprite_accessory/insect_wings/atlas
+	name = "Atlas"
+	icon_state = "atlas"
+
 /datum/sprite_accessory/insect_wings/bat
 	name = "Bat"
 	icon_state = "bat"
@@ -157,6 +161,10 @@
 /datum/sprite_accessory/insect_wings/bee
 	name = "Bee"
 	icon_state = "bee"
+
+/datum/sprite_accessory/insect_wings/deathhead
+	name = "Deathshead"
+	icon_state = "deathhead"
 
 /datum/sprite_accessory/insect_wings/fairy
 	name = "Fairy"
@@ -166,14 +174,6 @@
 	name = "Feathery"
 	icon_state = "feathery"
 
-/datum/sprite_accessory/insect_wings/atlas
-	name = "Atlas"
-	icon_state = "atlas"
-
-/datum/sprite_accessory/insect_wings/deathhead
-	name = "Deathshead"
-	icon_state = "deathhead"
-
 /datum/sprite_accessory/insect_wings/firewatch
 	name = "Firewatch"
 	icon_state = "firewatch"
@@ -181,6 +181,10 @@
 /datum/sprite_accessory/insect_wings/gothic
 	name = "Gothic"
 	icon_state = "gothic"
+
+/datum/sprite_accessory/insect_wings/jungle
+	name = "Jungle"
+	icon_state = "jungle"
 
 /datum/sprite_accessory/insect_wings/lovers
 	name = "Lovers"
@@ -197,6 +201,10 @@
 /datum/sprite_accessory/insect_wings/moonfly
 	name = "Moon Fly"
 	icon_state = "moonfly"
+
+/datum/sprite_accessory/insect_wings/oakworm
+	name = "Oak Worm"
+	icon_state = "oakworm"
 
 /datum/sprite_accessory/insect_wings/plain
 	name = "Plain"
@@ -229,14 +237,6 @@
 /datum/sprite_accessory/insect_wings/whitefly
 	name = "White Fly"
 	icon_state = "whitefly"
-
-/datum/sprite_accessory/insect_wings/oakworm
-	name = "Oak Worm"
-	icon_state = "oakworm"
-
-/datum/sprite_accessory/insect_wings/jungle
-	name = "Jungle"
-	icon_state = "jungle"
 
 /datum/sprite_accessory/insect_wings/witchwing
 	name = "Witch Wing"


### PR DESCRIPTION
## About The Pull Request
this is probably fine to merge without testmerging actually because it literally just changes the order

customization features appear in alphabetical order
'None' still appears at the top
'Bald' and 'Shaved' are now the top options on hair and facial hair (as they're equivalent to 'None' on the other options)

did you know they used to be in order
there's these cool comments at the top explaining they should be placed in order
however snowflake shitcoders just kept piling on new ones at the end of the file

## Why It's Good For The Game
qol

## Changelog
:cl:
tweak: customization features appear in alphabetical order where necessary
/:cl:
