### PR TITLE
Fixed newly created slimes being hungry

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -106,6 +106,7 @@
 	set_colour(new_colour)
 	. = ..()
 	AddComponent(/datum/component/footstep, FOOTSTEP_MOB_SLIME, 7.5)
+	set_nutrition(rand(650, 800))
 
 /mob/living/simple_animal/slime/Destroy()
 	for (var/A in actions)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's some new code in /mob/Initialize() that randomizes the starting nutrition of a newly created mob between a minimum and maximum value of 250 and 400 respectively. 

This code also affects slime mobs, making them hungry by their standards when it comes to nutrition, and therefore, each newly created slime requires 2 monkies to turn into an adult slime, and an additional monkey to split, **resulting in 3 monkies required to make a slime reproduce, instead of the standard 2**.

This fix adds a singular line of code that gives slime their own starting nutrition in /mob/living/simple_animal/slime/Initialize. It'll be between 650 and 800. I believe slimes at some earlier point were meant to always start at exactly 700 nutrition upon spawning, either by splitting or by being spawned in by admins or something, but if the element of randomness is getting involved with hunger, might as well include them in slimes too.

## Why It's Good For The Game

A change happened as mentioned above that accidentally nerfed xenobiology DRAMATICALLY, this unnerfs xenobiology back to what was normally expected.
This will conclude issue #13299 which I posted a while ago.

## Changelog
:cl:
fix: fixed slimes starting off hungry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
