### PR TITLE
Further tweaks the TEG's power output

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -66,7 +66,7 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				lastgen += LOGISTIC_FUNCTION(1000000,0.0034,delta_temperature,2000)
+				lastgen += LOGISTIC_FUNCTION(1250000,0.0001,delta_temperature,50000)
 
 				hot_air.set_temperature(hot_air.return_temperature() - energy_transfer/hot_air_heat_capacity)
 				cold_air.set_temperature(cold_air.return_temperature() + heat/cold_air_heat_capacity)


### PR DESCRIPTION
## About The Pull Request

Tweaks the TEG's power output. The previous pull request was more a proof of concept, and this is meant to finalize that change.

## Why It's Good For The Game

further buries the 3x3 in the ground while also adding incentive to go beyond a 7,000K heat difference (where before it would max at about 6,268K difference or so)
you can expect:
- the 3x3 to make 36kW (4 to 6 total 3x3s to power a normal station)
- 1MW output at 37,000K difference
- the station to be powered at about 19,000K difference, easily achievable with a burn chamber
- it to be maxed at 100,000K difference

## Changelog
:cl:
tweak: TEG power output
/:cl: