### PR TITLE
combat defibs now hit for disarm + 35 stamina (old stunbaton values) instead of disarm + 75 stamina 

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -447,8 +447,7 @@
 	if(do_after(user, isnull(defib?.disarm_shock_time)? disarm_shock_time : defib.disarm_shock_time, target = M))
 		M.visible_message("<span class='danger'>[user] zaps [M] with [src]!</span>", \
 				"<span class='userdanger'>[user] zaps [M] with [src]!</span>")
-		M.adjustStaminaLoss(50)
-		M.DefaultCombatKnockdown(100)
+		M.DefaultCombatKnockdown(140)
 		M.updatehealth() //forces health update before next life tick
 		playsound(src,  'sound/machines/defib_zap.ogg', 50, 1, -1)
 		M.emote("gasp")


### PR DESCRIPTION
people asked for this nerf for a while

i still think we should buff medbay's normal defibs since i'm nerfing defib stuns but whatever can't buff my own department :^)

why it's good for the game:
man you know something's scuffed when it's just a better stunbaton you can't disarm and two hits literally anyone.