### PR TITLE
Nerfs random brain trauma a good deal.

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -6,7 +6,7 @@
 /datum/round_event_control/brain_trauma/canSpawnEvent(var/players_amt, var/gamemode)
 	var/list/enemy_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
 	for (var/mob/M in GLOB.alive_mob_list)
-		if(M.stat != DEAD && M.mind?.assigned_role in enemy_roles)
+		if(M.stat != DEAD && (M.mind?.assigned_role in enemy_roles))
 			return TRUE
 	return FALSE
 
@@ -23,6 +23,8 @@
 			continue
 		if(HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
 			continue
+		if(!is_station_level(H.z))
+			continue
 		traumatize(H)
 		break
 
@@ -32,8 +34,8 @@
 		35;TRAUMA_RESILIENCE_SURGERY)
 
 	var/trauma_type = pickweight(list(
-		BRAIN_TRAUMA_MILD = 60,
-		BRAIN_TRAUMA_SEVERE = 30,
+		BRAIN_TRAUMA_MILD = 80,
+		BRAIN_TRAUMA_SEVERE = 10,
 		BRAIN_TRAUMA_SPECIAL = 10
 	))
 

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -3,6 +3,13 @@
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
 
+/datum/round_event_control/brain_trauma/canSpawnEvent(var/players_amt, var/gamemode)
+	var/list/enemy_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
+	for (var/mob/M in GLOB.alive_mob_list)
+		if(M.stat != DEAD && M.mind?.assigned_role in enemy_roles)
+			return TRUE
+	return FALSE
+
 /datum/round_event/brain_trauma
 	fakeable = FALSE
 
@@ -22,8 +29,7 @@
 /datum/round_event/brain_trauma/proc/traumatize(mob/living/carbon/human/H)
 	var/resistance = pick(
 		65;TRAUMA_RESILIENCE_BASIC,
-		30;TRAUMA_RESILIENCE_SURGERY,
-		5;TRAUMA_RESILIENCE_LOBOTOMY)
+		35;TRAUMA_RESILIENCE_SURGERY)
 
 	var/trauma_type = pickweight(list(
 		BRAIN_TRAUMA_MILD = 60,


### PR DESCRIPTION
…e's doctors.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the following for spontaneous brain trauma:
1. Will only roll if there is at least one MD, CMO or paramedic.
2. Will only roll if they're on the station Z-level.
3. Won't randomly cause lobotomy-tier traumas.
4. Significantly lower chance of severe traumas.

## Why It's Good For The Game

It really is an annoying event, but there's other ways to deal, and I'd rather the doctors have something to do.

## Changelog
:cl:
balance: Made spontaneous brain trauma a good deal less annoying.
/:cl: