### PR TITLE
Ports drip feeding mode for iv drips from tg.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -240,7 +240,7 @@
 
 /obj/machinery/iv_drip/telescopic
 	name = "telescopic IV drip"
-	desc = "An IV drip with an advanced infusion pump that can both drain blood into and inject liquids from attached containers. Blood packs are processed at an accelerated rate. This one is telescopic, and can be picked up and put down."
+	desc = "An IV drip with an advanced infusion pump that can both drain blood into and inject liquids from attached containers. Blood packs are processed at an accelerated rate. This one is telescopic, and can be picked up and put down.Alt-Click with a beaker attached to change the transfer rate."
 	icon_state = "iv_drip"
 
 /obj/machinery/iv_drip/telescopic/update_icon_state()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -3,13 +3,14 @@
 
 /obj/machinery/iv_drip
 	name = "\improper IV drip"
-	desc = "An IV drip with an advanced infusion pump that can both drain blood into and inject liquids from attached containers. Blood packs are processed at an accelerated rate."
+	desc = "An IV drip with an advanced infusion pump that can both drain blood into and inject liquids from attached containers. Blood packs are processed at an accelerated rate. Alt-Click to change the transfer rate."
 	icon = 'icons/obj/iv_drip.dmi'
 	icon_state = "iv_drip"
 	anchored = FALSE
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	var/mob/living/carbon/attached
 	var/mode = IV_INJECTING
+	var/dripfeed = FALSE
 	var/obj/item/reagent_containers/beaker
 	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
 									/obj/item/reagent_containers/food,
@@ -132,9 +133,11 @@
 		if(mode)
 			if(beaker.reagents.total_volume)
 				var/transfer_amount = 5
+				if (dripfeed)
+					transfer_amount = 1
 				if(istype(beaker, /obj/item/reagent_containers/blood))
 					// speed up transfer on blood packs
-					transfer_amount = 10
+					transfer_amount *= 2
 				var/fraction = min(transfer_amount/beaker.reagents.total_volume, 1) //the fraction that is transfered of the total volume
 				beaker.reagents.reaction(attached, INJECT, fraction, FALSE) //make reagents reacts, but don't spam messages
 				beaker.reagents.trans_to(attached, transfer_amount)
@@ -168,6 +171,16 @@
 		eject_beaker(user)
 	else
 		toggle_mode()
+
+/obj/machinery/iv_drip/AltClick(mob/living/user)
+	if(!user.canUseTopic(src, be_close=TRUE))
+		return
+	if(dripfeed)
+		dripfeed = FALSE
+		to_chat(usr, "<span class='notice'>You loosen the valve to speed up the [src].</span>")
+	else
+		dripfeed = TRUE
+		to_chat(usr, "<span class='notice'>You tighten the valve to slowly drip-feed the contents of [src].</span>")
 
 /obj/machinery/iv_drip/attack_robot(mob/user)
 	if(Adjacent(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request is essentially a straight port of https://github.com/tgstation/tgstation/pull/46845 (edit: am nerd and linked the wrong pr, should be the right one now). This will add an alternative slow mode to iv drips where you can have it transfer 1 reagent instead of 5. This works on both the telescopic and regular iv drip, although the telescopic drip needs to have a beaker on it to switch modes. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This gives doctors better control over the dosing of meds and it can be extremely useful when you need a medicine to be applied over time rather than just injecting it all at once. Also somewhat fits in with the flavor of medical. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds slow mode for iv drips
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
