### PR TITLE
makes handle_speech in ipc accent actually return the speech args so ipcs can talk

### DIFF
--- a/code/datums/accents.dm
+++ b/code/datums/accents.dm
@@ -94,6 +94,7 @@
 
 /datum/accent/robot/modify_speech(list/speech_args)
 	speech_args[SPEECH_SPANS] = SPAN_ROBOT
+	return speech_args
 
 /datum/accent/dullahan/modify_speech(list/speech_args, datum/source, mob/living/carbon/owner)
 	if(owner)


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
i broke it
i fix it
accents are good because they detach speech handling from tongues

## Changelog
:cl:
fix: ipcs can speak
/:cl:
