### PR TITLE
adds anchored state/anchoring tip to supermatter shard examine text

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -985,6 +985,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	layer = ABOVE_MOB_LAYER
 	moveable = TRUE
 
+/obj/machinery/power/supermatter_crystal/shard/examine(mob/user)
+	. = ..()
+	if(anchored)
+		. += "<span class='notice'>[src] is <b>anchored</b> to the floor.</span>"
+	else
+		. += "<span class='notice'>[src] is <i>unanchored</i>, but can be <b>bolted</b> down.</span>"
+
 /obj/machinery/power/supermatter_crystal/shard/engine
 	name = "anchored supermatter shard"
 	is_main_engine = TRUE


### PR DESCRIPTION
## About The Pull Request

![dreamseeker_913rD8VaM4](https://user-images.githubusercontent.com/47289484/92051256-d3888300-ed5a-11ea-8e4c-5f1e8c1ef5c4.png)

tested locally

## Why It's Good For The Game

hugbox zzzz
me and probably a lot of others assume the shard comes out of the box anchored, hopefully this will help a little bit with being certain it IS ACTUALLY ANCHORED and what to use to anchor it

snaxi, i'm looking at you

## Changelog
:cl:
tweak: supermatter shard examine text
/:cl: