### PR TITLE
Fixes threat adjustment in the game panel not to always go up.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -204,10 +204,7 @@ GLOBAL_VAR_INIT(dynamic_forced_storyteller, null)
 		var/threatadd = input("Specify how much threat to add (negative to subtract). This can inflate the threat level.", "Adjust Threat", 0) as null|num
 		if(!threatadd)
 			return
-		if(threatadd > 0)
-			create_threat(threatadd)
-		else
-			remove_threat(threatadd)
+		create_threat(threatadd)
 	else if (href_list["injectlate"])
 		latejoin_injection_cooldown = 0
 		forced_injection = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

turns out -1*-1 is 1. who knew.

## Why It's Good For The Game

things ought to work yes

## Changelog
:cl:
admin: admins can now actually reduce threat level in dynamic
/:cl: