### PR TITLE
pyro anomaly spam salt pr (offer_control now supports ignore_category)

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -285,7 +285,7 @@
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
-	offer_control(S)
+	offer_control(S,POLL_IGNORE_SENTIENCE_POTION)
 
 /////////////////////
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -431,7 +431,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 /mob/living/getImplant(type)
 	return locate(type) in implants
 
-/proc/offer_control(mob/M)
+/proc/offer_control(mob/M,ignore_category=null)
 	to_chat(M, "Control of your mob has been offered to dead players.")
 	if(usr)
 		log_admin("[key_name(usr)] has offered control of ([key_name(M)]) to ghosts.")
@@ -445,7 +445,7 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		var/datum/antagonist/A = M.mind.has_antag_datum(/datum/antagonist/)
 		if(A)
 			poll_message = "[poll_message] Status:[A.name]."
-	var/list/mob/candidates = pollCandidatesForMob(poll_message, ROLE_PAI, null, FALSE, 100, M)
+	var/list/mob/candidates = pollCandidatesForMob(poll_message, ROLE_PAI, null, FALSE, 100, M, ignore_category)
 
 	if(LAZYLEN(candidates))
 		var/mob/C = pick(candidates)


### PR DESCRIPTION
## About The Pull Request

Adds "Never for this round" dialog addition support to the offer_control proc.
Adds POLL_IGNORE_SENTIENCE_POTION (Sentience Potion) to the pyroclastic anomaly's detonation slime spawn.

tl;dr you will now see the "never for this round" dialogue option for pyro anomaly slime spawns

## Why It's Good For The Game

hehe sm delam go 
Do you want to play as red adult slime (394)?
Do you want to play as red adult slime (556)?
Do you want to play as orange adult slime (295)?
Do you want to play as red adult slime (693)?

addresses #13165 

## Changelog
:cl:
fix: pyroclastic anomaly client spam
/:cl: