### PR TITLE
Modifies the Eminence teleport-to abilties a bit

### DIFF
--- a/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
@@ -251,7 +251,8 @@
 	var/mob/camera/eminence/E = owner
 	E.eminence_help()
 
-//Returns to the Ark
+/*
+//Returns to the Ark - Commented out and replaced with obelisk_jump
 /datum/action/innate/eminence/ark_jump
 	name = "Return to Ark"
 	desc = "Warps you to the Ark."
@@ -265,6 +266,40 @@
 		flash_color(owner, flash_color = "#AF0AAF", flash_time = 25)
 	else
 		to_chat(owner, "<span class='warning'>There is no Ark!</span>")
+*/
+
+//Warps to a chosen Obelisk
+/datum/action/innate/eminence/obelisk_jump
+	name = "Warp to Obelisk"
+	desc = "Warps to a chosen clockwork obelisk."
+	button_icon_state = "Abscond"
+
+/datum/action/innate/eminence/obelisk_jump/Activate()
+	var/list/possible_targets = list()
+	var/list/warpnames = list()
+
+	for(var/obj/structure/destructible/clockwork/powered/clockwork_obelisk/O in GLOB.all_clockwork_objects)
+		if(!O.Adjacent(owner) && O.anchored)
+			var/area/A = get_area(O)
+			var/locname = initial(A.name)
+			possible_targets[avoid_assoc_duplicate_keys("[locname] [O.name]", warpnames)] = O
+
+	if(!possible_targets.len)
+		to_chat(owner, "<span class='warning'>There are no Obelisks to warp to!</span>")
+		return
+
+	var/target_key = input(owner, "Choose an Obelisk to warp to.", "Obelisk Warp") as null|anything in possible_targets
+	var/obj/structure/destructible/clockwork/powered/clockwork_obelisk/target = possible_targets[target_key]
+
+	if(!target_key || !owner)
+		return
+
+	if(!target)
+		to_chat(owner, "<span class='warning'>That Obelisk does no longer exist!</span>")
+		return
+	owner.forceMove(get_turf(target))
+	owner.playsound_local(owner, 'sound/magic/magic_missile.ogg', 50, TRUE)
+	flash_color(owner, flash_color = "#AF0AAF", flash_time = 25)
 
 //Warps to the Station
 /datum/action/innate/eminence/station_jump


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Due to new-clockcult not always having a ark, this PR removes the 'Teleport to Ark' ability of the eminence, and replaces it with a 'Teleport to Obelisk' ability which allows the eminence to teleport to any anchored obelisk the clock cultists have constructed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Due to gamemode changes, the Eminence was not able to return to reebe since there wasn't a ark there. This allows it to do so as reebe should always have a obelisk, plus it allows for better navigating the station by immediately teleporting to clockcult bases, which in general should have an obelisk after all.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: teleport-to-ark ability of the eminence, commented out
add: teleport-to-obelisk ability for the eminence
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
