### PR TITLE
Makes plastitanium rapier not silently poison for pacifists.

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -236,7 +236,7 @@
 	if(iscarbon(target))
 		if(HAS_TRAIT(user, TRAIT_PACIFISM))
 			visible_message("<span class='warning'>[user] gently taps [target] with [src].</span>",null,null,COMBAT_MESSAGE_RANGE)
-		log_combat(user, src, "slept", I)
+		log_combat(user, target, "slept", src)
 		var/mob/living/carbon/H = target
 		H.Dizzy(10)
 		H.adjustStaminaLoss(30)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -234,6 +234,9 @@
 /obj/item/melee/rapier/attack(mob/living/target, mob/living/user)
 	. = ..()
 	if(iscarbon(target))
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			visible_message("<span class='warning'>[user] gently taps [target] with [src].</span>",null,null,COMBAT_MESSAGE_RANGE)
+		log_combat(user, src, "slept", I)
 		var/mob/living/carbon/H = target
 		H.Dizzy(10)
 		H.adjustStaminaLoss(30)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Instead, it makes it LOUDLY poison. He he he.

## Why It's Good For The Game

Turns out this thing's pacifist safe, but best it have logging and not be completely silent.

## Changelog
:cl:
balance: Plastitanium rapier no longer silently sleeps with no chance at counterplay when used by pacifists.
/:cl: