### PR TITLE
Disables the 'random brain trauma' event

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/brain_trauma
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
-	weight = 25
+	weight = 0
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. The event is disabled via setting its weight to zero.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Issue about this event is that it is basically just the random appendicitis event, but more annoying, taking away from rolls of more interesting events whilst increasing the odds of ones that are just a annoyance to 'yikes'.
For example, an antagonist being selected by it. This can roll lobotomy-only-cureable-full-body-paralysis, or the trauma that makes you sleep every now and then, and so on. Best case it is a minor annoyance that can be fixed in a second, worse case it fucks the round over. Even appendicitis can be mitigated via getting toxheal chems, whilst this usually needs either surgery, or even a lobotomy to deal with if it rolls one of the more concerning traumas. And good luck getting those fixed if you are an antag, or it rolls you in a situation where medical isn't as easily available.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: The 'random brain trauma' event has been disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
