### PR TITLE
Experimental optimization for get_hearers_in_view.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -254,16 +254,11 @@
 	if(R == 0)
 		processing += T.contents
 	else
-		var/lum = T.luminosity
-		T.luminosity = 6
-		var/list/cached_view = view(R, T)
-		for(var/mob/M in cached_view)
-			processing += M
-		for(var/obj/O in cached_view)
-			processing += O
-		T.luminosity = lum
+		for(var/I in dview(R, T))
+			if(ismob(I) || isobj(I))
+				processing += I
 	var/i = 0
-	while(i < length(processing))
+	while(i < processing.len)
 		var/atom/A = processing[++i]
 		if(A.flags_1 & HEAR_1)
 			. += A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes get_hearers_in_view use dview instead of screwing around with tile luminosity, makes it iterate through the returned list only once instead of twice with filters, and replaces length() with .len, which doesn't check for null (it's a LOCAL PROC VARIABLE IT'S NOT GONNA DIE RANDOMLY) and thus is ~1.5 times (!) faster.

This overall results in an overall speedup in benchmarking (i.e. making every single mob say a phrase over the radio repeatedly) of approximately 2x.

## Why It's Good For The Game

get_hearers_in_view causes a weird amount of lag spikes, so it's best it isn't bad.

## Changelog
:cl:
refactor: get_hearers_in_view does fewer hackish things and runs a bit faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
