### PR TITLE
plasmamen are playable now

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -118,7 +118,6 @@
 	icon_state = "plasmaman"
 	item_state = "plasmaman"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 95, "acid" = 95)
-	slowdown = 1
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	mutantrace_variation = USE_TAUR_CLIP_MASK
 	can_adjust = FALSE


### PR DESCRIPTION

## About The Pull Request

removes plasmaman slowdown so you don't have to powergame a vehicle to play one without bashing your brains out

## Why It's Good For The Game

tg removed the slowdown because slowdowns make something literally just un-fun to play; I'd like to be able to play my plasmaman without powergaming an ATV or a secway every round tyvm

## Changelog
:cl:
tweak: plasmamen have no more slowdown
/:cl:
