### PR TITLE
Changes damage mods for lizardfolk

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -8,8 +8,8 @@
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_REPTILE
 	mutanttongue = /obj/item/organ/tongue/lizard
 	mutanttail = /obj/item/organ/tail/lizard
-	coldmod = 1.2
-	heatmod = 0.8
+	coldmod = 6/5
+	heatmod = 5/6
 	mutant_bodyparts = list("mcolor" = "0F0", "mcolor2" = "0F0", "mcolor3" = "0F0", "tail_lizard" = "Smooth", "mam_snouts" = "Round",
 							 "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None",
 							  "legs" = "Digitigrade", "taur" = "None", "deco_wings" = "None")

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -8,8 +8,8 @@
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_REPTILE
 	mutanttongue = /obj/item/organ/tongue/lizard
 	mutanttail = /obj/item/organ/tail/lizard
-	coldmod = 1.5
-	heatmod = 0.67
+	coldmod = 1.2
+	heatmod = 0.8
 	mutant_bodyparts = list("mcolor" = "0F0", "mcolor2" = "0F0", "mcolor3" = "0F0", "tail_lizard" = "Smooth", "mam_snouts" = "Round",
 							 "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None",
 							  "legs" = "Digitigrade", "taur" = "None", "deco_wings" = "None")


### PR DESCRIPTION
## About The Pull Request

Adjusts temp damage mods for lizards for the following:
+20% cold temp damage
-20% heat temp damage

## Why It's Good For The Game

The (relatively) new damage modifiers are not necessarily bad, but currently they are very unbalanced and large, the change should make lizard race more in line with humans and balanced

This is being made for Nayser#2314, any comments towards me, will be directed towards them instead. I'm just the middle man for this change, I have no skin in the game.

## Changelog
:cl:
tweak: Lizard temp damage mods adjusted to be an even 20% on either side
/:cl: