### PR TITLE
moves engineering projectors to the "tool designs" protolathe category

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -469,7 +469,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1000, /datum/material/gold = 1000, /datum/material/silver = 1000)
 	build_path = /obj/item/holosign_creator/engineering
-	category = list("Equipment")
+	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/holosignatmos
@@ -479,7 +479,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1000, /datum/material/gold = 1000, /datum/material/silver = 1000)
 	build_path = /obj/item/holosign_creator/atmos
-	category = list("Equipment")
+	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/holosignfirelock
@@ -489,7 +489,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 1000, /datum/material/gold = 1000, /datum/material/silver = 1000)
 	build_path = /obj/item/holosign_creator/firelock
-	category = list("Equipment")
+	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/holosigncombifan
@@ -499,7 +499,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 7500, /datum/material/glass = 2500, /datum/material/silver = 2500, /datum/material/gold = 2500, /datum/material/titanium = 1750)
 	build_path = /obj/item/holosign_creator/combifan
-	category = list("Equipment")
+	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/forcefield_projector
@@ -509,7 +509,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 2500, /datum/material/glass = 1000)
 	build_path = /obj/item/forcefield_projector
-	category = list("Equipment")
+	category = list("Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
 
 /datum/design/holobarrier_med


### PR DESCRIPTION
## About The Pull Request

moves these items to the "tool designs" category:
Engineering Holobarrier Projector
ATMOS Holofan Projector
ATMOS Holofirelock Projector
ATMOS Holo-Combifan Projector
Forcefield Projector

also planned to move Anomaly Neutralizers to tool designs but let's start here
also considering moving projectors in other departments to tool designs

tested locally

## Why It's Good For The Game

qol with not having to navigate menus as much + honestly equipment makes me think stuff you put on like meson scanners instead of a tool that you use to stop atmos flow

navigating menus too much salt pr

## Changelog
:cl:
tweak: protolathe item categories
/:cl: