### PR TITLE
Makes dwarf text not check every replacement every time.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -51,17 +51,16 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 //Dwarf Speech handling - Basically a filter/forces them to say things. The IC helper
 /datum/species/dwarf/proc/handle_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(speech_args[SPEECH_LANGUAGE] != /datum/language/dwarf) // No accent if they speak their language
-		if(message[1] != "*")
-			message = " [message]" //Credits to goonstation for the strings list.
-			var/list/dwarf_words = strings("dwarf_replacement.json", "dwarf") //thanks to regex too.
-			for(var/key in dwarf_words) //Theres like 1459 words or something man.
-				var/value = dwarf_words[key] //Thus they will always be in character.
-				if(islist(value)) //Whether they like it or not.
-					value = pick(value) //This could be drastically reduced if needed though.
-				message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
-				message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
-				message = replacetextEx(message, " [key]", " [value]") //Also its scottish.
+	if(speech_args[SPEECH_LANGUAGE] != /datum/language/dwarf && message[1] != "*") // No accent if they speak their language
+		message = " [message]" //Credits to goonstation for the strings list.
+		var/list/dwarf_words = strings("dwarf_replacement.json", "dwarf") //thanks to regex too.
+		for(var/word in splittext(message," "))
+			var/value = dwarf_words[word] //Thus they will always be in character.
+			if(islist(value)) //Whether they like it or not.
+				value = pick(value) //This could be drastically reduced if needed though.
+			message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
+			message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
+			message = replacetextEx(message, " [key]", " [value]") //Also its scottish.
 
 	if(prob(3))
 		message += " By Armok!"

--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -56,11 +56,13 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 		var/list/dwarf_words = strings("dwarf_replacement.json", "dwarf") //thanks to regex too.
 		for(var/word in splittext(message," "))
 			var/value = dwarf_words[word] //Thus they will always be in character.
+			if(!value)
+				continue
 			if(islist(value)) //Whether they like it or not.
 				value = pick(value) //This could be drastically reduced if needed though.
-			message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
-			message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
-			message = replacetextEx(message, " [key]", " [value]") //Also its scottish.
+			message = replacetextEx(message, " [uppertext(word)]", " [uppertext(value)]")
+			message = replacetextEx(message, " [capitalize(word)]", " [capitalize(value)]")
+			message = replacetextEx(message, " [word]", " [value]") //Also its scottish.
 
 	if(prob(3))
 		message += " By Armok!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rather than do a for loop through 1500 replacements and running replaceTextEx on the line of speech every single time, making this one proc one of the top 10 laggiest in the entire codebase, it runs through each individual word in the line of speech and grabs the line from the file that way, making it run approximately 100 times faster.

## Why It's Good For The Game

Just because they're both O(n) doesn't mean one isn't faster.

## Changelog
:cl:
refactor: Dwarf speech is no longer absolutely paranoid about word replacement.
/:cl: