### PR TITLE
Reverts desword block/parry for 75% RNG chance again

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -25,7 +25,8 @@
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -110
 	bare_wound_bonus = 20
-	block_parry_data = /datum/block_parry_data/dual_esword
+	block_chance = 75
+	// block_parry_data = /datum/block_parry_data/dual_esword - Disabled for now
 	var/hacked = FALSE
 	/// Can this reflect all energy projectiles?
 	var/can_reflect = TRUE
@@ -123,7 +124,7 @@
 	START_PROCESSING(SSobj, src)
 	set_light(brightness_on)
 	AddElement(/datum/element/sword_point)
-	item_flags |= (ITEM_CAN_BLOCK|ITEM_CAN_PARRY)
+	// item_flags |= (ITEM_CAN_BLOCK|ITEM_CAN_PARRY)
 
 /// Triggered on unwield of two handed item
 /// switch hitsounds
@@ -137,7 +138,7 @@
 	STOP_PROCESSING(SSobj, src)
 	set_light(0)
 	RemoveElement(/datum/element/sword_point)
-	item_flags &= ~(ITEM_CAN_BLOCK|ITEM_CAN_PARRY)
+	// item_flags &= ~(ITEM_CAN_BLOCK|ITEM_CAN_PARRY)
 
 /obj/item/dualsaber/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because after three goddamn months no one is just going to do the 3 line PR to revert this themselves when I keep telling people how to modify the system
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Block/parry is too clunky right now to carry desword usefulness. It's better to put it back to its old RNG block until the system is improved, or there's a viable way to balance it that someone figures out because I'm done.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Desword is back at 75% rng block, no longer block/parry capable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
