### PR TITLE
Removes growth pills and genital autosurgeons from the maint loot table. Shoves them in the kinkmates.

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -107,13 +107,8 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/toy/eightball = 1,
 	/obj/item/reagent_containers/pill/floorpill = 1,
 	/obj/item/reagent_containers/food/snacks/cannedpeaches/maint = 2,
-	/obj/item/storage/daki = 3, //VERY IMPORTANT CIT CHANGE - adds bodypillows to maint
-	/obj/item/storage/pill_bottle/penis_enlargement = 2,
-	/obj/item/storage/pill_bottle/breast_enlargement = 2,
 	/obj/item/clothing/shoes/wheelys = 1,
 	/obj/item/clothing/shoes/kindleKicks = 1,
-	/obj/item/autosurgeon/penis = 1,
-	/obj/item/autosurgeon/testicles = 1,
 	/obj/item/storage/box/marshmallow = 2,
 	/obj/item/clothing/gloves/tackler/offbrand = 1,
 	/obj/item/stack/sticky_tape = 1,

--- a/code/modules/vending/kinkmate.dm
+++ b/code/modules/vending/kinkmate.dm
@@ -26,7 +26,12 @@
 				/obj/item/clothing/under/shorts/polychromic/pantsu = 3,
 				/obj/item/clothing/under/misc/poly_bottomless = 3,
 				/obj/item/clothing/under/misc/poly_tanktop = 3,
-				/obj/item/clothing/under/misc/poly_tanktop/female = 3
+				/obj/item/clothing/under/misc/poly_tanktop/female = 3,
+				/obj/item/autosurgeon/penis = 3,
+				/obj/item/autosurgeon/testicles = 3,
+				/obj/item/storage/pill_bottle/penis_enlargement = 5,
+				/obj/item/storage/pill_bottle/breast_enlargement = 5,
+				/obj/item/storage/daki = 4
 				)
 	contraband = list(
 				/obj/item/clothing/neck/petcollar/locked = 2,


### PR DESCRIPTION
## About The Pull Request

Tin, also does the same with dakis.

## Why It's Good For The Game

It is silly to have "fetishistic content" clogging up the loot tables for maintenance when more useful and/or immersive items could have been spawning instead. It's especially weird seeing genital autosurgeons and growth pills in space ruins of all places, which also use the same loot tables. 

## Changelog
:cl: Tupinambis
tweak: moved the dakis, genital growth pills, and genital autosurgeons out of the maintenance loot table and into kinkmates.
/:cl:
