### PR TITLE
Rolling dynamic tweaks 'til it works

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -205,8 +205,10 @@
 	restricted_roles = list("AI","Cyborg")
 	required_candidates = 1
 	weight = 4
-	cost = 10
-	requirements = list(40,30,20,10,10,10,10,10,10,10)
+	cost = 25
+	requirements = list(60,60,60,55,50,50,50,50,50,50)
+	high_population_requirement = 50
+	property_weights = list("story_potential" = 1, "trust" = -1, "chaos" = 2, "extended" = -1, "valid" = 2)
 	repeatable = TRUE
 
 //////////////////////////////////////////////

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -200,7 +200,7 @@
 /datum/dynamic_ruleset/latejoin/heretic_smuggler
 	name = "Heretic Smuggler"
 	antag_datum = /datum/antagonist/heretic
-	antag_flag = ROLE_HERETIC
+	antag_flag = "latejoin_heretic"
 	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
 	restricted_roles = list("AI","Cyborg")
 	required_candidates = 1

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -162,6 +162,7 @@
 	requirements = list(60,60,60,55,50,50,50,50,50,50)
 	property_weights = list("story_potential" = 1, "trust" = -1, "chaos" = 2, "extended" = -1, "valid" = 2)
 	antag_cap = list(1,1,1,1,2,2,2,2,3,3)
+	high_population_requirement = 50
 
 
 /datum/dynamic_ruleset/roundstart/heretics/pre_execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -160,6 +160,7 @@
 	cost = 25
 	scaling_cost = 15
 	requirements = list(60,60,60,55,50,50,50,50,50,50)
+	property_weights = list("story_potential" = 1, "trust" = -1, "chaos" = 2, "extended" = -1, "valid" = 2)
 	antag_cap = list(1,1,1,1,2,2,2,2,3,3)
 
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -151,15 +151,15 @@
 
 /datum/dynamic_ruleset/roundstart/heretics
 	name = "Heretics"
-	antag_flag = ROLE_HERETIC
+	antag_flag = "heretic"
 	antag_datum = /datum/antagonist/heretic
 	protected_roles = list("Prisoner","Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	restricted_roles = list("AI", "Cyborg")
 	required_candidates = 1
 	weight = 3
-	cost = 20
+	cost = 25
 	scaling_cost = 15
-	requirements = list(50,45,45,40,35,20,20,15,10,10)
+	requirements = list(60,60,60,55,50,50,50,50,50,50)
 	antag_cap = list(1,1,1,1,2,2,2,2,3,3)
 
 

--- a/code/game/gamemodes/dynamic/dynamic_storytellers.dm
+++ b/code/game/gamemodes/dynamic/dynamic_storytellers.dm
@@ -126,8 +126,9 @@ Property weights are:
 				for(var/property in property_weights)
 					if(property in rule.property_weights) // just treat it as 0 if it's not in there
 						property_weight += rule.property_weights[property] * property_weights[property]
-				if(property_weight > 0)
-					drafted_rules[rule] = rule.get_weight() * property_weight * rule.weight_mult
+				var/calced_weight = (rule.get_weight() + property_weight) * rule.weight_mult
+				if(calced_weight > 0) // negatives in the list might cause problems
+					drafted_rules[rule] = calced_weight
 	return drafted_rules
 
 /datum/dynamic_storyteller/proc/midround_draft()
@@ -144,21 +145,22 @@ Property weights are:
 				for(var/property in property_weights)
 					if(property in rule.property_weights) // just treat it as 0 if it's not in there
 						property_weight += rule.property_weights[property] * property_weights[property]
-				if(property_weight > 0)
-					var/threat_weight = 1
-					if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)) // makes the traitor rulesets always possible anyway
-						var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
-						/*	Basically, the closer the cost is to the current threat-level-away-from-threat, the more likely it is to
-							pick this particular ruleset.
-							Let's use a toy example: there's 60 threat level and 10 threat spent.
-							We want to pick a ruleset that's close to that, so we run the below equation, on two rulesets.
-							Ruleset 1 has 30 cost, ruleset 2 has 5 cost.
-							When we do the math, ruleset 1's threat_weight is 0.538, and ruleset 2's is 0.238, meaning ruleset 1
-							is 2.26 times as likely to be picked, all other things considered.
-							Of course, we don't want it to GUARANTEE the closest, that's no fun, so it's just a weight.
-						*/
-						threat_weight = abs(1-abs(1-LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
-					drafted_rules[rule] = rule.get_weight() * property_weight * rule.weight_mult * threat_weight
+				var/threat_weight = 1
+				if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)) // makes the traitor rulesets always possible anyway
+					var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
+					/*	Basically, the closer the cost is to the current threat-level-away-from-threat, the more likely it is to
+						pick this particular ruleset.
+						Let's use a toy example: there's 60 threat level and 10 threat spent.
+						We want to pick a ruleset that's close to that, so we run the below equation, on two rulesets.
+						Ruleset 1 has 30 cost, ruleset 2 has 5 cost.
+						When we do the math, ruleset 1's threat_weight is 0.538, and ruleset 2's is 0.238, meaning ruleset 1
+						is 2.26 times as likely to be picked, all other things considered.
+						Of course, we don't want it to GUARANTEE the closest, that's no fun, so it's just a weight.
+					*/
+					threat_weight = abs(1-abs(1-LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
+				var/calced_weight =  (rule.get_weight() + property_weight) * rule.weight_mult * threat_weight
+				if(calced_weight > 0)
+					drafted_rules[rule] = calced_weight
 	return drafted_rules
 
 /datum/dynamic_storyteller/proc/latejoin_draft(mob/living/carbon/human/newPlayer)
@@ -180,12 +182,13 @@ Property weights are:
 				for(var/property in property_weights)
 					if(property in rule.property_weights)
 						property_weight += rule.property_weights[property] * property_weights[property]
-				if(property_weight > 0)
-					var/threat_weight = 1
-					if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET))
-						var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
-						threat_weight = 1-abs(1-(LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
-					drafted_rules[rule] = rule.get_weight() * property_weight * rule.weight_mult * threat_weight
+				var/threat_weight = 1
+				if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET))
+					var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
+					threat_weight = 1-abs(1-(LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
+				var/calced_weight = (rule.get_weight() + property_weight) * rule.weight_mult * threat_weight
+				if(calced_weight > 0)
+					drafted_rules[rule] = calced_weight
 	return drafted_rules
 
 /datum/dynamic_storyteller/proc/event_draft()
@@ -196,8 +199,9 @@ Property weights are:
 			for(var/property in property_weights)
 				if(property in rule.property_weights)
 					property_weight += rule.property_weights[property] * property_weights[property]
-			if(property_weight > 0)
-				drafted_rules[rule] = rule.get_weight() + property_weight * rule.weight_mult
+			var/calced_weight = (rule.get_weight() + property_weight) * rule.weight_mult
+			if(calced_weight > 0)	
+				drafted_rules[rule] = calced_weight
 	return drafted_rules
 
 

--- a/code/game/gamemodes/dynamic/dynamic_storytellers.dm
+++ b/code/game/gamemodes/dynamic/dynamic_storytellers.dm
@@ -147,7 +147,7 @@ Property weights are added to the config weight of the ruleset. They are:
 						property_weight += rule.property_weights[property] * property_weights[property]
 				var/threat_weight = 1
 				if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET)) // makes the traitor rulesets always possible anyway
-					var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
+					var/cost_difference = rule.cost-(mode.threat_level-mode.threat)
 					/*	Basically, the closer the cost is to the current threat-level-away-from-threat, the more likely it is to
 						pick this particular ruleset.
 						Let's use a toy example: there's 60 threat level and 10 threat spent.
@@ -157,7 +157,9 @@ Property weights are added to the config weight of the ruleset. They are:
 						is 2.26 times as likely to be picked, all other things considered.
 						Of course, we don't want it to GUARANTEE the closest, that's no fun, so it's just a weight.
 					*/
-					threat_weight = abs(1-abs(1-LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
+					threat_weight = abs(1-abs(1-LOGISTIC_FUNCTION(2,0.05,abs(cost_difference),0)))
+					if(cost_difference > 0)
+						threat_weight /= (1+(cost_difference*0.1))
 				var/calced_weight =  (rule.get_weight() + property_weight) * rule.weight_mult * threat_weight
 				if(calced_weight > 0)
 					drafted_rules[rule] = calced_weight
@@ -184,8 +186,10 @@ Property weights are added to the config weight of the ruleset. They are:
 						property_weight += rule.property_weights[property] * property_weights[property]
 				var/threat_weight = 1
 				if(!(rule.flags & TRAITOR_RULESET) || (rule.flags & MINOR_RULESET))
-					var/cost_difference = abs(rule.cost-(mode.threat_level-mode.threat))
-					threat_weight = 1-abs(1-(LOGISTIC_FUNCTION(2,0.05,cost_difference,0)))
+					var/cost_difference = rule.cost-(mode.threat_level-mode.threat)
+					threat_weight = 1-abs(1-(LOGISTIC_FUNCTION(2,0.05,abs(cost_difference),0)))
+					if(cost_difference > 0)
+						threat_weight /= (1+(cost_difference*0.1))
 				var/calced_weight = (rule.get_weight() + property_weight) * rule.weight_mult * threat_weight
 				if(calced_weight > 0)
 					drafted_rules[rule] = calced_weight

--- a/code/game/gamemodes/dynamic/dynamic_storytellers.dm
+++ b/code/game/gamemodes/dynamic/dynamic_storytellers.dm
@@ -22,14 +22,14 @@
 	var/datum/game_mode/dynamic/mode = null // Cached as soon as it's made, by dynamic.
 
 /**
-Property weights are:
+Property weights are added to the config weight of the ruleset. They are:
 "story_potential" -- essentially how many different ways the antag can be played.
 "trust" -- How much it makes the crew trust each other. Negative values means they're suspicious. Team antags are like this.
 "chaos" -- How chaotic it makes the round. Has some overlap with "valid" and somewhat contradicts "extended".
 "valid" -- How likely the non-antag-enemy crew are to get involved, e.g. nukies encouraging the warden to
            let everyone into the armory, wizard moving around and being a nuisance, nightmare busting lights.
 "extended" -- How much the antag is conducive to a long round. Nukies and cults are bad for this; Wizard is less bad; and so on.
-"conversion" -- Basically a bool. Conversion antags, well, convert. It's its own class for a good reason.
+"conversion" -- Basically a bool. Conversion antags, well, convert. It's in its own class 'cause people kinda hate conversion.
 */
 
 /datum/dynamic_storyteller/proc/start_injection_cooldowns()

--- a/code/game/gamemodes/dynamic/dynamic_storytellers.dm
+++ b/code/game/gamemodes/dynamic/dynamic_storytellers.dm
@@ -331,12 +331,6 @@ Property weights are added to the config weight of the ruleset. They are:
 	flags = USE_PREV_ROUND_WEIGHTS
 	property_weights = list("story_potential" = 2)
 
-
-/datum/dynamic_storyteller/story/calculate_threat()
-	var/current_time = (world.time / SSautotransfer.targettime)*180
-	mode.threat_level = round((mode.initial_threat_level*(sin(current_time)/2)+0.75),0.1)
-	return ..()
-
 /datum/dynamic_storyteller/classic
 	name = "Classic"
 	config_tag = "classic"

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -6,6 +6,7 @@
 	job_rank = ROLE_HERETIC
 	antag_hud_type = ANTAG_HUD_HERETIC
 	antag_hud_name = "heretic"
+	threat = 25
 	var/give_equipment = TRUE
 	var/list/researched_knowledge = list()
 	var/total_sacrifices = 0

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -6,7 +6,7 @@
 	job_rank = ROLE_HERETIC
 	antag_hud_type = ANTAG_HUD_HERETIC
 	antag_hud_name = "heretic"
-	threat = 25
+	threat = 10
 	var/give_equipment = TRUE
 	var/list/researched_knowledge = list()
 	var/total_sacrifices = 0
@@ -208,6 +208,14 @@
 
 /datum/antagonist/heretic/proc/get_all_knowledge()
 	return researched_knowledge
+
+/datum/antagonist/heretic/threat()
+	. = ..()
+	for(var/X in researched_knowledge)
+		var/datum/eldritch_knowledge/EK = researched_knowledge[X]
+		. += EK.cost
+	if(ascended)
+		. += 20
 
 ////////////////
 // Objectives //


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Fixed dynamic property weights being all messed up.

2. Fixed heretic rulesets.

3. Removed Story's weird unnecessary curve.

4. Made rulesets that would bring the mode over its target threat a bit more penalized.

## Why It's Good For The Game

1. Storytellers shouldn't *only* be able to pick antags that match their weights.

2. Heretic should follow the balance of the rest of the rulesets.

3. The curve caused more problems than it's worth.

4. If the target threat was 20 off, then a ruleset with 10 would have as much penalty as a ruleset with 30. Now, the one with 30 has twice as much penalty (which is less than it sounds, mind).

## Changelog
:cl:
fix: Dynamic storytellers now calculate property weights properly.
/:cl: