### PR TITLE
ttt_boxstation_v3 Maintenance and Command Updates

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_am.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_am.dmm
@@ -265,7 +265,7 @@
 	light_color = "#c1caff"
 	},
 /obj/machinery/camera/emp_proof{
-	c_tag = "Particle Accelerator";
+	c_tag = "Engineering - Particle Accelerator";
 	network = list("ss13","engine")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_singulo.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_singulo.dmm
@@ -136,7 +136,7 @@
 /area/engine/engineering)
 "fr" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Singularity Engine Southwest";
+	c_tag = "Engineering - Engine - Port Quarter";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -295,7 +295,7 @@
 "sr" = (
 /obj/machinery/light,
 /obj/machinery/camera/emp_proof{
-	c_tag = "Singularity Engine South";
+	c_tag = "Engineering - Engine - Aft";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -448,7 +448,7 @@
 	light_color = "#c1caff"
 	},
 /obj/machinery/camera/emp_proof{
-	c_tag = "Particle Accelerator";
+	c_tag = "Engineering - Particle Accelerator";
 	network = list("ss13","engine")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -496,7 +496,7 @@
 /area/engine/engineering)
 "DK" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Singularity Engine West";
+	c_tag = "Engineering - Engine - Port";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -638,7 +638,7 @@
 /area/engine/engineering)
 "LJ" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Singularity Engine Southeast";
+	c_tag = "Engineering - Engine - Starboard Quarter";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -727,7 +727,7 @@
 /area/engine/engineering)
 "Qk" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Singularity Engine Northeast";
+	c_tag = "Engineering - Engine - Starboard Bow";
 	network = list("ss13","engine")
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -773,7 +773,7 @@
 /area/template_noop)
 "UL" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Singularity Engine Northwest";
+	c_tag = "Engineering - Engine - Port Bow";
 	network = list("ss13","engine")
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm.dmm
@@ -256,7 +256,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
+	c_tag = "Engineering - Supermatter - Port";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -601,7 +601,7 @@
 /area/engine/engineering)
 "na" = (
 /obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
+	c_tag = "Engineering - Supermatter - Chamber";
 	network = list("engine");
 	pixel_x = 23
 	},
@@ -1269,7 +1269,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
+	c_tag = "Engineering - Supermatter - Starboard";
 	dir = 8;
 	network = list("ss13","engine")
 	},
@@ -1337,7 +1337,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
+	c_tag = "Engineering - Supermatter - Aft";
 	network = list("ss13","engine");
 	pixel_x = 23
 	},
@@ -1999,7 +1999,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
+	c_tag = "Engineering - Supermatter - Fore";
 	dir = 1;
 	network = list("ss13","engine");
 	pixel_x = 23

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_1x3.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_1x3.dmm
@@ -221,7 +221,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
+	c_tag = "Engineering - Supermatter - Port";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -991,7 +991,7 @@
 /area/engine/engineering)
 "yZ" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
+	c_tag = "Engineering - Supermatter - Fore";
 	dir = 1;
 	network = list("ss13","engine");
 	pixel_x = 23
@@ -1258,7 +1258,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
+	c_tag = "Engineering - Supermatter - Starboard";
 	dir = 8;
 	network = list("ss13","engine")
 	},
@@ -1589,7 +1589,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
+	c_tag = "Engineering - Supermatter - Aft";
 	network = list("ss13","engine");
 	pixel_x = 23
 	},

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_3x.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_3x.dmm
@@ -256,7 +256,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
+	c_tag = "Engineering - Supermatter - Port";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -592,7 +592,7 @@
 /area/engine/engineering)
 "na" = (
 /obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
+	c_tag = "Engineering - Supermatter - Chamber";
 	network = list("engine");
 	pixel_x = 23
 	},
@@ -1244,7 +1244,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
+	c_tag = "Engineering - Supermatter - Starboard";
 	dir = 8;
 	network = list("ss13","engine")
 	},
@@ -1312,7 +1312,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
+	c_tag = "Engineering - Supermatter - Aft";
 	network = list("ss13","engine");
 	pixel_x = 23
 	},
@@ -1949,7 +1949,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
+	c_tag = "Engineering - Supermatter - Fore";
 	dir = 1;
 	network = list("ss13","engine");
 	pixel_x = 23

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_5x5.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_5x5.dmm
@@ -268,7 +268,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
+	c_tag = "Engineering - Supermatter - Port";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -344,7 +344,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
+	c_tag = "Engineering - Supermatter - Fore";
 	dir = 1;
 	network = list("ss13","engine");
 	pixel_x = 23
@@ -1174,7 +1174,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
+	c_tag = "Engineering - Supermatter - Chamber Port";
 	network = list("engine");
 	pixel_x = 23
 	},
@@ -1196,7 +1196,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
+	c_tag = "Engineering - Supermatter - Chamber Starboard";
 	network = list("engine");
 	pixel_x = 23
 	},
@@ -1318,7 +1318,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
+	c_tag = "Engineering - Supermatter - Starboard";
 	dir = 8;
 	network = list("ss13","engine")
 	},
@@ -1745,7 +1745,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
+	c_tag = "Engineering - Supermatter - Aft";
 	network = list("ss13","engine");
 	pixel_x = 23
 	},

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
@@ -340,7 +340,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/camera{
-	c_tag = "TEG - South East";
+	c_tag = "Engineering - TEG - Starboard Quarter";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -922,7 +922,7 @@
 /obj/item/multitool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
-	c_tag = "TEG - North West";
+	c_tag = "Engineering - TEG - Port Bow";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -1062,7 +1062,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "TEG - East";
+	c_tag = "Engineering - TEG - Starboard";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1267,7 +1267,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/meter,
 /obj/machinery/camera{
-	c_tag = "TEG - South Center";
+	c_tag = "Engineering - TEG - Central Aft";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -1641,7 +1641,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera{
-	c_tag = "TEG - North Center";
+	c_tag = "Engineering - TEG - Central Fore";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1702,7 +1702,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
-	c_tag = "TEG - North"
+	c_tag = "Engineering - TEG - Fore"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -1755,7 +1755,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
-	c_tag = "TEG - West";
+	c_tag = "Engineering - TEG - Port";
 	dir = 4
 	},
 /turf/open/floor/plasteel,

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
@@ -172,7 +172,7 @@
 /area/engine/engineering)
 "fr" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine Southwest";
+	c_tag = "Engineering - Engine - Port Quarter";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -221,7 +221,7 @@
 /area/space/nearstation)
 "js" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine East";
+	c_tag = "Singularity Engine East";
 	dir = 8;
 	network = list("ss13","engine")
 	},
@@ -353,7 +353,7 @@
 "tc" = (
 /obj/machinery/light,
 /obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine South";
+	c_tag = "Engineering - Engine - Aft";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -442,7 +442,7 @@
 /area/space/nearstation)
 "yj" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine West";
+	c_tag = "Engineering - Engine - Port";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -511,16 +511,16 @@
 	dir = 1;
 	light_color = "#c1caff"
 	},
-/obj/machinery/camera/emp_proof{
-	c_tag = "Particle Accelerator";
-	network = list("ss13","engine")
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/the_singularitygen/tesla,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Particle Accelerator";
+	network = list("ss13","engine")
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -704,7 +704,7 @@
 /area/engine/engineering)
 "LJ" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine Southeast";
+	c_tag = "Engineering - Engine - Starboard Quarter";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -815,11 +815,11 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Qk" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine Northeast";
+	c_tag = "Engineering - Engine - Starboard Bow";
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Ra" = (
@@ -897,7 +897,7 @@
 /area/template_noop)
 "UL" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine Northwest";
+	c_tag = "Engineering - Engine - Port Bow";
 	network = list("ss13","engine")
 	},
 /turf/open/floor/plating/airless,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -41516,6 +41516,9 @@
 	name = "Shuttle Bay Bridge Control";
 	pixel_x = 27
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bWz" = (
@@ -46156,6 +46159,7 @@
 	name = "Cargo Bay Bridge Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ciR" = (
@@ -53925,6 +53929,7 @@
 /area/bridge/meeting_room)
 "hrF" = (
 /obj/item/wrench,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hsb" = (
@@ -54029,6 +54034,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"hKU" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "hLG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
@@ -54259,6 +54271,9 @@
 "inR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "iou" = (
@@ -56081,6 +56096,18 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"mhy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cargo Bay Bridge"
+	},
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Bridge Control";
+	pixel_x = 27
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mhN" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -57092,6 +57119,16 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"oPG" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Cargo Bay Bridge Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oRV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57158,6 +57195,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"oZt" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oZJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -76362,9 +76405,9 @@ aSg
 aSg
 aSg
 aSg
-bWy
+mhy
 chS
-ciQ
+oPG
 csl
 csl
 csl
@@ -78681,8 +78724,8 @@ aaa
 aaa
 bkF
 aSg
-aWv
-nLu
+oZt
+hKU
 hrF
 inR
 aSg

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -63,6 +63,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aai" = (
@@ -124,7 +127,7 @@
 /area/security/prison)
 "aaq" = (
 /obj/machinery/camera{
-	c_tag = "Prison Common Room";
+	c_tag = "Security - Prison Common Room";
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/tile/green{
@@ -323,7 +326,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaQ" = (
-/turf/closed/wall,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
 /area/security/warden)
 "aaR" = (
 /obj/structure/lattice,
@@ -396,6 +400,9 @@
 /obj/item/clothing/head/beret/sec/navyofficer,
 /obj/item/clothing/head/beret/sec/navywarden,
 /obj/item/clothing/head/beret/sec/navyhos,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aaZ" = (
@@ -467,9 +474,15 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abm" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "abn" = (
@@ -540,12 +553,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "abx" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory External Motion Sensor";
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "aby" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -597,8 +610,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "abG" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "abH" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -725,7 +745,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
+	c_tag = "Security - Equipment Room";
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -1034,7 +1054,7 @@
 /area/solar/starboard/fore)
 "acy" = (
 /obj/structure/lattice,
-/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/red,
 /turf/open/space,
 /area/space/nearstation)
 "acz" = (
@@ -1058,7 +1078,7 @@
 "acC" = (
 /obj/structure/bed,
 /obj/machinery/camera{
-	c_tag = "Prison Cell 3";
+	c_tag = "Security - Prison Cell 3";
 	network = list("ss13","prison")
 	},
 /obj/item/radio/intercom{
@@ -1087,7 +1107,7 @@
 "acE" = (
 /obj/structure/bed,
 /obj/machinery/camera{
-	c_tag = "Prison Cell 2";
+	c_tag = "Security - Prison Cell 2";
 	network = list("ss13","prison")
 	},
 /obj/item/radio/intercom{
@@ -1115,7 +1135,7 @@
 "acH" = (
 /obj/structure/bed,
 /obj/machinery/camera{
-	c_tag = "Prison Cell 1";
+	c_tag = "Security - Prison Cell 1";
 	network = list("ss13","prison")
 	},
 /obj/item/radio/intercom{
@@ -1189,9 +1209,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acN" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "acO" = (
@@ -1201,6 +1219,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -1419,6 +1440,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "adm" = (
@@ -1463,16 +1487,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "adq" = (
-/obj/machinery/computer/slot_machine{
-	balance = 15;
-	money = 500;
-	pixel_x = -5
-	},
-/obj/structure/sign/poster/contraband/robust_softdrinks{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "adr" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
@@ -1950,7 +1969,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Prison Hallway";
+	c_tag = "Security - Prison Hallway";
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/tile/red{
@@ -2059,6 +2078,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aeu" = (
@@ -2066,7 +2088,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/camera{
-	c_tag = "Head of Security's Office";
+	c_tag = "Security - Head of Security's Office";
 	dir = 4
 	},
 /obj/machinery/recharger{
@@ -2152,7 +2174,7 @@
 /area/security/main)
 "aeC" = (
 /obj/machinery/camera{
-	c_tag = "Security Escape Pod";
+	c_tag = "Security - Escape Pod";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -2290,9 +2312,6 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2528,6 +2547,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "afd" = (
@@ -2665,9 +2687,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -2778,9 +2797,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "afA" = (
@@ -2835,6 +2851,10 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 1;
+	pixel_y = -27
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -2892,13 +2912,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "afJ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 1;
-	pixel_y = -27
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -3074,10 +3094,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "age" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/range)
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "agf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal,
@@ -3212,10 +3231,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/processing)
+/turf/closed/wall/r_wall,
+/area/security/range)
 "ags" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3231,24 +3248,17 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "agu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"agv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
+/area/security/processing)
+"agv" = (
+/obj/machinery/gulag_teleporter,
+/turf/open/floor/plasteel,
 /area/security/processing)
 "agw" = (
 /obj/structure/cable{
@@ -3280,6 +3290,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -3348,8 +3361,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3365,9 +3378,8 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "agF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3445,10 +3457,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Security - Brig - Port";
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "agM" = (
@@ -3597,7 +3619,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor";
+	c_tag = "Security - Armory";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -3639,6 +3661,9 @@
 /area/security/main)
 "aha" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahb" = (
@@ -3763,10 +3788,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/crew_quarters/fitness)
 "ahn" = (
 /turf/closed/wall,
@@ -3782,34 +3810,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"ahq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/storage/box/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"ahr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "ahs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/sofa/right,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/rack,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/radio,
+/obj/item/storage/secure/briefcase,
+/obj/item/flashlight/seclite,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aht" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -3957,19 +3968,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"ahC" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/closet/wardrobe/white,
-/obj/item/clothing/under/suit/waiter,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"ahD" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "ahE" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/red,
@@ -4095,23 +4093,13 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahO" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"ahP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet/wardrobe/mixed,
-/obj/item/clothing/under/costume/kilt,
-/obj/structure/sign/poster/official/fashion{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/stock_parts/matter_bin,
+/obj/structure/closet,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "ahQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -4177,25 +4165,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"ahU" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"ahV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/computer/security/labor{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "ahW" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
@@ -4422,12 +4391,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"ail" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
 "aim" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -4637,13 +4600,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aiB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/fashion{
-	pixel_y = 32
-	},
-/obj/machinery/vending/autodrobe,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aiC" = (
@@ -4663,52 +4620,30 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
-"aiD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "aiE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aiF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/gulag_item_reclaimer{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Security Docking";
-	dir = 8
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -4731,7 +4666,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Brig Central";
+	c_tag = "Security - Brig - Central";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4762,7 +4697,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aiK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -4782,10 +4717,10 @@
 "aiN" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -4816,7 +4751,7 @@
 "aiP" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/structure/sign/poster/official/medical_green_cross{
+/obj/structure/sign/departments/chemistry{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white,
@@ -4838,23 +4773,28 @@
 /turf/open/space,
 /area/space/nearstation)
 "aiT" = (
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
 /area/security/processing)
 "aiU" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
-/area/security/processing)
-"aiV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hopqueue";
-	name = "HoP Queue Shutters"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/security/range)
 "aiW" = (
 /obj/structure/closet/bombcloset/security,
 /obj/effect/turf_decal/bot,
@@ -4927,7 +4867,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -4945,15 +4884,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/poster/official/pda_ad800{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/computer/bank_machine,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "aji" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -4975,7 +4909,7 @@
 	pixel_y = 20
 	},
 /obj/machinery/camera{
-	c_tag = "Courtroom North"
+	c_tag = "Security - Courtroom - Fore"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -5045,19 +4979,13 @@
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
 "ajs" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/effect/turf_decal/loading_area/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sign/poster/official/pda_ad600{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "ajt" = (
 /obj/machinery/camera{
-	c_tag = "Vacant Office B";
+	c_tag = "Security - Vacant Office B";
 	dir = 1
 	},
 /obj/structure/table/wood,
@@ -5163,12 +5091,29 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajD" = (
-/obj/effect/spawner/lootdrop/keg,
-/obj/structure/sign/poster/contraband/scum{
-	pixel_x = -32
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -4;
+	pixel_y = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "ajE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -5181,7 +5126,6 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ajF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -5191,18 +5135,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajG" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/condiment/sugar,
-/obj/structure/sign/poster/contraband/scum{
-	pixel_x = -32
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets,
+/obj/item/stock_parts/manipulator,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/fore/secondary)
 "ajH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -5217,13 +5160,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5266,19 +5206,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajM" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/sign/poster/contraband/scum{
-	pixel_y = 32
-	},
-/obj/structure/sign/poster/contraband/scum{
-	pixel_y = 32
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/girder,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "ajN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5286,10 +5217,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5398,15 +5329,18 @@
 /turf/open/space,
 /area/solar/port/fore)
 "ajX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5430,26 +5364,15 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "aka" = (
-/obj/structure/closet/secure_closet/bar{
-	req_access_txt = "25"
-	},
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/clothing/under/suit/waiter,
-/obj/item/gun/ballistic/revolver/doublebarrel,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/stack/spacecash/c100,
+/obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "akb" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/turf/closed/wall,
+/area/security/range)
 "akc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -5486,8 +5409,9 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "akg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akh" = (
@@ -5498,7 +5422,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -5509,10 +5432,6 @@
 "aki" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5546,9 +5465,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akm" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/processing)
 "akn" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -5587,8 +5512,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Brig West";
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5598,7 +5526,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5608,17 +5535,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/computer/security/telescreen/interrogation{
-	dir = 1;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/processing)
 "aks" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5680,11 +5600,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5734,34 +5654,31 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "akC" = (
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akE" = (
 /obj/machinery/holopad,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
-	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "akF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -5772,21 +5689,33 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/security/processing)
+"akH" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"akH" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"akI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"akI" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/security/processing)
 "akJ" = (
 /obj/machinery/door/firedoor,
@@ -5811,18 +5740,18 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "akM" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -5844,13 +5773,16 @@
 /area/science/xenobiology)
 "akQ" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-4"
 	},
-/turf/closed/wall,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
 /area/security/brig)
 "akR" = (
 /obj/machinery/camera{
-	c_tag = "Security Office";
+	c_tag = "Security - Office";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -5884,7 +5816,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "akU" = (
@@ -5917,47 +5849,39 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "akX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"akY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"akZ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"akY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/warden)
-"akZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"ala" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"ala" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
+/turf/open/floor/plasteel,
+/area/security/range)
 "alb" = (
 /obj/structure/chair{
 	dir = 4;
@@ -6090,6 +6014,26 @@
 "alo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/warden)
+"alp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"alq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
@@ -6100,18 +6044,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/security/warden)
-"alp" = (
-/turf/open/floor/plating,
-/area/security/processing)
-"alq" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "alr" = (
 /obj/machinery/computer/camera_advanced/xenobio{
@@ -6138,78 +6070,55 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alt" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alu" = (
-/obj/machinery/nuclearbomb/selfdestruct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/area/ai_monitored/turret_protected/ai)
 "alv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/brig)
-"alw" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "alx" = (
 /obj/structure/table/glass,
@@ -6235,24 +6144,18 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "aly" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_one_access_txt = "1;4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -6262,26 +6165,34 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"alB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"alB" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "alC" = (
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "alD" = (
@@ -6290,24 +6201,20 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "alE" = (
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_x = -30
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/computer/security{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plating,
+/area/security/brig)
 "alF" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alG" = (
@@ -6352,13 +6259,16 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "alK" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "alL" = (
@@ -6376,12 +6286,44 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "alM" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "alN" = (
-/obj/machinery/computer/prisoner/management,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/structure/table,
+/obj/machinery/magnetic_controller{
+	autolink = 1;
+	pixel_y = 3
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "alO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6448,6 +6390,54 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "alY" = (
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_x = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"alZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/obj/machinery/camera{
+	c_tag = "Security - Prisoner Processing";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"ama" = (
+/mob/living/simple_animal/sloth/paperwork,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"amb" = (
+/obj/machinery/computer/prisoner/management,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"amc" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"amd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6457,38 +6447,6 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"alZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/security/brig)
-"ama" = (
-/mob/living/simple_animal/sloth/paperwork,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"amb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/warden)
-"amc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
 "ame" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -6497,25 +6455,33 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amf" = (
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"amf" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amg" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
+/obj/structure/closet/secure_closet/warden,
+/obj/structure/sign/poster/official/ion_rifle{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/sign/poster/official/twelve_gauge{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom{
+	pixel_x = 32;
+	pixel_y = 20
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amh" = (
 /obj/machinery/door/firedoor,
@@ -6552,16 +6518,18 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amk" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"amk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "aml" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -6569,36 +6537,19 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "amm" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/brig)
-"amn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Cell Interior Shutters";
-	name = "brig shutters"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
-"amo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"amp" = (
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6608,10 +6559,47 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"amq" = (
-/obj/effect/turf_decal/tile/red{
+"amn" = (
+/obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -27;
+	prison_radio = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = -24;
+	pixel_y = -36
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/green,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"amo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"amp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"amq" = (
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amr" = (
@@ -6653,17 +6641,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"amx" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/security/brig)
 "amy" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -6687,44 +6664,37 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "amB" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Cell Interior Shutters";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amC" = (
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "amD" = (
-/obj/structure/sink{
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/airalarm{
 	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel,
+/area/security/range)
 "amE" = (
-/obj/structure/bed,
-/obj/effect/landmark/xeno_spawn,
-/obj/item/bedsheet,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"amF" = (
-/obj/machinery/computer/slot_machine{
-	balance = 15;
-	money = 500
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/item/coin/iron,
-/obj/item/coin/diamond,
-/obj/item/coin/diamond,
-/obj/item/coin/diamond,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel,
+/area/security/range)
+"amF" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "amG" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -6761,76 +6731,45 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "amI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"amJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "amK" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall,
-/area/security/processing)
+/obj/structure/target_stake,
+/obj/item/target/syndicate,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/security/range)
 "amL" = (
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"amM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/processing)
+"amM" = (
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "amN" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Reception Desk";
-	req_access_txt = "3"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
-	name = "brig shutters"
-	},
-/obj/machinery/door/window/southright{
-	dir = 8;
-	name = "Reception Desk";
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"amO" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amP" = (
 /obj/structure/disposalpipe/segment,
@@ -6857,25 +6796,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"amR" = (
+"amS" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/brig)
-"amS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
 /area/security/brig)
 "amT" = (
 /obj/structure/cable{
@@ -6896,28 +6826,61 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "amU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "amV" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "amW" = (
-/obj/effect/landmark/start/warden,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Reception Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
+/obj/machinery/door/window/southright{
+	dir = 8;
+	name = "Reception Desk";
+	req_access_txt = "63"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amX" = (
-/obj/structure/chair{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "amY" = (
 /obj/structure/chair{
 	dir = 1
@@ -6949,13 +6912,16 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "and" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/rack,
+/obj/item/storage/box/prisoner,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "ane" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6977,7 +6943,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/camera{
-	c_tag = "Fore Port Solar Control";
+	c_tag = "Solar Control - Port Bow";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -6999,37 +6965,54 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "anj" = (
-/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
+/turf/open/floor/plasteel,
+/area/security/range)
+"ank" = (
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Shooting Range"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"anl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"anm" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"ank" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	req_access_txt = "12"
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 2;
+	pixel_y = -2
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"anl" = (
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 9
+/obj/item/gun/energy/laser/practice{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"anm" = (
-/obj/item/trash/sosjerky,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "ann" = (
-/obj/item/electronics/airalarm,
-/obj/item/circuitboard/machine/seed_extractor,
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/security/range)
 "ano" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -7048,16 +7031,37 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "anq" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "anr" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ans" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"ant" = (
+/obj/effect/landmark/start/warden,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"anu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -7066,31 +7070,9 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"ant" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_access_txt = "3"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"anu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/warden)
 "anv" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "anw" = (
 /obj/effect/turf_decal/tile/red{
@@ -7106,17 +7088,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"any" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "anz" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -7126,31 +7097,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"anB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "anC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -7161,28 +7107,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anF" = (
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anG" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/fitness/pool";
-	name = "Pool APC";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "anH" = (
@@ -7204,39 +7141,26 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anK" = (
-/obj/effect/decal/cleanable/egg_smudge,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"anL" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"anM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel,
+/area/security/range)
+"anL" = (
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"anM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -27;
-	prison_radio = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -24;
-	pixel_y = -36
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/blue,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "anN" = (
@@ -7251,33 +7175,41 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "anO" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_home";
-	name = "fore bay 1";
-	roundstart_template = /datum/map_template/shuttle/labour/box;
-	width = 9
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/security/range)
 "anP" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "anQ" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7316,7 +7248,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera{
-	c_tag = "Courtroom South";
+	c_tag = "Security - Courtroom - Aft";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -7365,12 +7297,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"aoe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/maintenance/fore/secondary)
 "aof" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
@@ -7404,7 +7330,7 @@
 /area/maintenance/solars/starboard/fore)
 "aoj" = (
 /obj/machinery/camera{
-	c_tag = "Fore Port Solar Access"
+	c_tag = "Solar Access - Port Bow"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -7430,12 +7356,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aon" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel/airless,
+/area/space/nearstation)
 "aoo" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/monkey_recycler,
+/obj/structure/table,
+/obj/item/stamp,
+/obj/item/poster/random_official,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aop" = (
@@ -7466,15 +7392,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aor" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/taperecorder,
-/obj/item/folder/red,
-/obj/machinery/light_switch{
-	pixel_y = -24
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "aos" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7494,30 +7419,26 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aot" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aou" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
 	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6;
+	layer = 2.03
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/security/range)
 "aov" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -7533,7 +7454,7 @@
 /area/hallway/primary/fore)
 "aox" = (
 /obj/machinery/camera{
-	c_tag = "Fore Primary Hallway West";
+	c_tag = "Fore Primary Hallway - Port";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
@@ -7581,13 +7502,12 @@
 /area/hallway/primary/fore)
 "aoC" = (
 /obj/effect/turf_decal/tile/red,
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/table,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoD" = (
 /obj/machinery/camera{
-	c_tag = "Fore Primary Hallway East";
+	c_tag = "Fore Primary Hallway - Starboard";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -7600,14 +7520,12 @@
 /area/hallway/primary/fore)
 "aoE" = (
 /obj/effect/turf_decal/tile/red,
-/obj/item/storage/box/cups,
-/obj/structure/table,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoF" = (
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table,
+/obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoG" = (
@@ -7636,32 +7554,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/fitness";
+	name = "Fitness Room APC";
+	pixel_y = -24
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoJ" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"aoK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"aoL" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Out"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aoM" = (
@@ -7686,15 +7588,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"aoP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "aoQ" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "aoR" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
@@ -7718,49 +7615,29 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 9
 	},
-/obj/structure/bed,
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoV" = (
 /turf/open/space,
 /area/space)
 "aoW" = (
-/obj/structure/table,
-/obj/item/stamp,
-/obj/item/poster/random_official,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space/station_ruins)
 "aoX" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aoY" = (
+"aoZ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = -28
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aoZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
-	name = "brig shutters"
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "apa" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
@@ -7776,9 +7653,20 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "apc" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "apd" = (
 /turf/closed/wall,
 /area/security/detectives_office)
@@ -7910,27 +7798,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/fitness";
-	name = "Fitness Room APC";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "apv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 3
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 3
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plating,
 /area/security/warden)
 "apw" = (
 /obj/machinery/door/window/northleft{
@@ -7952,26 +7831,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"apx" = (
-/obj/machinery/door/airlock/atmos/abandoned{
-	name = "Atmospherics Maintenance";
-	req_access_txt = "12;24"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"apy" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "apz" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7996,7 +7855,7 @@
 /area/maintenance/solars/starboard/fore)
 "apB" = (
 /obj/machinery/camera{
-	c_tag = "Fore Starboard Solars";
+	c_tag = "Solar Control - Starboard Bow";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -8006,14 +7865,18 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "apC" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard/fore)
-"apD" = (
-/obj/structure/closet/wardrobe/mixed,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/coin/silver,
+/obj/item/cigbutt/cigarbutt,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
+"apD" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	name = "dusty sink";
+	pixel_x = -12
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "apE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -8030,27 +7893,11 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "apH" = (
-/obj/machinery/computer/crew{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/button/door{
-	id = "outerbrig";
-	name = "Brig Exterior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -40;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/door{
-	id = "innerbrig";
-	name = "Brig Interior Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -24;
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plasteel,
+/area/security/range)
 "apI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -8061,22 +7908,10 @@
 "apJ" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
-"apK" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "apL" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stock_parts/scanning_module,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "apM" = (
@@ -8084,6 +7919,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "apN" = (
@@ -8100,24 +7936,58 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "apQ" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch{
+	pixel_y = -23
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32;
+	pixel_y = -32
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/button/door{
+	id = "Secure Brig Control";
+	name = "Brig Control Shutters";
+	pixel_x = 6;
+	pixel_y = -40;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "Cell Interior Shutters";
+	name = "Cell Interior Shutters";
+	pixel_x = -6;
+	pixel_y = -40;
+	req_access_txt = "2"
 	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apR" = (
+/obj/machinery/light/small,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"apS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"apT" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
@@ -8142,21 +8012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"apS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"apT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall,
-/area/security/warden)
 "apU" = (
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
@@ -8181,27 +8036,17 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
+	id = "Secure Gate";
 	name = "brig shutters"
 	},
 /turf/open/floor/plating,
-/area/security/warden)
-"apY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/area/security/brig)
 "apZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"aqa" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
 "aqb" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase,
@@ -8298,14 +8143,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -8319,76 +8164,39 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqn" = (
-/obj/structure/bed,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/button/door{
-	id = "Dorm4";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/chair/comfy/black,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aqo" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"aqp" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/fire/firefighter,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/item/extinguisher,
-/obj/item/clothing/head/hardhat/red,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"aqq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
 "aqr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Reception Desk";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/southleft{
-	name = "Reception Desk";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
-	name = "brig shutters"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"aqs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"aqs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Pool"
@@ -8396,15 +8204,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "aqt" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Brig Control";
-	name = "brig shutters"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/security/warden)
 "aqu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -8442,21 +8248,18 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "aqy" = (
-/obj/structure/closet/emcloset,
+/obj/structure/bed,
+/obj/item/bedsheet/random,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "aqz" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/landmark/carpspawn,
+/turf/open/space,
+/area/space/station_ruins)
 "aqA" = (
-/obj/structure/closet/firecloset,
+/obj/item/cigbutt,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/fore/secondary)
 "aqB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8475,50 +8278,49 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"aqC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"aqD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Firing Range Gear Crate";
+	req_access_txt = "1"
+	},
+/obj/item/target,
+/obj/item/target,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target/syndicate,
+/obj/machinery/power/apc{
+	areastring = "/area/security/range";
+	dir = 4;
+	name = "Shooting Range APC";
+	pixel_x = 24
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aqD" = (
+/area/security/range)
+"aqE" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aqE" = (
-/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/obj/machinery/nuclearbomb/beer,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aqG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -8538,6 +8340,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aqI" = (
+/obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -8555,6 +8358,7 @@
 /area/solar/port/fore)
 "aqK" = (
 /obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "aqL" = (
@@ -8571,22 +8375,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqN" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/structure/sign/poster/official/ion_rifle{
-	pixel_y = 32
-	},
-/obj/structure/sign/poster/official/twelve_gauge{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom{
-	pixel_x = 32;
-	pixel_y = 20
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aqO" = (
@@ -8595,6 +8383,7 @@
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
+/obj/item/stock_parts/manipulator,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqP" = (
@@ -8611,9 +8400,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqQ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "aqR" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -8723,15 +8514,24 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "arj" = (
-/turf/closed/wall,
-/area/crew_quarters/fitness)
+/obj/structure/closet,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/cell/crap,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "ark" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
+	},
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
@@ -8747,13 +8547,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "arm" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "arn" = (
@@ -8763,7 +8557,9 @@
 	name = "Labor Shuttle Dock APC";
 	pixel_x = -24
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -8775,19 +8571,17 @@
 	},
 /area/holodeck/rec_center)
 "arp" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/door_assembly/door_assembly_mai,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/fore/secondary)
 "arq" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
+/obj/item/clothing/under/misc/vice_officer{
+	pixel_x = 4;
+	pixel_y = -3
 	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arr" = (
@@ -8812,7 +8606,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Fore Starboard Solar Access"
+	c_tag = "Solar Access - Starboard Bow"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8820,99 +8614,90 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aru" = (
-/obj/structure/chair/stool,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/crew_quarters/abandoned_gambling_den)
 "arv" = (
 /obj/structure/table,
-/obj/item/pen,
+/obj/item/reagent_containers/food/snacks/donut,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arw" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "arx" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/trash/plate,
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 28
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "ary" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/warden";
-	name = "Brig Control APC";
-	pixel_y = -24
+/obj/machinery/computer/crew{
+	dir = 4
 	},
 /obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = 6;
+	id = "outerbrig";
+	name = "Brig Exterior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
 	pixel_y = -40;
 	req_access_txt = "2"
 	},
 /obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_x = -6;
-	pixel_y = -40;
+	id = "innerbrig";
+	name = "Brig Interior Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = -24;
 	req_access_txt = "2"
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Brig Control";
-	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "arz" = (
-/obj/item/coin/gold,
-/obj/item/coin/iron,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "arA" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/plasma,
+/obj/item/trash/sosjerky,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "arB" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
 "arC" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "arD" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
+/obj/machinery/door/poddoor/preopen{
+	id = "Cell Interior Shutters";
+	name = "brig shutters"
 	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/brig)
 "arE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -8970,6 +8755,12 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 9
 	},
+/obj/structure/closet/crate,
+/obj/item/storage/belt/utility,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -8984,40 +8775,40 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arM" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range";
+	req_one_access_txt = "1;4"
 	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel,
+/area/security/range)
 "arN" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Security - Armory - External";
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"arO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
-"arO" = (
-/obj/item/clothing/gloves/color/rainbow,
-/obj/item/clothing/head/soft/rainbow,
-/obj/item/clothing/shoes/sneakers/rainbow,
-/obj/item/clothing/under/color/rainbow,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/security/main)
 "arP" = (
 /turf/closed/wall,
 /area/maintenance/fore)
 "arQ" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "arR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/table/wood,
@@ -9025,14 +8816,11 @@
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
 "arS" = (
-/obj/structure/chair{
-	dir = 8
+/obj/item/radio/intercom{
+	pixel_x = 26
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "arT" = (
 /turf/open/floor/plasteel,
 /area/security/vacantoffice/b)
@@ -9095,14 +8883,33 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "asb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/power/apc{
+	areastring = "/area/security/warden";
+	name = "Brig Control APC";
+	pixel_y = -24
 	},
+/obj/machinery/button/door{
+	id = "Secure Gate";
+	name = "Cell Shutters";
+	pixel_x = 6;
+	pixel_y = -40;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_x = -6;
+	pixel_y = -40;
+	req_access_txt = "2"
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light,
+/obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Brig Evidence Storage";
+	c_tag = "Security - Brig Control";
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "asc" = (
 /obj/structure/cable{
@@ -9114,10 +8921,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "asd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Room Two"
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "ase" = (
 /obj/structure/cable{
@@ -9132,7 +8940,6 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9140,12 +8947,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "asg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9155,29 +8960,20 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 4;
-	icon_state = "roomnum";
-	name = "Room Number 3";
-	pixel_x = -30;
-	pixel_y = -7
-	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "ash" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "asi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9198,13 +8994,11 @@
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
 "ask" = (
-/obj/item/flashlight/lamp/green{
-	pixel_x = -2;
-	pixel_y = 15
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/structure/dresser,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/turf/closed/wall,
+/area/maintenance/fore/secondary)
 "asl" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9213,10 +9007,12 @@
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
 "asm" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
+/obj/structure/dresser,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -2;
+	pixel_y = 15
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "asn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -9234,51 +9030,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "asp" = (
-/obj/machinery/camera{
-	c_tag = "Brig Interrogation";
-	dir = 8;
-	network = list("interrogation")
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "asq" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/button/door{
-	id = "Secure Brig Control";
-	name = "Brig Control Shutters";
-	pixel_x = 6;
-	pixel_y = -40;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/door{
-	id = "Cell Interior Shutters";
-	name = "Cell Interior Shutters";
-	pixel_x = -6;
-	pixel_y = -40;
-	req_access_txt = "2"
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "asr" = (
@@ -9288,38 +9046,28 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ass" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ast" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"asu" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/obj/machinery/door/airlock/atmos/abandoned{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "12;24"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "asv" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -9334,15 +9082,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asy" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Firefighting equipment";
-	req_access_txt = "12"
-	},
+/obj/structure/table,
+/obj/item/electronics/firelock,
+/obj/item/circuitboard/machine/smartfridge,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "asz" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/snacks/donut,
+/obj/item/paicard,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "asA" = (
@@ -9452,34 +9199,65 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "asN" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/turf/open/floor/carpet,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "asO" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "asP" = (
-/obj/structure/chair/stool,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/ai_monitored/security/armory)
 "asQ" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "asR" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/closet/secure_closet/chemical,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory)
 "asS" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "asT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -9571,39 +9349,37 @@
 /area/hallway/primary/fore)
 "ate" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "atf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/structure/dresser,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "atg" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm4";
-	name = "Room Three"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/closed/wall,
 /area/crew_quarters/dorms)
 "ath" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_y = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ati" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9621,15 +9397,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"atm" = (
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
 "atn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/newscaster{
+	pixel_y = 32
 	},
-/turf/closed/wall,
-/area/maintenance/port/fore)
+/obj/item/kirbyplants/random,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "atp" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -9637,11 +9414,9 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "atq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/port/fore)
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "atr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9649,10 +9424,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "att" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "atv" = (
@@ -9664,11 +9442,11 @@
 /obj/item/shard{
 	icon_state = "small"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atw" = (
 /obj/structure/rack,
+/obj/item/clothing/glasses/meson,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
@@ -9689,10 +9467,11 @@
 	},
 /area/maintenance/starboard/fore)
 "atA" = (
-/obj/structure/table,
-/obj/item/paicard,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "atB" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	req_access_txt = "12"
@@ -9700,45 +9479,57 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "atC" = (
-/obj/item/stack/rods/fifty,
-/obj/structure/rack,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/item/stack/cable_coil{
-	amount = 5
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 10
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 "atD" = (
-/obj/machinery/recharge_station,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/area/security/brig)
 "atE" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/computer/security/labor{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "atF" = (
-/turf/open/floor/mech_bay_recharge_floor,
-/area/maintenance/department/electrical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/security/brig)
 "atG" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "atH" = (
-/obj/machinery/computer/mech_bay_power_console,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/circuit,
-/area/maintenance/department/electrical)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "atI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -9749,17 +9540,31 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "atJ" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "atK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
 "atL" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "atM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -9783,36 +9588,38 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atS" = (
 /turf/closed/wall,
 /area/space/nearstation)
 "atU" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/security/warden)
 "atW" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "atY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/security/vacantoffice/b)
 "atZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/item/picket_sign,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "aub" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow,
@@ -9833,9 +9640,17 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aue" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/port/fore)
+/obj/structure/table/wood,
+/obj/item/storage/briefcase{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/secure/briefcase,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "auf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -9843,7 +9658,7 @@
 "aug" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
-	c_tag = "Law Office";
+	c_tag = "Security - Law Office";
 	dir = 1
 	},
 /obj/item/paper_bin{
@@ -9923,80 +9738,60 @@
 /turf/closed/wall,
 /area/security/vacantoffice/b)
 "aur" = (
-/obj/machinery/button/door{
-	id = "Room One";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = -25;
-	specialfunctions = 4
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"aut" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/machinery/door/window/westright{
+	name = "Red Corner"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"auv" = (
-/obj/structure/chair/comfy/black{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"auw" = (
-/obj/structure/bed,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/button/door{
-	id = "Dorm3";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"aux" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"auz" = (
-/obj/machinery/camera{
-	c_tag = "Holodeck"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"auB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 8
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"auv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"aux" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"auz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
+"auB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10036,32 +9831,82 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "auJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/closet{
+	name = "Evidence Closet 4"
+	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/area/security/brig)
 "auK" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
+"auL" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
-"auL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/area/security/brig)
 "auM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
 	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/area/security/brig)
 "auO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -10072,29 +9917,6 @@
 "auQ" = (
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"auR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 1;
-	icon_state = "roomnum";
-	name = "Room Number 2";
-	pixel_x = -30;
-	pixel_y = -7
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "auT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10102,58 +9924,61 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "auV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "auX" = (
-/obj/structure/mirror{
-	icon_state = "mirror_broke";
-	pixel_y = 28
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "auY" = (
-/obj/structure/mirror{
-	icon_state = "mirror_broke";
-	pixel_y = 28
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
 	},
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/item/circuitboard/computer/operating,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "auZ" = (
-/obj/structure/frame/computer,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/vending/snack/random,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "ava" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/chair,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/photocopier,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "avb" = (
-/turf/open/floor/plasteel/airless{
-	icon_state = "damaged3"
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2"
 	},
-/area/space/nearstation)
-"avc" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
-"avg" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm5";
-	name = "Room Four"
+/area/security/processing)
+"avc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet{
+	name = "Evidence Closet 4"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"avg" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "avh" = (
 /obj/structure/cable{
@@ -10205,16 +10030,22 @@
 /area/hallway/primary/fore)
 "avn" = (
 /obj/machinery/door/airlock{
-	id_tag = "Dorm6";
-	name = "Room Five"
+	id_tag = "Dorm4";
+	name = "Room Four"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "avo" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
-/area/maintenance/department/electrical)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "avp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/poddoor/shutters{
@@ -10236,7 +10067,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Detective's Office"
+	c_tag = "Security - Detective's Office"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -10254,15 +10085,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avt" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avv" = (
 /obj/machinery/camera{
-	c_tag = "Dorms West"
+	c_tag = "Dorms - Main - Fore"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -10276,68 +10109,83 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Dormitories Maintenance";
-	req_access_txt = "12"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"avy" = (
-/obj/machinery/door/airlock{
-	id_tag = "Room One";
-	name = "Room Six - Luxury Suite"
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"avz" = (
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"avy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"avz" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin/color,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"avA" = (
-/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/structure/bedsheetbin/towel,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"avC" = (
-/obj/structure/chair{
+/area/crew_quarters/fitness)
+"avA" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"avD" = (
-/obj/machinery/computer/holodeck{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"avC" = (
+/mob/living/simple_animal/hostile/carp/cayenne{
+	color = "";
+	desc = "A failed experiment of Nanotrasen to create weaponised carp technology. This less than intimidating carp now serves as an authority figure's pet.";
+	health = 200;
+	icon_dead = "magicarp_dead";
+	icon_gib = "magicarp_gib";
+	icon_living = "magicarp";
+	icon_state = "magicarp";
+	maxHealth = 200;
+	melee_damage_lower = 20;
+	melee_damage_upper = 20;
+	name = "Addison"
+	},
+/turf/open/pool,
+/area/crew_quarters/fitness/pool)
+"avD" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "avE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "maint3"
@@ -10354,13 +10202,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "avH" = (
-/obj/structure/sign/warning/electricshock,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -10373,55 +10218,119 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "avJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"avK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/department/electrical)
-"avL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/electrical";
-	dir = 1;
-	name = "Electrical Maintenance APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"avM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/machinery/computer/shuttle/labor{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"avK" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/secure_closet/evidence,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"avL" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -27;
+	prison_radio = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -24;
+	pixel_y = -36
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"avM" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/item/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	name = "Prison Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -27;
+	prison_radio = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -24;
+	pixel_y = -36
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "avN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"avO" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/fyellow,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
 	},
-/obj/item/multitool,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/area/security/brig)
+"avO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "avP" = (
 /obj/structure/sign/warning/pods,
 /turf/closed/wall,
@@ -10435,7 +10344,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Auxillary Base Construction";
+	c_tag = "Arrivals - Auxillary Base Construction";
 	dir = 8
 	},
 /obj/machinery/computer/camera_advanced/base_construction{
@@ -10449,13 +10358,6 @@
 /area/construction/mining/aux_base)
 "avR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 8;
-	icon_state = "roomnum";
-	name = "Room Number 4";
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -10465,9 +10367,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avS" = (
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "avT" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -10481,31 +10382,40 @@
 /turf/open/space,
 /area/space/nearstation)
 "avU" = (
-/obj/item/paper/crumpled,
-/turf/open/floor/plasteel/airless{
-	icon_state = "damaged2"
-	},
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "avV" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/security/processing)
 "avW" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "avX" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/structure/chair/stool,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/security/brig)
 "avY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10532,13 +10442,25 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "awc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/security/warden)
+"awe" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "awg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10637,14 +10559,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "awo" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm3";
-	name = "Room Two"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
+/turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "awp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10657,42 +10574,39 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 4;
+	icon_state = "roomnum";
+	name = "Room Number 3";
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "awr" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 6;
-	icon_state = "roomnum";
-	name = "Room Number 5";
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 8;
+	icon_state = "roomnum";
+	name = "Room Number 4";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awu" = (
@@ -10702,6 +10616,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "awv" = (
@@ -10736,95 +10651,64 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "awz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "awA" = (
-/obj/machinery/holopad,
-/obj/machinery/camera{
-	c_tag = "Dorms Central"
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "awB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/closet{
-	name = "Holodeck Outfits"
-	},
-/obj/item/clothing/under/misc/blue_camo,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "awC" = (
-/obj/structure/table,
-/obj/item/paper/fluff/holodeck/disclaimer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/cardboard,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "awD" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"awF" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
+"awF" = (
+/turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
 "awG" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awH" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/closet/wardrobe/mixed,
+/obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awI" = (
@@ -10873,78 +10757,71 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "awO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Reception Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Reception Desk";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "awP" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Brig Control";
+	name = "brig shutters"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/security/warden)
 "awQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering/abandoned{
-	name = "Electrical Maintenance";
-	req_access_txt = "11"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/airlock/maintenance/abandoned{
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/port/fore)
 "awR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/starboard/fore)
 "awS" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cigbutt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/port/fore)
 "awT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
+	dir = 9
 	},
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/structure/bed,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/port/fore)
 "awU" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/department/electrical)
+/area/hallway/primary/fore)
 "awV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10975,14 +10852,15 @@
 	},
 /area/hallway/secondary/entry)
 "axa" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "axb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11019,20 +10897,22 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "axe" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "axf" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "axg" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "axh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -11048,18 +10928,21 @@
 	},
 /area/hallway/secondary/entry)
 "axi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/crew_quarters/abandoned_gambling_den)
 "axj" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Firefighting equipment";
-	req_access_txt = "12"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "axk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -11071,12 +10954,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axn" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/egg_smudge,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axo" = (
@@ -11086,33 +10964,34 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "axp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"axq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"axr" = (
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"axq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"axr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "axt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11131,9 +11010,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -11239,16 +11115,17 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
 /area/hallway/secondary/entry)
 "axK" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "axL" = (
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -11257,39 +11134,80 @@
 /area/crew_quarters/dorms)
 "axN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/chair/comfy/brown,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/obj/structure/chair/comfy/black,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "axP" = (
+/obj/machinery/button/door{
+	id = "Dorm2";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"axS" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"axT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"axS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"axT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/crew_quarters/dorms)
 "axW" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastleft{
+	name = "Blue Corner"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "axX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -11297,8 +11215,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aya" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -11306,6 +11224,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "ayc" = (
@@ -11357,15 +11282,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/closet,
+/obj/item/stack/cable_coil/random,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayj" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/port/fore)
 "ayk" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -11423,23 +11349,19 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "ays" = (
-/obj/structure/closet/wardrobe/white,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "ayt" = (
-/obj/structure/table/glass,
-/obj/item/hemostat,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/vending/cola/random,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "ayu" = (
-/obj/structure/table/glass,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "ayv" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -11458,9 +11380,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayx" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/security/processing)
 "ayy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -11468,26 +11395,9 @@
 "ayz" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
-"ayA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"ayC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/fore)
-"ayD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/fore)
 "ayE" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/fore)
+/area/bridge/meeting_room)
 "ayG" = (
 /turf/closed/wall/r_wall,
 /area/gateway)
@@ -11516,7 +11426,7 @@
 "ayK" = (
 /obj/structure/closet/crate/rcd,
 /obj/machinery/camera/motion{
-	c_tag = "EVA Motion Sensor"
+	c_tag = "Command - EVA - Fore"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
@@ -11611,21 +11521,9 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "ayV" = (
-/obj/structure/bed,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/button/door{
-	id = "Dorm2";
-	name = "Dorm Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ayW" = (
@@ -11662,35 +11560,59 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aza" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"azb" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"azc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 1;
+	icon_state = "roomnum";
+	name = "Room Number 2";
+	pixel_x = -30;
+	pixel_y = -7
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"azb" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"azc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aze" = (
-/obj/structure/chair/comfy/brown{
+/obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "azf" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/door/airlock{
+	id_tag = "Dorm3";
+	name = "Room Three"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
@@ -11698,16 +11620,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "azh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "azi" = (
@@ -11719,31 +11635,36 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "azk" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"azm" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/toy/poolnoodle/blue,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
-"azo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"azp" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"azm" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
+"azo" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"azp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 "azq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -11765,40 +11686,40 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azt" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "azu" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/processing)
 "azv" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/structure/rack,
+/obj/item/circuitboard/machine/monkey_recycler,
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/maintenance/port/fore)
 "azw" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/area/security/processing)
 "azx" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/machinery/light{
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "azy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -11822,6 +11743,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "azC" = (
@@ -11860,15 +11782,22 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "azH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/crew_quarters/theatre)
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "azI" = (
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/instrument/eguitar,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/trash/popcorn,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "azK" = (
 /obj/machinery/light{
 	dir = 8
@@ -11931,9 +11860,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azU" = (
@@ -11952,9 +11879,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "azX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "azY" = (
@@ -11976,14 +11905,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAb" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Room One"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aAc" = (
 /obj/effect/spawner/structure/window,
@@ -11992,6 +11915,9 @@
 /area/maintenance/starboard/fore)
 "aAd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aAe" = (
@@ -12005,10 +11931,22 @@
 /turf/closed/wall,
 /area/crew_quarters/toilet)
 "aAi" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
+/obj/structure/bed,
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/button/door{
+	id = "Dorm1";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/bedsheet,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aAj" = (
 /obj/structure/cable{
@@ -12026,65 +11964,68 @@
 /area/maintenance/port/fore)
 "aAk" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"aAl" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "aAn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "aAo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Dorms - Fitness Room - Aft";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "aAp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "aAr" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "aAs" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAt" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "maint2"
-	},
+/obj/structure/table,
+/obj/item/pen,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAv" = (
-/obj/structure/closet,
-/obj/effect/landmark/blobstart,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aAw" = (
@@ -12105,37 +12046,38 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAy" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
 "aAz" = (
-/obj/machinery/computer/monitor{
-	dir = 1;
-	name = "backup power monitoring console"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "aAA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
-/turf/closed/wall,
-/area/maintenance/department/electrical)
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "aAB" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "aAC" = (
@@ -12170,7 +12112,7 @@
 /area/hallway/secondary/entry)
 "aAH" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Bay 1 North";
+	c_tag = "Arrivals - Shuttle Bay - Fore";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -12238,7 +12180,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAP" = (
-/obj/machinery/hydroponics/soil,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "aAQ" = (
@@ -12263,6 +12205,16 @@
 /area/hydroponics/garden)
 "aAT" = (
 /obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aAU" = (
@@ -12275,7 +12227,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
@@ -12302,9 +12253,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aAY" = (
@@ -12314,38 +12263,34 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAZ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin/bundlenatural{
-	pixel_x = 6;
-	pixel_y = 4
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
 	},
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/pen/fountain,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/pen/fourcolor,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"aBa" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
 "aBb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/showcase/cyborg/old{
+	dir = 4;
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "aBc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/showcase/cyborg/old{
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "aBe" = (
 /turf/open/floor/plasteel/dark,
 /area/gateway)
@@ -12369,7 +12314,7 @@
 /area/gateway)
 "aBh" = (
 /obj/machinery/camera{
-	c_tag = "EVA Maintenance";
+	c_tag = "Command - EVA - Maintenance";
 	dir = 8
 	},
 /obj/machinery/light/small{
@@ -12514,12 +12459,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aBx" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
@@ -12532,53 +12486,44 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aBz" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aBA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/table/wood,
-/obj/item/paicard,
-/obj/item/clothing/mask/balaclava{
-	pixel_x = -8;
-	pixel_y = 8
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/item/toy/cards/deck{
-	pixel_x = 2
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/item/storage/crayons,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "aBB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "aBC" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aBE" = (
-/obj/item/clothing/under/misc/mailman,
-/obj/item/clothing/head/mailman,
-/obj/structure/closet,
-/obj/effect/landmark/blobstart,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/hydroponics/garden)
 "aBF" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -12653,54 +12598,31 @@
 /turf/closed/wall/r_wall,
 /area/storage/primary)
 "aBT" = (
-/obj/machinery/computer/bank_machine,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"aBU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"aBV" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai)
+"aBU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"aBV" = (
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aBW" = (
-/obj/structure/filingcabinet,
-/obj/item/folder/documents,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai)
 "aBX" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
@@ -12772,18 +12694,19 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aCd" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/cryopod,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
 "aCe" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/obj/item/bikehorn/rubberducky,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
+/turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aCg" = (
 /obj/structure/cable{
@@ -12804,7 +12727,7 @@
 /area/ai_monitored/storage/eva)
 "aCj" = (
 /obj/machinery/camera{
-	c_tag = "EVA East";
+	c_tag = "Command - EVA - Starboard";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12835,7 +12758,7 @@
 /area/crew_quarters/dorms)
 "aCp" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals North";
+	c_tag = "Arrivals - Main - Fore";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -12864,31 +12787,24 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aCu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
-"aCv" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/area/crew_quarters/fitness)
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
 "aCw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -12902,15 +12818,19 @@
 /area/crew_quarters/fitness)
 "aCy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/cubancarp{
+	pixel_x = 6;
+	pixel_y = 7
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/obj/item/reagent_containers/food/drinks/bottle/rum{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
 "aCz" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -12929,7 +12849,6 @@
 	dir = 4
 	},
 /obj/structure/window,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -13043,6 +12962,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aCP" = (
@@ -13054,9 +12976,6 @@
 "aCQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -13075,10 +12994,11 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aCW" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/storage/primary)
 "aCX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
@@ -13169,6 +13089,16 @@
 /area/security/checkpoint/auxiliary)
 "aDg" = (
 /obj/machinery/biogenerator,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aDh" = (
@@ -13252,45 +13182,33 @@
 /area/storage/primary)
 "aDq" = (
 /obj/machinery/vending/tool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aDr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+"aDs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
-"aDs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/area/ai_monitored/turret_protected/ai)
 "aDt" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
+/area/ai_monitored/turret_protected/ai)
 "aDv" = (
-/obj/structure/window/reinforced,
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/sign/poster/official/safety_report{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aDw" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13320,11 +13238,12 @@
 /area/gateway)
 "aDz" = (
 /obj/structure/rack,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aDA" = (
@@ -13357,7 +13276,7 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light,
 /obj/machinery/camera{
-	c_tag = "EVA Storage";
+	c_tag = "Command - EVA - Central";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -13376,11 +13295,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Dorms South";
+	c_tag = "Dorms - Main - Aft";
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -13410,15 +13326,12 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "aDK" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cryogenics "
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/crew_quarters/cryopod)
 "aDL" = (
 /obj/structure/toilet/secret/low_loot{
@@ -13448,11 +13361,11 @@
 /area/crew_quarters/toilet)
 "aDN" = (
 /obj/machinery/camera{
-	c_tag = "Bathrooms";
+	c_tag = "Dorms - Bathrooms";
 	dir = 1
 	},
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
@@ -13461,8 +13374,6 @@
 	dir = 8;
 	pixel_y = -4
 	},
-/obj/effect/landmark/xeno_spawn,
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aDQ" = (
@@ -13475,35 +13386,44 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aDR" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/item/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "aDT" = (
 /obj/item/soap,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aDU" = (
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "aDY" = (
-/obj/structure/window{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "aDZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13532,11 +13452,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEc" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "aEd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13606,9 +13528,19 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aEl" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/rack,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/plant_analyzer,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/seeds/corn,
+/obj/item/seeds/cabbage,
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/grass,
+/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "aEm" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -13650,12 +13582,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 2;
 	sortType = 18
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -13712,6 +13642,12 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aEG" = (
@@ -13757,52 +13693,40 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aEM" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
-"aEN" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/structure/closet/crate/goldcrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/mob/living/simple_animal/bot/secbot/pingsky,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"aEO" = (
+/area/ai_monitored/turret_protected/ai)
+"aEN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"aEP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
-"aEP" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/structure/closet/crate/silvercrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/area/ai_monitored/turret_protected/ai)
 "aEQ" = (
 /obj/machinery/computer/gateway_control,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aER" = (
 /obj/machinery/camera{
-	c_tag = "Gateway";
+	c_tag = "Command - Gateway";
 	dir = 4
 	},
 /obj/structure/table,
@@ -13894,15 +13818,13 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
 "aFd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aFe" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -13911,26 +13833,32 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aFk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "aFl" = (
-/obj/structure/festivus{
-	anchored = 1;
-	desc = "A pole for dancing.";
-	name = "pole"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/dresser,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "aFm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -13941,9 +13869,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/biogenerator,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "aFo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -13952,10 +13880,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFp" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
+	},
+/obj/item/seeds/carrot,
+/obj/item/seeds/cannabis/white,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "aFq" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14058,7 +13989,7 @@
 /area/security/checkpoint/auxiliary)
 "aFI" = (
 /obj/machinery/camera{
-	c_tag = "Security Checkpoint";
+	c_tag = "Arrivals - Security Checkpoint";
 	dir = 1
 	},
 /obj/machinery/airalarm{
@@ -14138,11 +14069,17 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aFO" = (
 /obj/machinery/camera{
-	c_tag = "Garden";
+	c_tag = "Primary Tool Storage - Garden";
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -14234,53 +14171,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aGa" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "aGb" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"aGc" = (
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/camera/motion{
-	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"aGd" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/area/ai_monitored/turret_protected/ai)
 "aGf" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -14294,9 +14193,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aGh" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aGi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
@@ -14337,16 +14239,21 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aGm" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/toilet";
-	dir = 4;
-	name = "Dormitory Bathrooms APC";
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table/glass,
-/obj/structure/bedsheetbin/towel,
+/obj/item/razor{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/rag/towel/random,
+/obj/item/reagent_containers/rag/towel/random,
+/obj/item/reagent_containers/rag/towel/random,
+/obj/item/reagent_containers/rag/towel/random,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "aGo" = (
@@ -14378,37 +14285,32 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aGr" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/clown,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/sign/poster/official/nt_storm{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/hallway/primary/central)
 "aGs" = (
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "aGt" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aGu" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aGv" = (
@@ -14418,14 +14320,25 @@
 /turf/closed/wall,
 /area/crew_quarters/theatre)
 "aGw" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/closet/secure_closet/freezer/cream_pie,
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "aGx" = (
 /obj/item/radio/intercom{
 	pixel_x = -25
@@ -14452,6 +14365,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14497,25 +14413,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aGD" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/item/flashlight/lamp/bananalamp{
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/hallway/primary/central)
 "aGE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -14762,7 +14664,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Chapel Office"
+	c_tag = "Service - Chapel - Office"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -14837,9 +14739,10 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aHv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -14849,9 +14752,7 @@
 /area/gateway)
 "aHw" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "aHx" = (
@@ -14871,6 +14772,9 @@
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -14898,6 +14802,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aHB" = (
@@ -14916,6 +14824,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aHE" = (
@@ -14928,20 +14837,12 @@
 /obj/item/stack/packageWrap,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aHF" = (
-/obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
 "aHG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/sign/poster/official/bless_this_spess{
+	pixel_y = 32
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aHH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -14955,36 +14856,22 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aHI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/closet,
+/obj/item/stack/sheet/cardboard,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/gateway)
 "aHK" = (
-/obj/structure/closet/secure_closet/freezer/cream_pie,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aHL" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15020,24 +14907,23 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "aHP" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHQ" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHR" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
@@ -15045,6 +14931,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHS" = (
@@ -15074,23 +14961,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aHV" = (
-/obj/machinery/light/small{
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Room One"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/razor{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/rag/towel/random,
-/obj/item/reagent_containers/rag/towel/random,
-/obj/item/reagent_containers/rag/towel/random,
-/obj/item/reagent_containers/rag/towel/random,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
 "aHY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -15098,11 +14977,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aHZ" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/megaphone/clown,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "aIa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -15114,6 +15006,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
+	dir = 8;
+	name = "Theatre APC";
+	pixel_x = -25
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aIc" = (
@@ -15271,7 +15170,7 @@
 /area/library)
 "aIs" = (
 /obj/machinery/camera{
-	c_tag = "Library North"
+	c_tag = "Service - Library - Fore"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15410,7 +15309,7 @@
 /area/storage/primary)
 "aIO" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Lounge"
+	c_tag = "Arrivals - Lounge"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -15451,6 +15350,12 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aIT" = (
@@ -15471,6 +15376,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aIU" = (
@@ -15534,14 +15443,12 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aJe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aJf" = (
 /obj/machinery/camera{
-	c_tag = "EVA South";
+	c_tag = "Command - EVA - Aft";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15602,7 +15509,8 @@
 "aJk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Bar Back Room"
+	name = "Theatre Backstage";
+	req_access_txt = "46"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -15618,7 +15526,7 @@
 /area/ai_monitored/storage/eva)
 "aJm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/structure/reagent_dispensers/keg/milk,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aJn" = (
@@ -15630,7 +15538,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Central Hallway North"
+	c_tag = "Central Hallway - Fore"
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -16036,19 +15944,24 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/camera,
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
+/obj/structure/table/wood,
+/obj/item/cane,
+/obj/item/clothing/head/that,
+/obj/item/clothing/mask/fakemoustache,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKr" = (
-/obj/machinery/vending/snack/orange,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/obj/structure/sign/poster/contraband/donut_corp{
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/camera_film{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/camera,
+/obj/machinery/camera{
+	c_tag = "Service - Theatre"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -16058,32 +15971,16 @@
 /turf/open/floor/plating,
 /area/storage/primary)
 "aKu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/theatre)
+/obj/structure/rack,
+/obj/structure/rack,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/crowbar/red,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aKw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/theatre)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aKy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -16159,10 +16056,15 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKJ" = (
-/obj/machinery/vending/cola/black,
-/obj/structure/sign/poster/contraband/starkist{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/structure/table/wood,
+/obj/item/soap/nanotrasen,
+/obj/item/storage/crayons,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKL" = (
@@ -16170,7 +16072,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Hydroponics Storage"
+	c_tag = "Service - Hydroponics - Storage"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -16182,48 +16084,50 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aKM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/bed,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
 "aKN" = (
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 20
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 20
+/obj/structure/table/wood,
+/obj/item/staff/broom,
+/obj/item/clothing/head/witchwig,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKO" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKQ" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/wood,
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aKR" = (
@@ -16231,7 +16135,7 @@
 /area/crew_quarters/bar)
 "aKS" = (
 /obj/machinery/camera{
-	c_tag = "Bar Storage"
+	c_tag = "Service - Bar - Storage"
 	},
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -16274,17 +16178,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aKY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aKZ" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
 /obj/machinery/camera{
-	c_tag = "Chapel Crematorium";
+	c_tag = "Service - Chapel - Crematorium";
 	dir = 4
 	},
 /obj/structure/bodycontainer/morgue,
@@ -16378,9 +16278,6 @@
 /area/hallway/primary/port)
 "aLl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLm" = (
@@ -16430,11 +16327,15 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aLt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/port/fore)
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "aLu" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -16491,12 +16392,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "aLD" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -16538,20 +16441,22 @@
 /area/hallway/primary/port)
 "aLL" = (
 /obj/machinery/camera{
-	c_tag = "Port Hallway 2"
+	c_tag = "Port Primary Hallway - Central"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLM" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/obj/structure/grille/broken,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port)
 "aLN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16568,17 +16473,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/girder,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aLQ" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway North-East"
+	c_tag = "Central Hallway - Starboard Bow"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -16602,21 +16505,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLT" = (
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLU" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aLV" = (
@@ -16630,7 +16529,7 @@
 /area/hallway/primary/central)
 "aLW" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway North-West"
+	c_tag = "Central Hallway - Port Bow"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -16739,7 +16638,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMn" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/vg_decals/numbers/one{
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/vg_decals/numbers/three{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16751,14 +16656,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMq" = (
-/obj/structure/sign/poster/contraband/space_cola{
+/obj/structure/sign/departments/restroom{
 	pixel_x = -32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMr" = (
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aMs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -16784,13 +16695,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMw" = (
-/obj/machinery/vending/dinnerware{
-	contraband = list(/obj/item/reagent_containers/food/condiment/flour = 4);
-	desc = "This vendor is full of condiments to put on food.";
-	name = "\improper Condiments Vendor";
-	product_ads = "Get your sauces here!;No slave labour was used to make these products!;Nanotrasen Approved?!";
-	products = list(/obj/item/storage/bag/tray = 8, /obj/item/reagent_containers/food/drinks/drinkingglass = 10, /obj/item/storage/box/cups = 5, /obj/item/reagent_containers/food/condiment/pack/ketchup = 20, /obj/item/reagent_containers/food/condiment/pack/mustard = 20, /obj/item/reagent_containers/food/condiment/pack/hotsauce = 20, /obj/item/reagent_containers/food/condiment/pack/astrotame = 20, /obj/item/reagent_containers/food/condiment/saltshaker = 20, /obj/item/reagent_containers/food/condiment/peppermill = 20)
-	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMx" = (
@@ -16829,11 +16734,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aMB" = (
-/obj/structure/reagent_dispensers/keg/mead,
+/obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMC" = (
-/obj/structure/reagent_dispensers/keg/gargle,
+/obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aMD" = (
@@ -16873,7 +16778,7 @@
 /area/chapel/main)
 "aMM" = (
 /obj/machinery/camera{
-	c_tag = "Chapel North"
+	c_tag = "Service - Chapel - Central"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -16893,18 +16798,12 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "aMQ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aMR" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -16958,11 +16857,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aNc" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17026,9 +16927,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aNp" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -17049,16 +16952,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNu" = (
-/obj/structure/table/wood,
-/obj/item/paper/fluff{
-	info = "<b>Renovation Notice</b><br><br>The bar layout for the station is very old. We've decided to give it a facelift after our partnership with IKEA Intergalactic?.</li><li>We added some sweet retro arcade machines and much more seating area. We removed the stage since it hasn't ever been used.</li><li>You can run this place like a restaurant now that you have tables. Go whip up a menu with the Chef. You have a condiments table and your Requests Console has been moved so a noticeboard can be placed there. Take tickets from customers and pin them on the noticeboard for the Chef.</li><li><b>We hope you like the new bar!</ b>";
-	name = "Renovation Notice - Bar";
-	pixel_x = -5;
-	pixel_y = 3
+/obj/structure/closet/secure_closet/bar{
+	req_access_txt = "25"
 	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/stack/spacecash/c100,
-/obj/item/stack/spacecash/c100,
+/obj/item/gun/ballistic/revolver/doublebarrel,
+/obj/item/clothing/under/suit/waiter,
+/obj/item/clothing/under/suit/waiter,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/cable_coil/random,
+/obj/item/stack/cable_coil/random,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aNv" = (
@@ -17126,15 +17029,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"aNF" = (
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "aNI" = (
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
+/obj/machinery/computer/slot_machine,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aNK" = (
@@ -17200,9 +17100,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -17215,10 +17112,6 @@
 "aNU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Port Hallway";
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -17306,7 +17199,7 @@
 "aOe" = (
 /obj/item/beacon,
 /obj/machinery/camera{
-	c_tag = "Arrivals Bay 1 South"
+	c_tag = "Arrivals - Shuttle Bay - Aft"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17395,7 +17288,7 @@
 /area/hallway/primary/port)
 "aOp" = (
 /obj/machinery/camera{
-	c_tag = "Port Hallway 3";
+	c_tag = "Port Primary Hallway - Port";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -17504,19 +17397,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aOB" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOC" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -17559,28 +17456,31 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOH" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aOI" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aOJ" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aOL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/item/kirbyplants{
+	icon_state = "plant-24"
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
 "aOM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -17649,7 +17549,7 @@
 "aOW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/camera{
-	c_tag = "Hydroponics North"
+	c_tag = "Hydroponics - Main - Fore"
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
@@ -17737,7 +17637,7 @@
 /area/chapel/main)
 "aPp" = (
 /obj/machinery/camera{
-	c_tag = "Escape Arm Holding Area";
+	c_tag = "Departures - Holding Area";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -17770,9 +17670,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-20"
-	},
+/obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPu" = (
@@ -17862,6 +17760,10 @@
 /area/storage/emergency/port)
 "aPL" = (
 /obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Port Primary Hallway - Starboard";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aPM" = (
@@ -17954,38 +17856,33 @@
 /turf/open/floor/plating,
 /area/bridge)
 "aPY" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 9
-	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/chocolatebar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aPZ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/britcup,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aQa" = (
-/obj/machinery/computer/arcade/battle,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
 "aQb" = (
-/obj/structure/chair/sofa/right,
-/obj/structure/window{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
-/obj/structure/sign/poster/contraband/pwr_game{
-	pixel_x = -32
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "aQc" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -17994,16 +17891,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aQd" = (
-/obj/structure/window,
-/obj/structure/chair/sofa/right{
-	dir = 1
+/obj/structure/closet/emcloset,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aQe" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/xmastree,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aQf" = (
@@ -18248,7 +18146,10 @@
 /area/hallway/secondary/entry)
 "aQL" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aQM" = (
@@ -18271,45 +18172,39 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/vending/cigarette,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQR" = (
-/obj/machinery/vending/cola/pwr_game,
-/obj/structure/sign/poster/contraband/pwr_game{
+/obj/machinery/vending/cola/random,
+/obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQS" = (
-/obj/machinery/vending/coffee,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQW" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/crew_quarters/dorms)
 "aQX" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aQY" = (
@@ -18518,18 +18413,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/window,
-/obj/structure/sign/poster/official/high_class_martini{
-	pixel_x = -32
-	},
-/obj/effect/landmark/start/assistant,
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"aRx" = (
-/obj/machinery/computer/arcade/minesweeper,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aRy" = (
@@ -18560,7 +18443,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Kitchen"
+	c_tag = "Service - Kitchen"
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18662,7 +18545,7 @@
 /area/library)
 "aRP" = (
 /obj/machinery/camera{
-	c_tag = "Library South";
+	c_tag = "Service - Library - Aft";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -18737,9 +18620,10 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aRZ" = (
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aSa" = (
 /obj/machinery/light_switch{
@@ -18778,7 +18662,7 @@
 /area/hallway/secondary/entry)
 "aSf" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Hallway";
+	c_tag = "Arrivals - Hallway";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18796,9 +18680,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aSi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/dice{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/coin/iron{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/toy/cards/deck,
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/crew_quarters/dorms)
 "aSk" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -18824,11 +18717,11 @@
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "aSq" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -18947,45 +18840,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aSH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -9
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -9;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/condiment/pack/ketchup{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/pack/ketchup{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/pack/ketchup{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/condiment/pack/hotsauce{
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/food/condiment/pack/hotsauce{
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/food/condiment/pack/mustard{
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/food/condiment/pack/mustard{
-	pixel_x = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -19117,7 +18973,6 @@
 /area/maintenance/port)
 "aSY" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/that,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -19125,6 +18980,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/rag,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aSZ" = (
@@ -19164,27 +19021,25 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aTf" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "aTg" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
 /area/chapel/main)
 "aTh" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/chapel,
-/area/chapel/main)
-"aTi" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/chapel{
-	dir = 8
+/obj/structure/chair/pew/right{
+	dir = 1
 	},
+/turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "aTj" = (
 /obj/machinery/light{
@@ -19275,6 +19130,9 @@
 	dir = 8
 	},
 /obj/item/clothing/under/costume/kilt,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTy" = (
@@ -19282,23 +19140,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/start/assistant,
+/obj/structure/table,
+/obj/item/gps,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTB" = (
@@ -19308,19 +19151,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTD" = (
@@ -19329,15 +19162,13 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Locker Room East";
+	c_tag = "Locker Room - Starboard";
 	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/reagent_containers/rag/towel/random,
-/obj/item/razor,
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTE" = (
@@ -19520,10 +19351,8 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "aUg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair/comfy/brown,
+/obj/effect/landmark/xmastree,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aUh" = (
@@ -19583,37 +19412,19 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/clothing/head/soft/grey,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUs" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/clothing/head/mailman,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -19621,27 +19432,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -19665,7 +19467,7 @@
 /area/maintenance/starboard/fore)
 "aUy" = (
 /obj/machinery/camera{
-	c_tag = "Vacant Office";
+	c_tag = "Arrivals - Vacant Office";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -19709,31 +19511,39 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aUH" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/assistant,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
 /area/chapel/main)
 "aUI" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
 /area/chapel/main)
 "aUJ" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
 /area/chapel/main)
 "aUK" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -19749,7 +19559,7 @@
 /area/hallway/secondary/exit)
 "aUM" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Bay 2";
+	c_tag = "Arrivals - Main - Aft";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19806,18 +19616,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aUY" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -19825,6 +19626,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aVa" = (
@@ -19870,7 +19672,7 @@
 /area/bridge)
 "aVe" = (
 /obj/machinery/camera{
-	c_tag = "Bridge West";
+	c_tag = "Command - Bridge - Port";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19911,7 +19713,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
-	c_tag = "Fore Primary Hallway";
+	c_tag = "Fore Primary Hallway - Central";
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
@@ -20015,7 +19817,7 @@
 /area/bridge)
 "aVr" = (
 /obj/machinery/camera{
-	c_tag = "Bridge East";
+	c_tag = "Command - Bridge - Starboard";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20088,6 +19890,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/clothing/head/that,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aVz" = (
@@ -20260,15 +20063,17 @@
 /turf/open/floor/wood,
 /area/library)
 "aVU" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
 /area/chapel/main)
 "aVV" = (
 /obj/machinery/camera{
-	c_tag = "Chapel South";
+	c_tag = "Service - Chapel - Aft";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -20407,7 +20212,7 @@
 /area/crew_quarters/locker)
 "aWo" = (
 /obj/machinery/camera{
-	c_tag = "Locker Room West";
+	c_tag = "Locker Room - Port";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20447,11 +20252,11 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "aWu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -20719,7 +20524,7 @@
 	pixel_y = -25
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge Center";
+	c_tag = "Command - Bridge - Central";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -20885,9 +20690,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXi" = (
-/obj/structure/chair/sofa/right,
-/obj/structure/window{
-	dir = 1
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/chair/comfy/brown,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -20908,34 +20717,30 @@
 	dir = 8
 	},
 /obj/item/pen/fourcolor,
+/obj/item/lighter{
+	pixel_x = -4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aXk" = (
-/obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
 	},
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/rag,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/jukebox,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aXl" = (
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_one_access_txt = "25;28"
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/obj/structure/rack,
+/obj/item/clothing/suit/space/fragile,
+/obj/item/clothing/head/helmet/space/fragile,
+/obj/item/tank/internals/air,
+/obj/item/flashlight,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aXm" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria,
@@ -20971,32 +20776,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aXr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXu" = (
@@ -21006,32 +20792,13 @@
 /turf/open/floor/carpet,
 /area/library)
 "aXv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXy" = (
@@ -21082,25 +20849,18 @@
 /turf/closed/wall,
 /area/quartermaster/warehouse)
 "aXF" = (
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 10;
-	icon_state = "roomnum";
-	name = "Room Number 6";
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/washing_machine{
-	pixel_x = 7;
-	pixel_y = 7
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
 "aXG" = (
 /obj/machinery/light{
 	dir = 4
@@ -21252,14 +21012,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aYc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port";
-	dir = 8;
-	name = "Port Maintenance APC";
-	pixel_x = -27;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -21267,8 +21019,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aYd" = (
@@ -21289,6 +21045,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aYg" = (
@@ -21387,6 +21144,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Bridge"
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "aYs" = (
@@ -21398,14 +21162,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/bridge)
-"aYt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
 "aYu" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -21426,12 +21185,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"aYv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
 "aYw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21444,34 +21197,15 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYy" = (
 /obj/machinery/status_display/ai,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"aYA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"aYB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYC" = (
@@ -21539,14 +21273,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aYK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
@@ -21594,18 +21327,38 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aYS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/closet{
+	name = "Suit Closet"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/window,
-/obj/effect/turf_decal/tile/blue{
+/obj/item/clothing/under/suit/white,
+/obj/item/clothing/under/suit/tan,
+/obj/item/clothing/under/suit/red,
+/obj/item/clothing/under/suit/black_really,
+/obj/item/clothing/under/suit/navy,
+/obj/item/clothing/under/suit/green,
+/obj/item/clothing/under/suit/black/skirt,
+/obj/item/clothing/under/suit/checkered,
+/obj/item/clothing/under/suit/charcoal,
+/obj/item/clothing/under/suit/burgundy,
+/obj/item/clothing/under/suit/black,
+/obj/item/clothing/under/rank/civilian/lawyer/black,
+/obj/item/clothing/under/suit/black,
+/obj/item/clothing/under/rank/civilian/lawyer/blue,
+/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
+/obj/item/clothing/under/rank/civilian/lawyer/female,
+/obj/item/clothing/under/rank/civilian/lawyer/purpsuit,
+/obj/item/clothing/under/rank/civilian/lawyer/really_black,
+/obj/item/clothing/under/rank/civilian/lawyer/red,
+/obj/structure/window{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "aYT" = (
 /obj/machinery/camera{
@@ -21651,7 +21404,7 @@
 /area/security/detectives_office)
 "aZb" = (
 /obj/machinery/camera{
-	c_tag = "Bar South";
+	c_tag = "Service - Bar - Aft";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -21731,7 +21484,7 @@
 /area/hallway/secondary/exit)
 "aZm" = (
 /obj/machinery/camera{
-	c_tag = "Escape Arm Airlocks";
+	c_tag = "Departures - Main";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -21765,30 +21518,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"aZq" = (
-/obj/machinery/button/door{
-	id = "heads_meeting";
-	name = "Security Shutters";
-	pixel_y = 24
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "aZr" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 4
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/head/hardhat/red{
+	pixel_y = 6
 	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar,
+/obj/item/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aZs" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/book/manual/wiki/medical_cloning{
+	pixel_y = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/aft)
 "aZt" = (
 /obj/structure/toilet/secret/low_loot{
 	dir = 4
@@ -21813,9 +21564,11 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
 "aZu" = (
-/obj/machinery/photocopier,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "aZv" = (
 /obj/machinery/door/airlock{
 	id_tag = "LockerShitter1";
@@ -21829,34 +21582,58 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "aZx" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/window,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "aZy" = (
-/obj/machinery/camera{
-	c_tag = "Conference Room"
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"aZz" = (
-/obj/machinery/newscaster{
+/obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"aZz" = (
+/obj/machinery/button/flasher{
+	id = "hopflash";
+	pixel_x = 6;
+	pixel_y = 36
+	},
+/obj/machinery/button/door{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = 6;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/door{
+	id = "hopqueue";
+	name = "Queue Shutters Control";
+	pixel_x = -4;
+	pixel_y = 25;
+	req_access_txt = "57"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -4;
+	pixel_y = 36
+	},
+/obj/machinery/pdapainter,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "aZA" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/delivery,
@@ -21868,21 +21645,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aZC" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/bed/dogbed/ian,
+/mob/living/simple_animal/pet/dog/corgi/Ian{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "aZD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/crate,
+/obj/item/storage/secure/briefcase,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/grenade/smokebomb,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aZE" = (
@@ -21934,8 +21713,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "aZM" = (
-/turf/closed/wall/r_wall,
-/area/bridge/meeting_room)
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/hallway/primary/central)
 "aZN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
@@ -21944,41 +21724,52 @@
 "aZO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
-/area/bridge/meeting_room)
-"aZP" = (
-/turf/closed/wall,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/hop)
 "aZQ" = (
 /obj/machinery/door/airlock/command{
-	name = "Conference Room";
-	req_access_txt = "19"
+	name = "Head of Personnel";
+	req_access_txt = "57"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "aZR" = (
-/turf/open/floor/circuit,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aZS" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = -24
+	},
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aZT" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aZU" = (
 /obj/machinery/porta_turret/ai{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 24
+	},
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "aZV" = (
 /turf/closed/wall/r_wall,
@@ -22008,33 +21799,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZZ" = (
-/obj/structure/chair/sofa{
+/obj/structure/chair/sofa/right{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"baa" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bab" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/chair/sofa/left{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bac" = (
-/obj/structure/noticeboard{
-	pixel_y = -27
+/obj/machinery/newscaster{
+	pixel_y = -28
 	},
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
+/obj/machinery/light,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bad" = (
@@ -22054,21 +21834,37 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bag" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"bah" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/door/window/westleft{
+	name = "Bar Access";
+	req_one_access_txt = "25;28"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"bai" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bah" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"bai" = (
-/obj/machinery/light/small,
-/turf/open/floor/wood,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "baj" = (
 /obj/structure/table/reinforced,
@@ -22181,7 +21977,7 @@
 /area/library)
 "baw" = (
 /obj/machinery/camera{
-	c_tag = "Locker Room Toilets";
+	c_tag = "Locker Room - Toilets";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22194,12 +21990,11 @@
 /turf/open/floor/wood,
 /area/library)
 "bay" = (
-/obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/hop)
 "baz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -22269,11 +22064,20 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "baI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "baJ" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -22281,17 +22085,14 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"baK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
 "baL" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 4
+/obj/structure/rack,
+/obj/item/pipe{
+	pixel_x = 8;
+	pixel_y = 2
 	},
+/obj/item/clothing/ears/earmuffs,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "baM" = (
@@ -22312,11 +22113,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "baN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/aft)
 "baO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/freezer,
@@ -22398,10 +22205,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bbc" = (
 /obj/machinery/door/airlock/maintenance{
@@ -22438,56 +22244,25 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bbg" = (
-/obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bbh" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bbi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bbj" = (
-/obj/structure/table,
-/obj/item/aiModule/reset,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"bbk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
 "bbl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bbm" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"bbn" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "bbo" = (
 /obj/machinery/disposal/bin,
@@ -22497,9 +22272,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bbp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/structure/table/wood/poker,
+/obj/item/paicard,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "bbq" = (
 /obj/machinery/light{
 	dir = 8
@@ -22587,12 +22363,14 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbC" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/hop)
 "bbD" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22650,9 +22428,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/aft)
 "bbL" = (
 /obj/machinery/door/airlock{
 	id_tag = "LockerShitter2";
@@ -22661,20 +22445,15 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
 "bbM" = (
-/obj/item/book/manual/wiki/security_space_law,
-/obj/structure/table/wood,
+/obj/machinery/holopad,
 /turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/hop)
 "bbO" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/locker)
+/obj/structure/closet/wardrobe/mixed,
+/obj/item/clothing/under/costume/kilt,
+/obj/item/clothing/under/rank/civilian/janitor/maid,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bbP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -22710,29 +22489,52 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbW" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hopqueue";
+	name = "Queue Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bbX" = (
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bbY" = (
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/machinery/computer/security/telescreen/vault{
+	pixel_y = 30
 	},
-/obj/structure/table,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"bbY" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bca" = (
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/obj/machinery/computer/bounty{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bcb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -22744,45 +22546,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcc" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/sign/poster/official/pda_ad600{
+	pixel_x = 32
+	},
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/toy/figure/hop{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/toy/figure/ian,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bcd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bce" = (
-/obj/structure/table,
-/obj/item/aiModule/supplied/quarantine,
-/obj/machinery/camera/motion{
-	dir = 4;
-	network = list("aiupload")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"bcf" = (
-/obj/machinery/holopad,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"bcg" = (
-/obj/structure/table,
-/obj/item/aiModule/supplied/freeform,
-/obj/structure/sign/plaques/kiddie{
-	pixel_x = 32
-	},
-/obj/machinery/camera/motion{
-	dir = 8;
-	network = list("aiupload")
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bch" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -22859,9 +22644,6 @@
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway"
 	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcs" = (
@@ -22896,10 +22678,15 @@
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 5"
 	},
+/obj/structure/sign/departments/holy{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bcy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -22978,6 +22765,8 @@
 /area/quartermaster/warehouse)
 "bcK" = (
 /obj/structure/rack,
+/obj/item/tank/internals/air,
+/obj/item/clothing/mask/gas,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -22991,17 +22780,26 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcM" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/breath/medical,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"bcN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bcN" = (
-/obj/item/folder/blue,
-/obj/structure/table/wood,
 /turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/hop)
 "bcP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -23028,8 +22826,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bcU" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/bar)
 "bcV" = (
 /obj/machinery/airalarm{
@@ -23041,34 +22841,25 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bcX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/bridge/meeting_room)
-"bcY" = (
-/obj/item/hand_labeler,
-/obj/item/assembly/timer,
-/obj/structure/table,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/area/hallway/primary/central)
 "bcZ" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Command)"
-	},
 /turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/hop)
 "bda" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/machinery/computer/card{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bdb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white/side,
@@ -23081,57 +22872,31 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/starboard)
 "bdd" = (
-/obj/machinery/vending/cola/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bde" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bdf" = (
 /obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bdg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/holopad,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	name = "Private AI Channel";
+	pixel_y = 21
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdh" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "bdi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/vending/wardrobe/cap_wardrobe,
+/obj/machinery/computer/arcade/minesweeper,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bdj" = (
@@ -23164,7 +22929,7 @@
 /area/hallway/primary/starboard)
 "bdn" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway East";
+	c_tag = "Central Hallway - Starboard";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -23237,16 +23002,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bdw" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bdx" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -23311,7 +23080,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -23327,11 +23095,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bdF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bdG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23339,15 +23104,16 @@
 /area/maintenance/port)
 "bdH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/port)
 "bdI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bdJ" = (
 /obj/machinery/door/airlock{
 	id_tag = "LockerShitter3";
@@ -23356,24 +23122,25 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
 "bdK" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/item/paper_bin/bundlenatural{
+	pixel_x = 6;
+	pixel_y = 4
 	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
-"bdL" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/bedsheetbin/color,
+/obj/item/pen/fountain,
 /obj/structure/table,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/locker)
+/obj/item/pen/fourcolor,
+/obj/item/stamp/hop,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"bdL" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bdN" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -23410,8 +23177,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -23438,20 +23205,12 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"bdX" = (
-/obj/item/storage/fancy/donut_box,
-/obj/structure/table,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "bdY" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/item/pen,
-/obj/structure/table/wood,
 /turf/open/floor/carpet,
-/area/bridge/meeting_room)
+/area/crew_quarters/heads/hop)
 "bdZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23462,15 +23221,13 @@
 /area/maintenance/port)
 "bea" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"beb" = (
+"bec" = (
 /obj/structure/table,
-/obj/item/aiModule/core/full/asimov,
-/obj/item/aiModule/core/freeformcore,
 /obj/machinery/door/window{
 	base_state = "right";
 	dir = 4;
@@ -23478,95 +23235,86 @@
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
-/obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_harmless,
-/obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = -24
 	},
+/obj/item/aiModule/core/full/asimov,
+/obj/effect/spawner/lootdrop/aimodule_harmless,
+/obj/item/aiModule/core/freeformcore,
+/obj/effect/spawner/lootdrop/aimodule_neutral,
 /obj/item/aiModule/core/full/custom,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"bec" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "bed" = (
+/obj/effect/turf_decal/vg_decals/numbers/five,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
+"bee" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	name = "Upload APC";
 	pixel_y = -24
 	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai_upload)
-"bee" = (
-/obj/machinery/computer/upload/ai{
-	dir = 1
+/obj/effect/turf_decal/vg_decals/numbers/four,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_y = -21
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/circuit,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "bef" = (
-/obj/machinery/computer/upload/borg{
-	dir = 1
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/obj/structure/sign/warning/securearea{
+	pixel_y = -32
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_y = -29
-	},
-/turf/open/floor/circuit,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"beg" = (
+"beh" = (
 /obj/structure/table,
-/obj/item/aiModule/supplied/oxygen,
-/obj/item/aiModule/zeroth/oneHuman,
 /obj/machinery/door/window{
 	dir = 8;
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
-/obj/item/aiModule/reset/purge,
-/obj/structure/window/reinforced,
-/obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_y = -24
 	},
+/obj/item/aiModule/supplied/oxygen,
+/obj/item/aiModule/zeroth/oneHuman,
 /obj/item/aiModule/supplied/protectStation,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"beh" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
+/obj/item/aiModule/reset/purge,
+/obj/effect/spawner/lootdrop/aimodule_harmful,
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "bej" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bek" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "bel" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/port)
 "bem" = (
 /obj/structure/cable{
@@ -23577,7 +23325,7 @@
 "ben" = (
 /obj/structure/table/wood,
 /obj/machinery/camera{
-	c_tag = "Captain's Office";
+	c_tag = "Command - Captain's Office";
 	dir = 8
 	},
 /obj/item/storage/lockbox/medal,
@@ -23747,9 +23495,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "beG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit)
 "beH" = (
 /obj/machinery/newscaster{
@@ -23916,11 +23665,10 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "beZ" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8
-	},
-/turf/closed/wall,
-/area/maintenance/disposal)
+/obj/structure/closet/athletic_mixed,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bfb" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -23955,17 +23703,16 @@
 /area/maintenance/port)
 "bfe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bff" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfg" = (
@@ -24008,23 +23755,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"bfo" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bfp" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Bridge";
-	departmentType = 5;
-	name = "Bridge RC";
-	pixel_y = -30
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "bfq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -24032,83 +23762,60 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bfr" = (
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bfs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
 "bft" = (
 /obj/machinery/status_display/ai,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"bfu" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfv" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfw" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
+/obj/machinery/status_display/ai,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfx" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfy" = (
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/item/clothing/mask/balaclava,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"bfz" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"bfA" = (
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/stamp/captain,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"bfB" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = -30
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bfz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
-"bfA" = (
-/obj/structure/table/wood,
-/obj/item/hand_tele,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bfB" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/stamp/captain,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bfC" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/item/hand_tele,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bfD" = (
@@ -24145,7 +23852,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/port)
 "bfJ" = (
 /obj/machinery/door/firedoor,
@@ -24325,7 +24034,7 @@
 /area/hallway/secondary/entry)
 "bgi" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Bay 3 & 4";
+	c_tag = "Arrivals -  Auxiliary Shuttle Bay";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -24346,12 +24055,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bgm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bgn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -24359,6 +24062,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgo" = (
@@ -24403,7 +24107,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
 "bgt" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/door/airlock/maintenance/abandoned{
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bgu" = (
@@ -24432,11 +24138,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bgy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/computer/cryopod{
+	pixel_y = 26
 	},
-/turf/closed/wall,
-/area/quartermaster/warehouse)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
 "bgz" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -24463,7 +24172,7 @@
 	id = "packageSort2"
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Delivery Office";
+	c_tag = "Cargo - Delivery Office";
 	dir = 4
 	},
 /obj/machinery/requests_console{
@@ -24509,45 +24218,66 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgH" = (
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Bridge Delivery";
-	req_access_txt = "19"
-	},
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/bridge/meeting_room)
+/area/hallway/primary/central)
 "bgI" = (
-/obj/machinery/computer/slot_machine,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/head_of_personnel,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bgJ" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/machinery/keycard_auth{
+	pixel_x = -24
+	},
+/obj/machinery/computer/cargo{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bgK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "bgL" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
+/obj/structure/table,
+/obj/item/folder/blue,
+/obj/item/stack/packageWrap{
+	pixel_x = -1;
+	pixel_y = -1
 	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bgM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"bgN" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
-"bgO" = (
+/obj/item/hand_labeler,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"bgN" = (
+/obj/structure/closet/lasertag/blue,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/item/clothing/under/misc/pj/blue,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"bgO" = (
+/obj/structure/closet/lasertag/red,
+/obj/item/clothing/under/misc/pj/red,
+/obj/item/clothing/under/misc/pj/red,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bgQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -24559,38 +24289,34 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bgS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/coin/plasma,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bgT" = (
-/obj/machinery/computer/communications{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bgU" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/effect/landmark/start/captain,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"bgU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/filingcabinet/employment,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_x = -30
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bgV" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/coin/plasma,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/computer/communications{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -24599,9 +24325,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bgX" = (
@@ -24651,7 +24374,7 @@
 /area/medical/chemistry)
 "bhc" = (
 /obj/machinery/camera{
-	c_tag = "Chemistry"
+	c_tag = "Medbay - Chemistry"
 	},
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
@@ -24687,7 +24410,7 @@
 /area/security/checkpoint/medical)
 "bhj" = (
 /obj/machinery/camera{
-	c_tag = "Security Post - Medbay"
+	c_tag = "Medbay - Security Post"
 	},
 /obj/machinery/requests_console{
 	department = "Security";
@@ -24952,36 +24675,20 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bhJ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/vr_sleeper{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bhL" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 8
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/disposal)
 "bhM" = (
 /turf/open/floor/circuit,
@@ -25011,33 +24718,17 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/toilet/locker)
-"bhR" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bhS" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/window{
-	dir = 8
-	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bhT" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bhU" = (
@@ -25105,97 +24796,81 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bid" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"bie" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster{
+	pixel_y = -28
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bie" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	dir = 1;
-	freq = 1400;
-	location = "Bridge"
-	},
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/bridge/meeting_room)
-"bif" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
 "big" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bih" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/vr_sleeper{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bii" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"bij" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
-"bij" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bik" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Command)";
-	pixel_x = -28
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/suit_storage_unit/captain,
-/obj/machinery/light{
-	light_color = "#c9d3e8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopod)
 "bil" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
+"bim" = (
 /obj/machinery/computer/card{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"bim" = (
-/obj/structure/table/wood,
-/obj/machinery/recharger,
-/obj/item/melee/chainofcommand,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bin" = (
@@ -25406,7 +25081,7 @@
 /area/science/robotics/lab)
 "biO" = (
 /obj/machinery/camera{
-	c_tag = "Robotics Lab";
+	c_tag = "Science - Robotics - Fore";
 	network = list("ss13","rd")
 	},
 /obj/machinery/button/door{
@@ -25456,7 +25131,7 @@
 /area/science/research)
 "biS" = (
 /obj/machinery/camera{
-	c_tag = "Research Division Access"
+	c_tag = "Science - Research Division Access"
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -25501,7 +25176,7 @@
 /area/science/lab)
 "biX" = (
 /obj/machinery/camera{
-	c_tag = "Research and Development";
+	c_tag = "Science - Research and Development";
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -25557,12 +25232,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bje" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"bjf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Disposal Access";
 	req_access_txt = "12"
@@ -25572,9 +25241,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bjf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bjg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -25591,11 +25269,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bji" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/structure/closet/crate/medical,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/mesh,
+/obj/item/stack/medical/suture,
+/obj/item/healthanalyzer,
+/obj/item/reagent_containers/syringe/epinephrine,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bjj" = (
@@ -25656,7 +25338,7 @@
 /area/quartermaster/storage)
 "bjo" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Bay North"
+	c_tag = "Cargo - Bay - Fore"
 	},
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
@@ -25724,77 +25406,65 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bjx" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"bjz" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"bjz" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/central)
-"bjA" = (
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjB" = (
-/turf/open/floor/plating,
-/area/maintenance/central)
-"bjC" = (
-/obj/structure/closet/wardrobe/black,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"bjE" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "bjF" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/suit_storage_unit/captain,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bjG" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Captain's Desk Door";
-	req_access_txt = "20"
+/obj/structure/table/wood,
+/obj/machinery/requests_console{
+	department = "Theatre";
+	name = "theatre RC";
+	pixel_x = -32
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
+/obj/item/reagent_containers/food/snacks/baguette,
+/obj/item/toy/dummy,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
 "bjH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25958,7 +25628,7 @@
 /area/science/lab)
 "bkb" = (
 /obj/machinery/camera{
-	c_tag = "Medbay Morgue";
+	c_tag = "Medbay - Morgue";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
@@ -26157,16 +25827,20 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bkC" = (
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/light_switch{
-	pixel_x = 25
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bkD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
 "bkE" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/r_wall,
@@ -26284,17 +25958,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bkT" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "bkU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26312,58 +25978,59 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bkV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
 "bkW" = (
+/obj/structure/closet/wardrobe/green,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/central)
+"bkX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/central)
-"bkX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/bridge/meeting_room";
-	dir = 4;
-	name = "Conference Room APC";
-	pixel_x = 24
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "2-4"
 	},
+/obj/structure/closet/crate/trashcart,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/item/trash/candy,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bkY" = (
-/obj/effect/landmark/blobstart,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hop";
+	dir = 1;
+	name = "Head of Personnel APC";
+	pixel_y = 24
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bkZ" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/button/door{
+	id = "holoprivacy";
+	name = "Holodeck Privacy";
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bla" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26487,7 +26154,7 @@
 "bln" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
-	c_tag = "Medbay Foyer";
+	c_tag = "Medbay - Foyer";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
@@ -26559,7 +26226,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/crowbar/large,
 /obj/machinery/camera{
-	c_tag = "Mech Bay";
+	c_tag = "Science - Robotics - Mech Bay";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -26747,8 +26414,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "blQ" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -26772,15 +26441,31 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "blU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/button/door{
+	id = "Dorm3";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
 	},
-/turf/open/floor/wood,
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "blV" = (
-/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/aft)
 "blW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26922,16 +26607,14 @@
 /area/quartermaster/sorting)
 "bmm" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmn" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -26939,35 +26622,55 @@
 	pixel_x = -28;
 	pixel_y = 2
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmo" = (
-/turf/closed/wall,
-/area/crew_quarters/heads/hop)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "bmp" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bmq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/crew_quarters/heads/hop)
-"bmr" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hop)
-"bms" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel";
-	req_access_txt = "57"
+/obj/machinery/power/apc{
+	areastring = "/area/security/nuke_storage";
+	name = "Vault APC";
+	pixel_y = -25
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-8"
 	},
-/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"bmr" = (
+/turf/closed/wall,
+/area/maintenance/central)
+"bms" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/central/secondary";
+	dir = 4;
+	name = "Central Maintenance APC";
+	pixel_x = 24
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plating,
+/area/maintenance/central)
 "bmt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27379,14 +27082,12 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "bnt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "bnu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -27549,113 +27250,51 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bnN" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bnO" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
+/obj/machinery/camera{
+	c_tag = "Service - Theatre Backroom"
 	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bnP" = (
-/obj/machinery/button/flasher{
-	id = "hopflash";
-	pixel_x = 6;
-	pixel_y = 36
-	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/door{
-	id = "hopqueue";
-	name = "Queue Shutters Control";
-	pixel_x = -4;
-	pixel_y = 25;
-	req_access_txt = "57"
-	},
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 36
-	},
-/obj/machinery/pdapainter,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bnQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/bed/dogbed/ian,
-/mob/living/simple_animal/pet/dog/corgi/Ian{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bnR" = (
-/obj/machinery/computer/security/telescreen/vault{
-	pixel_y = 30
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/area/crew_quarters/theatre)
 "bnS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/highsecurity{
+	name = "Emergency Vault Access";
+	req_access_txt = "53"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plating,
+/area/security/nuke_storage)
 "bnT" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
+/obj/machinery/camera{
+	c_tag = "Dorms - Holodeck"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bnV" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bnW" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
-"bnX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bnY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
@@ -27663,18 +27302,26 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bnZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /obj/item/pen/fountain/captain,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "boa" = (
 /obj/structure/toilet{
 	contents = newlist(/obj/item/toy/snappop/phoenix);
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -28053,106 +27700,76 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "boV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"boW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"boW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "boY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/ian{
-	pixel_x = 32;
-	pixel_y = 32
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"boZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	name = "Reception Window"
-	},
-/obj/machinery/door/window/brigdoor{
-	base_state = "rightsecure";
-	dir = 4;
-	icon_state = "rightsecure";
-	name = "Head of Personnel's Desk";
-	req_access_txt = "57"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "hopflash";
-	pixel_y = 28
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "bpb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/nuclearbomb/selfdestruct,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "bpc" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/machinery/camera/motion{
+	c_tag = "Command - Vault - Fore";
+	network = list("vault")
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/status_display/ai{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/circuit/green,
+/area/security/nuke_storage)
 "bpd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/nuke_storage)
 "bpe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/circuit/green,
+/area/security/nuke_storage)
 "bph" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "bpj" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Captain's Quarters";
+	c_tag = "Command - Captain's Quarters";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -28543,15 +28160,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bqg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "bqh" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bqi" = (
@@ -28633,18 +28253,25 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bqq" = (
+/obj/machinery/door/airlock/vault{
+	id_tag = "Nuke Lock";
+	name = "Self Destruct Access";
+	req_access_txt = "53"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "bqr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plating,
+/area/security/nuke_storage)
 "bqs" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -28657,101 +28284,82 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bqv" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/hallway/primary/central)
 "bqw" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/closed/wall,
+/area/crew_quarters/toilet)
 "bqx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
+/area/security/nuke_storage)
 "bqy" = (
-/obj/effect/turf_decal/bot,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"bqB" = (
+/turf/open/floor/circuit/green,
+/area/security/nuke_storage)
+"bqD" = (
+/obj/machinery/computer/holodeck{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bqz" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
-"bqA" = (
-/obj/machinery/computer/card{
-	dir = 1
+/area/crew_quarters/fitness)
+"bqE" = (
+/obj/machinery/door/window/southleft{
+	name = "AI Core Access";
+	req_access_txt = "16"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"bqF" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bqB" = (
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/hop)
-"bqC" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/turretid{
+	name = "AI Chamber turret control";
+	pixel_x = 5;
+	pixel_y = 24
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bqD" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"bqE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"bqF" = (
-/obj/machinery/vending/cigarette/beach,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "bqG" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
+/obj/machinery/holopad,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/ai_monitored/turret_protected/ai)
 "bqH" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
 "bqI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/teleporter)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "bqJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/teleporter)
+/obj/machinery/door/airlock{
+	name = "Shower Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/toilet)
 "bqK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Teleporter Maintenance";
@@ -28842,7 +28450,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay West";
+	c_tag = "Medbay - Main - Port";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29149,7 +28757,7 @@
 	},
 /obj/item/radio/off,
 /obj/machinery/camera{
-	c_tag = "Experimentor Lab";
+	c_tag = "Science - Experimentor Lab";
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white/side,
@@ -29246,7 +28854,7 @@
 	},
 /obj/item/multitool,
 /obj/machinery/camera{
-	c_tag = "Cargo Office";
+	c_tag = "Cargo - Office";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29290,30 +28898,28 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "brS" = (
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "brU" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -32
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/nuke_storage)
+"brW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
-"brW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/vending/cart,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/area/security/nuke_storage)
 "brY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -29324,37 +28930,41 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/button/door{
+	id = "Nuke Lock";
+	name = "Self Destruct Lockdown Override";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -8;
+	req_access_txt = "20";
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bsa" = (
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/security/nuke_storage)
 "bsb" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "bsc" = (
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"bsg" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/machinery/camera{
-	c_tag = "Medbay Morgue";
-	dir = 8;
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"bsg" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "bsh" = (
 /turf/closed/wall,
 /area/teleporter)
@@ -29411,7 +29021,7 @@
 /area/teleporter)
 "bsn" = (
 /obj/machinery/camera{
-	c_tag = "Teleporter"
+	c_tag = "Command - Teleporter"
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -29478,7 +29088,7 @@
 	pixel_x = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay East";
+	c_tag = "Medbay - Main - Starboard";
 	dir = 8;
 	network = list("ss13","medbay");
 	pixel_y = -22
@@ -29661,7 +29271,7 @@
 /area/science/robotics/lab)
 "bsS" = (
 /obj/machinery/camera{
-	c_tag = "Robotics Lab - South";
+	c_tag = "Science - Robotics - Aft";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -29672,12 +29282,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bsU" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/item/surgical_drapes,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "bsV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29699,12 +29308,9 @@
 	},
 /area/science/research)
 "bsY" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/head_of_personnel,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "bsZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -29749,6 +29355,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "bte" = (
@@ -29847,16 +29454,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "btq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "btr" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Receiving Dock";
+	c_tag = "Cargo - Receiving Dock";
 	dir = 4
 	},
 /obj/machinery/button/door{
@@ -29962,61 +29577,48 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "btB" = (
-/obj/machinery/computer/bounty{
-	dir = 4
+/obj/structure/safe{
+	pixel_x = 3
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/obj/item/stack/sheet/mineral/diamond,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/stack/spacecash/c500,
+/obj/item/gun/ballistic/automatic/pistol/deagle,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "btC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/obj/structure/closet/crate/silvercrate,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "btD" = (
-/obj/item/paper_bin/bundlenatural{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/pen/fountain,
-/obj/structure/table,
-/obj/item/pen/fourcolor,
-/obj/item/stamp/hop,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/obj/structure/closet/crate/goldcrate,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "btE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "btG" = (
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "btH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btI" = (
@@ -30029,6 +29631,12 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btJ" = (
@@ -30036,6 +29644,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/bluespace_beacon,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btK" = (
@@ -30043,11 +29654,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -30060,6 +29677,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/teleporter)
 "btN" = (
@@ -30068,6 +29688,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -30081,6 +29704,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -30213,20 +29839,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bue" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	departmentType = 5;
-	name = "Head of Personnel RC";
-	pixel_y = -30
-	},
-/obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
 "buf" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -30501,13 +30113,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"buK" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "buL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -30522,40 +30127,26 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "buM" = (
-/obj/machinery/keycard_auth{
-	pixel_x = -24
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/computer/cargo{
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"buN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"buN" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"buO" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/obj/item/stack/packageWrap{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/hand_labeler,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"buQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/area/security/nuke_storage)
+"buO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"buQ" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "buT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30821,7 +30412,7 @@
 /area/science/research)
 "bvy" = (
 /obj/machinery/camera{
-	c_tag = "Genetics Research";
+	c_tag = "Medbay - Genetics - Research";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -30858,7 +30449,7 @@
 /area/medical/genetics)
 "bvB" = (
 /obj/machinery/camera{
-	c_tag = "Genetics Access";
+	c_tag = "Medbay - Genetics - Access";
 	dir = 8;
 	network = list("ss13","medbay");
 	pixel_y = -22
@@ -31030,20 +30621,27 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "bvW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/theatre)
 "bvX" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Bay South";
+	c_tag = "Cargo - Bay - Aft";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31067,26 +30665,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bwa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/sign/poster/official/enlist{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/urinal{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
 "bwc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -31118,69 +30710,47 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/sign/departments/cargo{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bwg" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hopqueue";
-	name = "HoP Queue Shutters"
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bwh" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bwi" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/structure/closet/secure_closet/hop,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/closed/wall/r_wall,
+/area/security/nuke_storage)
+"bwj" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/clothing/suit/ianshirt,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bwj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "bwk" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Command - Vault - Aft";
+	dir = 1;
+	network = list("vault")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "bwl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical/old,
+/obj/item/crowbar/large,
+/obj/item/clothing/gloves/color/fyellow/old,
+/obj/item/gun/ballistic/revolver/russian,
+/obj/item/gun/ballistic/revolver/russian,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "bwq" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/plating,
@@ -31189,6 +30759,7 @@
 /obj/machinery/computer/teleporter{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/teleporter)
 "bws" = (
@@ -31222,7 +30793,7 @@
 "bww" = (
 /obj/structure/chair,
 /obj/machinery/camera{
-	c_tag = "Surgery Observation";
+	c_tag = "Medbay - Surgery - Observation";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -31288,7 +30859,7 @@
 "bwJ" = (
 /obj/structure/table/glass,
 /obj/machinery/camera{
-	c_tag = "Medbay Cryogenics";
+	c_tag = "Medbay - Cryogenics";
 	network = list("ss13","medbay")
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
@@ -31306,7 +30877,7 @@
 /area/medical/medbay/central)
 "bwL" = (
 /obj/machinery/camera{
-	c_tag = "Genetics Cloning";
+	c_tag = "Medbay - Genetics - Cloning";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
@@ -31760,49 +31331,34 @@
 	},
 /area/science/research)
 "bxG" = (
-/obj/machinery/door/airlock/command{
-	name = "Head of Personnel";
-	req_access_txt = "57"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
-"bxI" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/hallway/primary/central)
-"bxK" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/hallway/primary/central)
+/turf/closed/wall/r_wall,
+/area/security/nuke_storage)
+"bxI" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	pixel_y = 25
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
+"bxK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
 "bxL" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway South-East";
+	c_tag = "Central Hallway - Starboard Quarter";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32314,53 +31870,37 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "byP" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/freezer/cream_pie,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/theatre)
 "byR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall,
+/area/bridge)
 "byT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -32374,9 +31914,6 @@
 /area/security/checkpoint/supply)
 "byU" = (
 /obj/machinery/light,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "byW" = (
@@ -32603,7 +32140,7 @@
 /area/science/server)
 "bzy" = (
 /obj/machinery/camera{
-	c_tag = "Server Room";
+	c_tag = "Science - Server Room";
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -32691,12 +32228,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bzG" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bzH" = (
@@ -32885,8 +32424,8 @@
 /area/hallway/primary/central)
 "bAf" = (
 /obj/machinery/holopad,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -32895,8 +32434,10 @@
 	codes_txt = "patrol;next_patrol=AftH";
 	location = "AIW"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAh" = (
@@ -32904,7 +32445,9 @@
 	codes_txt = "patrol;next_patrol=CHE";
 	location = "AIE"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAi" = (
@@ -32922,8 +32465,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bAk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -32986,7 +32529,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Treatment Center";
+	c_tag = "Medbay - Treatment Center";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
@@ -33089,7 +32632,7 @@
 /area/science/server)
 "bAE" = (
 /obj/machinery/camera{
-	c_tag = "Security Post - Science";
+	c_tag = "Science - Security Post";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -33184,22 +32727,22 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "bAN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAO" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAP" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAQ" = (
@@ -33213,7 +32756,7 @@
 /area/science/explab)
 "bAS" = (
 /obj/machinery/camera{
-	c_tag = "Quartermaster's Office";
+	c_tag = "Cargo - Quartermaster's Office";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -33335,7 +32878,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera{
-	c_tag = "Security Post - Cargo";
+	c_tag = "Cargo - Security Post";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -33390,12 +32933,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBk" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway South-West";
+	c_tag = "Central Primary Hallway - Port Quarter";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33403,9 +32945,6 @@
 "bBl" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -33440,18 +32979,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bBq" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -33470,8 +33001,8 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -33488,8 +33019,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -33498,7 +33029,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway South";
+	c_tag = "Central Primary Hallway - Aft";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33525,12 +33056,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBx" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/locker)
 "bBy" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -33857,7 +33386,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/camera{
-	c_tag = "Research Director's Office";
+	c_tag = "Science - Research Director's Office";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -33894,7 +33423,7 @@
 /area/crew_quarters/heads/hor)
 "bCl" = (
 /obj/machinery/camera{
-	c_tag = "Experimentor Lab Chamber";
+	c_tag = "Science - Experimentor Lab - Chamber";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -33973,13 +33502,15 @@
 /area/janitor)
 "bCu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -34100,7 +33631,7 @@
 "bCL" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
-	c_tag = "Medbay Storage";
+	c_tag = "Medbay - Storage";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
@@ -34171,7 +33702,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay South";
+	c_tag = "Medbay - Main - Aft";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
@@ -34272,24 +33803,21 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bDg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "bDh" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"bDi" = (
-/obj/structure/sign/warning/docking{
-	pixel_y = 32
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "bDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34484,7 +34012,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Recovery Room";
+	c_tag = "Medbay - Recovery Room";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
@@ -34524,10 +34052,12 @@
 /obj/item/storage/bag/trash,
 /obj/item/clothing/under/rank/civilian/janitor/maid,
 /obj/item/clothing/under/rank/civilian/janitor/maid,
-/obj/item/clothing/under/rank/civilian/janitor/maid,
 /obj/item/clothing/under/costume/maid,
 /obj/item/clothing/under/costume/maid,
-/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidapron,
 /turf/open/floor/plasteel,
 /area/janitor)
 "bDK" = (
@@ -34535,7 +34065,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Custodial Closet"
+	c_tag = "Service - Custodial Closet"
 	},
 /obj/vehicle/ridden/janicart,
 /turf/open/floor/plasteel,
@@ -34770,7 +34300,7 @@
 	pixel_x = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Chief Medical Office";
+	c_tag = "Medbay - Chief Medical Office";
 	dir = 8;
 	network = list("ss13","medbay");
 	pixel_y = -22
@@ -34788,7 +34318,7 @@
 /area/science/xenobiology)
 "bEn" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
+	c_tag = "Science - Xenobiology - Test Chamber";
 	network = list("xeno","rd")
 	},
 /obj/machinery/light{
@@ -34871,7 +34401,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Toxins Lab West";
+	c_tag = "Science - Toxins - Port";
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -34930,14 +34460,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bEF" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bEG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34978,7 +34500,7 @@
 /area/maintenance/port/fore)
 "bEK" = (
 /obj/machinery/camera{
-	c_tag = "Mining Dock";
+	c_tag = "Cargo - Mining Dock";
 	dir = 4
 	},
 /obj/machinery/computer/security/mining,
@@ -35330,18 +34852,6 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
-"bFC" = (
-/obj/structure/table/wood/poker,
-/obj/item/clothing/mask/cigarette/cigar{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bFD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -35633,7 +35143,7 @@
 /area/quartermaster/miningdock)
 "bGo" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Firefighting equipment";
+	name = "Mineral Room";
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
@@ -35661,7 +35171,7 @@
 /area/storage/tech)
 "bGs" = (
 /obj/machinery/camera{
-	c_tag = "Secure Tech Storage"
+	c_tag = "Engineering - Secure Tech Storage"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35798,6 +35308,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bGJ" = (
@@ -35999,7 +35510,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/camera{
-	c_tag = "Toxins Storage";
+	c_tag = "Science - Toxins - Storage";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -36068,6 +35579,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/under/rank/civilian/janitor/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/accessory/maidapron,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bHp" = (
@@ -36169,14 +35684,23 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bHC" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bHD" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"bHD" = (
+/obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bHE" = (
@@ -36268,7 +35792,7 @@
 "bHR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 2";
+	c_tag = "Aft Primary Hallway - Fore";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36362,7 +35886,7 @@
 	pixel_y = -28
 	},
 /obj/machinery/camera{
-	c_tag = "Surgery Operating";
+	c_tag = "Medbay - Surgery - Operating";
 	dir = 1;
 	network = list("ss13","medbay");
 	pixel_x = 22
@@ -36698,7 +36222,7 @@
 	pixel_y = 29
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Break Room";
+	c_tag = "Medbay - Virology - Break Room";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -36883,12 +36407,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bJe" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/stack/ore/iron,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bJf" = (
-/obj/structure/closet/firecloset,
+/obj/structure/table,
+/obj/item/storage/backpack/satchel/explorer,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bJg" = (
@@ -37013,6 +36537,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJw" = (
@@ -37174,9 +36699,9 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "bJP" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "bJQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37296,7 +36821,7 @@
 /area/science/mixing)
 "bKd" = (
 /obj/machinery/camera{
-	c_tag = "Toxins Launch Room Access";
+	c_tag = "Science - Toxins - Launch Room Access";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -37337,7 +36862,7 @@
 /area/science/test_area)
 "bKj" = (
 /obj/machinery/camera{
-	c_tag = "Mining Dock External";
+	c_tag = "Cargo - Mining Dock External";
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank,
@@ -37632,13 +37157,14 @@
 /area/quartermaster/sorting)
 "bKQ" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/screwdriver{
+	pixel_y = 6
+	},
+/obj/item/crowbar,
+/obj/item/storage/pill_bottle,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bKR" = (
@@ -37874,6 +37400,7 @@
 /area/science/test_area)
 "bLu" = (
 /obj/structure/rack,
+/obj/item/radio,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -37932,7 +37459,7 @@
 /obj/item/t_scanner,
 /obj/item/multitool,
 /obj/machinery/camera{
-	c_tag = "Tech Storage";
+	c_tag = "Engineering - Tech Storage";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -38327,13 +37854,9 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bMB" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"bMC" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bMD" = (
@@ -38414,7 +37937,7 @@
 /area/engine/atmos)
 "bMS" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics North East"
+	c_tag = "Atmospherics - Main - Starboard Bow"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -38461,11 +37984,15 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNb" = (
-/obj/item/airlock_painter,
-/obj/structure/lattice,
-/obj/structure/closet,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -38644,7 +38171,7 @@
 	pixel_x = 27
 	},
 /obj/machinery/camera{
-	c_tag = "Toxins Lab East";
+	c_tag = "Science - Toxins - Starboard";
 	dir = 8;
 	network = list("ss13","rd");
 	pixel_y = -22
@@ -38655,19 +38182,18 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bNA" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bNB" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bNC" = (
-/obj/structure/closet/wardrobe/grey,
+/obj/structure/frame/computer,
+/obj/item/circuitboard/computer/operating,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bND" = (
@@ -38766,7 +38292,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics Monitoring"
+	c_tag = "Atmospherics - Monitoring"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -38785,7 +38311,7 @@
 /area/engine/atmos)
 "bNT" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics North West";
+	c_tag = "Atmospherics - Main - Port Bow";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -38872,10 +38398,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bOi" = (
-/turf/open/floor/plasteel/airless{
-	icon_state = "damaged5"
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
 	},
-/area/space/nearstation)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bOj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -38922,7 +38453,7 @@
 "bOp" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
-	c_tag = "Virology Airlock";
+	c_tag = "Medbay - Virology - Airlock";
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -39099,8 +38630,8 @@
 /turf/open/floor/plating,
 /area/science/test_area)
 "bOK" = (
-/obj/structure/barricade/wooden,
 /obj/structure/girder,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bOL" = (
@@ -39600,12 +39131,8 @@
 /turf/closed/wall,
 /area/science/misc_lab)
 "bPO" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bPP" = (
@@ -39619,41 +39146,62 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bPU" = (
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/chair/stool,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "bPV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maint Bar Access";
-	req_access_txt = "12"
-	},
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/table/wood/poker,
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/item/lighter,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "bPW" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "bPX" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bPY" = (
-/obj/structure/girder,
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"bPZ" = (
+/obj/structure/chair/sofa{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bQa" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bQb" = (
@@ -39773,7 +39321,7 @@
 /area/engine/atmos)
 "bQq" = (
 /obj/machinery/camera{
-	c_tag = "Security Post - Engineering";
+	c_tag = "Engineering - Security Post";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -39917,7 +39465,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology North";
+	c_tag = "Science - Xenobiology - Fore";
 	dir = 8;
 	network = list("ss13","rd")
 	},
@@ -39954,7 +39502,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/camera{
-	c_tag = "Testing Lab North";
+	c_tag = "Science - Testing Lab - Fore";
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
@@ -40015,19 +39563,14 @@
 /area/science/circuit)
 "bRg" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/item/soap,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bRh" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/table,
+/obj/item/paper/fluff/holodeck/disclaimer,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bRi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -40459,36 +40002,34 @@
 /turf/closed/wall/r_wall,
 /area/science/circuit)
 "bSm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/structure/closet,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/lootdrop/organ_spawner,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bSn" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bSo" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/bar)
 "bSp" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "bSq" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "bSs" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -40496,7 +40037,7 @@
 "bSt" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
-	c_tag = "Telecomms Monitoring";
+	c_tag = "Engineering - Telecomms - Monitoring";
 	dir = 8;
 	network = list("tcomms")
 	},
@@ -40505,7 +40046,7 @@
 /area/tcommsat/computer)
 "bSv" = (
 /obj/machinery/camera{
-	c_tag = "Construction Area";
+	c_tag = "Engineering - Construction Area";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -40671,7 +40212,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Module";
+	c_tag = "Medbay - Virology - Main";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
@@ -40805,11 +40346,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bTz" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/maintenance/bar)
 "bTA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -40844,10 +40391,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTF" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTG" = (
@@ -41158,21 +40705,28 @@
 /turf/open/space,
 /area/space/nearstation)
 "bUs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/maintenance/bar)
 "bUt" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#cee5d2"
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41180,21 +40734,18 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bUx" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
@@ -41594,78 +41145,89 @@
 /turf/open/space,
 /area/space/nearstation)
 "bVx" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/turf/open/floor/plating/airless,
-/area/maintenance/port/aft)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
 "bVy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bVz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"bVA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bVB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bVC" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port)
+"bVA" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"bVB" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"bVC" = (
+/obj/structure/barricade/wooden,
+/obj/structure/mineral_door/wood{
+	name = "Mason's Rest"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "bVD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/barricade/wooden,
+/obj/structure/mineral_door/wood{
+	name = "Mason's Rest"
 	},
-/obj/structure/sign/warning/deathsposal{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/bar)
 "bVE" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bVF" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bVG" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/crew_quarters/fitness)
+"bVG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "bVI" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
@@ -41682,7 +41244,7 @@
 /area/maintenance/port/aft)
 "bVN" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics Access";
+	c_tag = "Atmospherics - Access";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -41933,29 +41495,49 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "bWw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bWx" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"bWy" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cargo Bay Bridge"
+	},
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Bridge Control";
+	pixel_x = 27
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bWy" = (
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/area/maintenance/port)
 "bWz" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"bWA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bWA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general,
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bWB" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42110,6 +41692,7 @@
 /area/engine/atmos)
 "bWV" = (
 /obj/structure/door_assembly/door_assembly_mai,
+/obj/item/electronics/airlock,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bWW" = (
@@ -42323,17 +41906,27 @@
 /turf/open/space,
 /area/space)
 "bXw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/item/cane,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bXx" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/obj/structure/table,
+/obj/item/grenade/smokebomb,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bXy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/crew_quarters/fitness)
 "bXz" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -42467,7 +42060,7 @@
 /area/engine/atmos)
 "bXV" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics East";
+	c_tag = "Atmospherics - Main - Starboard";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -42502,6 +42095,8 @@
 /area/engine/atmos)
 "bXZ" = (
 /obj/structure/closet/crate,
+/obj/item/storage/box,
+/obj/item/hand_labeler_refill,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -42666,59 +42261,66 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYr" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"bYs" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"bYs" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/under/color/lightpurple,
-/obj/item/stack/spacecash/c200,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bYt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/vending/games,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bYu" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/vending/clothing,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "bYv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Space"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
-"bYw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
-"bYx" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
-"bYy" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Incinerator Access";
-	req_access_txt = "12"
-	},
-/obj/structure/barricade/wooden{
-	name = "wooden barricade (CLOSED)"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/crew_quarters/fitness)
+"bYw" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bYx" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
+"bYy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/maintenance/bar)
 "bYz" = (
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -42823,9 +42425,9 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bYP" = (
-/obj/effect/landmark/event_spawn,
-/turf/closed/wall,
-/area/crew_quarters/bar)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "bYQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -42889,7 +42491,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology South";
+	c_tag = "Science - Xenobiology - Aft";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -42941,35 +42543,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bZj" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bZk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "bZl" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Port"
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Auxiliary Port";
+	req_access_txt = "24"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "bZm" = (
-/obj/structure/disposaloutlet{
-	dir = 8
+/obj/structure/lattice,
+/obj/structure/sign/warning{
+	name = "\improper KEEP CLEAR: HIGH SPEED DELIVERIES";
+	pixel_y = 32
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/turf/open/space/basic,
 /area/space/nearstation)
 "bZn" = (
 /obj/structure/cable{
@@ -43023,7 +42619,7 @@
 /area/engine/break_room)
 "bZu" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Foyer";
+	c_tag = "Engineering - Foyer";
 	dir = 1
 	},
 /obj/structure/noticeboard{
@@ -43184,7 +42780,6 @@
 /area/maintenance/aft)
 "bZO" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -43229,16 +42824,21 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bZT" = (
-/obj/structure/rack,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bZU" = (
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/item/rack_parts,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bZV" = (
@@ -43308,28 +42908,35 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "cac" = (
-/obj/structure/chair/stool,
+/obj/structure/mirror{
+	icon_state = "mirror_broke";
+	pixel_x = -28
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/item/shard{
+	icon_state = "small"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cad" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
+	},
+/obj/item/surgical_drapes,
+/obj/item/clothing/mask/surgical,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cae" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/item/wrench,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "caf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/port/aft)
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
 "cag" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -43443,10 +43050,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "car" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cas" = (
 /obj/machinery/door/airlock/maintenance{
@@ -43494,11 +43099,11 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cax" = (
-/obj/structure/closet/wardrobe/black,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
+/obj/structure/closet/wardrobe/yellow,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cay" = (
@@ -43554,6 +43159,8 @@
 /area/space/nearstation)
 "caK" = (
 /obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/extinguisher,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -43746,43 +43353,26 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
-"cbh" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/folder/white,
-/obj/item/pen,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cbi" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cbj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = 28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/port/aft)
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
 "cbk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/departments/restroom{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Mix to Space"
-	},
-/turf/open/floor/plating/airless,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cbl" = (
 /obj/machinery/camera{
-	c_tag = "Telecomms Server Room";
+	c_tag = "Engineering - Telecomms - Server Room";
 	dir = 4;
 	network = list("tcomms")
 	},
@@ -43878,7 +43468,7 @@
 	dir = 10
 	},
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 1";
+	c_tag = "Aft Primary Hallway - Aft";
 	dir = 8;
 	pixel_y = -22
 	},
@@ -43898,17 +43488,10 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cbv" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Research Delivery access";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cbw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -43918,6 +43501,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbx" = (
@@ -44081,7 +43665,7 @@
 /area/science/xenobiology)
 "cbV" = (
 /obj/machinery/camera{
-	c_tag = "Testing Chamber";
+	c_tag = "Science - Testing Lab - Test Chamber";
 	dir = 1;
 	network = list("test","rd")
 	},
@@ -44124,44 +43708,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"cca" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/solar{
-	id = "portsolar";
-	name = "Port Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
-"ccb" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar{
-	id = "portsolar";
-	name = "Port Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
 "ccc" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/musician/piano{
+	icon_state = "piano"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ccd" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
+/obj/machinery/door/window/eastleft{
+	name = "Theatre Stage"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cce" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44256,11 +43820,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccn" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Access"
+	c_tag = "Engineering - Access"
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
@@ -44281,16 +43848,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -44380,11 +43952,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ccG" = (
-/obj/structure/chair/stool,
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ccI" = (
@@ -44450,13 +44022,11 @@
 /area/maintenance/aft)
 "ccO" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccQ" = (
@@ -44475,49 +44045,44 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"ccU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
 "ccV" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower";
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccW" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccX" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Bridge Control";
+	pixel_y = 27
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
+/turf/open/space/basic,
+/area/space)
 "ccZ" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cda" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"cda" = (
+/obj/machinery/atmospherics/components/trinary/filter,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "cdb" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "cdc" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -44607,13 +44172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cdq" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cdr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -44637,7 +44195,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/camera{
-	c_tag = "Aft Starboard Solar Access";
+	c_tag = "Solar Access - Starboard Quarter";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44649,13 +44207,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"cdu" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cdv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -44722,12 +44273,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdI" = (
@@ -44755,6 +44307,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/sign/warning/biohazard{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cdL" = (
@@ -44763,6 +44318,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/sign/departments/medbay{
+	pixel_y = -32
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -44781,14 +44339,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cdQ" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
+/obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cdR" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/structure/chair/stool,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "cdS" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -44815,22 +44372,22 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "cdV" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "cdW" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
-	dir = 8;
-	name = "Port Quarter Maintenance APC";
-	pixel_x = -25;
-	pixel_y = 1
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "cdX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45021,7 +44578,7 @@
 /area/engine/break_room)
 "cex" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics South West";
+	c_tag = "Atmospherics - Main - Port Quarter";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -45077,10 +44634,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ceF" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ceG" = (
@@ -45113,21 +44670,18 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ceM" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceN" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 9
-	},
+/obj/structure/table/glass,
+/obj/item/hemostat,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceO" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/obj/structure/table/glass,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceP" = (
@@ -45144,20 +44698,19 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "ceR" = (
-/obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceS" = (
-/obj/item/stack/sheet/cardboard,
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceT" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/sleeper{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -45168,13 +44721,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ceV" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/table/wood,
+/obj/item/instrument/guitar{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/instrument/eguitar{
+	pixel_x = 6
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ceW" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -45189,9 +44748,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ceY" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ceZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -45306,37 +44867,66 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "cfm" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 4;
+	pixel_y = 5
 	},
-/obj/item/toy/minimeteor,
-/obj/item/poster/random_contraband,
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfn" = (
+/obj/structure/table,
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/blood{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/reagent_containers/food/snacks/donkpocket,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfo" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/roller,
+/obj/structure/table,
+/obj/item/retractor,
+/obj/item/hemostat,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/c_tube,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfq" = (
-/obj/structure/mopbucket,
-/obj/item/caution,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cfr" = (
@@ -45346,15 +44936,14 @@
 	pressure_checks = 0
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Kill Room";
+	c_tag = "Science - Xenobiology - Kill Room";
 	dir = 4;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "cfs" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Air Supply Maintenance";
+/obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
@@ -45376,19 +44965,9 @@
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
 "cfv" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Firefighting equipment";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cfw" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/aft)
-"cfx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/solars/port/aft)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "cfy" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/winterboots,
@@ -45600,15 +45179,18 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cgc" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/aft)
 "cgd" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -45621,10 +45203,15 @@
 /area/maintenance/aft)
 "cgf" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cgg" = (
@@ -45632,11 +45219,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/iv_drip,
+/obj/item/roller,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cgh" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -45647,7 +45237,6 @@
 /area/science/xenobiology)
 "cgj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -45682,12 +45271,10 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cgo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/chem_master,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "cgp" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -45695,16 +45282,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cgq" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "cgr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45725,22 +45308,20 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard/aft)
 "cgu" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "cgv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -45764,70 +45345,29 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/chair/stool,
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille,
+/obj/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cgz" = (
-/obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
-"cgA" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
-"cgB" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/smes,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
-"cgC" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
-"cgD" = (
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Access";
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/aft)
 "cgE" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/aft)
-"cgF" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/girder,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cgF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "cgG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -45856,7 +45396,7 @@
 /area/crew_quarters/heads/chief)
 "cgQ" = (
 /obj/machinery/camera{
-	c_tag = "Engineering East";
+	c_tag = "Engineering - Main - Starboard";
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
@@ -46031,7 +45571,7 @@
 /area/engine/atmos)
 "chf" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics South East";
+	c_tag = "Atmospherics - Main - Starboard Quarter";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -46060,6 +45600,7 @@
 	level = 2
 	},
 /obj/machinery/meter,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "chj" = (
@@ -46118,7 +45659,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chq" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -46192,7 +45733,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chz" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46202,7 +45742,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "chA" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -46225,16 +45764,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chC" = (
-/obj/structure/rack,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "chD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46259,86 +45792,55 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chH" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/disposalpipe/segment,
+/obj/item/cigbutt/roach,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/aft)
 "chI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
-"chJ" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/solar/port/aft)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "chK" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
-"chL" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
-"chN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "chO" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "chP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/door/poddoor/shutters{
+	id = "supplybridge"
 	},
 /turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/area/maintenance/port)
 "chQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/door{
+	id = "supplybridge";
+	name = "Shuttle Bay Bridge Control";
+	pixel_y = -27
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
-"chR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/turf/open/space/basic,
+/area/space)
 "chS" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Port Quarter Solar Access";
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
-"chT" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port)
 "chY" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -46497,6 +45999,9 @@
 /area/crew_quarters/heads/chief)
 "cis" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cit" = (
@@ -46579,22 +46084,19 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ciF" = (
-/obj/structure/table,
-/obj/item/cartridge/medical,
+/obj/machinery/chem_heater,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ciG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/firecloset/full,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/hatchet,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ciH" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
 /obj/item/latexballon,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ciI" = (
@@ -46608,18 +46110,18 @@
 	},
 /area/maintenance/starboard/aft)
 "ciK" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
+/obj/item/storage/firstaid/regular,
+/obj/item/stack/medical/mesh,
+/obj/item/stack/medical/suture,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "ciL" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "ciM" = (
 /obj/machinery/power/compressor{
 	comp_id = "incineratorturbine";
@@ -46631,7 +46133,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
-	c_tag = "Turbine Chamber";
+	c_tag = "Atmospherics - Turbine Chamber";
 	dir = 4;
 	network = list("turbine")
 	},
@@ -46646,43 +46148,34 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciP" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
 "ciQ" = (
-/obj/machinery/power/solar_control{
-	dir = 4;
-	id = "portsolar";
-	name = "Port Quarter Solar Control"
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Cargo Bay Bridge Access"
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/area/maintenance/port)
 "ciR" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/port/aft";
-	dir = 4;
-	name = "Port Quarter Solar APC";
-	pixel_x = 23;
-	pixel_y = 2
+/obj/structure/sign/warning/docking{
+	pixel_y = -32
 	},
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Control";
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/turf/open/space/basic,
+/area/space)
 "ciS" = (
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
 "ciT" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "ciU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -46706,7 +46199,6 @@
 	amount = 30
 	},
 /obj/item/lightreplacer,
-/obj/item/lightreplacer,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ciY" = (
@@ -46722,6 +46214,9 @@
 "cja" = (
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -46797,7 +46292,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/camera{
-	c_tag = "Chief Engineer's Office";
+	c_tag = "Engineering - Chief Engineer's Office";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -46849,26 +46344,22 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjk" = (
-/obj/structure/sign/warning/securearea,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall,
 /area/engine/engineering)
 "cjl" = (
-/obj/machinery/camera{
-	c_tag = "Engineering MiniSat Access";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/crew_quarters/locker)
 "cjm" = (
-/obj/machinery/door/airlock/command{
-	name = "MiniSat Access";
-	req_access_txt = "65"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46876,11 +46367,22 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjn" = (
-/obj/structure/chair/wood/normal{
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/bar)
 "cjo" = (
 /obj/structure/closet/toolcloset,
@@ -46930,8 +46432,14 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "cjy" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/under/color/white,
+/obj/item/clothing/head/soft/mime,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
 /obj/structure/disposalpipe/segment,
-/obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cjz" = (
@@ -46941,8 +46449,12 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "cjA" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin{
+	pixel_x = 2
+	},
+/obj/item/clothing/mask/muzzle,
 /obj/structure/disposalpipe/segment,
-/obj/item/cigbutt/roach,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cjB" = (
@@ -46958,17 +46470,15 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "cjC" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cjD" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "cjE" = (
-/obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -46986,35 +46496,16 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
-"cjH" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
-"cjI" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cjJ" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
 "cjK" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/window/reinforced,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cjL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47027,7 +46518,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Secure Storage";
+	c_tag = "Engineering - Secure Storage";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47043,6 +46534,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjP" = (
@@ -47052,11 +46546,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/structure/table,
+/obj/item/clothing/head/beret,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/crew_quarters/locker)
 "cjR" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -47070,14 +46566,21 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cjT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cjT" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "cjU" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -47099,9 +46602,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cjV" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "cjW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -47206,6 +46711,7 @@
 /area/maintenance/disposal/incinerator)
 "ckg" = (
 /obj/machinery/atmospherics/components/binary/valve,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ckh" = (
@@ -47220,6 +46726,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "ckl" = (
@@ -47241,12 +46748,15 @@
 /area/maintenance/starboard/aft)
 "ckp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window,
+/obj/structure/rack,
+/obj/item/mmi,
+/obj/item/assembly/prox_sensor,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ckr" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cks" = (
@@ -47278,12 +46788,6 @@
 /obj/machinery/power/smes,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"ckv" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ckw" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -47334,6 +46838,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/lightreplacer,
+/obj/item/lightreplacer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ckF" = (
@@ -47429,9 +46935,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "ckS" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/aft)
 "ckT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47501,6 +47008,7 @@
 /area/maintenance/disposal/incinerator)
 "cle" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "clf" = (
@@ -47534,12 +47042,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "clj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "clk" = (
@@ -47585,14 +47095,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "clq" = (
-/obj/structure/rack,
 /obj/structure/disposalpipe/segment,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/machinery/iv_drip,
+/obj/item/roller,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "clr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -47601,10 +47108,9 @@
 /area/maintenance/starboard/aft)
 "cls" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/machinery/mecha_part_fabricator{
+	name = "counterfeit exosuit fabricator";
+	req_access = null
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -47621,19 +47127,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "clv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/starboard/aft)
-"clw" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/rack,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/gas,
+/obj/structure/disposalpipe/segment,
+/obj/item/restraints/handcuffs/cable/white,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
+"clw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "clx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -47643,7 +47150,7 @@
 "cly" = (
 /obj/structure/chair/stool,
 /obj/machinery/camera{
-	c_tag = "Aft Starboard Solar Control";
+	c_tag = "Solar Control - Starboard Quarter";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -47660,18 +47167,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"clA" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "clB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -47767,15 +47271,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"clO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet/wardrobe/grey,
-/obj/machinery/camera{
-	c_tag = "Dorms East - Holodeck";
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
 "clQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -47791,6 +47286,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"clS" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "clT" = (
 /obj/effect/turf_decal/vg_decals/atmos/nitrogen,
 /turf/open/floor/engine/n2,
@@ -47834,6 +47337,7 @@
 	dir = 4;
 	name = "Incinerator to Space"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cmg" = (
@@ -47864,22 +47368,22 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cmk" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"cmo" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cmo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/maintenance/starboard/aft)
 "cmq" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/circuit,
 /area/maintenance/starboard/aft)
 "cmr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -48131,28 +47635,27 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cne" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/recharge_station,
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/starboard/aft)
 "cnf" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/item/cartridge/medical,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cng" = (
 /obj/machinery/light/small,
-/obj/structure/table,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/clipboard,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cnj" = (
@@ -48171,15 +47674,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cnl" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/solar/port/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/maintenance/solars/port/aft)
 "cnm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -48214,7 +47711,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera{
-	c_tag = "SMES Room";
+	c_tag = "Engineering - SMES Room";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -48230,7 +47727,7 @@
 /area/engine/engineering)
 "cnt" = (
 /obj/machinery/camera{
-	c_tag = "Engineering West";
+	c_tag = "Engineering - Main - Port";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -48309,10 +47806,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cnG" = (
-/obj/structure/closet/emcloset,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cnH" = (
@@ -48326,7 +47823,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cnJ" = (
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -48506,11 +48002,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/window/reinforced,
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "con" = (
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
@@ -48552,22 +48049,21 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cou" = (
-/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/aft)
 "cov" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -48586,9 +48082,6 @@
 "cox" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -48714,6 +48207,9 @@
 	name = "Cable Toolbox";
 	pixel_y = 6
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpa" = (
@@ -48763,14 +48259,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/structure/chair/office/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cpk" = (
@@ -48781,9 +48269,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cpl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -48805,8 +48290,8 @@
 "cpn" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
@@ -48905,12 +48390,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
-"cpR" = (
-/obj/machinery/door/airlock/abandoned{
-	name = "Observatory Access"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cpS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -48921,8 +48400,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/table,
-/obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cpT" = (
@@ -48933,18 +48410,24 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cpU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/chair/office/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "cpV" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Storage";
+	c_tag = "Engineering - Storage";
 	dir = 4
 	},
 /obj/machinery/rnd/production/protolathe/department/engineering,
@@ -48970,15 +48453,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpY" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cqn" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/bar)
 "cqo" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
@@ -48990,7 +48470,7 @@
 /area/engine/engineering)
 "cqp" = (
 /obj/machinery/camera{
-	c_tag = "Engineering Escape Pod";
+	c_tag = "Engineering - Escape Pod";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -49023,10 +48503,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"cqv" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cqw" = (
 /obj/machinery/light{
 	dir = 8
@@ -49040,12 +48516,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cqy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cqz" = (
 /obj/machinery/light{
 	dir = 4
@@ -49064,25 +48534,17 @@
 /turf/open/space,
 /area/solar/starboard/aft)
 "cqK" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cqL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cqM" = (
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -49124,15 +48586,19 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"crh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"crh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "cri" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -49146,22 +48612,15 @@
 /turf/open/space,
 /area/solar/starboard/aft)
 "crl" = (
-/obj/structure/table,
-/obj/item/taperecorder,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/crew_quarters/bar)
 "crm" = (
-/obj/structure/table,
-/obj/item/storage/box/matches,
-/obj/item/storage/fancy/cigarettes,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"crn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/structure/table/wood/poker,
+/obj/item/storage/box/dice,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cro" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -49192,8 +48651,17 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crw" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -49212,15 +48680,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "crA" = (
-/obj/structure/transit_tube_pod,
-/obj/structure/transit_tube/station/reverse/flipped{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "crB" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -49282,16 +48745,31 @@
 /turf/open/space,
 /area/solar/starboard/aft)
 "crP" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port";
+	dir = 8;
+	name = "Port Maintenance APC";
+	pixel_x = -27;
+	pixel_y = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "crR" = (
-/obj/structure/transit_tube,
-/obj/effect/turf_decal/stripes/line{
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/bridge)
 "crW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49306,10 +48784,19 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crY" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/transit_tube,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/structure/bedsheetbin/color,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
 "csc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -49327,17 +48814,19 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "csi" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "csl" = (
-/obj/structure/transit_tube/curved{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "csm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -49345,14 +48834,23 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/aft)
 "csn" = (
-/obj/structure/transit_tube/horizontal,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor5"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "cso" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/crossing/horizontal,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "csq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -49361,6 +48859,7 @@
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "csr" = (
@@ -49375,59 +48874,66 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"csy" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "csD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "csM" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/crossing/horizontal,
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/captain)
 "csN" = (
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
 "csO" = (
-/obj/structure/window/reinforced/fulltile,
-/obj/structure/transit_tube/horizontal,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "csT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "csU" = (
-/obj/structure/transit_tube/station/reverse,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/maintenance/port)
 "csV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/maintenance/port)
 "csW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "csX" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/structure/table,
+/obj/item/aiModule/reset,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
 	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
 "csZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -49436,1625 +48942,911 @@
 /turf/open/space,
 /area/solar/starboard/aft)
 "cta" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctb" = (
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctd" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/space,
-/area/space/nearstation)
-"ctg" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cth" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cti" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/securearea{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctj" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat Pod Access";
-	dir = 1;
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cto" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Foyer";
-	req_one_access_txt = "65"
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctc" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctd" = (
+/obj/structure/table,
+/obj/item/toy/talking/AI{
+	pixel_y = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctg" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
+"cth" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
+"cti" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctp" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
+/turf/open/floor/plating,
+/area/maintenance/port)
+"ctj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/plating/airless,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ctk" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctr" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/folder{
-	pixel_x = 3
-	},
-/obj/item/phone{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cto" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Reception Window"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cts" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/door/window/brigdoor{
+	base_state = "rightsecure";
+	dir = 4;
+	icon_state = "rightsecure";
+	name = "Head of Personnel's Desk";
+	req_access_txt = "57"
 	},
-/obj/machinery/light_switch{
+/obj/machinery/flasher{
+	id = "hopflash";
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/radio/off{
-	pixel_y = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
 	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"ctp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hop)
+"ctq" = (
+/obj/structure/table,
+/obj/item/aiModule/supplied/quarantine,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
+"cts" = (
+/obj/machinery/computer/upload/ai{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/camera{
+	c_tag = "Command - AI Upload - Port";
+	dir = 8;
+	network = list("aicore");
+	start_active = 1
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
 "ctt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/computer/upload/borg{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/camera{
+	c_tag = "Command - AI Upload - Starboard";
+	dir = 4;
+	network = list("aicore");
+	start_active = 1
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "ctv" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "ctw" = (
+/obj/structure/table,
+/obj/item/aiModule/supplied/freeform,
 /obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/machinery/computer/station_alert{
-	dir = 4
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/camera{
+	c_tag = "Locker Room - Aft";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "cty" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ctz" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "teledoor";
-	name = "MiniSat Teleport Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ctA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ctB" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
 "ctE" = (
-/obj/machinery/teleport/hub,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ctF" = (
-/obj/machinery/button/door{
-	id = "teledoor";
-	name = "MiniSat Teleport Shutters Control";
-	pixel_y = 25;
-	req_access_txt = "17;65"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctG" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctH" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
 	},
-/obj/machinery/computer/monitor{
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
+"ctG" = (
+/obj/machinery/porta_turret/ai{
 	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctH" = (
+/obj/structure/easel,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/twentythreeXtwentythree,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"ctI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/rack,
+/obj/item/clothing/under/misc/mailman,
+/obj/item/clothing/head/mailman{
+	pixel_y = 12
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"ctJ" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctJ" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctK" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter";
-	req_access_txt = "17;65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctL" = (
-/obj/machinery/teleport/station,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/crew_quarters/heads/hop)
+"ctK" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/vending/cart,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"ctL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "ctM" = (
-/obj/machinery/bluespace_beacon,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "ctP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/closet/crate,
+/obj/item/storage/box/lights/mixed,
+/obj/item/coin/silver,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ctQ" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
+/obj/item/hand_labeler,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ctR" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall,
 /area/engine/engineering)
 "ctS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"ctT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"ctU" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "AI Chamber Access";
+	req_access_txt = "16"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
+"ctV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctT" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-8"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 4;
-	name = "MiniSat Foyer APC";
-	pixel_x = 27
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ctW" = (
-/obj/machinery/computer/teleporter{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hopqueue";
+	name = "Queue Shutters"
 	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ctX" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat Teleporter";
-	dir = 1;
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ctY" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"ctZ" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cua" = (
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cub" = (
 /obj/item/radio/intercom{
+	dir = 8;
 	name = "Station Intercom (General)";
-	pixel_y = -29
+	pixel_x = -28
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuc" = (
-/obj/structure/rack,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/closet/secure_closet/hop,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cud" = (
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	name = "Antechamber Turret Control";
-	pixel_y = -24;
-	req_access = null;
-	req_access_txt = "65"
+/obj/item/clothing/suit/ianshirt,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"ctY" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	name = "Head of Personnel RC";
+	pixel_y = -30
 	},
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Foyer";
-	dir = 1;
-	network = list("minisat")
+/obj/machinery/camera{
+	c_tag = "Command - Head of Personnel's Office";
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cue" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuf" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/service)
-"cug" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"ctZ" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuh" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/crowbar/red,
-/obj/item/clothing/head/welding,
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cui" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuj" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuk" = (
+/obj/machinery/recharger,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cul" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access_txt = "65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cum" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service)
-"cun" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Incinerator to MiniSat"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuo" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cup" = (
-/obj/structure/showcase/cyborg/old{
-	dir = 8;
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air Out"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cur" = (
-/obj/structure/showcase/cyborg/old{
-	dir = 4;
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cus" = (
-/obj/structure/showcase/cyborg/old{
-	dir = 8;
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"cua" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuu" = (
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"cub" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuv" = (
-/obj/structure/showcase/cyborg/old{
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
+"cuc" = (
+/obj/machinery/porta_turret/ai{
 	dir = 4;
-	pixel_x = -9;
-	pixel_y = 2
+	installation = /obj/item/gun/energy/e_gun
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cud" = (
+/obj/machinery/porta_turret/ai{
+	dir = 4;
+	installation = /obj/item/gun/energy/e_gun
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuw" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service)
-"cux" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/clothing/head/welding,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 35
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuy" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuA" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Atmospherics";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cue" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Command)";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/vending/wardrobe/cap_wardrobe,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"cuf" = (
+/obj/structure/table/wood,
+/obj/machinery/recharger,
+/obj/item/melee/chainofcommand,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"cug" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"cuh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuC" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuD" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Antechamber";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
-	name = "Atmospherics Turret Control";
-	pixel_x = -27;
-	req_access = null;
-	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuF" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat/service";
-	name = "Service Bay Turret Control";
-	pixel_x = 27;
-	req_access = null;
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuG" = (
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cui" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/holopad,
+/obj/machinery/door/airlock/maintenance{
+	name = "Command Maintenance";
+	req_access_txt = "57"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/plating,
+/area/maintenance/central)
+"cuj" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/central)
+"cuk" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Captain's Desk Door";
+	req_access_txt = "20"
 	},
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuH" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"cul" = (
+/obj/structure/sign/poster/official/love_ian{
+	pixel_x = 32
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cum" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuJ" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Service Bay";
-	dir = 8;
-	network = list("minisat");
-	start_active = 1
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"cun" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/clothing/head/hardhat/red{
+	pixel_y = 10
+	},
+/obj/item/tank/internals/oxygen/red,
+/obj/item/extinguisher,
+/obj/item/clothing/mask/gas,
+/obj/item/radio,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"cuo" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"cup" = (
+/obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cuq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cur" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
+"cus" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
+"cuu" = (
+/obj/machinery/porta_turret/ai{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cuv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/security/nuke_storage)
+"cuw" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -3;
 	pixel_y = 3
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cux" = (
+/obj/structure/table/reinforced,
+/obj/item/phone{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 5;
+	pixel_y = -1
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuM" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
+/obj/machinery/firealarm{
 	dir = 8;
-	name = "MiniSat Atmospherics APC";
-	pixel_x = -27
+	pixel_x = 24
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cuy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/closed/wall,
+/area/crew_quarters/heads/captain)
+"cuz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
+/turf/closed/wall,
+/area/hallway/primary/central)
+"cuA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cuB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cuC" = (
+/obj/machinery/camera{
+	c_tag = "Command - AI Chamber External - Port";
+	dir = 8;
+	network = list("aicore");
+	start_active = 1
 	},
+/turf/open/space/basic,
+/area/space)
+"cuD" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 35
+	},
+/obj/structure/sign/plaques/kiddie{
+	pixel_x = -32
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cuE" = (
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuQ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Atmospherics";
-	req_one_access_txt = "65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuS" = (
+/mob/living/simple_animal/bot/floorbot,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"cuF" = (
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/mob/living/simple_animal/bot/secbot/pingsky,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuT" = (
+/mob/living/simple_animal/bot/cleanbot,
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/area/ai_monitored/turret_protected/ai)
+"cuG" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/blue{
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/item/pen,
+/obj/structure/sign/poster/official/state_laws{
+	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Service Bay";
-	req_one_access_txt = "65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cuV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/service";
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cuH" = (
+/obj/machinery/camera{
+	c_tag = "Command - AI Chamber External - Starboard";
 	dir = 4;
-	name = "MiniSat Service Bay APC";
-	pixel_x = 27
+	network = list("aicore");
+	start_active = 1
+	},
+/turf/open/space/basic,
+/area/space)
+"cuI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"cuJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/security/nuke_storage)
+"cuK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/service)
-"cuY" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
+/area/security/nuke_storage)
+"cuL" = (
+/obj/machinery/power/terminal,
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cuZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/mob/living/simple_animal/bot/floorbot,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cva" = (
-/turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"cvb" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
-"cvc" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
+"cuM" = (
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_y = -29
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cvd" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/structure/sign/warning/securearea{
+/area/ai_monitored/turret_protected/ai)
+"cuN" = (
+/obj/structure/sign/poster/contraband/kss13{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cuO" = (
+/obj/structure/filingcabinet,
+/obj/item/folder/documents,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"cuP" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"cuQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"cuR" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/security/nuke_storage)
+"cuS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cuT" = (
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"cuU" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cuV" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cuW" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cuX" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/vault{
+	name = "Vault Door";
+	req_access_txt = "53"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
+"cuY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/teleporter)
+"cuZ" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cva" = (
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cvb" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cvc" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cvd" = (
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cve" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
-	name = "Chamber Hallway Turret Control";
-	pixel_x = 32;
-	pixel_y = -24;
-	req_access = null;
-	req_access_txt = "65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cvf" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cvg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cvh" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cvi" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cvj" = (
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvk" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvl" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cvm" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Hallway";
-	req_one_access_txt = "65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvp" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cvq" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvr" = (
-/obj/machinery/porta_turret/ai{
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"cvh" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cvs" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvv" = (
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/ai)
-"cvw" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvx" = (
-/obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_y = 28
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = 5
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_y = -25
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cvy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvA" = (
-/obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_y = 28
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = 27;
-	pixel_y = 5
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_y = -25
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cvB" = (
-/obj/structure/rack,
-/obj/item/crowbar/red,
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvD" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvE" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvF" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External NorthWest";
-	dir = 8;
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cvG" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4;
-	installation = /obj/item/gun/energy/e_gun
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvJ" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4;
-	installation = /obj/item/gun/energy/e_gun
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvK" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External NorthEast";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cvL" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvM" = (
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Core Hallway";
-	dir = 4;
-	network = list("aicore")
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvN" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cvO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cvP" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvU" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvV" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvW" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvX" = (
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cvZ" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cwa" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	dir = 4;
-	name = "MiniSat Chamber Hallway APC";
-	pixel_x = 27
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cwb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cwc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cwd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_x = -28;
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cwe" = (
-/obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
-"cwf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Chamber Observation";
-	req_one_access_txt = "65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwg" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwh" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwi" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+"cwE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwm" = (
-/obj/structure/table/reinforced,
-/obj/item/folder/white,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwp" = (
-/obj/structure/chair/office/dark,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwq" = (
-/obj/structure/grille,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cwr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai)
-"cws" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai)
-"cwt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core";
-	req_access_txt = "65"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwv" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cww" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwx" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwA" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cwC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cwD" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/turretid{
-	name = "AI Chamber turret control";
-	pixel_x = 5;
-	pixel_y = -24
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cwE" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai";
-	name = "AI Chamber APC";
-	pixel_y = -24
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -11;
-	pixel_y = -24
-	},
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat AI Chamber North";
-	dir = 1;
-	network = list("aicore")
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/area/crew_quarters/abandoned_gambling_den)
 "cwH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51062,11 +49854,16 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "cwT" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Escape Pod 2";
+	c_tag = "Arrivals - Escape Pod - Fore";
 	dir = 8
 	},
 /obj/machinery/light/small,
@@ -51086,9 +49883,25 @@
 /turf/open/space,
 /area/space/nearstation)
 "cxo" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/wood,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/maintenance/bar)
+"cxz" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer{
+	name = "Box-Beer"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cxE" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -51100,6 +49913,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"cxJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "cxN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51114,8 +49933,13 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "cxP" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/security/processing)
 "cxW" = (
 /obj/structure/lattice,
@@ -51131,7 +49955,18 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cya" = (
-/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/fore";
+	dir = 1;
+	name = "Fore Maintenance APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "cyb" = (
@@ -51237,16 +50072,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"cyE" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cyG" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -51255,28 +50080,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cyK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "cyL" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/maintenance/bar)
 "cyM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -51308,6 +50115,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cyY" = (
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/syringe,
+/obj/item/paper/fluff/ruins/thederelict/syndie_mission,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "czg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -51318,16 +50131,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"czk" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
 "czG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -51385,15 +50188,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czT" = (
 /obj/structure/disposalpipe/segment{
@@ -51405,6 +50207,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czU" = (
@@ -51429,14 +50232,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czX" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -51460,24 +50263,33 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cAa" = (
-/obj/structure/chair,
-/obj/item/storage/fancy/cigarettes,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/chair,
+/obj/item/storage/fancy/cigarettes,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cAb" = (
-/obj/structure/closet,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/closet/crate/science,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science,
+/obj/item/assembly/igniter{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/item/grenade/chem_grenade,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cAc" = (
@@ -51490,10 +50302,10 @@
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cAd" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cAe" = (
@@ -51512,25 +50324,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"cAh" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cAi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port)
 "cAy" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cAz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -51539,63 +50343,52 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cAA" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cAB" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "cAC" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 11
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/closed/wall,
+/area/maintenance/bar)
 "cAD" = (
-/obj/structure/table,
-/obj/item/kitchen/knife,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/computer/arcade{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cAE" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_y = 2
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck{
+	pixel_y = 4
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/food/snacks/mint{
-	pixel_y = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cAF" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cAG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hop";
-	name = "Head of Personnel APC";
-	pixel_y = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "cAH" = (
-/obj/machinery/processor,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cAI" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -51605,206 +50398,63 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cAJ" = (
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/reagent_containers/food/snacks/burger/cheese,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "cAK" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/chair/comfy/brown,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "cAL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/plasteel,
 /area/janitor)
 "cAQ" = (
-/obj/structure/chair,
+/obj/structure/table/wood,
+/obj/item/kitchen/fork,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"cBa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cAR" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "AI Core Door";
-	req_access_txt = "16"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cAS" = (
-/obj/effect/landmark/start/ai,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = -9
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_y = -31
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 27;
-	pixel_y = -9
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -28;
-	pixel_y = -28
-	},
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = 28;
-	pixel_y = -28
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cAT" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cAU" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External SouthWest";
-	dir = 8;
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cAV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/showcase/cyborg/old{
-	dir = 8;
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cAW" = (
-/obj/structure/showcase/cyborg/old{
-	dir = 4;
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cAX" = (
-/obj/structure/lattice,
-/obj/machinery/camera{
-	c_tag = "MiniSat External SouthEast";
-	dir = 4;
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cAY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/ai)
-"cAZ" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cBa" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cBb" = (
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat AI Chamber South";
-	network = list("aicore")
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cBc" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cBd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cBe" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
-"cBf" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat External South";
-	network = list("minisat");
-	start_active = 1
-	},
-/turf/open/space,
-/area/space/nearstation)
 "cBg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/hydroponics)
-"cBh" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/locker)
 "cBi" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "cBj" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/dark,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1447;
+	name = "Private AI Channel";
+	pixel_y = -25
+	},
+/obj/machinery/light,
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "cBk" = (
 /obj/structure/disposalpipe/segment{
@@ -51832,7 +50482,8 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "cBo" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "cBp" = (
@@ -51845,10 +50496,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cBr" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "cBt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -51870,11 +50519,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"cBw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cBx" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -52013,14 +50657,6 @@
 /obj/effect/turf_decal/vg_decals/atmos/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cBS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
 "cBT" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -52131,12 +50767,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "cCt" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/obj/item/poster/random_official,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cCB" = (
@@ -52239,6 +50870,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/tool,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDm" = (
@@ -52246,6 +50880,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/engivend,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDB" = (
@@ -52267,6 +50904,12 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDL" = (
@@ -52274,7 +50917,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/engine/gravity_generator)
 "cDN" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -52282,15 +50925,8 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "cDY" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/closed/wall,
+/area/space)
 "cDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52299,9 +50935,17 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cEo" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/structure/table/wood,
+/obj/item/phone{
+	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 7
+	},
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "cFG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -52316,31 +50960,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "cGz" = (
-/obj/structure/table/wood,
-/obj/item/instrument/violin,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"cHf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 20
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 20
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/reagent_containers/food/drinks/britcup,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/candy,
+/obj/item/trash/can,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cHD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52656,19 +51280,54 @@
 /turf/closed/wall,
 /area/lawoffice)
 "cJW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
-"cKC" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/camera/motion{
+	c_tag = "Command - AI Chamber - Fore";
+	dir = 1;
+	network = list("aicore")
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"cKC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/item/radio/headset{
+	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
+	name = "prisoner headset";
+	prison_radio = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"cKE" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cKP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "cLS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -52732,17 +51391,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/central";
-	dir = 1;
-	name = "Central Maintenance APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/turf/closed/wall,
+/area/crew_quarters/heads/hop)
 "cNM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52847,14 +51497,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cOw" = (
-/obj/effect/spawner/structure/window,
+/obj/structure/girder,
+/obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/bar)
 "cOx" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/closed/wall/mineral/titanium/nosmooth,
+/area/space/nearstation)
 "cOT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52875,16 +51524,21 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"cOY" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "cPn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "cPA" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/hollow/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/space/nearstation)
 "cPH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -52922,24 +51576,23 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cQF" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
 	},
-/obj/item/radio/intercom{
-	pixel_y = 25
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/corn,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"cRJ" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"cQT" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
 "cSA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53054,7 +51707,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Power Storage"
+	c_tag = "Engineering - Power Storage"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -53207,6 +51860,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cTo" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/space/fragile,
+/obj/item/clothing/head/helmet/space/fragile,
+/obj/item/tank/internals/air,
+/obj/item/flashlight,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "cTD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53219,6 +51880,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -53233,11 +51897,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "cTF" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	req_access_txt = "12"
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/bar)
 "cTJ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -53302,11 +51965,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "cTT" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Chamber";
+	req_access_txt = "16"
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "cTX" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -53329,19 +51997,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cUx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
+"cUI" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "cVs" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "cVK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -53354,12 +52020,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cZe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"daf" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "daq" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -53390,16 +52068,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dce" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/storage/box/matches{
+	pixel_y = 5
 	},
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dev" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -53412,8 +52087,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -53432,27 +52107,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"dfL" = (
-/obj/structure/reagent_dispensers/keg/gargle,
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "dgz" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
-"dgO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+"diq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"diq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "diH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -53468,51 +52131,74 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dly" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/closet/secure_closet{
+	name = "Persuasion Storage";
+	req_access = "list(2)"
 	},
-/turf/open/floor/plating,
-/area/security/range)
-"dml" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/melee/baton/cattleprod,
+/obj/item/stock_parts/cell/high,
+/obj/item/electropack,
 /turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"dqb" = (
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+/area/security/brig)
+"dml" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "dqu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"drQ" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"drV" = (
+/obj/structure/kitchenspike_frame,
+/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/item/stack/rods{
+	amount = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"dso" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "dsC" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dtx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sink{
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/toilet";
 	dir = 4;
-	pixel_x = 11
+	name = "Dormitory Bathrooms APC";
+	pixel_x = 26
 	},
-/obj/structure/mirror{
-	pixel_x = 25
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/structure/bedsheetbin/towel,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "dvc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
 "dvO" = (
@@ -53522,8 +52208,12 @@
 /turf/closed/wall,
 /area/science/circuit)
 "dyE" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet{
+	name = "Evidence Closet 2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -53540,18 +52230,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"dzi" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+"dzc" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"dzQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/turf/open/floor/plating,
+/area/maintenance/port)
+"dzA" = (
+/obj/machinery/door/airlock/abandoned{
+	name = "Observatory Access"
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dAe" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -53560,14 +52250,22 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dBm" = (
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dCr" = (
 /obj/structure/pool/Rboard,
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "dCt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -53575,17 +52273,15 @@
 /turf/open/space,
 /area/space/nearstation)
 "dCV" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"dEM" = (
+/obj/structure/closet/wardrobe/white,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dEX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/requests_console{
@@ -53615,8 +52311,8 @@
 /turf/closed/wall,
 /area/maintenance/bar)
 "dKV" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/maintenance/bar)
 "dMj" = (
 /obj/machinery/space_heater,
@@ -53625,12 +52321,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dMN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "meetingblast";
+	name = "Meeting Room Blast Door"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "dMZ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"dOP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "dPk" = (
 /obj/structure/closet{
 	name = "Costume Closet"
@@ -53652,38 +52371,65 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dPq" = (
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/abandoned{
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"dQr" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/red,
+/obj/item/clothing/glasses/meson,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "dQD" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Incinerator to MiniSat"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"dRm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/airlock_painter,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dTI" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
-"dXq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"dYR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/starboard/aft)
+"dYZ" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"dYZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
-/area/security/range)
+/area/maintenance/fore)
 "dZm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -53697,6 +52443,11 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"eaJ" = (
+/obj/effect/landmark/blobstart,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "eaR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -53705,10 +52456,38 @@
 /turf/open/space,
 /area/solar/starboard/fore)
 "ecg" = (
-/turf/open/floor/plasteel/yellowsiding/corner{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
+"eci" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/area/crew_quarters/fitness/pool)
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"ecJ" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
 "edA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -53718,6 +52497,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eeV" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "efO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53738,12 +52527,79 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"eih" = (
-/obj/structure/chair{
+"egL" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"ehb" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Command - Meeting Room";
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"ehe" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"eih" = (
+/obj/effect/landmark/start/ai/secondary,
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = -30
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = -27;
+	pixel_y = -10
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 27;
+	pixel_y = -10
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = -25;
+	pixel_y = 8
+	},
+/obj/machinery/door/window/northright{
+	name = "Secondary AI Core";
+	pixel_y = 4;
+	req_access_txt = "16"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"eiL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eiZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
@@ -53752,11 +52608,30 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "elh" = (
-/obj/structure/chair/comfy/black{
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/cola,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"emc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ene" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53767,17 +52642,32 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/execution/transfer)
-"epD" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
+"eoI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/chair/sofa/right{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/rack,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"eoU" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"epD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/crew_quarters/locker)
 "eqd" = (
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
@@ -53793,15 +52683,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"esK" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Chemical Storage";
-	req_access_txt = "12"
-	},
-/obj/structure/barricade/wooden,
-/obj/structure/girder,
+"esA" = (
+/obj/machinery/shieldgen,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "esL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -53831,26 +52717,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"evR" = (
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "ewu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/structure/noticeboard{
+	pixel_y = -27
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
+/obj/structure/chair/sofa/right{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "exP" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-14"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"eyH" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eyM" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -53877,64 +52763,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"eAG" = (
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/shoes/sneakers/white,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "eAJ" = (
-/obj/structure/chair{
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "eBX" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "eCr" = (
-/obj/structure/closet{
-	name = "Suit Closet"
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/obj/item/clothing/under/suit/white,
-/obj/item/clothing/under/suit/tan,
-/obj/item/clothing/under/suit/red,
-/obj/item/clothing/under/suit/black_really,
-/obj/item/clothing/under/suit/navy,
-/obj/item/clothing/under/suit/green,
-/obj/item/clothing/under/suit/black/skirt,
-/obj/item/clothing/under/suit/checkered,
-/obj/item/clothing/under/suit/charcoal,
-/obj/item/clothing/under/suit/burgundy,
-/obj/item/clothing/under/suit/black,
-/obj/item/clothing/under/rank/civilian/lawyer/black,
-/obj/item/clothing/under/suit/black,
-/obj/item/clothing/under/rank/civilian/lawyer/blue,
-/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
-/obj/item/clothing/under/rank/civilian/lawyer/female,
-/obj/item/clothing/under/rank/civilian/lawyer/purpsuit,
-/obj/item/clothing/under/rank/civilian/lawyer/really_black,
-/obj/item/clothing/under/rank/civilian/lawyer/red,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/crew_quarters/bar)
 "eCR" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
 "eEe" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "eFx" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -53953,44 +52815,80 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "eFW" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"eGC" = (
+/obj/structure/chair/stool/bronze,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"eHR" = (
+/obj/structure/chair,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eJa" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck{
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eMg" = (
+/turf/open/floor/plasteel/airless{
+	icon_state = "damaged5"
+	},
+/area/space/nearstation)
 "eMs" = (
-/obj/structure/rack,
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/fitness/pool";
+	dir = 4;
+	name = "Pool APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"eMH" = (
+/obj/structure/closet,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/obj/machinery/light/small{
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"ePT" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Auxiliary Power";
+	req_access_txt = "10"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"eUe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"eQb" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"eRz" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
-"eSe" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
+/area/maintenance/port/fore)
 "eUW" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -53998,16 +52896,29 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"eVC" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/crew_quarters/cryopod)
-"eVJ" = (
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 1
+"eUX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/area/crew_quarters/fitness/pool)
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "8;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"eVa" = (
+/obj/machinery/processor,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"eVr" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "eVL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light_switch{
@@ -54029,31 +52940,46 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eXz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/processing)
 "fbp" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/storage)
-"fcn" = (
-/obj/structure/lattice,
+"fbW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
+/area/bridge/meeting_room)
+"fcc" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/aft";
+	dir = 1;
+	name = "Port Quarter Maintenance APC";
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fcG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"fdQ" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+"fej" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "feE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54064,32 +52990,20 @@
 	},
 /area/maintenance/starboard/fore)
 "feG" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "fgG" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theatre";
-	name = "theatre RC";
-	pixel_x = -32
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/food/snacks/baguette,
-/obj/item/toy/dummy,
-/obj/item/lipstick/random{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lipstick/random{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fiy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -54097,9 +53011,30 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "fjS" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "fjU" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -54107,33 +53042,36 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"fka" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "flc" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"flE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
+"flK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "fne" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/landmark/start/mime,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
+/obj/structure/lattice,
+/obj/structure/camera_assembly,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fnC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -54147,44 +53085,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"foT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"fpl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"fpz" = (
-/obj/structure/disposalpipe/segment,
+"fnN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"foT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"fpz" = (
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 1;
+	stack_amt = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
+/area/maintenance/disposal)
 "fpI" = (
 /obj/machinery/light{
 	dir = 1
@@ -54199,6 +53124,21 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"frv" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space,
+/area/solar/port/aft)
+"frW" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas/glass,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fsa" = (
 /obj/machinery/button/door{
 	id = "armory3";
@@ -54217,31 +53157,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "fsj" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/light_switch{
+	pixel_y = -24
 	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fty" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -54261,27 +53183,48 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fvY" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
 "fxa" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 3;
+	pixel_y = 3
 	},
+/obj/item/stock_parts/capacitor,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/electrical";
+	dir = 4;
+	name = "Auxiliary Power APC";
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
 /area/maintenance/bar)
 "fxe" = (
-/obj/structure/chair/sofa,
-/obj/structure/window{
-	dir = 1
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/structure/table/wood,
+/obj/item/instrument/violin,
+/obj/item/instrument/recorder,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"fxh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "fxx" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -54289,6 +53232,10 @@
 "fxV" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
+"fyI" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "fyS" = (
 /obj/structure/pool/ladder{
 	dir = 1;
@@ -54296,44 +53243,75 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
+"fyX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fzd" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"fAj" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/love_ian{
-	pixel_x = 32;
-	pixel_y = -32
+"fBg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/gravity_generator)
+"fBs" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "fBy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
+	},
+/obj/item/plant_analyzer,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"fCx" = (
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/light_switch{
+	pixel_x = 25
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"fFr" = (
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"fCx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"fFx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/button/door{
-	id = "holoprivacy";
-	name = "Holodeck Privacy";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fFA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"fGe" = (
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Auxiliary Port";
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "fGf" = (
 /obj/machinery/smartfridge/disks{
 	pixel_y = 2
@@ -54359,17 +53337,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"fJY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "fKl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/event_spawn,
@@ -54382,17 +53349,40 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fLn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"fLw" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fMp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"fOA" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
+"fNG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"fOA" = (
+/obj/structure/lattice,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "fOI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -54409,6 +53399,16 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fQV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fSO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -54426,36 +53426,45 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fTC" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"fZm" = (
-/obj/structure/chair/sofa/left,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"gav" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"fUZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"fXg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/security/processing)
+/area/engine/gravity_generator)
+"fYD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/port/fore)
+"fZm" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"fZq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/mecha_wreckage/ripley,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gbd" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -54463,15 +53472,11 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "gbh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gbq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -54502,6 +53507,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"gfj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "gfC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/chair{
@@ -54509,16 +53520,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"gfD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
 "ghD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/space_heater{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "giT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54533,6 +53543,21 @@
 "gjl" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"glY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
+"gmC" = (
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "gnf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54542,21 +53567,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gpD" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "grc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/rack,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_official{
+	pixel_y = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -54567,69 +53586,66 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "grA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"grT" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
-"gsM" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"gvX" = (
-/turf/open/floor/plasteel/yellowsiding,
-/area/crew_quarters/fitness/pool)
+/area/engine/gravity_generator)
 "gwd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"gxc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"gwL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gxw" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "gyr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gzf" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/item/extinguisher,
+/obj/item/clothing/head/hardhat/red,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/curtain,
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"gzY" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/crew_quarters/dorms)
 "gAu" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -54642,10 +53658,10 @@
 /area/engine/atmos)
 "gBo" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-4"
 	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "gCC" = (
 /obj/structure/sign/poster/contraband/tools,
 /turf/closed/wall,
@@ -54654,19 +53670,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
-"gDP" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "gIU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -54678,14 +53681,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "gLz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/poddoor/preopen{
+	id = "Cell Interior Shutters";
+	name = "brig shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/security/brig)
 "gLH" = (
 /obj/machinery/door/airlock/external{
@@ -54697,12 +53701,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"gMl" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "gMD" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -54712,34 +53710,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gNC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+"gMQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"gNE" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/security/brig)
-"gOZ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/starboard/aft)
+"gNE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/closed/wall,
+/area/security/brig)
+"gOZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "gQX" = (
 /obj/machinery/button/door{
 	id = "LockerShitter4";
@@ -54763,6 +53758,11 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
+"gRP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gRZ" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -54770,19 +53770,31 @@
 /turf/open/floor/carpet,
 /area/library)
 "gTx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/showcase/cyborg/old{
+	dir = 8;
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"gUu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"gUu" = (
-/obj/structure/lattice,
+/area/ai_monitored/turret_protected/ai)
+"gUV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
@@ -54792,9 +53804,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"gWo" = (
-/turf/closed/wall,
-/area/security/range)
 "gXs" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -54823,19 +53832,41 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"hcb" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"hcA" = (
+"hbU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/effect/turf_decal/tile/blue,
+/area/maintenance/starboard/aft)
+"hcb" = (
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"hcu" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/central)
+"hcA" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/closed/wall,
+/area/ai_monitored/turret_protected/ai)
+"hei" = (
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"hel" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hgG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/extinguisher_cabinet{
@@ -54844,54 +53875,58 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hgO" = (
-/obj/structure/table,
-/obj/item/storage/box/dice{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/cherrycupcake,
+/obj/structure/table/wood,
+/obj/item/instrument/trombone,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"hiV" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"hlT" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/processing)
-"hlV" = (
+"hhH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"hnU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Shooting Range"
-	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"hkT" = (
+/obj/structure/table,
+/obj/item/shovel,
+/obj/item/stack/ore/silver,
 /turf/open/floor/plating,
-/area/security/range)
-"hrF" = (
-/obj/structure/lattice/catwalk,
+/area/maintenance/port/aft)
+"hlj" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/space,
-/area/solar/port/aft)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/rack,
+/obj/item/stack/cable_coil/random,
+/obj/item/clothing/glasses/meson,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"hnU" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"hod" = (
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
+"hrF" = (
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "hsb" = (
 /obj/structure/table/wood,
 /obj/item/book/codex_gigas,
@@ -54905,28 +53940,45 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"hsA" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
+"htl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/starboard/aft)
+"huK" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hxn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"hzK" = (
-/turf/open/floor/plasteel/yellowsiding/corner{
-	dir = 1
-	},
-/area/crew_quarters/fitness/pool)
-"hBw" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/fore)
 "hBA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"hCf" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/central)
+"hDr" = (
+/obj/structure/closet/wardrobe/pink,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hGH" = (
 /obj/machinery/door/airlock{
 	desc = "Private study room where nerds are probably playing Dungeons and Dragons 13e, or a place for blood cult rituals.";
@@ -54943,10 +53995,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hIn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "hIL" = (
-/obj/structure/sign/poster/contraband/space_up{
-	pixel_x = -32;
-	pixel_y = 32
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -54957,15 +54015,40 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"hOv" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	pixel_y = 5
+"hJp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/gravity_generator";
+	dir = 8;
+	name = "Gravity Generator APC";
+	pixel_x = -25;
+	pixel_y = 1
 	},
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"hLG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"hNE" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/solars/port/aft";
+	dir = 4;
+	name = "Port Quarter Solar APC";
+	pixel_x = 23;
+	pixel_y = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Solar Control - Port Quarter";
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "hPs" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -54973,15 +54056,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"hPP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"hPy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/quartermaster/warehouse)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hQY" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -55003,80 +54085,154 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "hRI" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/item/cultivator,
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"hSl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/area/maintenance/port/fore)
+"hSZ" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"hTK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/closet,
+/obj/item/caution,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"hSZ" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
+/area/maintenance/port/aft)
+"hVp" = (
+/obj/machinery/power/solar_control{
+	dir = 4;
+	id = "portsolar";
+	name = "Port Quarter Solar Control"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "hWd" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/vr_sleeper{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"ibK" = (
-/turf/open/floor/plasteel,
-/area/security/processing)
-"idK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Firing Range";
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
-/area/security/range)
-"iiW" = (
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"ijG" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/window,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"ikk" = (
+/area/crew_quarters/fitness)
+"hWK" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/abandoned_gambling_den";
+	name = "Abandoned Gambling Den APC";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"hWV" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"hXP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"ibb" = (
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
+	},
+/obj/item/seeds/watermelon,
+/obj/item/seeds/cannabis,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"ibK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/processing)
+"icJ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"idl" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/bar)
+"idG" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"idK" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/taperecorder,
+/obj/item/folder/red,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"iej" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/light_construct/small{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
+"ieX" = (
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/mre,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"ihF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/item/robot_suit,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"iiG" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"iiW" = (
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"ijG" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"ikk" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ikm" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -55086,6 +54242,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ikB" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "imk" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -55093,40 +54256,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"imH" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"inq" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"inw" = (
-/mob/living/simple_animal/hostile/retaliate/goose{
-	desc = "Some evil loose goose.";
-	name = "Cere"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "inR" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iou" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "ipA" = (
 /turf/open/floor/plating,
@@ -55143,6 +54283,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "itG" = (
@@ -55153,30 +54294,27 @@
 /area/science/circuit)
 "itK" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
 /obj/structure/light_construct{
 	dir = 8
 	},
+/obj/item/stock_parts/cell/crap,
+/obj/item/stock_parts/capacitor,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"itQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/range)
 "ium" = (
 /mob/living/simple_animal/bot/cleanbot{
 	name = "C.L.E.A.N."
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"iur" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "iuR" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -55187,27 +54325,79 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"izg" = (
-/obj/item/cigbutt/cigarbutt,
+"iws" = (
+/obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"izv" = (
-/obj/machinery/vending/clothing,
-/obj/machinery/light/small{
+/area/maintenance/bar)
+"iyv" = (
+/obj/structure/shuttle/engine/propulsion/burst/left,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"iyD" = (
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	desc = "Cooks and boils stuff, somehow.";
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"iyT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/closet,
+/obj/item/extinguisher/mini,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"izf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"izv" = (
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "iBv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/obj/item/clothing/glasses/sunglasses,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
+"iCB" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/gloves,
+/obj/effect/spawner/lootdrop/low_tools,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iDo" = (
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"iEn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -55217,12 +54407,20 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"iHk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+"iFJ" = (
+/obj/structure/sign/warning/docking{
+	pixel_x = -32
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/turf/open/space/basic,
+/area/space)
+"iHk" = (
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "iIS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -55240,59 +54438,109 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/table/glass,
-/obj/structure/bedsheetbin/towel,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/closet/athletic_mixed,
+/obj/item/toy/poolnoodle/blue,
+/obj/item/toy/poolnoodle/blue,
+/obj/item/toy/poolnoodle/red,
+/obj/item/toy/poolnoodle/red,
+/obj/item/toy/poolnoodle/yellow,
+/obj/item/toy/poolnoodle/yellow,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
+"iMZ" = (
+/obj/structure/rack,
+/obj/item/stack/cable_coil/random,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iNn" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
+	c_tag = "Service - Kitchen - Cold Room"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"iPX" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
+"iOP" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/obj/item/lighter,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
+"iQX" = (
+/obj/machinery/door/airlock/maintenance/abandoned{
+	name = "Storage Room";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"iRf" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iRj" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/item/radio/intercom{
+	pixel_y = 20
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/area/security/processing)
+"iRp" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "iTq" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iTU" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
+/obj/structure/chair/stool,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/structure/light_construct/small{
+	dir = 1
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
+/area/maintenance/bar)
 "iVJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55303,31 +54551,57 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "iVU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenics "
 	},
-/obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/cryopod)
 "iWx" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iWD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard/aft)
+"iXH" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/storage/belt/utility,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"iXN" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "iYE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel,
+/obj/structure/dresser,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
+"iYL" = (
+/obj/item/bot_assembly/cleanbot,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "jaF" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -55352,6 +54626,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"jcx" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"jcG" = (
+/obj/item/restraints/handcuffs/fake,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jdj" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -55360,12 +54642,25 @@
 	},
 /turf/open/space,
 /area/space)
+"jdv" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "jex" = (
 /obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
 /area/medical/sleeper)
 "jez" = (
-/obj/effect/landmark/blobstart,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/green,
+/area/hydroponics/garden)
+"jeG" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/double,
+/obj/item/clothing/mask/gas/glass,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "jgm" = (
@@ -55376,18 +54671,39 @@
 	dir = 6
 	},
 /obj/machinery/camera{
-	c_tag = "Circuitry Lab";
+	c_tag = "Science - Circuitry Lab - Starboard";
 	dir = 8;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "jgA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/clothing/head/fedora,
+/obj/item/toy/cards/deck{
+	pixel_y = 12
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"jgG" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "jiK" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
@@ -55397,40 +54713,117 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jkx" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/computer/slot_machine,
-/obj/item/coin/iron,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"jkz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+"jkl" = (
+/obj/structure/closet/crate/internals,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen/double{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"jkx" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/green,
+/area/hydroponics/garden)
+"jkz" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "jlm" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "jmV" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/reagent_containers/food/drinks/britcup{
-	desc = "Kingston's personal cup.";
-	pixel_x = 5;
-	pixel_y = 5
+/obj/machinery/vending/kink,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"joq" = (
+/obj/structure/flora/rock/pile,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"joB" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"jpw" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"jqa" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jqv" = (
-/obj/structure/chair/wood/normal{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel,
 /area/maintenance/bar)
+"jqP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "meetingblast";
+	name = "Meeting Room Blast Door"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
+"jrA" = (
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jrE" = (
 /obj/item/beacon,
 /turf/open/floor/plasteel/white,
@@ -55443,28 +54836,23 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "juG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
+/obj/structure/chair/sofa/right{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/snacks/bluecherrycupcake{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"jvd" = (
-/obj/structure/closet/athletic_mixed,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"jxF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/port/aft)
+"jvd" = (
+/obj/structure/closet/secure_closet/bar{
+	pixel_x = -3;
+	pixel_y = -1;
+	req_access_txt = "25"
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"jwF" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jyO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -55479,7 +54867,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "jzM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -55488,38 +54876,37 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"jAD" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+"jAE" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/healthanalyzer,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "jAN" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/area/maintenance/bar)
+"jAY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/crew_quarters/fitness)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jBi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/rag,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "jBA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/area/maintenance/bar)
 "jBQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
@@ -55536,6 +54923,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jDq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "jDr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -55547,48 +54941,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jEc" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
+"jFH" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/area/maintenance/bar)
+"jGs" = (
+/obj/machinery/light/small{
 	dir = 1
 	},
-/area/crew_quarters/fitness)
-"jFH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "jGI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"jGW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+"jGR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/starboard/aft)
 "jHh" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
@@ -55618,12 +54994,24 @@
 	},
 /turf/open/space,
 /area/solar/starboard/fore)
+"jIM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table_frame,
+/obj/item/shard,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/starboard/aft)
 "jJF" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jKP" = (
 /obj/structure/disposalpipe/segment,
@@ -55633,18 +55021,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "jLn" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
+/obj/structure/chair/stool,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
+/area/maintenance/bar)
 "jLv" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -55652,28 +55037,55 @@
 /turf/open/space,
 /area/space)
 "jLT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "jMW" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "PoolShut";
 	name = "Pool Shutters";
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
+"jOs" = (
+/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "jRw" = (
 /obj/machinery/computer/arcade/minesweeper{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jSb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jSO" = (
 /obj/machinery/light{
 	dir = 4
@@ -55683,6 +55095,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"jSZ" = (
+/obj/item/bot_assembly/floorbot{
+	build_step = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"jTJ" = (
+/turf/open/floor/plasteel/airless{
+	icon_state = "damaged3"
+	},
+/area/space/nearstation)
+"jUU" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "jVl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55713,31 +55140,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "kaq" = (
-/turf/closed/wall/mineral/titanium,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
-"kbm" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kcx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
@@ -55745,15 +55150,18 @@
 /area/space/nearstation)
 "kdO" = (
 /obj/machinery/pool/controller,
-/turf/open/floor/plasteel/yellowsiding,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "kdP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ker" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -55761,7 +55169,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -55775,6 +55183,11 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"kfk" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "kfv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55785,11 +55198,11 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "kfX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken2"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
+/area/maintenance/bar)
 "kgr" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -55822,48 +55235,43 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"kic" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"kjY" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "kls" = (
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"kmw" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
+"klD" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"kmS" = (
-/obj/structure/dresser,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -2;
-	pixel_y = 15
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"knx" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"kmw" = (
+/obj/machinery/light,
+/obj/structure/closet/wardrobe/pjs,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"knu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/closed/wall,
+/area/maintenance/port/fore)
 "kob" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -55872,80 +55280,79 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kqI" = (
-/obj/structure/window,
+"kqy" = (
+/obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"ktP" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/area/maintenance/bar)
+"kqI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/bananalamp{
+	pixel_y = 3
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
+"krs" = (
+/obj/structure/rack,
+/obj/item/stack/cable_coil/random,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"ksg" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"ksm" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 10
 	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"ksA" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
+"ktP" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ktS" = (
 /turf/open/space/basic,
 /area/space/nearstation)
 "kuh" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kuA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/item/radio/intercom{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
-"kvl" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "kvL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"kxf" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/hop)
 "kyF" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/maintenance/bar)
 "kzT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -55953,55 +55360,76 @@
 /area/science/mixing)
 "kAH" = (
 /obj/machinery/camera{
-	c_tag = "Bar West";
+	c_tag = "Service - Bar - Port";
 	dir = 4
 	},
-/obj/machinery/computer/arcade/orion_trail,
-/obj/structure/sign/poster/official/foam_force_ad{
-	pixel_x = -32
+/obj/machinery/computer/arcade/minesweeper{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"kAI" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/mask/gas,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "kAJ" = (
-/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/girder,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "kAO" = (
-/obj/structure/chair/sofa{
-	dir = 1
-	},
-/obj/structure/window,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"kCa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/range)
-"kCo" = (
+/obj/structure/light_construct/small{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"kCj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
+"kCo" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"kEm" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
-"kEm" = (
-/mob/living/simple_animal/opossum/poppy,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/bar)
 "kEY" = (
 /obj/effect/landmark/stationroom/box/engine,
 /turf/open/space/basic,
@@ -56029,23 +55457,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kHd" = (
+"kJg" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Prisoner Processing";
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/security/processing)
+/area/hallway/primary/port)
 "kJE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -56053,25 +55476,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kMt" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"kNv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"kKe" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/mineral/titanium/blue,
+/area/space/nearstation)
+"kLZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/turf/closed/wall,
+/area/maintenance/port/fore)
+"kMr" = (
+/obj/structure/closet,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"kNq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/sign/poster/contraband/free_drone{
+/obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/engine/gravity_generator)
+"kNv" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -56086,6 +55524,10 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kPp" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kQk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -56105,70 +55547,106 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kQK" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/frame/machine,
+/obj/item/stack/sheet/glass,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "kSb" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"kTj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"kSv" = (
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "maintenance access";
-	req_access_txt = "12"
+/obj/structure/disposaloutlet{
+	dir = 8
 	},
-/obj/structure/barricade/wooden,
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"kUC" = (
-/obj/machinery/chem_master/condimaster,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"kTl" = (
+/obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "kWp" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
+/obj/structure/rack,
+/obj/item/crowbar/large,
+/obj/item/toy/minimeteor,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kYk" = (
-/obj/machinery/door/firedoor,
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"kZS" = (
-/obj/machinery/light{
-	dir = 8
-	},
+"kYZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"kZS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/processing)
 "laq" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"laL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"ldR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/security/range)
+/area/maintenance/bar)
+"leD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"leK" = (
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/pen,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "lfV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56188,12 +55666,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"lgB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "lgX" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/crew_quarters/fitness)
+"lhg" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "lhQ" = (
 /obj/machinery/power/floodlight,
 /obj/structure/cable{
@@ -56201,49 +55699,55 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"lip" = (
-/obj/structure/closet{
-	name = "Suit Closet"
-	},
-/obj/item/clothing/under/suit/white,
-/obj/item/clothing/under/suit/tan,
-/obj/item/clothing/under/suit/red,
-/obj/item/clothing/under/suit/black_really,
-/obj/item/clothing/under/suit/navy,
-/obj/item/clothing/under/suit/green,
-/obj/item/clothing/under/suit/black/skirt,
-/obj/item/clothing/under/suit/checkered,
-/obj/item/clothing/under/suit/charcoal,
-/obj/item/clothing/under/suit/burgundy,
-/obj/item/clothing/under/suit/black,
-/obj/item/clothing/under/rank/civilian/lawyer/black,
-/obj/item/clothing/under/suit/black,
-/obj/item/clothing/under/rank/civilian/lawyer/blue,
-/obj/item/clothing/under/rank/civilian/lawyer/bluesuit,
-/obj/item/clothing/under/rank/civilian/lawyer/female,
-/obj/item/clothing/under/rank/civilian/lawyer/purpsuit,
-/obj/item/clothing/under/rank/civilian/lawyer/really_black,
-/obj/item/clothing/under/rank/civilian/lawyer/red,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "lnk" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "lnu" = (
-/obj/structure/chair/wood/normal{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"lqt" = (
+/obj/structure/table,
+/obj/item/folder/white,
+/obj/item/pen,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"lsk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/wood{
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken4"
 	},
 /area/maintenance/bar)
-"lsk" = (
-/obj/machinery/vending/kink,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+"lsX" = (
+/obj/item/stack/tile/plasteel{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/obj/item/cigbutt,
+/obj/machinery/light/built,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/aft)
+"ltC" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "ltK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -56256,22 +55760,87 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"luB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/book/manual/wiki/engineering_construction{
+	pixel_y = 3
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"luK" = (
+/turf/open/floor/plasteel/airless{
+	icon_state = "floorscorched1"
+	},
+/area/space/nearstation)
 "lva" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"lvZ" = (
+/obj/structure/shuttle/engine/propulsion/burst/right,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "lwN" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"lwP" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/snacks/mint{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"lxg" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"lxF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "meetingblast";
+	name = "Meeting Room Blast Door"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "lzt" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line,
@@ -56281,16 +55850,14 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/science/circuit)
-"lAH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"lBf" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lBz" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -56308,21 +55875,31 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"lCo" = (
-/obj/machinery/light{
-	dir = 8
+"lDo" = (
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/screwdriver{
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
-"lGV" = (
-/obj/machinery/button/door{
-	id = "maintdiy";
-	name = "Shutters Control Button";
-	pixel_x = -6;
-	pixel_y = 24
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/maintenance/port/aft)
+"lFn" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/can,
+/obj/item/trash/energybar,
+/obj/item/trash/raisins,
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
+/area/maintenance/aft)
+"lGV" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/dice{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/toy/cards/deck/unum,
+/turf/open/floor/carpet/green,
+/area/hydroponics/garden)
 "lJC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -56332,68 +55909,125 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"lJI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "lKj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"lLn" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "lMg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"lNH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
+"lNs" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 27
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"lNH" = (
+/turf/closed/wall,
 /area/security/processing)
+"lOe" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/maintenance/bar)
 "lPr" = (
 /obj/item/kirbyplants{
 	icon_state = "applebush"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"lPJ" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"lQe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Gravity Generator - Foyer";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "lQG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/science/circuit)
 "lRb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lSa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
+"lUS" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"lUS" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"lZl" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"lYT" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/extinguisher,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/starboard/fore)
+"lZl" = (
+/obj/machinery/computer,
+/turf/open/floor/mineral/titanium/blue,
+/area/space/nearstation)
 "lZn" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
@@ -56407,86 +56041,87 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"lZs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "lZK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall,
-/area/crew_quarters/fitness/pool)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"lZL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/starboard/aft)
 "maT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"mbU" = (
-/obj/machinery/vr_sleeper{
+"mdr" = (
+/obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"mdH" = (
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/disposal/deliveryChute{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/crew_quarters/fitness)
-"mcp" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/security/range)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "meb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/bed,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "mfI" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"mgF" = (
-/obj/structure/bed,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+"mhN" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"miU" = (
+/obj/structure/table,
+/obj/item/paicard,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mjr" = (
-/obj/structure/reagent_dispensers/keg/milk,
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mkv" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"mkO" = (
-/obj/machinery/door/airlock{
-	name = "Shower Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/toilet)
-"mkU" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/rack,
+/obj/item/storage/belt{
+	desc = "Can hold quite a lot of stuff.";
+	name = "multi-belt"
 	},
 /turf/open/floor/plating,
-/area/security/processing)
+/area/maintenance/port/aft)
+"mkO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
+"mkU" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_home";
+	name = "fore bay 1";
+	roundstart_template = /datum/map_template/shuttle/labour/box;
+	width = 9
+	},
+/turf/open/space/basic,
+/area/space)
 "mml" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -56501,44 +56136,20 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"mnC" = (
-/obj/structure/target_stake,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/range)
+/area/security/brig)
 "mos" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -27;
-	prison_radio = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_x = -24;
-	pixel_y = -36
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/yellow,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "moD" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/bluecherrycupcake{
-	pixel_y = 5
-	},
+/obj/structure/table/wood/fancy,
+/obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "moS" = (
@@ -56552,25 +56163,67 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	icon_state = "roomnum";
+	name = "Room Number 1";
+	pixel_x = -30;
+	pixel_y = -7
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "mpI" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 1
 	},
-/area/maintenance/bar)
-"mqZ" = (
-/obj/item/reagent_containers/glass/beaker,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"mrR" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/wood,
+"mqZ" = (
+/obj/structure/rack,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil{
+	amount = 5
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
 /area/maintenance/bar)
+"mrs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/build{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mrR" = (
+/obj/machinery/computer/monitor{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"mtc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mvt" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -56578,6 +56231,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mvI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mwo" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "mxn" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -56588,60 +56256,98 @@
 /turf/open/floor/plating,
 /area/security/main)
 "myh" = (
-/obj/structure/musician/piano,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"mzB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/window,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/glass{
+	amount = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"mzB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"mzF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "mAH" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/aft)
+"mBO" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mCU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mHU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/light_construct{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mHY" = (
+/obj/structure/table/wood,
+/obj/item/folder/yellow,
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
+"mIj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "mIZ" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/security/prison)
 "mJo" = (
-/obj/structure/door_assembly/door_assembly_mai,
-/obj/item/electronics/airlock,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"mJG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/paper/crumpled,
+/turf/open/floor/mineral/titanium/blue,
+/area/space/nearstation)
+"mJq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
+"mJG" = (
+/obj/structure/closet/crate,
+/obj/item/stack/rods,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mNi" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -56658,18 +56364,11 @@
 	},
 /area/hallway/primary/starboard)
 "mOB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mOG" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -56677,32 +56376,19 @@
 /turf/closed/wall,
 /area/engine/atmos)
 "mPk" = (
-/obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm5";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/wood,
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "mPr" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/clothing/under/color/grey,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"mPE" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/wood,
+/area/maintenance/bar)
+"mPE" = (
+/turf/open/floor/plating,
 /area/maintenance/bar)
 "mQp" = (
 /obj/structure/cable{
@@ -56718,12 +56404,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "mQS" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mRe" = (
 /obj/machinery/light{
 	dir = 8
@@ -56731,100 +56414,118 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"mRQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+"mVo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"mTG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"mYt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mYJ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"naf" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "naI" = (
 /turf/open/space,
 /area/space/station_ruins)
-"nbT" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
+"nbw" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"nbM" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
-"nbY" = (
-/obj/item/melee/baton/cattleprod,
-/obj/item/stock_parts/cell/high,
-/obj/item/electropack,
-/obj/structure/closet/secure_closet{
-	name = "Persuasion Storage";
-	req_access = "list(2)"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/area/maintenance/starboard/fore)
 "ndq" = (
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "nez" = (
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nfm" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/structure/sign/warning{
+	name = "\improper KEEP CLEAR: HIGH SPEED DELIVERIES";
+	pixel_x = 32
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ngs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"ngU" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid,
-/obj/item/clothing/glasses/hud/health,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/table,
+/obj/item/flashlight/lamp,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port)
 "ngV" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/table,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"nhy" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
 "nhY" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
+/obj/structure/sink/kitchen{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink";
+	pixel_y = 28
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"niz" = (
+/obj/structure/tank_dispenser{
+	oxygentanks = 2;
+	plasmatanks = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/aft)
+"nki" = (
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
 "nkP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
+/obj/item/cigbutt,
+/obj/structure/ore_box,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"nln" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"nmI" = (
+/obj/structure/rack,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/item/clipboard,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/pen,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nmZ" = (
@@ -56840,11 +56541,6 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"nnp" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "noy" = (
 /obj/structure/sign/poster/contraband/smoke{
 	desc = "This poster reminds us all that the Detective is a parasite. Year after year, they must get replacement lungs because of their addiction. ";
@@ -56853,11 +56549,29 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "noF" = (
-/obj/machinery/door/airlock{
-	name = "Instrument Storage"
+/obj/item/seeds/watermelon,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"noY" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/port/aft)
+"nrL" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/fore)
+/area/engine/gravity_generator)
 "nss" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -56872,18 +56586,38 @@
 "nsA" = (
 /turf/closed/wall,
 /area/crew_quarters/abandoned_gambling_den)
-"nuw" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
+"nuv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
+/area/maintenance/port/aft)
+"nuw" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nuV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nwX" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nxv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/construction";
@@ -56895,27 +56629,22 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"nyE" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "nzR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"nBI" = (
-/obj/item/cigbutt/cigarbutt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"nEj" = (
-/obj/effect/spawner/structure/window/reinforced,
+"nCV" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/security/processing)
+/area/maintenance/port/aft)
 "nFj" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -56941,6 +56670,33 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nIq" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"nIB" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nJg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nJQ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
@@ -56949,36 +56705,29 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"nLk" = (
+/obj/machinery/door/airlock/command{
+	name = "Corporate Meeting Office";
+	req_access_txt = "19"
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "nLu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"nLw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nQi" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"nQR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "nRG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -56986,26 +56735,24 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nSt" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"nTG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/area/crew_quarters/fitness)
 "nTU" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Ports"
@@ -57018,26 +56765,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"nYe" = (
-/obj/structure/safe,
-/obj/item/clothing/head/bearpelt,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+"nWM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/item/gun/ballistic/revolver/nagant,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"nYe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/area/ai_monitored/turret_protected/ai)
 "nYT" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -57057,41 +56799,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"nZL" = (
-/obj/machinery/computer/arcade/minesweeper,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "oax" = (
 /obj/structure/table/wood/fancy,
-/obj/machinery/light,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 20
+/obj/effect/spawner/lootdrop{
+	loot = list(/obj/item/gun/ballistic/revolver/russian = 5, /obj/item/storage/box/syndie_kit/throwing_weapons, /obj/item/toy/cards/deck/syndicate = 2);
+	name = "gambling valuables spawner"
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/hardhat/cakehat,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oby" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = 20
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/interrogation{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -57101,60 +56834,70 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"ocv" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/boxing/yellow,
-/obj/item/clothing/gloves/boxing/green,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"odx" = (
-/obj/machinery/vending/kink,
-/turf/open/floor/plating,
-/area/maintenance/bar)
 "ofU" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/structure/chair/comfy/brown{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"ogp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ohq" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
+"ohs" = (
+/obj/structure/rack,
+/obj/item/radio/off,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"ohA" = (
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/multitool,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"oiX" = (
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
+"ojo" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hydroponics/garden";
+	dir = 1;
+	name = "Garden APC";
+	pixel_y = 24
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "okK" = (
-/obj/machinery/light/small{
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -27;
-	prison_radio = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -24;
-	pixel_y = -36
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/green,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"okW" = (
+/obj/structure/sign/warning{
+	name = "\improper KEEP CLEAR: HIGH SPEED DELIVERIES";
+	pixel_y = 32
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "old" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -57208,136 +56951,94 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet/locker)
-"oqj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
+"oqa" = (
+/obj/structure/table,
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/port/fore)
+"oqj" = (
+/obj/structure/table/wood,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"oqz" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "oqO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"ouQ" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/pen/fountain,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"ovv" = (
-/obj/structure/table,
+/area/maintenance/bar)
+"osT" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "meetingblast";
+	name = "Meeting Room Blast Door"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/recharger,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
+"ovv" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"owM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/maintenance/port/fore)
 "oxm" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/grass,
-/area/crew_quarters/bar)
-"oyl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/door/window/eastleft{
-	name = "Blue Corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+/area/maintenance/bar)
+"oyc" = (
+/obj/structure/closet,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "oyz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/closet/cardboard,
+/obj/item/storage/box,
+/obj/item/choice_beacon/box/plushie,
+/obj/item/storage/fancy/nugget_box,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oyN" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oyX" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air In"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"oAb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"ozq" = (
+/turf/open/floor/mech_bay_recharge_floor,
+/area/maintenance/bar)
+"oDf" = (
+/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = 32
 	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"oAB" = (
-/obj/structure/fireplace{
-	pixel_y = -6
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"oDm" = (
-/obj/machinery/gulag_teleporter,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "oDN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/structure/chair/stool,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/bar)
 "oEZ" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"oHB" = (
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/space/nearstation)
 "oHU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57348,60 +57049,71 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "oIW" = (
-/obj/structure/toilet/secret/low_loot{
-	dir = 8
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"oKh" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"oLl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light_switch{
-	pixel_y = -25
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"oNz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/area/crew_quarters/dorms)
+"oKh" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"oLl" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"oLy" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"oMF" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"oOl" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"oPb" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"oRV" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "oSl" = (
 /obj/machinery/door/airlock/security{
 	name = "Firing Range";
 	req_access_txt = "2"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"oSo" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/security/range)
+/area/bridge/meeting_room)
 "oTW" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oUh" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -57409,6 +57121,16 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oUt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "oVo" = (
 /obj/structure/pool/ladder,
 /turf/open/pool,
@@ -57424,15 +57146,41 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"oXR" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"oYL" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "oZl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet/wardrobe/pjs,
-/obj/item/clothing/under/rank/civilian/janitor/maid,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"oZJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"pcW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"pdB" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
 "pem" = (
 /obj/machinery/button/door{
 	desc = "Bolts the doors to the Private Study.";
@@ -57445,60 +57193,60 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"pfd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"pfo" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/bar)
 "pgf" = (
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"pgn" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air In"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/range)
-"pjg" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/area/crew_quarters/dorms)
 "pkF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
 	pixel_y = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "plC" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/closed/wall,
+/area/crew_quarters/theatre)
 "plS" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"pmY" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "poc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -57509,63 +57257,86 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "pou" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
+/obj/structure/chair/comfy/green{
+	dir = 4
 	},
+/turf/open/floor/carpet/green,
+/area/hydroponics/garden)
+"ppV" = (
+/obj/machinery/vending/kink,
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
+/area/maintenance/port/fore)
 "pqe" = (
-/obj/structure/chair/sofa,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "pqs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"psk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"pqJ" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"prA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"psk" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "pst" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"puh" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/area/ai_monitored/turret_protected/ai)
+"ptv" = (
+/obj/machinery/computer/station_alert{
+	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"ptS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"puh" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/turf/open/space/basic,
+/area/space)
+"pwM" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
-/area/crew_quarters/fitness)
-"pzk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pzG" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -57583,32 +57354,37 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "pAK" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/security/brig)
+"pBp" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"pBN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
-"pBp" = (
-/obj/effect/landmark/event_spawn,
-/turf/closed/wall,
-/area/crew_quarters/fitness)
+/area/engine/gravity_generator)
 "pCj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -57616,15 +57392,28 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"pDe" = (
-/obj/machinery/door/window/southright{
-	name = "Target Storage"
+"pEE" = (
+/obj/structure/sink/kitchen{
+	dir = 8;
+	name = "dusty sink";
+	pixel_x = 12
 	},
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/syndicate,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating,
-/area/security/range)
+/area/maintenance/port/aft)
+"pGi" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"pGr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pHl" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -57659,16 +57448,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pIf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
+/turf/open/floor/plating,
+/area/maintenance/port)
 "pJR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/comfy/brown{
@@ -57676,6 +57460,23 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"pKk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/rods{
+	amount = 23
+	},
+/obj/item/stack/cable_coil/white,
+/obj/item/flashlight/seclite,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"pKu" = (
+/obj/item/cigbutt,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -57683,60 +57484,102 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"pLq" = (
+/obj/machinery/door/airlock/maintenance/abandoned{
+	name = "Garden Maintenance";
+	req_access_txt = "12"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"pLt" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/solar/port/aft)
+"pOc" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -31
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"pPd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/maintenance/bar)
 "pPi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "pPI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"pQp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
+/area/maintenance/port/aft)
+"pQp" = (
+/turf/closed/wall,
 /area/crew_quarters/fitness)
 "pQr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet{
+	name = "Evidence Closet 3"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pQN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai)
 "pRs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/port/aft)
+"pSC" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"pSG" = (
+/obj/structure/closet{
+	name = "spare parts locker"
+	},
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/wood/twenty,
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "pTB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -57744,16 +57587,6 @@
 	},
 /turf/open/space,
 /area/solar/starboard/aft)
-"pUy" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "pUP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -57761,67 +57594,78 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"pYp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"qaL" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "qaY" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"qcm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"qeb" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/abandoned_gambling_den";
-	name = "Abandoned Gambling Den APC";
-	pixel_y = -24
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"qeA" = (
+/area/maintenance/port/aft)
+"qbI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Pool"
+/obj/machinery/door/airlock/maintenance/abandoned{
+	req_access_txt = "12"
 	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"qda" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
+/area/maintenance/bar)
+"qeb" = (
+/turf/open/floor/carpet/green,
+/area/hydroponics/garden)
+"qez" = (
+/obj/item/kirbyplants/random,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"qeA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "qeQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"qeZ" = (
+/obj/structure/rack,
+/obj/item/kitchen/knife,
+/obj/item/storage/box/donkpockets,
+/obj/item/stack/packageWrap,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qfk" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/window,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "qfD" = (
@@ -57833,6 +57677,19 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/wood,
 /area/library)
+"qim" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "qje" = (
 /obj/structure/sign/mining{
 	pixel_y = 7
@@ -57844,117 +57701,228 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qqs" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/sink{
-	pixel_y = 25
+"qnr" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
-"qus" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/cheesynachos{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"quT" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
 /area/space/nearstation)
-"qvf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"qpx" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/solar{
+	id = "portsolar";
+	name = "Port Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
+"qrv" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
+"qrY" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"qtl" = (
+/obj/item/clothing/under/color/rainbow,
+/obj/item/clothing/under/color/jumpskirt/rainbow,
+/obj/item/clothing/shoes/sneakers/rainbow,
+/obj/item/clothing/shoes/sneakers/rainbow,
+/obj/item/clothing/gloves/color/rainbow,
+/obj/item/clothing/gloves/color/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/obj/item/dualsaber/hypereutactic/toy/rainbow,
+/obj/item/dualsaber/hypereutactic/toy/rainbow,
+/obj/item/toy/tennis/rainbow,
+/obj/item/toy/tennis/rainbow,
+/obj/item/bedsheet/rainbow,
+/obj/structure/bed,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"qtm" = (
+/obj/structure/grille,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"qtE" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"qus" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
+"qvb" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/camera{
+	c_tag = "Solar Control - Port Quarter";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"qvf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"qxC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table_frame,
+/obj/item/wirerod,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"qyj" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"qEz" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"qyj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/fore)
-"qBi" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/captain)
+/area/maintenance/bar)
+"qGl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "qIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
-"qJr" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-4"
+"qIA" = (
+/obj/machinery/computer/arcade{
+	dir = 4
 	},
-/turf/open/space,
-/area/solar/port/aft)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"qJr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "qJV" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "qLR" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air Out"
 	},
-/obj/structure/sink{
-	pixel_y = 25
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/light/small{
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
+"qOe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/chapel/main)
+"qOQ" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
+"qOZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"qOc" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/camera{
-	c_tag = "VR Sleepers";
-	dir = 1
+	c_tag = "Engineering - Gravity Generator - Main"
 	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/fitness)
-"qOB" = (
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"qPv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"qTG" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"qTG" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port)
 "qTV" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"qVA" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
 "qVP" = (
-/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "qWV" = (
@@ -57967,37 +57935,39 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qYl" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/black,
+/obj/item/watertank,
+/obj/item/clothing/glasses/meson/engine/tray,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"qYA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/rack,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/crowbar/red,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"qZj" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"rcI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
-/obj/item/radio/headset{
-	desc = "An updated, modular intercom that fits over the head. Takes encryption keys. It looks like it has been modified to not broadcast.";
-	name = "prisoner headset";
-	prison_radio = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "rdl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -58014,37 +57984,40 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "reA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/vending/games,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/maintenance/port/aft)
 "rgL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/dorms)
-"rhX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
+"riz" = (
+/obj/machinery/door/airlock/maintenance/abandoned{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rjQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"rkz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/bridge/meeting_room)
+"rlq" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rmN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
 	},
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rmQ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line{
@@ -58054,24 +58027,21 @@
 /area/engine/atmos)
 "rmX" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/beer,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"rnt" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/item/gps/mining{
+	gpstag = "добывать0"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
-"rnK" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
-	},
-/turf/open/space/basic,
+/turf/open/floor/mineral/titanium/blue,
 /area/space/nearstation)
+"rnt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/hop)
+"rnK" = (
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rqf" = (
 /obj/machinery/light{
 	dir = 1
@@ -58081,17 +58051,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rqk" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "rqE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -58099,53 +58058,32 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rqW" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/structure/dresser,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 8;
-	name = "Theatre APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
+/area/maintenance/port/aft)
 "rrM" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/camera{
+	c_tag = "Dorms - Fitness Room - Fore";
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/under/dress/sundress,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "rtl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"rts" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator - Fore"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"rtC" = (
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
 "rtU" = (
-/mob/living/simple_animal/opossum,
+/obj/item/seeds/sunflower/moonflower,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
 "ruo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58159,22 +58097,20 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"rus" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rvr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
 	},
-/obj/structure/chair{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "rvS" = (
 /obj/structure/chair/comfy/brown{
 	color = "#66b266";
@@ -58182,56 +58118,85 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rxn" = (
+/obj/structure/lattice,
+/obj/structure/closet,
+/obj/item/airlock_painter/decal,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ryr" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/food/drinks/beer{
+	pixel_x = -3;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"rAR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
+/obj/item/reagent_containers/food/drinks/ale,
+/obj/item/instrument/saxophone,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"ryU" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
+"rAn" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/aft)
+"rAR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security{
+	name = "Labor Shuttle";
+	req_access_txt = "2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/processing)
 "rBq" = (
-/obj/item/clothing/head/kitty,
-/obj/item/clothing/under/costume/maid,
-/obj/item/clothing/mask/muzzle,
+/obj/machinery/power/smes,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"rBs" = (
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 8;
+	name = "Ports to Distro"
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "rCl" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/security/brig)
+"rDC" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
+"rFy" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "rGq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -58243,30 +58208,51 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rHv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rIA" = (
-/obj/machinery/light{
-	dir = 8
+/obj/item/seeds/berry,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"rIE" = (
+/obj/structure/table,
+/obj/item/taperecorder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/maintenance/port/aft)
+"rIH" = (
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"rIS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
+/area/maintenance/port/aft)
 "rJv" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
-"rJw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/port/fore)
+"rKj" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -58274,12 +58260,13 @@
 /turf/open/floor/plating,
 /area/construction)
 "rMN" = (
-/obj/structure/bed,
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath,
-/obj/effect/decal/cleanable/semen,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/plating,
+/obj/structure/table/wood/poker,
+/obj/item/dice/d20,
+/obj/item/dice,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "rNc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -58300,17 +58287,18 @@
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
 "rPU" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rQJ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"rTg" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/chips,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rTo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -58319,20 +58307,48 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rTu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Command Access To Vault";
-	req_access = "19"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hop)
 "rTD" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/ai_monitored/turret_protected/ai";
+	name = "AI Chamber APC";
+	pixel_y = 24
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Command - AI Chamber - Aft";
+	network = list("aicore")
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"rUu" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/snacks/meat/slab/human{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"rUv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"rVw" = (
+/obj/machinery/computer/slot_machine,
+/obj/item/coin/antagtoken,
+/obj/item/coin/diamond,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rVN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -58346,16 +58362,11 @@
 	},
 /area/engine/atmos)
 "rXl" = (
-/obj/structure/chair/office/light,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/computer/arcade{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "saK" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -58368,30 +58379,33 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"saO" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "saU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "saX" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/grass,
 /area/security/prison)
 "sci" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/turf/open/floor/plating,
 /area/crew_quarters/fitness)
 "seP" = (
 /obj/structure/cable{
@@ -58410,10 +58424,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
-"sfs" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "shR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -58439,29 +58449,51 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"sqg" = (
-/obj/structure/table/wood,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/shoes/sneakers/white,
+"smW" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"snc" = (
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"sqp" = (
+/area/maintenance/solars/port/aft)
+"spC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command{
-	name = "Captain's Vault Access";
-	req_access_txt = "20"
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"spD" = (
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"srG" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/item/stack/sheet/cardboard,
+/obj/item/grenade/empgrenade,
+/obj/item/toy/cards/deck/syndicate,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"sqr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "meetingblast";
+	name = "Meeting Room Blast Door"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
+/area/bridge/meeting_room)
+"srG" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ssB" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -58474,21 +58506,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"sth" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
 "str" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Pool"
 	},
-/turf/closed/wall,
-/area/crew_quarters/fitness/pool)
-"stF" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/toy/poolnoodle/yellow,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
+"svZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sxs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
@@ -58502,62 +58537,70 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"syf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
 "syJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/vending_refill/snack,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"szl" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "szG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/item/stock_parts/scanning_module,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "sAk" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sAM" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/bar)
-"sEi" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
-"sEt" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/bar)
-"sEM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
+/area/maintenance/bar)
+"sEt" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/wiki/engineering_construction{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"sEM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "sFW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58574,6 +58617,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"sGA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"sGZ" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "sHx" = (
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people{
@@ -58586,6 +58642,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"sJv" = (
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "sJx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -58593,34 +58652,26 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "sJI" = (
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 9
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix Outlet Pump"
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 9
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"sLa" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/area/maintenance/port/aft)
+"sJJ" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"sKb" = (
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
 	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"sLa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -58631,25 +58682,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sLv" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/mineral/titanium/blue,
+/area/space/nearstation)
 "sNK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/area/maintenance/bar)
 "sOs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "sOA" = (
@@ -58661,20 +58700,36 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"sPT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+"sON" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/maintenance/port/aft)
+"sPw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "sPY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "sRH" = (
 /obj/machinery/autolathe/secure{
 	name = "public autolathe"
@@ -58682,13 +58737,21 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "sRT" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sSW" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"sUb" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
 "sWR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58698,6 +58761,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"sWZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/clipboard,
+/obj/item/folder,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "sXy" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -58709,16 +58781,26 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "sXA" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/wall,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/maintenance/bar)
-"sXV" = (
-/turf/closed/wall/r_wall,
-/area/security/range)
 "sYm" = (
 /obj/effect/turf_decal/vg_decals/atmos/mix,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
+"sYr" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"sYA" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/toggle/owlwings,
+/obj/item/clothing/mask/gas/owl_mask,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "sYR" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -58730,10 +58812,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"tgH" = (
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
+"tan" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/crew_quarters/abandoned_gambling_den)
+"tdR" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"thu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "thB" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
@@ -58741,12 +58838,17 @@
 /turf/open/space,
 /area/space)
 "tif" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"tjt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tkq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58765,28 +58867,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "tkU" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/turf/open/floor/plasteel,
 /area/maintenance/bar)
-"tmO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+"tnB" = (
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/item/seeds/berry,
 /turf/open/floor/plating,
-/area/security/range)
-"tqg" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
+/area/maintenance/port/fore)
 "tqB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -58800,67 +58893,84 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ttL" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tur" = (
-/obj/item/restraints/handcuffs/fake,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"tvi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"tyX" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"tzQ" = (
-/obj/machinery/shower{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/soap,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/port/aft)
+"tvs" = (
+/obj/structure/closet/crate,
+/obj/item/stack/ore/gold,
+/obj/item/stack/ore/silver,
 /turf/open/floor/mineral/titanium/blue,
+/area/space/nearstation)
+"txC" = (
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
+	},
+/obj/item/seeds/ambrosia,
+/obj/item/seeds/ambrosia,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"tyX" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/start/cyborg,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
+"tza" = (
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"tzM" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"tzQ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
 /area/crew_quarters/dorms)
 "tAC" = (
-/obj/structure/closet/athletic_mixed,
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/blue,
-/obj/item/toy/poolnoodle/yellow,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/stack/medical/mesh{
+	pixel_x = 6
+	},
+/obj/item/stack/medical/suture{
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "tAH" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"tCa" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar{
-	pixel_x = -7
-	},
-/obj/item/instrument/eguitar{
-	pixel_x = 5
-	},
-/obj/item/instrument/violin,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+"tBK" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "tCd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -58873,18 +58983,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tEK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/turf/open/floor/plating/airless,
+/area/maintenance/port/aft)
 "tHh" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/red,
@@ -58898,41 +58999,20 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tJi" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/structure/closet/crate/wooden/toy,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = -32
-	},
-/obj/item/megaphone/clown,
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
-"tJK" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"tJS" = (
-/obj/effect/spawner/lootdrop/keg,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port)
+"tJu" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"tJS" = (
+/obj/machinery/jukebox,
+/turf/open/floor/carpet/green,
+/area/hydroponics/garden)
 "tKb" = (
 /obj/item/radio/intercom{
 	pixel_y = 20
@@ -58946,28 +59026,27 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	icon_state = "roomnum";
-	name = "Room Number 1";
-	pixel_x = -30;
-	pixel_y = -7
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"tLQ" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "tMl" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"tNF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"tNb" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "tOq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -58975,25 +59054,28 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "tPT" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
 /area/maintenance/bar)
 "tRe" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tRB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/port/aft)
 "tRF" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/computer/atmos_alert{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/maintenance/bar)
 "tSo" = (
 /obj/structure/lattice,
@@ -59003,11 +59085,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tWj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/area/maintenance/bar)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -59015,49 +59097,35 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "tZe" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/official/pda_ad{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/ore_silo,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/nuke_storage)
 "uaw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/bar";
-	dir = 1;
-	name = "Maint bar";
-	pixel_y = 24
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Auxiliary Power";
+	req_access_txt = "10"
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"ubj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/window/westright{
-	name = "Red Corner"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"ucq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"ucq" = (
-/obj/structure/sign/poster/contraband/red_rum{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "udT" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/plasteel,
@@ -59075,26 +59143,24 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/camera{
-	c_tag = "Atmospherics Central";
+	c_tag = "Atmospherics - Main - Central";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ufD" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/disposal/bin,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ugp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
@@ -59102,22 +59168,33 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ugu" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/item/coin/silver,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uhm" = (
 /obj/machinery/door/airlock{
 	name = "Recharging Station"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"uhJ" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ujv" = (
-/obj/structure/sign/departments/restroom,
-/turf/closed/wall,
-/area/crew_quarters/toilet)
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "ujF" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -59125,33 +59202,40 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
 "ujS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
-"ulM" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/item/toy/poolnoodle/red,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "unA" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table,
+/obj/item/electronics/apc{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
+/obj/item/electronics/apc,
+/obj/item/stock_parts/manipulator,
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "unR" = (
-/turf/open/floor/plasteel/yellowsiding{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "uoB" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool,
 /obj/item/screwdriver,
 /obj/machinery/camera{
-	c_tag = "Circuitry Lab North";
+	c_tag = "Science - Circuitry Lab - Fore";
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
@@ -59168,90 +59252,159 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"usE" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"usO" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"uua" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"uuG" = (
+"uqg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/solar/port/aft)
+"urN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/glass,
+/obj/item/trash/tray,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/starboard/aft)
+"usu" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"usO" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/five,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"utX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"uua" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/bar)
+"uuq" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
+"uuG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uve" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/watermelon,
+/obj/item/reagent_containers/food/snacks/grown/watermelon,
+/obj/item/reagent_containers/food/snacks/grown/watermelon,
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/cocoapod,
+/obj/structure/rack,
+/obj/item/seeds/wheat,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/grape,
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/cannabis/rainbow,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"uvZ" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"uxY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/junction,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"uzs" = (
-/turf/open/floor/plasteel/yellowsiding{
+/area/maintenance/port/fore)
+"uvQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/area/crew_quarters/fitness/pool)
-"uAH" = (
-/turf/open/floor/plasteel/yellowsiding/corner{
-	dir = 8
-	},
-/area/crew_quarters/fitness/pool)
-"uBa" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"uvZ" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
 	pixel_x = -3;
-	pixel_y = 2
+	pixel_y = 3
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"uCo" = (
-/obj/structure/chair{
+/obj/item/storage/toolbox/electrical,
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"uCU" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation";
-	req_access_txt = "2"
+/area/maintenance/bar)
+"uxY" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"uzH" = (
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/assembly/timer{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cartridge/signal,
+/turf/open/floor/plasteel/white,
+/area/maintenance/port/aft)
+"uBa" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/multitool,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"uBu" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"uCd" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"uCU" = (
+/turf/closed/wall/r_wall,
+/area/security/processing)
+"uDs" = (
+/obj/item/clothing/under/rank/civilian/janitor/maid,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "uDO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -59259,6 +59412,15 @@
 	},
 /turf/open/space,
 /area/solar/port/fore)
+"uEq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uEx" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "PoolShut";
@@ -59283,14 +59445,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "uFZ" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light{
-	light_color = "#cee5d2"
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/processing)
 "uGI" = (
 /turf/open/floor/grass,
@@ -59319,9 +59475,6 @@
 /area/security/main)
 "uIO" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59334,11 +59487,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "uJx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/bar)
+"uKt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "uNu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59349,24 +59508,60 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"uOJ" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/vault,
-/obj/structure/cable{
-	icon_state = "1-2"
+"uNv" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"uOo" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"uOJ" = (
+/obj/effect/landmark/start/ai,
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = 24
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 27;
+	pixel_y = 5
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = -27;
+	pixel_y = 5
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 20;
+	pixel_y = -8
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = -28;
+	pixel_y = 32
+	},
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = 28;
+	pixel_y = 28
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "uQR" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -59376,29 +59571,25 @@
 /area/engine/atmos)
 "uQS" = (
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
 "uRd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/sign/poster/official/wtf_is_co2{
+	pixel_y = 32
 	},
-/obj/machinery/power/terminal,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "uRS" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
+/obj/structure/door_assembly/door_assembly_mai,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uSC" = (
 /obj/machinery/pool/drain,
 /turf/open/pool,
@@ -59410,12 +59601,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"uUi" = (
-/obj/effect/decal/cleanable/vomit,
+"uTi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uTP" = (
+/obj/structure/table,
+/obj/item/storage/box/matches,
+/obj/item/storage/fancy/cigarettes{
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/maintenance/port/aft)
+"uVL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uVS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59428,10 +59633,39 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uXk" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "uXt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"uYe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"uZI" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "vae" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59439,21 +59673,19 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "vbi" = (
-/obj/structure/table,
-/obj/item/instrument/guitar{
-	pixel_x = -7
-	},
-/obj/item/instrument/eguitar{
-	pixel_x = 5
-	},
-/obj/item/instrument/violin,
-/obj/item/instrument/trombone,
-/obj/item/instrument/saxophone,
-/obj/item/instrument/piano_synth,
-/obj/item/instrument/recorder,
-/obj/item/instrument/accordion,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/port/fore)
+"vbt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "vbD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -59466,20 +59698,20 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "vcN" = (
-/obj/machinery/light{
+/obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"vda" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/range)
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"vda" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vdu" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -59489,77 +59721,120 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "veS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Pool"
 	},
-/turf/closed/wall,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness/pool)
 "vfX" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"vgJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"vhs" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/fore";
-	dir = 1;
-	name = "Fore Maintenance APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"vhb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/area/maintenance/port/aft)
+"viq" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/glowstick{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/locker)
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "viF" = (
-/obj/structure/table/wood,
-/obj/item/instrument/trumpet,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"vjm" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/rag,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/bar";
+	name = "Maintenance Bar APC";
+	pixel_y = -24
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"vmQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+"viU" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"vnI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"viX" = (
+/obj/item/electropack/shockcollar,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"vjm" = (
+/obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"vkd" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
+"vkV" = (
+/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"vlE" = (
+/obj/item/reagent_containers/glass/beaker,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"vmJ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/item/cigbutt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"vmQ" = (
+/turf/open/floor/plating/airless,
+/area/hydroponics/garden)
+"vnq" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/under/color/lightpurple,
+/obj/effect/spawner/lootdrop/space_cash,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"vnI" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
 	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
@@ -59567,39 +59842,58 @@
 	pixel_x = 26
 	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vob" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/maintenance/bar)
 "voW" = (
 /obj/structure/pool/Lboard,
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
 "vpY" = (
-/obj/structure/closet/lasertag/blue,
-/obj/item/clothing/under/misc/pj/blue,
-/obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"vqP" = (
-/obj/structure/bed/dogbed{
-	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.";
-	name = "pet bed"
+/obj/machinery/vending/cigarette,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"vqP" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"vsM" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
+"vrv" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"vsC" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "vsT" = (
 /obj/structure/closet/crate,
 /obj/item/book/manual/wiki/telescience,
@@ -59627,38 +59921,53 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"vww" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "vxh" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vxX" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+"vxk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/security/processing)
+/area/maintenance/port/aft)
 "vyp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "vyK" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/security/brig)
+"vyQ" = (
+/turf/open/floor/plasteel/airless{
+	icon_state = "damaged1"
+	},
+/area/space/nearstation)
+"vzm" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vzp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -59670,38 +59979,69 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "vzO" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/wood,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
 /area/maintenance/bar)
+"vzS" = (
+/obj/structure/rack,
+/obj/item/weldingtool,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vAl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
-	c_tag = "Pool East";
+	c_tag = "Dorms - Pool - Starboard";
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
-"vBa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
+"vAA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/starboard/aft)
 "vCb" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "vCn" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/landmark/start/ai/secondary,
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = -30
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = -27;
+	pixel_y = -10
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = 27;
+	pixel_y = -10
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 8
+	},
+/obj/machinery/door/window/northleft{
+	name = "Secondary AI Core";
+	pixel_y = 4;
+	req_access_txt = "16"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "vCt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
@@ -59744,48 +60084,41 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "vFr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"vGn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"vHj" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cryogenics "
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopod)
-"vHz" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"vGn" = (
+/obj/structure/sign/warning/docking,
+/turf/closed/wall,
+/area/security/processing)
+"vGO" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"vHz" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
 /obj/machinery/light/small{
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/maintenance/bar)
 "vHT" = (
-/obj/machinery/door/firedoor,
 /obj/structure/sign/departments/evac{
 	pixel_y = -32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -59793,23 +60126,17 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "vIi" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/camera{
+	c_tag = "Security - Interrogation";
+	dir = 8;
+	network = list("interrogation")
 	},
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/range";
 	dir = 4;
-	name = "Firing Range APC";
-	pixel_x = 24
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel,
-/area/security/range)
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "vIo" = (
 /obj/machinery/light{
 	dir = 4;
@@ -59826,7 +60153,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Brig East";
+	c_tag = "Security - Brig - Starboard";
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -59835,32 +60162,18 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vJu" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"vLo" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/machinery/light/small{
-	dir = 1
+"vJY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"vOC" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "vOU" = (
-/obj/structure/sign/warning/securearea,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
+/turf/closed/wall,
+/area/ai_monitored/turret_protected/ai)
 "vOV" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -59882,6 +60195,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"vPF" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Port"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vPQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -59900,16 +60220,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"vTP" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2"
+"vQs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/processing)
+/area/engine/gravity_generator)
+"vXz" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/item/analyzer,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "vZA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -59922,11 +60257,21 @@
 /turf/open/floor/wood,
 /area/library)
 "wag" = (
-/obj/structure/chair/comfy/black{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
+"wan" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"wbg" = (
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "wbE" = (
 /obj/effect/turf_decal/tile/blue{
 	alpha = 255
@@ -59953,45 +60298,46 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "wcR" = (
-/turf/open/floor/plasteel/yellowsiding/corner,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
-"wdr" = (
-/obj/machinery/door/window/southleft{
-	name = "Target Storage"
-	},
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target,
-/obj/item/target,
-/turf/open/floor/plating,
-/area/security/range)
 "wdv" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
 /area/space)
 "weM" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"wfR" = (
-/obj/item/electropack/shockcollar,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"wig" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
-"wje" = (
-/obj/structure/rack,
-/obj/item/instrument/banjo,
-/obj/item/instrument/harmonica,
-/obj/item/instrument/accordion,
-/obj/item/instrument/recorder,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"wfR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"wgA" = (
+/obj/structure/table/bronze,
+/obj/item/crowbar/bronze,
+/obj/item/reagent_containers/food/drinks/bottle/cognac,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/starboard/fore)
+"wig" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
 "wkN" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -60009,12 +60355,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"woR" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
+"wpa" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "wph" = (
 /obj/docking_port/stationary{
 	area_type = /area/construction/mining/aux_base;
@@ -60030,29 +60376,25 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "wql" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
-"wqF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/comfy/brown{
+/obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/machinery/status_display/ai{
+	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"wqm" = (
+/obj/structure/table/wood,
+/obj/item/instrument/saxophone,
+/obj/item/flashlight/lantern{
+	icon_state = "lantern-on"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/turf/open/floor/grass,
+/area/hydroponics/garden)
 "wrp" = (
 /obj/machinery/light{
 	dir = 8
@@ -60060,6 +60402,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "wvg" = (
@@ -60076,14 +60419,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "wxT" = (
-/obj/structure/chair/sofa/left,
-/obj/structure/window{
-	dir = 1
-	},
+/obj/structure/window/reinforced,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "wyE" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Dormitories Maintenance";
+	req_access_txt = "12"
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -60095,11 +60439,44 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"wEa" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"wFu" = (
+/obj/item/storage/box/monkeycubes,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"wFA" = (
+/obj/structure/table,
+/obj/item/kitchen/rollingpin,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/reagent_containers/food/condiment/sugar,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"wFF" = (
+/obj/structure/mineral_door/woodrustic{
+	name = "Garden"
+	},
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"wFG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "wHk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/structure/bed,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "wHz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60107,18 +60484,80 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"wHI" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "wHT" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wJP" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
 "wKe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "maintdiy";
-	name = "Security Shutters"
+/obj/machinery/hydroponics/soil{
+	pixel_y = 8
+	},
+/obj/item/seeds/glowshroom,
+/obj/item/seeds/cannabis/ultimate,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"wKh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"wMk" = (
+/obj/machinery/button/door{
+	id = "meetingblast";
+	name = "Meeting Blast Doors";
+	pixel_x = -26
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"wON" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"wPp" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/solar{
+	id = "portsolar";
+	name = "Port Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
+"wPw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
+/area/maintenance/port/aft)
 "wQg" = (
 /obj/structure/pool/ladder{
 	dir = 2;
@@ -60126,15 +60565,6 @@
 	},
 /turf/open/pool,
 /area/crew_quarters/fitness/pool)
-"wTf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "wTk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -60142,25 +60572,20 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "wUg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wUr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/bar)
 "wUY" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -60168,6 +60593,13 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"wVF" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/solar/port/aft)
 "wWi" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -60184,21 +60616,20 @@
 /area/science/robotics/lab)
 "wWW" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/item/toy/poolnoodle/yellow,
-/obj/machinery/button/door{
-	id = "PoolShut";
-	name = "Pool Shutters";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "wXl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
-	c_tag = "Pool West";
+	c_tag = "Dorms - Pool - Port";
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "wYc" = (
 /obj/machinery/vr_sleeper{
@@ -60206,50 +60637,52 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wYQ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"wZc" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = -26
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "wZI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"xal" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "xaB" = (
-/obj/structure/closet/athletic_mixed,
-/obj/item/toy/poolnoodle/red,
-/obj/item/toy/poolnoodle/blue,
-/obj/item/toy/poolnoodle/yellow,
-/obj/machinery/button/door{
-	id = "PoolShut";
-	name = "Pool Shutters";
-	pixel_y = 24
-	},
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/pool)
-"xbn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/structure/table,
-/obj/item/coin/gold,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/fitness/pool)
+"xbn" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/maintenance/bar)
 "xcl" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -60257,6 +60690,27 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"xcp" = (
+/obj/structure/rack,
+/obj/item/stock_parts/micro_laser,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"xdl" = (
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xed" = (
+/obj/structure/closet/crate,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xgk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60269,48 +60723,48 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xgm" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xgC" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/gravity_generator";
-	dir = 8;
-	name = "Gravity Generator APC";
-	pixel_x = -25;
-	pixel_y = 1
-	},
-/obj/structure/table,
-/obj/item/paper/guides/jobs/engi/gravity_gen,
-/obj/item/pen/blue,
 /obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/bar)
+"xgF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"xgF" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
+/area/maintenance/bar)
+"xhl" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xhS" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
 	},
 /area/maintenance/bar)
-"xhS" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "xhV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60320,6 +60774,16 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"xhW" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/structure/table,
+/obj/item/paper/guides/jobs/engi/gravity_gen,
+/obj/item/pen/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "xib" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -60344,20 +60808,31 @@
 	dir = 4;
 	light_color = "#d8b1b1"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"xmo" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/structure/table,
+/obj/item/stack/medical/mesh{
+	pixel_x = 3;
+	pixel_y = -2
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/item/stack/medical/suture{
+	pixel_x = -3;
+	pixel_y = 2
 	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"xkI" = (
+/obj/structure/ore_box,
+/turf/open/floor/mineral/titanium/blue,
+/area/space/nearstation)
+"xmc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/turf/open/floor/grass,
+/area/hydroponics/garden)
+"xmo" = (
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xmS" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -60369,11 +60844,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/closed/wall/r_wall,
+/area/security/processing)
 "xqG" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar,
@@ -60381,69 +60853,80 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = -3;
-	pixel_y = 5
-	},
+/obj/item/reagent_containers/food/snacks/fries,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"xrN" = (
+"xqH" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
+"xsB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"xsO" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Port Quarter Solar Access";
+	req_access_txt = "10"
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"xtP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
+"xtI" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/aft)
+"xtP" = (
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xud" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "xxi" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xzv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"xxp" = (
-/turf/open/floor/plating,
-/area/security/range)
-"xzv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xAk" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/light_construct{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "xAv" = (
@@ -60452,6 +60935,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"xAI" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "xBk" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60468,33 +60964,51 @@
 /obj/item/radio/headset/headset_cargo,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"xDM" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room South";
+"xCt" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"xCO" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xDj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"xEB" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/nuke_storage";
-	dir = 1;
-	name = "Vault APC";
-	pixel_y = 25
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"xEb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"xEv" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/stock_parts/micro_laser,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xEB" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai)
 "xEE" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -60502,6 +61016,14 @@
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/carpet,
 /area/library)
+"xFf" = (
+/obj/machinery/door/airlock/titanium{
+	desc = "From another era.";
+	name = "Dusty Shuttle Airlock"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "xGQ" = (
 /obj/structure/sign/plaques/golden{
 	pixel_y = 32
@@ -60516,11 +61038,24 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
+"xHD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"xHP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "xIa" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/maintenance/starboard/aft)
 "xJC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -60544,6 +61079,18 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"xKg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet,
+/obj/item/storage/box/lights/mixed,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xLX" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/marker_beacon{
@@ -60565,26 +61112,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xPk" = (
-/obj/structure/bed,
 /obj/machinery/button/door{
-	id = "Dorm6";
+	id = "Dorm4";
 	name = "Cabin Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/dresser,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "xPY" = (
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/instrument/trombone,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xSW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -60595,11 +61137,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "xTe" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -60612,36 +61154,25 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "xTy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"xUe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/prison)
-"xUn" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space,
-/area/space/station_ruins)
+/area/space/nearstation)
 "xUL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/showcase/cyborg/old{
+	dir = 4;
+	pixel_x = -4;
+	pixel_y = 2
 	},
-/obj/machinery/light,
-/obj/machinery/camera/motion{
-	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
+/area/ai_monitored/turret_protected/ai)
 "xUX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -60663,29 +61194,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"xWq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "xXi" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"xZD" = (
-/obj/structure/closet/lasertag/red,
-/obj/item/clothing/under/misc/pj/red,
-/obj/item/clothing/under/misc/pj/red,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"xZL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xYm" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"xZD" = (
+/obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/bridge/meeting_room";
+	dir = 1;
+	name = "Meeting Room APC";
+	pixel_x = 26
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"xZL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/fitness/pool)
 "yan" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -60695,6 +61231,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"yay" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ycd" = (
 /obj/structure/toilet/secret/low_loot{
 	dir = 4
@@ -60728,19 +61271,23 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_x = 32
+	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#d1dfff"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"yds" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Security - Docking";
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/turf/open/floor/plasteel,
+/area/security/processing)
 "ydD" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/rd,
@@ -60763,10 +61310,8 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "yhz" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai)
 
 (1,1,1) = {"
 cNd
@@ -64714,62 +65259,62 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -64971,62 +65516,62 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -65228,62 +65773,62 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -65485,62 +66030,62 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -65742,66 +66287,66 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -65993,6 +66538,8 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -66043,22 +66590,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -66250,6 +66795,8 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -66300,22 +66847,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -66507,6 +67052,8 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -66557,22 +67104,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -66764,8 +67309,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -66805,7 +67350,6 @@ aaa
 aaa
 aaa
 aaa
-gDl
 aaa
 aaa
 aaa
@@ -66817,19 +67361,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -67021,8 +67566,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -67073,20 +67618,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -67278,8 +67823,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -67330,20 +67875,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -67535,8 +68080,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -67587,20 +68132,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -67792,8 +68337,8 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -67844,20 +68389,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -68049,6 +68594,8 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -68059,9 +68606,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+gDl
 aaa
 aaa
 aaa
@@ -68095,32 +68640,32 @@ aaa
 aaa
 aaa
 aaa
-aae
+aoV
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -68298,6 +68843,16 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -68311,31 +68866,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-gXs
-aaa
-aaa
-aaa
-gXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aoV
 aaa
 gXs
 aaa
@@ -68351,6 +68882,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaa
+aaa
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -68359,6 +68895,7 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
 aaa
 aaa
@@ -68366,18 +68903,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -68555,16 +69100,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -68615,26 +69160,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -68812,16 +69357,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -68872,34 +69417,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -69069,16 +69614,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -69129,34 +69674,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -69326,16 +69871,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -69386,34 +69931,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -69583,16 +70128,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -69643,34 +70188,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -69840,16 +70385,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -69900,34 +70445,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -70097,16 +70642,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -70139,7 +70684,7 @@ awW
 awW
 awW
 aQG
-aRX
+vkd
 arB
 aaa
 aaa
@@ -70147,7 +70692,7 @@ aaa
 aaa
 aaa
 arB
-awZ
+qrv
 ayk
 awW
 aAD
@@ -70157,34 +70702,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -70354,16 +70899,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -70414,34 +70959,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -70611,16 +71156,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -70671,34 +71216,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -70868,16 +71413,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -70928,34 +71473,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -71125,16 +71670,16 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -71185,34 +71730,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -71370,28 +71915,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -71442,34 +71987,34 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -71627,28 +72172,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -71699,60 +72244,60 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -71884,28 +72429,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -71957,6 +72502,7 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
 aaa
 aaa
@@ -71990,6 +72536,7 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
 aaa
 aaa
@@ -72006,10 +72553,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -72141,28 +72686,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -72224,6 +72769,19 @@ aaa
 aaa
 aaa
 aaa
+gDl
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gDl
 aaa
 aaa
 aaa
@@ -72252,21 +72810,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -72398,28 +72943,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -72522,8 +73067,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -72655,28 +73200,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -72774,13 +73319,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aae
-aaa
+gDl
 aaa
 aaa
 aaa
 aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -72912,28 +73457,28 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -73000,6 +73545,32 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaS
+aaS
+aaS
+aaS
+aaS
 aaa
 aaa
 aaa
@@ -73010,34 +73581,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -73163,35 +73708,35 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+gDl
 aaa
 aaa
 aaa
@@ -73256,6 +73801,33 @@ aaa
 aaa
 aaa
 aaa
+gXs
+gXs
+gXs
+gXs
+gXs
+aaa
+aaa
+aaa
+aaa
+gXs
+gXs
+aaa
+nfm
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaS
+aaa
+aaf
+aaa
+aaS
 aaa
 aaa
 aaa
@@ -73266,35 +73838,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -73420,34 +73965,34 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -73460,7 +74005,7 @@ aaf
 aaf
 aaf
 alU
-atJ
+uBu
 amC
 aKf
 bEJ
@@ -73505,6 +74050,41 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gXs
+aaH
+aaH
+aaH
+gXs
+aaa
+aaa
+aaa
+aaa
+gXs
+kic
+kSv
+ctv
+gXs
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaS
+aaf
+wVF
+aaf
+aaS
 aaa
 aaa
 aaa
@@ -73515,43 +74095,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -73677,6 +74222,12 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -73704,12 +74255,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
 aaa
 aaa
 aag
@@ -73717,7 +74262,7 @@ alU
 alU
 alU
 alU
-aCW
+vbi
 amC
 asK
 alU
@@ -73754,67 +74299,67 @@ beO
 beO
 beO
 beO
+bZm
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+aaH
+aaH
+aaH
+gXs
+gXs
+gXs
+gXs
+gXs
+kic
+ctv
+sRT
+kic
+gXs
+aaa
+aaa
+aaS
+aaS
+aaS
+aaS
+aaS
+aaf
+aaf
+aaa
+uqg
+aaa
+aaf
+aaf
+aaS
+aaS
+aba
+aaS
+aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -73934,12 +74479,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -73977,10 +74522,10 @@ gLH
 ase
 avq
 aum
-avq
-avq
+fFx
+qYA
 cwH
-avq
+fnN
 aAj
 aBK
 aCL
@@ -74019,6 +74564,7 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
@@ -74026,52 +74572,51 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaH
+aaH
+aaH
+gXs
 aaa
 aaa
 aaa
 aaa
+kjY
+ktP
+mdr
+kic
+gXs
+aaa
+aaa
+aaS
+aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+uqg
+aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -74191,12 +74736,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -74232,12 +74777,12 @@ alU
 alU
 alU
 asc
-atn
-aLt
-aue
-aue
-aue
-aue
+axk
+aAO
+ayy
+ayy
+ayy
+ayy
 aAe
 aBJ
 aCs
@@ -74263,72 +74808,72 @@ bbd
 beO
 beP
 bgj
-beO
+fjS
 bja
 beO
 bja
 bja
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+aaH
+iXN
+aaH
+gXs
+gXs
+gXs
+gXs
+gXs
+kic
+kic
+sRT
+ctv
+gXs
+aaa
+aaa
+aaS
+aaf
+qpx
+qpx
+qpx
+qpx
+qpx
+aaa
+ksA
+aaa
+qpx
+qpx
+qpx
+qpx
+qpx
+aaf
+aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -74448,12 +74993,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -74489,12 +75034,12 @@ apL
 aqK
 alU
 asc
-atq
-aon
-amC
-axe
-ays
+fYD
 alU
+alU
+alU
+ali
+ali
 auT
 aBI
 aCY
@@ -74520,7 +75065,7 @@ bbe
 beO
 beS
 bgj
-bhJ
+bgj
 bjd
 bkB
 cAI
@@ -74533,14 +75078,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -74548,44 +75086,51 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaH
+aaH
+aaH
+aaH
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+ctv
+mdH
+ctv
+okW
 aaa
 aaa
 aaS
+aaa
+pdB
+ryU
+ryU
+ryU
+ryU
+qOQ
+ciP
+nhy
+qVA
+qVA
+qVA
+qVA
+ecJ
+aaa
 aaS
-aaS
-aaS
-aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -74705,12 +75250,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -74746,12 +75291,12 @@ apM
 aqL
 alU
 asc
-atq
-auX
-avS
-amC
-amC
-alU
+fYD
+eMg
+vyQ
+luK
+aaH
+ali
 auT
 aBI
 aDc
@@ -74777,10 +75322,10 @@ bbe
 beO
 beR
 bgj
-bgj
+fpz
 bjc
 cAF
-cAF
+fZm
 bja
 aaa
 aaa
@@ -74790,59 +75335,59 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
+aPz
+fne
+gXs
+gXs
+gXs
+gXs
+aaH
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaS
+gXs
+gXs
+gJi
+gXs
+gXs
 aaa
 aaf
+aaS
+aaf
+wPp
+wPp
+wPp
+wPp
+wPp
 aaa
+ciP
+aaa
+wPp
+wPp
+wPp
+wPp
+wPp
+aaf
 aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -74962,12 +75507,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -75001,14 +75546,14 @@ alU
 aoS
 amC
 aom
-ank
+awQ
 asc
-atq
-auZ
-bsU
-axf
-amC
-alU
+fYD
+aaH
+gXs
+gXs
+aaH
+ali
 auT
 aBI
 aDf
@@ -75036,8 +75581,8 @@ beU
 bgk
 bhL
 bjc
-cAF
-blV
+fCx
+vrv
 beO
 aaa
 aaa
@@ -75047,59 +75592,59 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
+aPz
+iXN
+gXs
+kaq
+aaH
+aaH
+gXs
+atS
 aaa
 aaa
 aaa
 aaa
+gXs
+gJi
+gXs
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaS
-aaf
-chJ
 aaf
 aaS
 aaa
 aaa
 aaa
+aaf
+aaa
+aaa
+aaa
+ciP
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
+aaa
+aba
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -75219,14 +75764,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gDl
 aaa
 aaa
 aaa
@@ -75260,12 +75805,12 @@ apO
 aqM
 arF
 asc
-atq
-auY
-amC
-amC
-ayt
-alU
+fYD
+jTJ
+rxn
+gXs
+gXs
+ali
 aAw
 aBl
 aCZ
@@ -75291,72 +75836,72 @@ bbf
 beT
 beT
 bdQ
-beZ
-bje
-bkC
-cAJ
 beO
+bje
+beO
+beO
+beO
+ccX
 aaa
 aaa
 aaa
 aaa
 aaa
+chQ
+aPz
+aPz
+aPz
+aaa
+aPz
+aBU
+aBU
+aPz
+gXs
+aaH
+aaH
+aaH
+mJG
+aaH
+atS
 aaa
 aaa
 aaa
 aaa
+gXs
+gJi
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaS
-aaS
-aaS
-aaS
-aaS
-aaf
-aaf
-aaa
-chI
 aaa
 aaf
+aaS
+aaf
+qpx
+qpx
+qpx
+qpx
+qpx
+aaa
+ciP
+aaa
+qpx
+qpx
+qpx
+qpx
+qpx
 aaf
 aaS
-aaS
-aba
-aaS
-aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -75476,12 +76021,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -75517,11 +76062,11 @@ amC
 aqO
 arG
 asc
-atq
-ava
-amC
-axg
-ayu
+fYD
+aaH
+gXs
+jTJ
+eMg
 azF
 azF
 azF
@@ -75548,72 +76093,72 @@ bbg
 bdG
 bdu
 bdT
-beO
+aSg
 bjf
-beO
-beO
-beO
+aPz
+ghD
+aPz
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+aPz
+ghD
+aPz
+aPz
+aPz
+cTo
+bcI
+aPz
+fOA
+aaH
+iXN
+aaH
+aaH
+aaH
+atS
 aaa
 aaa
 aaa
 aaa
+gXs
+gJi
+gXs
 aaa
 aaa
+aaf
+aaS
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
+pdB
+ryU
+ryU
+ryU
+ryU
+qOQ
+ciP
+nhy
+qVA
+qVA
+qVA
+qVA
+ecJ
 aaa
 aaS
 aaa
 aaa
-aaf
-aaa
-aaf
 aaa
 aaa
-chI
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -75733,17 +76278,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
 aaa
 aaa
 abY
@@ -75773,11 +76318,11 @@ alU
 alU
 alU
 arG
-ash
-atq
+asc
+fYD
 alU
 alU
-alU
+ali
 alU
 azF
 aAP
@@ -75805,72 +76350,72 @@ bcI
 aPz
 bdt
 bdR
-aSg
+csl
 aYf
-bkD
+ciQ
+bVz
+bWy
+aSg
+cAi
+aSg
+aSg
+aSg
+aSg
+aSg
+bWy
+chS
+ciQ
+csl
+csl
+csl
+sEM
+aPz
+aaH
+aaH
+aaH
+aaH
+nez
+aaH
+atS
+gXs
 aaa
 aaa
 aaa
+gXs
+kSv
+gXs
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaS
-aaf
-cca
-cca
-cca
-cca
-cca
-aaa
-chK
-aaa
-cca
-cca
-cca
-cca
-cca
 aaf
 aaS
+acy
+wPp
+wPp
+wPp
+wPp
+wPp
+aaa
+ciP
+aaa
+wPp
+wPp
+wPp
+wPp
+wPp
+aaf
+aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -75990,12 +76535,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -76032,9 +76577,9 @@ aoX
 arI
 asi
 atr
-atN
-atN
-atN
+izf
+eUe
+oZJ
 ayi
 azq
 aAK
@@ -76064,70 +76609,70 @@ bdB
 aWv
 aTu
 bjg
-bkD
+aPz
+aBU
+aPz
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+aPz
+aBU
+aPz
+aPz
+aPz
+dzc
+aWv
+aPz
+aaH
+gXs
+aaH
+aaH
+aPz
+kCo
+aPz
+gXs
 aaa
 aaa
 aaa
+gXs
+sRT
+gXs
+gXs
+aaa
+aaf
+aba
 aaa
 aaa
 aaa
+aaf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaS
-aaa
-ccc
-ccX
-ccX
-ccX
-ccX
-cgz
-chL
 ciP
-cjH
-cjH
-cjH
-cjH
-cnl
+aaa
+aaa
+aaa
+aaf
+aaa
+aaa
 aaa
 aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -76247,12 +76792,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -76288,9 +76833,9 @@ ali
 amC
 arH
 atP
-auV
-auV
-auV
+axl
+axl
+axl
 axK
 ayh
 azi
@@ -76303,8 +76848,8 @@ azF
 azF
 azF
 aLD
-aNh
-aNh
+xsB
+xsB
 aPz
 aPz
 aPz
@@ -76318,7 +76863,7 @@ bbI
 bcK
 aPz
 bdB
-aWv
+azI
 bfh
 aPz
 aPz
@@ -76335,56 +76880,56 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aPz
+aPz
+aLM
+aPz
+aaH
+gXs
+aaH
+myh
+aPz
+aSg
+aPz
+gXs
+gXs
+gXs
+gXs
+gJi
+sRT
+gJi
+gJi
 aaa
 aaf
 aaS
 aaf
-ccb
-ccb
-ccb
-ccb
-ccb
+qpx
+qpx
+qpx
+qpx
+qpx
 aaa
-chL
+ciP
 aaa
-ccb
-ccb
-ccb
-ccb
-ccb
+qpx
+qpx
+qpx
+qpx
+qpx
 aaf
 aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -76504,12 +77049,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -76545,9 +77090,9 @@ alU
 aqP
 arJ
 alU
-avb
-aaH
-bOi
+alU
+sGZ
+alU
 atO
 asK
 azF
@@ -76559,9 +77104,9 @@ aAQ
 aHz
 aIS
 aKn
-aLF
-aLF
-aLF
+mIj
+mIj
+mIj
 aPz
 aQL
 aSg
@@ -76569,10 +77114,10 @@ aSg
 aSg
 aWl
 aSg
-aZs
-baN
-bbK
-bcM
+aSg
+aSg
+aWA
+aTu
 bdH
 bdD
 bea
@@ -76592,56 +77137,56 @@ aaa
 aaa
 aaa
 aaa
+bkF
+aHI
+aWv
+aPz
+aaH
+gXs
+aaH
+aPz
+aPz
+aSg
+aPz
+gXs
+gXs
 aaa
 aaa
+gXs
+sRT
+aaa
+gJi
 aaa
 aaa
+aaS
 aaa
+pdB
+ryU
+ryU
+ryU
+ryU
+qOQ
+ciP
+nhy
+qVA
+qVA
+qVA
+qVA
+ecJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
 aaS
 aaa
 aaa
 aaa
-aaf
 aaa
-aaa
-aaa
-chL
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aba
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -76761,12 +77306,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -76802,9 +77347,9 @@ apP
 amC
 arH
 alU
-aaH
-bNb
-aaf
+vlE
+amC
+ppV
 atO
 asK
 azF
@@ -76848,57 +77393,57 @@ aaa
 aaa
 aaa
 aaa
+ciR
+bkF
+aHK
+aWv
+aBU
+iXN
+gXs
+aaH
+nLu
+aSg
+oTW
+aPz
+gXs
+gXs
 aaa
 aaa
+gXs
+sRT
+gXs
+gJi
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
 aaS
 aaf
-cca
-cca
-cca
-cca
-cca
+wPp
+wPp
+wPp
+wPp
+wPp
 aaa
-chL
+frv
 aaa
-cca
-cca
-cca
-cca
-cca
+wPp
+wPp
+wPp
+wPp
+wPp
 aaf
 aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -77018,12 +77563,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -77059,9 +77604,9 @@ aol
 aol
 arL
 alU
-avU
-avb
-bOi
+uDs
+amC
+wbg
 atO
 asK
 azF
@@ -77106,56 +77651,56 @@ aaa
 aaa
 aaa
 aaa
+bkF
+aSg
+aWv
+aBU
+aaH
+gXs
+aaH
+aPz
+ngs
+pIf
+aPz
+gXs
+gXs
 aaa
 aaa
+tEK
+tur
 aaa
+gJi
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaS
 aaa
 aaa
 aaf
-aaS
 aaa
-ccc
-ccX
-ccX
-ccX
-ccX
-cgz
-chL
-ciP
-cjH
-cjH
-cjH
-cjH
-cnl
+aaf
+aaa
+aaf
+pLt
+aaf
+aaa
+aaf
+aaa
+aaf
+aaa
 aaa
 aaS
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -77275,12 +77820,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -77312,13 +77857,13 @@ anh
 anH
 amC
 aok
-anJ
+aAr
 aFJ
 arK
 alU
-alU
-ali
-alU
+jcG
+jrA
+viX
 atO
 asK
 azF
@@ -77363,56 +77908,56 @@ aaa
 aaa
 aaa
 aaa
+bkF
+aSg
+aWv
+aBU
+aaH
+gXs
+aaH
+aPz
+ngV
+pKu
+aPz
+aBU
+aBU
+aPz
 aaa
 aaa
+tRB
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gJi
+gXs
+gXs
+aaS
+aaS
+aaS
+aaf
+aaf
+aaf
+aaf
+cnl
+qim
+cnl
+aaf
+aaf
+aaf
 aaf
 aaS
-acy
-ccb
-ccb
-ccb
-ccb
-ccb
-aaa
-chL
-aaa
-ccb
-ccb
-ccb
-ccb
-ccb
-aaf
+aaS
 aaS
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gDl
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -77532,12 +78077,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -77569,14 +78114,14 @@ alR
 alR
 amC
 aom
-apP
-amC
-arN
-amC
-amC
-amC
-amC
-axi
+alU
+alU
+alU
+alU
+alU
+alU
+alU
+atO
 asK
 azF
 azF
@@ -77620,49 +78165,40 @@ aaa
 aaa
 aaa
 aaa
+bkF
+aJe
+aLP
+aPz
+aPz
+aPz
+kCo
+aPz
+aPz
+nLu
+aPz
+rPU
+tJi
+aPz
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aba
-aaa
-aaa
+tRB
+bLv
+pRs
+bLv
+gXs
 aaa
 aaf
-aaa
-aaa
-aaa
-chL
-aaa
 aaa
 aaa
 aaf
 aaa
 aaa
+cnl
+cxJ
+cnl
 aaa
-aaS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aoV
+aaf
 aaa
 aaa
 aaa
@@ -77670,6 +78206,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -77789,12 +78334,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -77817,22 +78362,22 @@ amv
 adA
 aaf
 aaf
-aaa
 aaa
 aaa
 aaa
 alU
+avU
 alF
-anj
 anJ
-aoU
+anJ
+awT
 alU
+aEl
 amC
-arM
+rtU
+uve
 alU
-avc
-asO
-avV
+rVw
 atO
 ayw
 atN
@@ -77876,44 +78421,42 @@ aaa
 aaa
 aaa
 aaa
+ciR
+bkF
+aSg
+aMr
+aPz
+hcb
+ikk
+kNv
+aPz
+nkP
+aSg
+aPz
+aSg
+aSg
+aPz
 aaa
 aaa
+tRB
+bLv
+bHE
+bLv
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
 aaa
 aaa
 aaf
-aaS
-aaf
-cca
-cca
-cca
-cca
-cca
 aaa
-chL
 aaa
-cca
-cca
-cca
-cca
-cca
-aaf
-aaS
+cnl
+cxJ
+cnl
+aaa
+aaa
+gXs
+aoV
 aaa
 aaa
 aaa
@@ -77921,22 +78464,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -78046,12 +78591,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78076,23 +78621,23 @@ aaa
 aaf
 aaf
 aaf
-aaf
 gXs
 alU
-alF
-anl
+avU
+aoU
 amC
 alU
 alU
+alU
+aFn
 amC
+amC
+vbi
 alU
 alU
-apP
-alU
-alU
-atP
-auV
-axK
+knu
+owM
+kLZ
 aAN
 aBL
 aDd
@@ -78134,43 +78679,40 @@ aaa
 aaa
 aaa
 aaa
+bkF
+aSg
+aWv
+nLu
+hrF
+inR
+aSg
+aPz
+nwX
+qTG
+aPz
+syJ
+aSg
+aPz
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoV
-bZm
-aoV
-aoV
-aoV
-aaa
-aaS
-aaa
-ccc
-ccX
-ccX
-ccX
-ccX
-cgz
-chL
-ciP
-cjH
-cjH
-cjH
-cjH
+tRB
+bLv
+bHE
+bLv
+gXs
+bCq
+bCq
+bCq
+bCq
+bCq
+bCq
+cnl
+cnl
+lJI
+cnl
 cnl
 aaa
-aaS
+gXs
 aaa
 aaa
 aaa
@@ -78179,21 +78721,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -78303,12 +78848,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78334,26 +78879,26 @@ aaf
 aaa
 aaa
 aaa
+alU
+alU
+awQ
+alU
+alU
 aaa
 alU
 alU
-ank
+nhY
+amC
 alU
 alU
-alU
+oqa
 amC
-amC
-amC
-arN
-alU
-avW
-amC
-ayx
+cUI
 atO
 aAL
 aBQ
 aDb
-aDo
+bYP
 aFY
 aDo
 aDo
@@ -78364,7 +78909,7 @@ aOn
 aPA
 aQP
 aQN
-aTB
+cAB
 aUt
 aWo
 aXQ
@@ -78391,6 +78936,40 @@ aaa
 aaa
 aaa
 aaa
+aPz
+aKu
+aWv
+aPz
+aPz
+aSg
+kWp
+aPz
+oyz
+aPz
+aPz
+aKw
+aSg
+aPz
+gXs
+bCq
+ucq
+bLv
+qaY
+bLv
+bLv
+bCq
+rUu
+huK
+wFA
+lwP
+eVa
+ciS
+hsA
+dOP
+hVp
+ciS
+aaa
+gXs
 aaa
 aaa
 aaa
@@ -78399,58 +78978,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoV
-bVz
-aaf
-aaf
-aoV
-aaa
-aaS
-aaf
-ccb
-ccb
-ccb
-ccb
-ccb
-aaa
-qJr
-aaa
-ccb
-ccb
-ccb
-ccb
-ccb
-aaf
-aaS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -78560,12 +79105,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78588,24 +79133,24 @@ aqJ
 adA
 aaa
 aaS
-aaa
 aaa
 aaa
 aaa
 alU
-amD
-anm
-amC
+apD
+arA
 amC
 ali
+aaa
+ali
+aFp
 amC
-alU
-asO
-atL
-alU
-avX
-axf
 amC
+wKe
+alU
+rlq
+amC
+dQr
 atO
 aAY
 aBQ
@@ -78621,17 +79166,17 @@ aOp
 aPA
 aQR
 aQN
-aQN
-aUt
+bBx
+cjQ
 aWq
-aQN
-aQN
-aQN
-aQN
-vhb
-bbO
+cqY
+crY
+csN
+ctg
 aPA
-bgt
+azH
+ctP
+aPz
 bhS
 bjk
 aPz
@@ -78646,52 +79191,43 @@ bvT
 blW
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+aPz
+aKw
+aWv
+aSg
+aPz
+aPz
+aPz
+aPz
+aPz
+aPz
+aSg
+szG
+aSg
+aPz
+bCq
+bCq
+mvI
+bHE
+bHE
+saU
+uVL
+bCq
+awe
+bHE
+bHE
+bHE
+xhl
+ciS
+jgG
+uuq
+snc
+ciS
 aag
-bVz
 aag
 aag
-aoV
-aaa
-aaS
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-hrF
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gDl
 aaa
 aaa
 aaa
@@ -78699,15 +79235,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -78817,12 +79362,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -78845,7 +79390,6 @@ aaa
 aaf
 aaa
 aaS
-aaf
 aaf
 aaf
 gXs
@@ -78853,15 +79397,16 @@ alU
 amC
 amC
 amC
-amC
 ali
+gXs
+ali
+cQF
 amC
+rIA
+ibb
 alU
 alU
-alU
-alU
-alU
-axj
+awQ
 alU
 atO
 aAY
@@ -78880,16 +79425,16 @@ aQN
 aQN
 aTz
 aUp
-ubj
+aWq
 aXr
 aZx
-aQN
-aQN
-cBh
-bdL
+eCR
+cth
 aPA
+aSg
+aSg
 bgt
-bhR
+bhT
 bjk
 aZE
 blW
@@ -78905,6 +79450,41 @@ aaa
 aaa
 aaa
 aaa
+aPz
+aKw
+aOH
+csl
+csl
+csl
+lSa
+mzB
+csl
+csl
+csl
+csl
+sEM
+nLu
+bHE
+bHE
+mAH
+ckA
+qus
+syf
+vhs
+bCq
+eFW
+rTg
+pEE
+qeZ
+drV
+ciS
+ltC
+mJq
+hNE
+ciS
+bCq
+egL
+bCq
 aaa
 aaa
 aaa
@@ -78912,59 +79492,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gJi
-aaa
-aaf
-bVz
-aoV
-aag
-aoV
-aaa
-aaS
-aaS
-aaS
-aaf
-aaf
-aaf
-aaf
-cfx
-tEK
-cfx
-aaf
-aaf
-aaf
-aaf
-aaS
-aaS
-aaS
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -79074,12 +79619,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79105,21 +79650,21 @@ aaS
 aaa
 aaa
 aaa
+alU
+aqy
+asy
+amC
+alU
 aaa
-alU
-amE
-ann
+ali
+fBy
+noF
 amC
-amC
+tnB
 alU
+uBu
 amC
-alU
-arN
-atU
-alU
-atU
-amC
-atJ
+vzS
 atO
 aAY
 aBQ
@@ -79134,18 +79679,18 @@ aLE
 aOq
 aPD
 aQT
-aQN
+aQT
 aTC
 aUs
 aUY
 aXv
 aYS
-aQN
-aQN
-vhb
-bbO
+csN
+ctg
 aPA
-aSg
+ctH
+ctQ
+aPz
 bhT
 bjk
 aZE
@@ -79162,6 +79707,41 @@ aaa
 aaa
 aaa
 aaa
+aPz
+aPz
+aPz
+dsC
+aSg
+aJe
+aPz
+aPz
+aPz
+dKP
+dKP
+dKP
+cAC
+dKP
+dKP
+dKP
+mOB
+qJr
+qJr
+sJI
+vPF
+bCq
+pBp
+bCq
+bCq
+bCq
+bCq
+ciS
+rAn
+xsO
+ciS
+ciS
+bCq
+bHE
+bCq
 aaa
 aaa
 aaa
@@ -79169,59 +79749,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gJi
-aaa
-aaf
-bVz
-aaf
-aag
-aoV
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-cfx
-chN
-cfx
-aaa
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -79331,13 +79876,12 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79366,17 +79910,18 @@ aaa
 alU
 alU
 alU
-ank
+awQ
 alU
-alU
+aaa
+ali
+hRI
 amC
 amC
-amC
-amC
+txC
 alU
-avc
+uBu
 amC
-atJ
+qrY
 atO
 aAY
 aBQ
@@ -79392,16 +79937,16 @@ aOl
 aPA
 pqs
 aQN
-aTC
-aUs
-mTG
+aTB
+cjT
+aWq
 aXt
-ijG
-aQN
-aQN
 aPA
 aPA
 aPA
+aPA
+aPA
+aPz
 bel
 bfI
 bgq
@@ -79415,47 +79960,45 @@ bjr
 buB
 bvU
 aZE
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaa
-aaa
-aag
-aaa
-bVx
-caf
-aoV
-aag
-aaf
 gXs
 gXs
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-cfx
-chN
-cfx
-aaa
-aaa
-aaf
-aaf
 aaa
 aaa
 aaa
+gXs
+aPz
+eEe
+ieX
+iTq
+aPz
+gXs
+gXs
+dKP
+izv
+jvd
+kAO
+oqj
+kqy
+dKP
+ufD
+bHE
+qJr
+sON
+wUg
+bCq
+bHE
+bCq
+frW
+fcc
+jkl
+bCq
+qvb
+lPJ
+bHE
+lxg
+bCq
+nCV
+bCq
 aaa
 aaa
 aaa
@@ -79463,22 +80006,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -79583,18 +80128,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79621,19 +80165,20 @@ aaa
 aaa
 aaa
 alU
-amF
-alU
-amC
-alU
-alU
-alU
+aqF
 alU
 amC
-amC
+alU
+gXs
+alU
+alU
+oLl
+alU
+alU
 alU
 atM
 axl
-auV
+owM
 azG
 aAY
 aBQ
@@ -79649,13 +80194,13 @@ aOl
 aPE
 aQV
 aQN
-aTC
+cjl
 aUu
-gxc
-aXt
+aWq
+aXw
 ijG
-aQN
-aQN
+ijG
+ijG
 aZB
 aPA
 bfc
@@ -79678,64 +80223,64 @@ aaa
 aaa
 aaa
 aaa
+aPz
+aBU
+aBU
+aBU
+aPz
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dKP
+iHk
+jAN
+kEm
+rtl
+rtl
+pPd
+nbw
+bVM
+reA
+sPY
+tjt
+mhN
+pwM
+mhN
+cat
+hXP
+fLw
 bCq
+rIS
+bHE
+bHE
+xEv
 bCq
+iOP
 bCq
-bLv
-bCq
-aoV
-cbj
-bLv
-cDY
-bLv
-aaf
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-cfx
-cfx
-cyK
-cfx
-cfx
-aaa
-aaa
-aaf
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -79840,18 +80385,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -79882,19 +80426,20 @@ alU
 alU
 amC
 alU
+gXs
 aaH
-rJw
-arO
+alU
+amC
+srG
 amC
 amC
-avc
-atO
+qbI
 axk
 ayy
 ayy
 aAO
 aBN
-aDe
+ayu
 aDe
 aFT
 aDe
@@ -79906,13 +80451,13 @@ aOl
 aPA
 aiB
 aQN
-nLw
+aQN
 sLa
-oyl
+aWq
 aXw
 qfk
-aQN
-aQN
+qfk
+qfk
 aZA
 aPA
 aWv
@@ -79935,64 +80480,64 @@ aaa
 aaa
 aaa
 aaa
+iFJ
 aaa
 aaa
 aaa
+iFJ
 aaa
 aaa
-aaa
-aaa
-bCq
+dKP
 ajD
-bCq
+jBi
 bSn
-bCq
-bCq
-cbj
-bLv
+oqO
+viF
+dKP
 bHE
-bLv
-aaf
+bHE
+rmN
+tif
+xtI
 bCq
-cAy
-cAB
-ajG
-cAD
-cAH
-cfw
-cgA
-chP
-ciQ
-cfw
-aaa
-aaa
+bEP
+bCq
+iej
+rIS
+bCq
+cgE
+rIS
+bHE
+bHE
+bHE
+pGr
+bHE
+bCq
 gXs
-aaf
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -80097,18 +80642,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80137,19 +80681,20 @@ aaa
 aaa
 aaa
 ali
-anK
-ali
-aaf
-alU
-rJw
-alU
-atW
-atW
-atO
 axn
+ali
+aaH
+gXs
+alU
+alU
+alU
+rlq
+rlq
+atO
+aAY
 alU
 aoX
-atJ
+lLn
 aBQ
 aDq
 aDo
@@ -80163,13 +80708,13 @@ aOr
 aPA
 aQX
 aQN
-aSi
+aQN
 aUv
 aWp
-aTy
-aTy
-aTy
-aTy
+crh
+csi
+csi
+csi
 bbs
 bcw
 bfd
@@ -80199,57 +80744,57 @@ aaa
 aaa
 aaa
 aaa
-bCq
-bHE
+rjQ
 bJP
-bHE
 bJP
+tNb
+bJP
+weM
+dKP
+bHE
+bHE
+rUv
+rUv
+jpw
 bCq
-cbk
-bLv
-bHE
-bLv
-aaf
+nmI
 bCq
-cAA
+bUD
+cBa
+klD
+cdj
+nJg
+iiG
+mBO
 bHE
 bHE
-ccZ
-cAK
-cfw
-cgC
-chR
-ciS
-cfw
-aag
-aag
-aag
+iiG
+bCq
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -80354,6 +80899,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80381,53 +80937,42 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ali
-aKY
-ali
-aaf
-aoV
-aaf
+alU
+amC
+alU
+aaH
+gXs
+gXs
+aaH
 alU
 ali
 ali
 atO
-axo
+dPq
+alU
 ayz
 ayz
-ayz
+aBR
+aCW
 aBR
 aBR
 aBR
 aBR
 aBR
-aBR
-aBR
-aLm
+axr
 aLE
 aOl
 aPA
 vJu
-aQN
+vJu
 aTD
-ocv
+vJu
 aUZ
+crA
+epD
+csO
 aYU
-aYU
-aYU
-aYU
-aYU
+ctx
 bcu
 bfe
 aYb
@@ -80456,35 +81001,36 @@ aaa
 aaa
 aaa
 aaa
+rjQ
+cTF
+bSp
+tWj
+oxm
+rvr
+dKP
+pBp
 bCq
-bHE
-bHE
-bHE
-bHE
 bCq
-bVy
-bLv
-cyE
-bLv
-bLv
-bCq
-bHE
+dKP
+dKP
+dKP
 cAC
-ccZ
-cAE
-ceV
-cfw
-cgB
-chQ
-ciR
-cfw
+dKP
+dKP
+dKP
 bCq
-cDY
+bCq
+uOo
+bCq
+bCq
+bCq
+bCq
+bCq
 bCq
 aaa
 aaa
-aaf
-aaf
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -80494,19 +81040,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -80611,6 +81156,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80629,6 +81185,7 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
 aaa
 aaa
@@ -80637,41 +81194,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ali
 ali
 amC
-alU
-alU
-alU
-aaf
-aoV
-aae
+ali
+aon
+gXs
 aaH
+gXs
+aaa
+aaa
+gXs
 avY
 axo
-arP
-fgG
-rqW
-aGD
-tJi
-aCr
-hcb
-qTG
-hcb
-aKu
-aLM
+wFu
+ayE
+amF
+ava
+aLt
+hei
+qIA
+wMk
+tzM
+jqP
+aLF
 aLF
 aOs
 aPG
@@ -80679,14 +81224,14 @@ aPG
 aPG
 aPG
 aPG
-lip
-aQW
-aQW
-aQW
-aQW
-xDM
 aPA
-jxF
+aPA
+aPA
+aPA
+aPA
+aPA
+aPA
+aWv
 aYb
 aZE
 bjp
@@ -80704,44 +81249,6 @@ bxu
 bxx
 bxu
 bxu
-bDi
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bCq
-bHE
-bPW
-bHE
-bHE
-bCq
-bVB
-bHE
-bHE
-bYu
-bZk
-bCq
-cTF
-bCq
-bCq
-bCq
-bCq
-cfw
-cgE
-chS
-cfw
-cfw
-bCq
-bHE
-bCq
-aaa
-aaa
-aaa
-aaf
 aaf
 aaa
 aaa
@@ -80750,6 +81257,38 @@ aaa
 aaa
 aaa
 aaa
+gXs
+dKP
+iTU
+jBA
+bSp
+oDN
+ryr
+dKP
+bHE
+bHE
+oYL
+dKP
+uRd
+xbn
+kAI
+vXz
+qda
+dKP
+qtl
+bCq
+jSb
+xgm
+viq
+bCq
+iRf
+eFW
+bCq
+aaa
+aaa
+aaa
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -80758,12 +81297,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -80868,6 +81413,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -80893,41 +81449,30 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
 aaa
 aaa
 ali
-yds
 amC
+ali
 aon
-aoW
-arP
-aqQ
-aqQ
-aqQ
-aqQ
-avZ
+aaH
+gXs
+aaa
+aaa
+aaa
+aaa
+avY
 axo
-arP
-rPU
-fne
-aGr
-aHI
-fOA
-tWj
-oyz
-hcb
-aKu
+aqR
+ayE
+atn
+avS
+bsU
+avS
+avS
+avS
+tzM
+dMN
 aLL
 bDe
 aOl
@@ -80936,15 +81481,15 @@ aQY
 aSk
 aTE
 aPG
-aPA
-aPA
-aPA
-aPA
-aPA
-aPA
-aPA
-aWv
-aYb
+cjV
+crP
+csl
+csU
+cti
+cty
+cty
+ctS
+ctV
 aZE
 bjo
 bjr
@@ -80970,43 +81515,38 @@ aaa
 aaa
 aaa
 aaa
-bCq
+rjQ
+jkz
+jFH
+sNK
+bJP
+rMN
+dKP
+xdl
 bHE
-bHE
-bSo
-bHE
-bCq
-bVA
-bWw
-bXw
-bYt
-bZj
-bCq
-bHE
-bCq
+hkT
+dKP
+vcN
+xgC
+rBs
 bSq
 cdW
-ceW
+dKP
 bCq
-cgD
-bUs
+bCq
+jSb
 bHE
-cjI
-bCq
-clA
-bCq
+bHE
+riz
+pqJ
+bHE
+bLv
 aaa
 aaa
 aaa
 aaa
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -81014,21 +81554,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -81125,20 +81670,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -81164,28 +81706,31 @@ aaa
 aaa
 aaa
 ali
-aKY
+ali
+alU
+alU
 amC
-amC
-amC
-gsM
-aqR
-aqR
-aGh
-aqR
-awb
+alU
+alU
+alU
+aaH
+gXs
+aaa
+gXs
+gXs
+avY
 axo
-arP
-aCh
-pIf
-kCo
-aHK
-aCr
-uJx
-ikk
-hcb
-aKu
-aLN
+clS
+ayE
+atq
+axe
+bYx
+bYx
+axe
+wON
+ayE
+ayE
+viU
 aLE
 aOl
 aPH
@@ -81196,10 +81741,10 @@ aPG
 aWu
 aYc
 aZD
-aZD
+csV
 vnI
-aZD
-aZD
+ctz
+ctI
 bff
 dev
 aZE
@@ -81227,30 +81772,31 @@ aaa
 aaa
 aaa
 aaa
-bCq
+rjQ
 bPV
-bCq
-bCq
-cTF
-bCq
+jLn
+lsk
+uJx
+wfR
 bVD
-bWy
-bXx
-bYw
-bZj
+ckA
+mYt
+xPY
+cyL
 bYy
-bHE
+xhS
 bTz
-bHE
+lOe
 bUs
-ceY
+dKP
+xPY
+wPw
+eiL
 bCq
-bJP
-bUs
 bHE
-bLu
 bCq
-cyE
+esA
+esA
 bCq
 aaa
 aaa
@@ -81262,30 +81808,29 @@ bLv
 bLv
 bLv
 aaa
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
 aaa
 aaa
 gDl
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -81382,20 +81927,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -81421,28 +81963,31 @@ aaa
 aaa
 aaa
 ali
-nBI
+aoQ
+aqQ
+atA
+amC
 anL
 aoo
-aoX
-arP
-arP
-arP
-arP
-arP
+alU
+vqP
+vqP
+vqP
+vqP
+vqP
 avZ
-axp
-ayC
-azH
-eEe
-aGv
-aCr
-aCr
-uJx
-ikk
-hcb
-aKu
-aLN
+axo
+nyE
+ayE
+aue
+axg
+bZk
+hod
+rDC
+avS
+osT
+rkz
+sPw
 aLE
 aOl
 aPF
@@ -81451,14 +81996,14 @@ aRa
 aTF
 dZm
 aSX
-hPP
-aZF
-aZF
-aZF
-aZF
-aZF
-aZF
-bgy
+aXE
+gjl
+gjl
+gjl
+gjl
+gjl
+gjl
+gjl
 gjl
 bjq
 bjr
@@ -81484,65 +82029,65 @@ bGi
 bGi
 aoV
 aoV
-bCq
+dKP
 bPU
-bHE
+sNK
+sNK
 bSp
-bHE
-bCq
+wUr
 bVC
-bWx
-bWy
-bYv
+cKE
+nIq
+ckA
 bZl
-bCq
-bHE
-bCq
+dKV
+dKV
+hLG
 cda
 cgF
+fGe
+mYt
+jSb
+vzm
 bCq
-cqn
-cAh
-chT
-bHE
-bHE
-ckv
-bHE
+jwF
+bCq
+bCq
+bCq
 bCq
 bLv
 bLv
 bLv
 bLv
 bCq
-ciT
-cqK
-crl
+niz
+lDo
+rIE
 bLv
 aaa
-iDo
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
-iDo
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -81639,20 +82184,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -81678,28 +82220,31 @@ aaa
 aaa
 aaa
 ali
-ali
-ali
-alU
-alU
-arP
+amC
+amC
+awS
+amC
+amC
+amC
+awQ
 aqR
-wje
+aqR
+aqR
 rQJ
-uUi
-avZ
-xtP
-ayA
-sNK
-xmo
-aBV
-mzB
-mJG
-szG
-aHG
-aJe
-aKw
-aLP
+aqR
+awb
+axo
+aqR
+ayE
+auX
+ays
+cEo
+leK
+sUb
+avS
+nLk
+oSo
+lgB
 aMR
 aNU
 aPJ
@@ -81741,65 +82286,65 @@ bKk
 bGi
 aoV
 aoV
-bCq
+dKP
 bPW
-bCq
-bCq
-cOw
-bCq
-bVF
-bWA
-bXy
-bYx
-bWz
-bCq
-bHE
-bCq
-bQa
+kfX
+sNK
+bJP
+oDN
+dKP
+qtm
+bTE
+iiG
+dKP
+vob
+kyF
+pfo
+idl
 cpY
 cyL
-cqy
-cAi
-bQa
+bTE
+jSb
+iCB
+uhJ
 bHE
 bHE
 bHE
 bHE
+noY
 bHE
 bHE
 bHE
 bHE
-bHE
-cpR
-bHE
-cAQ
-crm
+dzA
+ikB
+eHR
+uTP
 bLv
 aaa
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
-iDo
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -81889,6 +82434,32 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+gDl
 aaa
 aaa
 aaa
@@ -81905,58 +82476,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ali
+apC
+arx
+atA
+ayj
+azv
+aoX
 arP
 vqP
-inw
-gzY
-rtC
-izg
-awa
-axq
-qyj
-azI
-rjQ
-aBU
-myh
-inR
-wUr
-iTq
-hcb
-aKu
-aLN
+vqP
+vqP
+vqP
+vqP
+avZ
+axo
+aqR
+ayE
+auY
+axg
+cOY
+mHY
+rDC
+avS
+osT
+rkz
+sPw
 aMQ
 aNT
 aPI
@@ -81996,67 +82541,67 @@ bHy
 byE
 bKj
 bGi
-aoV
-aoV
-bCq
-bHE
-bHE
+aaa
+aaa
+dKP
+jmV
+sNK
 mPr
 cdb
-bCq
-bVE
-bWz
-bHE
-bHE
-bLu
-bCq
-bLu
-bCq
-cdb
-bSs
-bCq
-bCq
+rXl
+dKP
+kYZ
+rts
+oYL
+dKP
+szl
+sYr
+iws
+oDf
+ehe
+dKP
+bTA
 cgG
 bCq
 bCq
 bCq
 bCq
-cTF
+riz
+bCq
 bCq
 bLv
 bLv
 bLv
 bLv
 bCq
-cqv
 cqL
-bJe
+vGO
+uzH
 bLv
 aaa
 aaa
 aaa
-gXs
 aaa
-aaa
-aaa
-gXs
-aaa
-aaa
-aaa
-iDo
-iDo
-iDo
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -82146,6 +82691,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -82170,50 +82733,32 @@ aaa
 aaa
 aaa
 aaa
+ali
+ali
+alU
+alU
+ali
+alU
+alU
+arP
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aqQ
-uCo
-gzY
-eAG
-aqR
-aqR
-kTj
-xxi
-ayD
-cGz
-aMr
-ngs
-aDv
-uRS
-uJx
-dsC
-hcb
-aKu
-aLN
+gJi
+avY
+axo
+uTi
+ayE
+atq
+axe
+daf
+daf
+axe
+wZc
+ayE
+ayE
+kJg
 aMS
 aOt
 aPK
@@ -82253,32 +82798,33 @@ bxy
 bJd
 bKm
 bxy
-aaf
-aaf
-bCq
-bPY
+gXs
+gXs
+dKP
+dKP
 cOw
-bCq
-bCq
-bCq
-bCq
-bCq
-bYy
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bUs
+dKP
+dKP
+dKP
+dKP
+xCO
+dKP
+dKP
+dKP
+rjQ
+rjQ
+rjQ
+dKP
+dKP
+dKP
+nln
+jSb
 bLv
 aaa
 bCq
-ckv
+qYl
 bHE
+ceW
 bCq
 aaa
 aaa
@@ -82289,31 +82835,30 @@ bCq
 bCq
 bCq
 bCq
-gXs
-gXs
-aaa
-gXs
-aaa
-aaa
-aaa
-gXs
-aaa
-aaa
-aaa
-iDo
-ctv
-iDo
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -82403,6 +82948,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -82439,40 +83002,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aqQ
-aqR
-aqR
-pjg
-sqg
-inq
-avZ
-xxi
-ayD
-viF
-aMr
-aMr
-aOH
-uRS
-lSa
-oTW
-hcb
-aKu
-aLN
-aMS
-aOi
+gJi
+avY
+axo
+krs
+ayE
+atn
+avS
+diq
+avS
+avS
+avS
+tzM
+lxF
+sGA
+spC
+qPv
 lPr
 aPK
 aSl
@@ -82513,64 +83058,64 @@ bxy
 aaH
 aaH
 bCq
-bPX
-bRg
+rnK
+bHE
 bRg
 bCq
+xmo
 bHE
-bVG
-bHE
-bHE
-bCq
+vxk
+dKP
+rBq
 tPT
 tRF
 mrR
-dKP
-odx
+ptv
+tPT
 rBq
-evR
-bCq
-bUs
+dKP
+bTE
+jSb
 bLv
 aaa
 bLv
-bJf
-ccd
+kPp
+eFW
+tdR
 bCq
 aaa
 aaa
-aaf
-aaa
-aaa
-aaf
-aaf
-aaa
-aaf
 gXs
-gUu
-crn
-bij
-bij
-bij
-bij
-bij
-jkz
-btG
 aaa
-iDo
-ctv
-iDo
+aaf
+aaf
+atS
+aaf
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -82660,6 +83205,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -82696,38 +83259,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aqQ
-uCo
-gzY
-arP
-arP
-arP
-avZ
-xxi
-ayD
-nez
-ngV
-xPY
-aOH
-hcb
-hcb
-syJ
-hcb
-aKu
-aLN
+gJi
+avY
+axo
+wan
+ayE
+auZ
+ayt
+ehb
+qyj
+vpY
+xZD
+qez
+sqr
+aLE
 aMS
 aOi
 aLE
@@ -82767,27 +83312,27 @@ byE
 byE
 byE
 bGi
-aaf
-aaf
+ktS
+ktS
 bLv
 bQa
 bHE
-bHE
+lZK
 bCq
-bHE
-bCq
-bCq
-bCq
+xtP
+uEq
+laL
+dKP
 sXA
 mPE
 kyF
 sAM
-imH
-evR
-evR
-rMN
-bCq
-bUs
+mPE
+kyF
+vsC
+dKP
+dRm
+jSb
 bLv
 aaf
 cjJ
@@ -82797,37 +83342,37 @@ cjJ
 cjJ
 cjJ
 cjJ
-kfX
-saU
-saU
-bij
-crn
-bij
-bij
-eCR
-wUg
-bnT
-bph
-bsc
-mQS
-bsc
-tNF
-btG
-gXs
-iDo
-ctv
-iDo
+cjJ
+cjJ
+cjJ
+aaa
+xTy
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -82917,6 +83462,40 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aoV
 aaa
 aaa
 aaa
@@ -82935,50 +83514,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-anO
-aaa
-aaa
+gXs
 arP
+bNb
+avZ
+axo
 aqR
-aqR
-arP
-asQ
-aqR
-awb
-axr
 ayE
 ayE
 ayE
-ayE
-ayE
+fbW
 ayE
 ayE
 ayE
@@ -83024,27 +83569,27 @@ bEQ
 bGM
 bKn
 bGi
-aoV
-aoV
+hSZ
+hSZ
 bLv
 bPZ
 bHE
 bHE
-cTF
+uRS
 bHE
-bCq
-iiW
-iiW
-iiW
-iiW
-iiW
-dfL
+vxk
 dKP
+dKP
+dKP
+uvZ
+mPE
+mPE
+kyF
 mqZ
-tur
-wfR
-bCq
-bUs
+dKP
+dKP
+uYe
+jSb
 bLv
 aaa
 cjJ
@@ -83057,23 +83602,8 @@ cov
 cpj
 cpS
 cjJ
-fjS
-sPT
-btG
-rXl
-xgC
-ugu
-bnV
-bph
-bih
-big
-bii
-bsc
-btG
 aaa
-iDo
-ctv
-iDo
+xTy
 aaa
 aaa
 aaa
@@ -83085,6 +83615,21 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -83174,6 +83719,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -83208,34 +83771,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aiU
-hlT
-aiU
-aaa
-aiU
-vxX
-aiU
 gXs
 arP
-lZs
-dPq
-arP
-asP
-cya
+aqR
 awa
 axu
 ayH
 ayH
 ayH
 ayH
-ayH
+gOZ
 ayH
 aFV
 ayH
@@ -83281,27 +83826,27 @@ byE
 byE
 bKp
 bGi
-aaf
-aaf
+ktS
+ktS
 bLv
+juG
 bHE
-bHE
-bSs
+ugu
 bCq
 bHE
-bCq
-uvZ
+vxk
 dKP
+ujv
 vjm
 bcU
+vFr
 bcU
-bcU
+vFr
+ksm
+wHI
 dKP
-dKP
-dKP
-dKP
-bCq
-bUs
+luB
+jSb
 bLv
 aaa
 cjJ
@@ -83313,24 +83858,9 @@ cnN
 cox
 cpl
 cpU
-jLn
+cjJ
+gXs
 xTy
-xTy
-tJK
-xTy
-vob
-xhS
-mOB
-bph
-big
-bgN
-bkZ
-bsc
-btG
-aaa
-iDo
-ctv
-iDo
 aaa
 aaa
 aaa
@@ -83342,6 +83872,21 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -83431,17 +83976,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -83463,29 +84008,29 @@ jLv
 aaa
 aaa
 aaa
-gWo
-gWo
-gWo
-dYZ
-gWo
-gWo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 gXs
-gXs
-gXs
-aiU
-alp
-aiU
-gXs
-aiU
-alp
-aiU
 arP
-arP
-arP
-arP
-arP
-arP
-arP
+aqR
 avZ
 axt
 ayG
@@ -83541,24 +84086,24 @@ bxy
 aaH
 aaH
 bCq
-bHE
-bRh
-bLu
+rqW
+eFW
+usO
 bCq
-bHE
-bCq
-iiW
+xxi
+jJF
+dKP
 iiW
 dKV
 xgF
-dKV
-dKV
-iiW
-gMl
-gMl
-iiW
-bLv
-bUs
+wJP
+lnu
+mVo
+bDg
+jdv
+dKP
+thu
+jSb
 bLv
 aaf
 cjJ
@@ -83571,23 +84116,8 @@ cow
 cpk
 cpT
 cjJ
-fjS
-dXq
-btG
-rtl
-oqO
-vFr
-bnV
-bph
-bii
-big
-bih
-bsc
-btG
 aaa
-iDo
-ctv
-iDo
+xTy
 aaa
 aaa
 aaa
@@ -83599,6 +84129,21 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -83688,17 +84233,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -83721,29 +84266,29 @@ abc
 abc
 afu
 abc
-wdr
-itQ
-pgn
-tmO
-gWo
-xUe
-aiU
-aiT
-nEj
-vTP
-aiU
-amK
-aiU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 mkU
-xWq
+aaa
+aaa
+aaa
+aaa
 arP
-asR
-gzY
-fdQ
-ngU
-kUC
 arP
-awc
+arP
+bOi
+avZ
 axt
 ayG
 azK
@@ -83795,27 +84340,27 @@ bGn
 bGn
 bKq
 bxy
-aaf
-aaf
+gXs
+gXs
 bCq
 bOK
 bCq
 bCq
 bCq
-bUt
-bCq
+xPY
+blV
 uaw
 tkU
-iiW
-lnu
+bqg
+btq
 cjn
-iiW
-cxo
-bcU
-bcU
-vzO
-bLv
-bUs
+btq
+ldR
+eVr
+ozq
+dKP
+hTK
+jSb
 bLv
 aaa
 cjJ
@@ -83826,25 +84371,10 @@ clG
 cnP
 coz
 cpn
-sPY
-sPY
-bgO
-dgO
-bgO
-pPI
-uRd
-ktP
-bnW
-bph
-bsc
-mkv
-bsc
-jFH
-btG
-gXs
-iDo
-ctv
-iDo
+cjJ
+cjJ
+aaa
+xTy
 aaa
 aaa
 aaa
@@ -83856,6 +84386,21 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -83945,17 +84490,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -83978,29 +84523,29 @@ aea
 aeH
 aft
 abc
-pDe
-dly
-mnC
-mcp
-gWo
-oDm
-ibK
-akb
-ahq
-akI
-ahU
-aiT
-aiD
+aaa
+gXs
+aaa
+aaa
+aaa
+aaa
+gXs
+aaa
+uFZ
 akI
 uFZ
-hBw
-vLo
-gzY
+aaa
+uFZ
+ayx
+uFZ
+gXs
+gXs
+gXs
+arP
+sJJ
+hel
 aqR
-gzY
-gzY
-esK
-awb
+avZ
 axt
 ayG
 aBY
@@ -84059,20 +84604,20 @@ bHE
 bLv
 aaa
 bLv
-uuG
+xXi
 jJF
-gBo
+dKP
 sEt
 cxo
-bcU
-bcU
+xgF
+lnu
 jqv
-cxo
-bcU
+vJY
+bDh
 mpI
-vzO
-bLv
-bUs
+dKP
+nln
+jSb
 bLv
 aaa
 cjJ
@@ -84084,23 +84629,23 @@ cnO
 coy
 cpm
 cjJ
-aaf
-aaf
-aaa
-aaa
 gXs
-iHk
-bgO
-bgO
-bgO
-bgO
-bgO
-bgO
-jBA
-btG
+gXs
+xTy
 aaa
-kvl
-ctv
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+iDo
 iDo
 aaa
 aaa
@@ -84111,8 +84656,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -84202,17 +84747,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -84236,27 +84781,27 @@ aeJ
 afw
 abc
 abc
-dly
-xxp
-mcp
-dYZ
-kMt
-nTG
-rhX
-ahr
-ahD
-ahV
-agr
-fJY
+agj
+agj
+gXs
+gXs
+gXs
+gXs
+gXs
+uFZ
 eXz
-pUy
+uFZ
+gXs
+uFZ
+eXz
+uFZ
 arP
 arP
 arP
 arP
-iPX
-nnp
-arP
+aqR
+aqR
+uTi
 awb
 axt
 ayG
@@ -84308,28 +84853,28 @@ bCq
 bHD
 bJe
 bCq
-nkP
+mkv
 bHE
 bHE
 bHE
 bHE
 bLv
-aaf
+gXs
 bLv
-bUs
-bCq
-iiW
-iiW
+vmJ
+vxk
+dKP
+unA
 fxa
-bcU
-bcU
+uBa
+vHz
 vzO
-iiW
+qEz
 oKh
-oKh
-iiW
-bLv
-bUs
+qaL
+dKP
+ogp
+jSb
 bLv
 aaf
 cjJ
@@ -84343,22 +84888,23 @@ cjJ
 cjJ
 aaa
 aaa
-aaa
-aaa
+xTy
 gXs
-aaa
-aaa
-gXs
-aaa
-aaa
-gXs
-aaa
-aaa
-aaa
-aaa
 iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+aaa
+aaa
+gXs
 ctv
-aaT
+iDo
+iDo
 aaa
 aaa
 aaa
@@ -84367,9 +84913,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -84459,17 +85004,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aqz
 aaa
 aaa
 aaa
@@ -84494,28 +85039,28 @@ afv
 agf
 abc
 dly
-xxp
-mcp
-gWo
-gDP
-lAH
+agj
+agj
+agj
+uFZ
+uFZ
 lNH
 akG
-akG
-kHd
+avb
+uFZ
 vGn
-gav
+uFZ
 cxP
-pUy
+azw
 arP
 aqU
 arg
 arP
-arP
-arP
-arP
-vgJ
-hSl
+aqR
+uTi
+dso
+avZ
+axt
 ayG
 aBX
 aBf
@@ -84562,31 +85107,31 @@ bwe
 bAo
 bTE
 bGo
-bHC
+eFW
 bHE
 bCq
 bCq
 bLv
 bLv
-bHE
+eFW
 bLv
 bCq
 aaa
 bLv
-bUs
-bCq
-sRT
-usO
-iiW
-oKh
-oKh
-iiW
-iiW
-iiW
-izv
-nfm
-bCq
-bUs
+bHE
+mrs
+dKP
+dKP
+uua
+dKP
+dKP
+dKP
+ePT
+dKP
+dKP
+dKP
+gwL
+jSb
 bCq
 aaa
 aaf
@@ -84600,22 +85145,23 @@ cpo
 cjJ
 aaa
 aaa
-aaa
-aaa
+xTy
 gXs
-aaa
-aaa
-gXs
-aaa
-aaa
-gXs
-aaa
-aaa
-aaa
-aaa
 iDo
+ctv
+ctv
+ctv
+ctv
+ctv
+ctv
+ctv
 iDo
-aaT
+aaa
+aaa
+gXs
+ctv
+ctv
+iDo
 aaa
 aaa
 aaa
@@ -84624,9 +85170,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -84716,17 +85261,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -84750,28 +85295,28 @@ aeL
 afy
 agh
 abc
-kCa
+lRb
 hnU
 vda
-sXV
+aiX
 agv
 amM
-aiX
-aiX
-aiX
-aiX
-aiX
+atE
+atW
+ibK
+avJ
+lNH
 foT
 ibK
-pUy
+azx
 arP
 aqR
 arl
 arP
-asS
-sfs
-aqR
-awb
+hDr
+kTl
+arP
+avZ
 axt
 ayG
 azN
@@ -84819,31 +85364,31 @@ bwe
 bAJ
 bCe
 bCq
-bHE
+hBA
 bJf
 bCq
 aaa
-aaf
+gXs
 bLv
-bHE
+eFW
 bLv
 aaa
 aaa
 bTB
-bUv
-bES
-bES
-bES
-bES
-bGp
-bGp
-bGp
-bGp
-bES
-bES
-bES
+ckA
+usu
+ckA
+ckA
+uuG
+ckA
+ckA
+pOc
+fyX
+pOc
+fUZ
+fZq
 car
-bUs
+fQV
 bCq
 bCq
 bCq
@@ -84855,17 +85400,26 @@ cnS
 coC
 cpp
 cjJ
-aaf
-aaf
-aaa
-aaa
+gXs
+gXs
+atS
+gXs
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+gXs
+gXs
+gXs
+gXs
 gXs
 aaa
 aaa
-gXs
-aaa
-aaa
-gXs
 aaa
 aaa
 aaa
@@ -84873,17 +85427,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -84973,17 +85518,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -85013,11 +85558,11 @@ idK
 age
 kZS
 agu
-agj
+kZS
 amL
-apK
+kZS
 amX
-aiX
+avV
 aiE
 aiK
 aiN
@@ -85025,11 +85570,11 @@ arP
 arc
 arP
 arP
-usE
-aqR
-aqR
-awb
-axt
+arP
+arP
+arP
+cya
+dYZ
 ayG
 ayG
 ayG
@@ -85040,7 +85585,7 @@ ayG
 ayG
 ayG
 ayG
-aHP
+hCf
 aNc
 aOB
 aPQ
@@ -85088,24 +85633,24 @@ bLv
 bLv
 bTA
 bUu
+ptS
 bLw
-bLw
-bLw
-bLw
-bLw
-bLw
-bLw
-bLw
+svZ
+nuV
+eoI
+hlj
+xKg
+nuv
 bLw
 bLw
 bLw
 caq
 cbw
 bHE
-ciT
+lZK
 bCq
 bSs
-ceY
+mQS
 ccw
 ccw
 cnR
@@ -85116,19 +85661,17 @@ ccw
 ccw
 ccw
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaf
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
@@ -85141,6 +85684,8 @@ aaa
 aaa
 aaa
 aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -85230,17 +85775,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -85264,17 +85809,17 @@ aeN
 afA
 afA
 abc
-kuA
+lRb
 laq
 kdP
 mGw
 akm
 akr
 alZ
-amO
+arQ
 arQ
 aor
-aiX
+avW
 aiF
 aqI
 asv
@@ -85288,7 +85833,7 @@ apS
 ajw
 ajy
 ayJ
-ayJ
+rus
 aBi
 aqR
 aqR
@@ -85309,16 +85854,16 @@ aJq
 aJq
 aLY
 aJq
-aJq
-aRh
+ctj
+ctA
 bbV
-bfo
+boW
 bkS
-bfo
+boW
 bgn
-bfo
+boW
 bmn
-bfo
+boW
 boW
 bmE
 bmE
@@ -85333,8 +85878,8 @@ bCr
 bAK
 bCn
 bGq
-bGq
-bGq
+fgG
+fgG
 rGq
 bLw
 bGq
@@ -85358,9 +85903,9 @@ bVI
 bVI
 bTA
 xgk
-bHE
-kEm
-bHE
+iiG
+bCq
+bCq
 bHE
 bHE
 cmD
@@ -85396,8 +85941,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -85487,17 +86032,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -85520,21 +86065,21 @@ aef
 aeM
 afz
 oSl
-ail
+lRb
 lRb
 vIi
 fsj
-sXV
+aiX
 xnm
 rAR
 uCU
 and
 arS
 anq
-aiX
+uCU
 aiT
 ass
-aiT
+aiN
 arP
 arP
 arP
@@ -85566,22 +86111,22 @@ aJq
 aJq
 aLY
 aJq
-aJq
+aXf
 bHt
 aJq
 aJq
 beX
 aJq
-bgm
+bAk
 bjx
 bmm
 bnM
-boV
 bnM
 bnM
 bnM
 bnM
 bnM
+cuS
 bnM
 bnM
 bAe
@@ -85617,7 +86162,7 @@ cax
 cbx
 cdh
 ciU
-cjK
+ckA
 ckA
 ckA
 cmC
@@ -85653,8 +86198,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -85744,17 +86289,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -85776,22 +86321,22 @@ adH
 aei
 aeO
 afJ
-sXV
-sXV
-sXV
-sXV
-sXV
-sXV
+aiX
+aiX
+aiX
+aiX
+aiX
+aiX
 oby
 ajX
 agj
-amL
-asp
-nbY
+aiX
+aiX
+aiX
 aiX
 iRj
-anz
-aov
+azt
+aAy
 cCi
 apU
 ajd
@@ -85822,24 +86367,24 @@ aLX
 aJq
 aYl
 aZN
-aYl
-aYl
-aYl
-aYl
-aYl
+csW
+ctk
+ctE
+aJq
+aJq
 bgG
-bid
-aYl
-bBi
-aLY
-bnN
+aKF
+cuh
+cul
+cuq
+aJq
 boY
-bqw
 aJq
 aJq
-aYl
-fAj
-aLX
+cuN
+aJq
+aLY
+aJq
 aJq
 aJq
 bBi
@@ -85910,8 +86455,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -86001,17 +86546,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -86041,14 +86586,14 @@ aiI
 afn
 vfX
 akD
-agj
-agj
-agj
-agj
+atF
+auJ
+avc
+avK
 aiX
 ycY
-anz
-aov
+ass
+aAz
 cCi
 air
 aqY
@@ -86079,24 +86624,24 @@ aJs
 aJq
 aYk
 aZM
-aZM
+aJw
 bbW
 bcX
 bcX
-aZM
-aZM
-aZM
-bjz
-bkT
-bjz
-bjz
-aiV
-bqv
-bqv
-bqv
-bqv
-bwg
+bcX
+bcX
+ctW
 aJw
+bmr
+bjz
+bwg
+bwg
+bwg
+bwg
+bwg
+bwg
+bwg
+bwg
 aJq
 aJq
 bBi
@@ -86114,7 +86659,7 @@ aaa
 aaf
 aaf
 bCq
-bTE
+pPI
 bAx
 bVI
 bWC
@@ -86167,8 +86712,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -86258,17 +86803,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -86300,12 +86845,12 @@ akg
 kuh
 aly
 anP
-gyr
+akN
 okK
-xal
-aqC
-anz
-aov
+aiX
+lNH
+azu
+lNH
 cCi
 aqX
 arR
@@ -86335,25 +86880,25 @@ aJn
 aJs
 aJq
 aYn
-aZM
+aJw
 aZu
 bbY
-bcY
-bdX
-bbX
 bgH
+bgH
+bgH
+aGh
 bie
-bjB
+aJw
 bkW
 bmp
-bjz
+bwg
 ajh
 bqy
 cBr
-bqy
-buK
+cBr
+cBr
 tZe
-aJw
+bwg
 aJq
 aJq
 bBi
@@ -86384,7 +86929,7 @@ bWB
 bWB
 cec
 bVI
-kNv
+cay
 ccw
 chY
 ciX
@@ -86424,8 +86969,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -86515,17 +87060,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -86555,12 +87100,12 @@ aiM
 ajz
 alz
 cZe
-alg
+agj
 plS
 dyE
 pQr
-aou
-aqC
+aiX
+awU
 anz
 aov
 ape
@@ -86592,26 +87137,26 @@ aJw
 aVb
 aWH
 aYm
-aZM
-aZq
-bbX
-bbX
-bbX
-bfp
-aZP
-aZP
-bjA
+rTu
+rTu
+cto
+ctF
+ctJ
+rTu
+rTu
+rTu
+cNL
 cAG
 bmo
-bmr
-boZ
+cuv
+bqx
 bqx
 brU
-bmr
-bmr
-bmr
-bmr
-byN
+cuO
+cuQ
+cuT
+bwg
+cuZ
 aJq
 bBj
 aJw
@@ -86681,8 +87226,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -86772,17 +87317,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -86812,12 +87357,12 @@ aiO
 afn
 xzv
 agL
-akT
-gNE
-gLz
-rcI
-seP
-aqC
+agj
+agj
+agj
+agj
+aiX
+axa
 anz
 aov
 cCi
@@ -86849,26 +87394,26 @@ aTQ
 aVd
 aWJ
 aYp
-aZM
+rTu
 aZz
 baI
 bda
-bda
+ctK
 bca
 bgJ
-aZP
+ctX
 cNL
 bkY
-bmo
-bnP
+bmp
+bwg
 bpc
-bqA
+bqB
 brW
 btB
 buM
-bwi
-bmr
-aMm
+bwj
+bwg
+cva
 aJq
 vEi
 bCs
@@ -86938,8 +87483,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -87029,17 +87574,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -87074,7 +87619,7 @@ akQ
 amB
 amn
 amS
-anz
+anw
 anz
 aov
 cCi
@@ -87106,25 +87651,25 @@ aPR
 aVc
 aWI
 aYo
-aZM
+rTu
 aZy
 bay
 bcZ
 bdY
 bdF
 bgI
-aZP
-bjC
+ctY
+cNL
 bkX
-bmo
-bnO
+cur
+bwg
 bpb
-bqz
+bqB
 bqq
 brS
 bsY
-bue
-bmr
+bwj
+cuX
 aMn
 aJq
 bBi
@@ -87143,7 +87688,7 @@ apV
 bLC
 cCf
 bNI
-bUz
+uCd
 bVI
 bWB
 bWB
@@ -87155,7 +87700,7 @@ bYz
 bWB
 bWB
 bVI
-cay
+emc
 ccw
 ccw
 ciY
@@ -87195,8 +87740,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -87286,17 +87831,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aqz
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -87328,10 +87873,10 @@ lfV
 akl
 akM
 amm
-gyr
+amp
 anM
 rJv
-aqC
+anw
 anz
 aox
 cCi
@@ -87363,27 +87908,27 @@ aPR
 aPR
 aWL
 aPR
-aZM
+rTu
 bbX
-bay
+ctp
 bbM
 bcN
 bdK
 bgL
-aZP
-aZP
-aZP
-bmo
-bnR
+ctZ
+aZO
+cum
+cus
+bwg
 bpe
 bqB
-bqq
+cuK
 btD
 buO
 bwk
-bmr
-aLY
-cBw
+bwg
+cvb
+aJq
 bBk
 bCs
 bDx
@@ -87452,8 +87997,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -87543,17 +88088,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -87582,13 +88127,13 @@ akU
 afM
 lBz
 alA
-ene
-alg
-kbm
-dyE
+uTe
+atG
+pAK
+avo
 cKC
 seP
-aqC
+anw
 anR
 aow
 apg
@@ -87622,26 +88167,26 @@ aWK
 aYq
 aZO
 aZC
-baK
+rnt
 rnt
 bbC
 bdI
 bgK
-bgK
-bjE
-bgK
+cua
+cNL
+cun
 bmq
-bnQ
+bwg
 bpd
-bpd
+cuJ
 bqr
 btC
 buN
 bwj
-bmr
+bwg
 byP
-aJq
-bBi
+cvd
+cvg
 bCs
 bDw
 bEZ
@@ -87657,7 +88202,7 @@ bKx
 cjL
 gbq
 bNI
-bUz
+uCd
 bVJ
 bWH
 bXE
@@ -87709,8 +88254,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -87800,17 +88345,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -87839,13 +88384,13 @@ afM
 afM
 nss
 kQz
-alB
+ene
 akT
 gNE
 gLz
-anB
-amR
-aqC
+arD
+rCl
+anw
 anz
 aov
 aph
@@ -87878,26 +88423,26 @@ aVg
 aWN
 aYs
 aZQ
-bbi
-bde
+kvL
+kvL
 kvL
 bcd
-bcd
-gNC
-bcd
-bcd
-bcd
+ctT
+kvL
+cub
+cui
+cuo
 bms
 bnS
 ajs
-bqC
+btE
 brZ
 btE
-bnS
+cuR
 bwl
 bxG
 byR
-bnM
+cve
 bBl
 bCs
 bFa
@@ -87966,8 +88511,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -88057,17 +88602,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -88096,13 +88641,13 @@ ahG
 ajY
 fxx
 ako
-ene
+akl
 amj
-akQ
+auK
 amB
-amn
-amS
-anz
+avL
+avX
+anw
 anz
 aov
 aph
@@ -88129,33 +88674,33 @@ aLY
 aOF
 aPR
 aPR
-aPR
+byS
 aTS
 aVf
 aWM
 aYr
-aZP
-bbh
+cNL
+cVs
 bcc
 bdd
 cVs
-bfr
-bgM
-bif
-aZM
-aZM
+rTu
+rTu
+rTu
+cuj
 bmr
 bmr
-bmr
-bmr
-bmr
-bmr
-bmr
-bmr
-bmr
-byQ
+bwg
+bwg
+bwg
+bwg
+bwg
+bwg
+bwg
+bwg
 aJq
-bBi
+bBo
+aJq
 bCs
 bFa
 bFa
@@ -88223,8 +88768,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -88314,17 +88859,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -88353,13 +88898,13 @@ agT
 all
 all
 aku
-akl
-amk
-amm
-gyr
+ene
+alg
+auL
+amp
 mos
-rJv
-aqC
+seP
+anw
 anz
 aov
 aph
@@ -88391,28 +88936,28 @@ aTV
 aVi
 aWP
 aYu
-aYt
-bbk
-bbk
-bfu
-bbk
-bfs
 rTu
-aZM
-aZM
-aaf
-aaf
-ktS
-aaf
-ktS
-aaf
-ktS
-aaf
-ktS
+cNL
+cNL
+cNL
+cNL
+rTu
+rTu
+gXs
+gXs
+aaa
+gXs
+aaa
+cuC
+gXs
+aaa
+gXs
+gXs
 fxV
-aXf
+fxV
+aBV
+bBo
 aJq
-bBi
 bCs
 bAM
 bFa
@@ -88480,8 +89025,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -88571,17 +89116,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -88611,12 +89156,12 @@ akF
 aiy
 akv
 uXt
-alg
+atH
 pAK
-dyE
+avo
 anQ
-seP
-aqC
+alv
+anw
 anz
 aov
 api
@@ -88647,28 +89192,28 @@ aSu
 aTU
 cpC
 aWO
-aYt
-aYx
-bbj
-bce
-bdf
-beb
-aYv
-cUx
-fcn
-aaf
-aaf
-ktS
-ktS
-aaf
+bfx
+bfx
+bfx
+bfx
+bfx
+bfx
+bfx
+gXs
+gXs
+yhz
+yhz
+yhz
+yhz
+yhz
+yhz
+yhz
+yhz
+gXs
+cuU
 fxV
-fxV
-fxV
-fxV
-fxV
-fxV
-aXf
 aJq
+bBo
 byU
 bCs
 bAL
@@ -88737,8 +89282,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -88828,17 +89373,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaf
@@ -88868,12 +89413,12 @@ aiQ
 xUX
 akx
 uTe
-akT
-amx
-any
+atJ
+gNE
+gLz
 arD
-amR
-aqC
+rCl
+axf
 anz
 aov
 aph
@@ -88904,29 +89449,29 @@ aSx
 aTX
 aVi
 aWR
-aYv
+bfx
 aZS
-aZR
-aZR
-bbm
+csX
+ctq
+ctG
 bec
-bfu
-vBa
-aBa
-aBa
-aBa
-aBa
-aBa
-aBa
-fxV
+bfx
+yhz
+yhz
+yhz
+cup
+cuu
+cuw
+cuD
+cuu
 bsb
 yhz
-ouQ
-cQT
-nbT
-aXf
+yhz
+fTC
+fxV
+aDv
+bBo
 aJq
-bBi
 bCs
 bFa
 bFa
@@ -88994,8 +89539,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -89085,22 +89630,22 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -89109,7 +89654,7 @@ aaa
 aaf
 aaf
 aaT
-aaf
+arN
 abx
 aaZ
 aeF
@@ -89124,13 +89669,13 @@ aij
 aiR
 ajc
 akz
-ene
+akl
 als
-akQ
+auK
 amB
-amn
-amS
-aqD
+avM
+avX
+anw
 anz
 aov
 aph
@@ -89161,29 +89706,29 @@ aSw
 aTW
 aVj
 aWQ
-aYv
+bfx
 aZR
-aZR
-aZR
-aZR
-aZR
+cta
+ctr
+ctr
+ctL
 bft
 psk
-aBa
+cuc
 aBT
 aDs
 aEN
 aGb
-aBa
-bqD
-bsa
+cuE
+bqG
+gBo
 vCn
-dzQ
-bsa
-nbT
-byS
+yhz
+fTC
+fxV
 aJq
-wTf
+bBo
+aMh
 bCs
 bCs
 bCs
@@ -89251,9 +89796,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -89342,22 +89887,22 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -89386,8 +89931,8 @@ alg
 alt
 amp
 aot
-apR
-aqE
+seP
+anw
 anz
 old
 apk
@@ -89419,25 +89964,25 @@ aTY
 aVl
 aWT
 aYx
-aZR
+csn
 bbm
-bbm
+cts
 bdh
 bee
 bfv
 xUL
 aBb
-gpD
-aDr
+xEB
+aDt
 cJW
-aGa
-aHF
+vOU
+vOU
 bqF
-buQ
-buQ
-pzk
-buQ
-bxI
+gUu
+vOU
+yhz
+fTC
+fxV
 bwa
 bAg
 bBq
@@ -89504,13 +90049,13 @@ cgI
 cgI
 cgI
 aaa
+aaa
+aaa
+aaa
 gDl
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -89599,22 +90144,22 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -89637,14 +90182,14 @@ aaZ
 aaZ
 aaZ
 fsa
-akz
+atD
 itD
-alg
+atG
 vyK
 amI
-alg
+avN
 alv
-aqE
+anw
 anS
 aoy
 apj
@@ -89662,7 +90207,7 @@ anz
 anz
 anz
 anz
-apj
+uXk
 aHP
 aJq
 aJq
@@ -89678,27 +90223,27 @@ aWS
 aYw
 aZT
 cBj
-bcf
+bfx
 bdg
 bed
-bfv
+ctU
 tyX
 pst
 cTT
 alu
 aEM
-aGd
+vOU
 uOJ
 bqE
-bqE
-bqE
-bqE
-bqE
-knx
-bvW
+cuL
+cuP
+yhz
+fTC
+fxV
+aNr
 bAf
 bBp
-aHP
+hcu
 bAN
 bQg
 bQg
@@ -89765,9 +90310,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -89856,22 +90401,22 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -89896,10 +90441,10 @@ aiZ
 jyO
 ajC
 akC
-akX
-alw
-amJ
-aoY
+alC
+gNE
+gLz
+arD
 rCl
 aqE
 anz
@@ -89933,9 +90478,9 @@ aTZ
 aVn
 aWV
 aYz
-aZR
-bbm
-bbm
+cso
+ctb
+ctt
 bdh
 bef
 bfv
@@ -89943,16 +90488,16 @@ gTx
 aBc
 xEB
 aDt
-aEO
-aGc
+buQ
+vOU
 vOU
 rTD
 dml
-dml
-oNz
-dml
-bxK
-bwh
+hcA
+yhz
+fTC
+fxV
+aGr
 bAh
 bBs
 bzG
@@ -90022,9 +90567,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -90113,22 +90658,22 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -90152,13 +90697,13 @@ aip
 aja
 xTe
 akz
-alg
-agn
-agn
+afM
+atL
+auM
 amN
 aoZ
 apT
-anw
+axj
 anz
 cXU
 apl
@@ -90190,27 +90735,27 @@ aTX
 aVm
 aWU
 aYy
-aZR
-aZR
-aZR
-aZR
-aZR
+csD
+ctc
+ctu
+ctu
+ctu
 bfw
 wZI
-aBa
+cud
 aBW
 bjy
 aEP
 nYe
-aBa
+cuF
 bqG
-bsa
+cuM
 eih
 pQN
-bsa
-nbT
-bwb
-aJq
+cuV
+fxV
+aNs
+aNr
 bBr
 bCv
 bCv
@@ -90279,9 +90824,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -90370,35 +90915,35 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
 aaf
 aaa
 aaf
 aaf
 abY
 gXs
-abG
-aaZ
+asP
+asR
 afc
-aco
+asS
 agU
 ahp
 ahY
@@ -90410,12 +90955,12 @@ ajb
 mml
 ajF
 akN
-akY
+ajc
 alE
 amU
-apH
+alg
 apX
-aqC
+xYm
 anz
 gfC
 aod
@@ -90446,28 +90991,28 @@ aSD
 ceh
 aVp
 aWX
-aYB
+bfx
 aZU
-aZR
-aZR
-bbm
+ctd
+ctw
+ctG
 beh
 bfx
-qcm
-aBa
-aBa
-aBa
-aBa
-aBa
-aBa
+yhz
+yhz
+yhz
+cup
+wql
+cux
+cuG
 wql
 bsg
 yhz
-ouQ
+yhz
 fTC
-nbT
-aJq
-aJq
+fxV
+aGD
+aNr
 bBu
 bCv
 bAT
@@ -90536,9 +91081,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -90627,31 +91172,31 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
+gXs
+gXs
+gXs
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aaf
+agr
+agr
+agr
+agr
 adR
-abo
+arO
 adR
 adR
 adR
@@ -90672,7 +91217,7 @@ alM
 amV
 apc
 aqr
-aqC
+fLn
 anT
 aoA
 apn
@@ -90690,8 +91235,8 @@ dgz
 dgz
 dgz
 dgz
-dgz
-dgz
+anF
+ahn
 aJn
 aJn
 aJq
@@ -90703,28 +91248,28 @@ aSC
 aUa
 aVo
 aWW
-aYA
-aYz
-bbn
-bcg
-aZU
-beg
-aYB
-qOB
-qBi
-aaf
-aaf
-ktS
-ktS
-aaf
-fxV
-fxV
-fxV
-fxV
-fxV
+bfx
+bfx
+bfx
+bfx
+bfx
+bfx
+bfx
+gXs
+gXs
+yhz
+yhz
+yhz
+yhz
+yhz
+yhz
+yhz
+yhz
+gXs
+cuW
 fxV
 aJq
-aJq
+aNr
 bBt
 bCv
 bDH
@@ -90793,9 +91338,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -90884,29 +91429,29 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aaa
+gDl
 aaa
 aaa
 aaa
+gXs
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aaf
+agr
+akX
+amE
+anK
 adR
 aaY
 abJ
@@ -90923,32 +91468,32 @@ aiv
 adg
 xSW
 ajI
-alC
-ala
-alN
+amq
+agn
+agn
 amW
 apv
 aqt
-aqF
+anA
 anz
 aoB
 aod
 aqe
 arf
-aqa
+aqo
 atf
+axO
+avg
 arf
-aqa
-atf
+azo
+aFd
 arf
-aqa
-atf
-dgz
-tqg
-ujF
+bfz
 ujF
 ujF
 dgz
+anF
+ahn
 aaa
 aJn
 aJq
@@ -90961,27 +91506,27 @@ aUc
 aVm
 aWY
 aYC
-aYA
-bbp
-bbp
-bfx
-bbp
-bfz
-sqp
+aZV
+bmx
+bmx
+bmx
+bmx
 aZV
 aZV
-aaf
-aaf
-ktS
-aaf
-ktS
-aaf
-ktS
-aaf
-ktS
+gXs
+gXs
+aaa
+gXs
+aaa
+cuH
+gXs
+aaa
+gXs
+gXs
 fxV
-aJq
-aJq
+fxV
+aHG
+aNr
 aXf
 bCv
 bDK
@@ -91050,9 +91595,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -91141,31 +91686,31 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
-aaa
-abo
-abk
+gXs
+aoV
+agr
+akY
+amK
+anO
+adR
+ash
 abk
 abk
 adR
@@ -91185,27 +91730,27 @@ alo
 alY
 ans
 ary
-agn
+awc
 anA
 anz
 gfC
 aod
 aqe
 arf
-apY
+rgL
 ate
+rgL
+rgL
 arf
-apY
-ath
+aAb
+ayV
 arf
-apY
-ath
-dgz
+bgy
 fvY
 dvc
-dzi
-vsM
 dgz
+anF
+ahn
 aaa
 aJn
 aLY
@@ -91213,32 +91758,32 @@ aLY
 aOG
 aPR
 aPR
-aPR
+byS
 aUb
 aVq
 aWM
-aYr
+crR
 aZV
 bbo
 bch
 bdi
 bbw
-bfy
-bgS
-bik
 aZV
 aZV
+aZV
+aZV
+aZV
 bmx
 bmx
 bmx
+aZV
+bsh
+bsh
+bsh
 bqH
-bsh
-bsh
-bsh
-bsh
 bqH
 aJq
-aJq
+aNr
 gnf
 bCv
 bDJ
@@ -91307,9 +91852,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -91398,31 +91943,31 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+gXs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaa
-adR
-abO
+aiU
+ala
+anj
+anO
+abo
+asp
 wlI
 abO
 abV
@@ -91442,7 +91987,7 @@ anr
 aqN
 arC
 asq
-agn
+awO
 anA
 anz
 aoD
@@ -91451,18 +91996,18 @@ aqe
 arf
 aqn
 ath
+axP
+rgL
 arf
-auw
-ath
-arf
+aAi
 ayV
-ath
-dgz
+arf
+bid
 aCd
 qIw
-gfD
-woR
 dgz
+anF
+ahn
 aJw
 yeA
 aMh
@@ -91478,24 +92023,24 @@ aYD
 aZX
 baf
 bdk
-mRQ
-bek
+bdk
+bdk
 bfB
 bgU
-bdk
+cue
 bjF
 blc
 bmz
 bnY
 bpk
-bqJ
+blc
 bsj
 btI
 btd
 bwr
-bqH
-aMm
-aJq
+cuY
+cvc
+cvf
 bBv
 cBy
 bDM
@@ -91531,8 +92076,8 @@ cfb
 cfb
 cfb
 clR
+cje
 cgR
-cgR
 cgI
 cgI
 cgI
@@ -91564,9 +92109,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -91655,36 +92200,36 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+gXs
+gXs
+gXs
+gXs
+aiU
+alp
+anj
+anO
 abo
-abO
-abO
-abO
-abO
-abO
-abO
+asO
+asQ
+asQ
+asQ
+asQ
+atC
 adk
 abo
 afD
@@ -91695,31 +92240,31 @@ akk
 akq
 lwN
 amq
-agn
+atU
 amb
 ant
-agn
-agn
+avO
+awP
 anA
 anz
 aoC
 aod
 aqe
 arf
-asd
+arf
 atg
-arf
+axT
 asd
-awo
 arf
-asd
-aAb
-dgz
+axT
+aHV
+arf
+bik
 iVU
 aDK
-vHj
-eVC
 dgz
+aoa
+ahn
 aJv
 khV
 aMg
@@ -91736,24 +92281,24 @@ aZW
 aZG
 bej
 bdj
-bej
+ctM
 bfA
 bgT
-bil
+bej
 bej
 blb
 bmy
-bnX
+bmy
 bpj
-bqI
+aZW
 bsi
 btH
 btc
 bwq
 bqH
-aJq
-aJq
-aXf
+aLY
+aLY
+cvh
 bCv
 bAU
 cAL
@@ -91821,9 +92366,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -91912,6 +92457,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -91919,22 +92475,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+gXs
+akb
+alB
+ank
+aou
 adR
 abl
 abN
@@ -91964,13 +92509,13 @@ apo
 aqh
 arh
 asg
-atj
+tKk
+aza
+aFe
 aul
-auR
-atj
 mps
 tKk
-atj
+bWw
 aAX
 azc
 atj
@@ -91997,26 +92542,26 @@ bcQ
 bfC
 bgV
 bim
-bjG
+bbw
 aZV
 bmB
 bnZ
 bpl
-bqH
+aZV
 bsl
 btK
 buW
 bwt
 bqH
-aLY
-aLY
-bBx
+aJq
+aJq
+aXf
 bCv
 apG
 bFk
 bDs
 bCv
-bJs
+bbK
 bHo
 bLK
 bMK
@@ -92045,9 +92590,9 @@ cel
 cyM
 ckT
 cgU
-cco
-cgU
-cgU
+prA
+rHv
+rHv
 cis
 cjN
 cgI
@@ -92078,9 +92623,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -92169,30 +92714,30 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
-abo
+gXs
+gXs
+gXs
+gXs
+gXs
+akb
+alN
+anj
+apH
+arM
 abm
 abP
 abS
@@ -92222,7 +92767,7 @@ aqg
 aun
 asf
 ati
-auk
+azb
 aux
 avt
 axL
@@ -92231,7 +92776,7 @@ azT
 nZE
 ker
 aDG
-aFd
+auk
 auk
 aHH
 aJg
@@ -92253,13 +92798,13 @@ asD
 bcP
 cBo
 bgS
-bbw
-bbw
+cuf
+cuk
 aZV
 bmA
+cuy
 bmx
-bmx
-bqH
+aZV
 bsk
 btJ
 buV
@@ -92335,9 +92880,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -92426,6 +92971,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -92433,22 +92989,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+gXs
+aiU
+amk
+anl
+apR
 adR
 abn
 abH
@@ -92467,7 +93012,7 @@ akf
 akJ
 yhx
 agn
-agn
+auV
 agn
 agn
 agn
@@ -92483,7 +93028,7 @@ arf
 arf
 ltK
 xAv
-awr
+aQW
 awr
 ruo
 aAh
@@ -92516,7 +93061,7 @@ aZV
 bmC
 boa
 bpm
-bqH
+aZV
 bsn
 btL
 buY
@@ -92528,7 +93073,7 @@ aXf
 bCv
 bDP
 bCv
-bAw
+cGz
 bHV
 bJw
 bKC
@@ -92592,9 +93137,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -92683,29 +93228,29 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
 aaf
-aaf
-aaf
-aaf
-aaf
+akb
+amD
+anm
+aqD
 abq
 abq
 abq
@@ -92735,12 +93280,12 @@ cSA
 aqe
 arf
 aqo
-atm
 rgL
-arf
+rgL
+azf
 avv
 awu
-awr
+aSi
 aAd
 tkq
 aAh
@@ -92771,9 +93316,9 @@ bbw
 bjH
 aZV
 bmx
+cuy
 bmx
-bmx
-bqH
+aZV
 bsm
 btL
 buX
@@ -92849,9 +93394,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -92940,6 +93485,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -92947,22 +93503,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+gXs
+akb
+akb
+ann
+akb
 abq
 adN
 aeu
@@ -92992,13 +93537,13 @@ cSA
 aqe
 arf
 asm
-atm
+rgL
 blU
-avg
+vyp
 awp
 axN
-awr
-awr
+bbp
+bek
 haM
 aAh
 aDQ
@@ -93018,18 +93563,18 @@ aVv
 aXg
 aYF
 aZV
-nZL
+bbw
 bcn
-tgH
+bbw
 ben
 bfE
 bgX
-bbw
+cug
 bjJ
 bld
 bmD
 cTD
-bmD
+cuI
 bqK
 bso
 btN
@@ -93077,12 +93622,12 @@ clU
 bOh
 ccw
 coZ
-cgU
-cgU
+rHv
+hPy
 cDK
 crw
 cjO
-ccw
+cig
 crX
 ciZ
 jiK
@@ -93099,16 +93644,16 @@ aaT
 aaa
 aaa
 aaa
-aae
+aoV
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -93197,17 +93742,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -93216,10 +93761,10 @@ aaa
 aaa
 aaa
 aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
 aaL
 adO
 acr
@@ -93249,7 +93794,7 @@ cSA
 aqe
 arf
 ari
-asu
+rgL
 mPk
 aun
 avR
@@ -93274,6 +93819,7 @@ aJn
 aJs
 aXf
 aYk
+csM
 aZV
 aZV
 aZV
@@ -93282,12 +93828,11 @@ aZV
 aZV
 aZV
 aZV
-aZV
-aZV
-bmx
-bmx
-bmx
-bqH
+fxV
+aJw
+cuz
+aJw
+fxV
 bqH
 btM
 bqH
@@ -93336,23 +93881,14 @@ ccw
 cpa
 cjc
 cqo
-cDL
+cDN
 cjk
 cjm
-ccw
-ccw
 cig
 cig
-aag
-aag
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-eRz
+cig
+cig
+gJi
 aaa
 aaa
 aaa
@@ -93366,6 +93902,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -93457,14 +94002,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aae
@@ -93476,7 +94021,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaM
 abr
 abQ
@@ -93505,20 +94050,20 @@ ajo
 apq
 aqe
 arf
+avg
+rgL
+aze
 arf
-arf
-arf
-arf
-ltK
-axP
-azb
-aAi
+bsc
+xAv
+awr
+awr
 uIO
 aCn
 xBk
 dtx
 aGm
-aHV
+caf
 aDM
 hIM
 aJq
@@ -93542,7 +94087,7 @@ aYG
 aYG
 ble
 bmE
-bmE
+cuA
 bpn
 bqL
 bsp
@@ -93593,23 +94138,14 @@ ccw
 ccw
 cpI
 ccw
-cDL
-cjl
-cjQ
-cjV
-cig
-aaf
-aaf
-aaf
-aaf
-aag
-aaa
-aaa
-aae
-aaa
-aaa
-aaa
-eRz
+cDN
+vkV
+pGi
+lQe
+mzF
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -93623,6 +94159,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -93714,26 +94259,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aag
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aaO
 adQ
 act
@@ -93762,20 +94307,20 @@ ajo
 app
 aqi
 arf
-ask
-atm
-rgL
 arf
-awq
-axO
-aza
+arf
+arf
+arf
+ltK
+xAv
+awr
 kmw
-xrN
+arf
 aAh
 aAh
+bqw
 aAh
-aAh
-aAh
+bwb
 aDN
 aAh
 aMo
@@ -93799,12 +94344,12 @@ aJq
 aJq
 aJq
 aJq
-aJq
+bBo
 aJq
 aLY
 aJq
 bAk
-aJq
+bjx
 aJq
 aJq
 aJq
@@ -93851,22 +94396,17 @@ cpb
 ciZ
 cqp
 cDN
-cjT
-cgR
-crP
-cig
+jOs
+hhH
+xHP
+mzF
+gXs
 aaa
-aaa
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-quT
+gXs
+gXs
+iDo
+iDo
+iDo
 aaa
 aaa
 aaa
@@ -93880,6 +94420,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -93971,6 +94516,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -93982,15 +94535,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+gXs
 abq
 aes
 aey
@@ -94019,23 +94564,23 @@ ajo
 aps
 aqk
 arf
-aqo
-atm
+awo
+awq
 aHw
 avn
 awv
 axX
-aze
 awr
-flE
-aAh
+bfy
+arf
+bil
 aDU
 aBz
-aBz
 aAh
+bwb
 dTI
-ujv
-aJq
+aAh
+cbk
 aJq
 aJq
 aJq
@@ -94056,7 +94601,7 @@ aJq
 aJq
 aJq
 bAi
-bmS
+cuB
 bmS
 bpC
 bqN
@@ -94107,23 +94652,18 @@ cig
 cig
 czg
 cig
-cDN
-crh
-crA
-crR
-crY
-csi
+icJ
+gUV
+lNs
+nki
+nki
+nki
+nki
+gXs
 aaa
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-eRz
+iDo
+ctv
+iDo
 aaa
 aaa
 aaa
@@ -94132,11 +94672,16 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -94228,14 +94773,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -94277,36 +94822,36 @@ apr
 aqj
 arf
 ark
-asu
+awA
 xPk
 aun
 awt
-awr
-awr
+azT
+azT
 azX
-aAZ
+aun
 aCe
 aDT
 cPn
-cPn
+bqJ
 mkO
 uQS
 aAh
 aJC
 aJC
 aJC
-aQg
-bYP
-aJC
-aQg
 aJC
 aJC
 aQg
 aJC
+aQg
 aJC
-aHP
-aHP
-aHP
+aQg
+aJC
+aJC
+nIB
+nIB
+nIB
 bfF
 bfF
 bfF
@@ -94364,23 +94909,19 @@ cig
 aaa
 afp
 aaa
-cDN
-cqY
-cqY
-cqY
-cig
-aaa
-csl
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-quT
+cDL
+eci
+xHD
+hJp
+leD
+fka
+nki
+gXs
+gXs
+iDo
+ctv
+iDo
+gXs
 aaa
 aaa
 aaa
@@ -94394,6 +94935,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -94485,14 +95030,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -94538,32 +95083,32 @@ arf
 arf
 arf
 awz
-awr
-awr
+aAZ
+aAZ
 avG
-aBA
-aAh
+arf
+bjB
 aDP
 aBx
-aBx
 aAh
-qqs
+bxI
+cbj
 sYR
 aMq
-adq
-aQb
+aKR
+aKR
 aPZ
 aRu
 kAH
+cAD
 aKR
-tCa
 aXi
 hgO
-baa
+bab
 aJC
-bcq
-bcq
-bcq
+fBs
+fBs
+fBs
 bfF
 bha
 bio
@@ -94621,23 +95166,18 @@ cig
 aaa
 aaa
 aaa
-cDN
+cDL
+uZI
+pBN
+iEn
+fXg
+xhW
+nki
 aaa
 aaa
-aaa
-aaf
-aaf
-cso
-aaf
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gXs
+iDo
+ctv
+iDo
 aaa
 aaa
 aaa
@@ -94651,6 +95191,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -94742,14 +95287,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -94790,15 +95335,15 @@ ajo
 apt
 aql
 wyE
-wyE
-wyE
-wyE
 avw
+lgX
+arz
+axp
 awy
 lgX
 lgX
 qvf
-wqF
+pQp
 aAh
 aAh
 aAh
@@ -94806,14 +95351,14 @@ aAh
 aAh
 aAh
 aAh
-aKR
-aKR
+ccc
+ceV
 fxe
-aPY
-kAO
-aRx
+sLj
 aKR
-iTU
+hIL
+hIL
+aKR
 pqe
 aPY
 aZZ
@@ -94879,22 +95424,17 @@ aaa
 aaa
 aaa
 cDL
-aaf
+kNq
+glY
+xAI
+kCj
+vQs
+nki
+gXs
 aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-quT
+iDo
+ctv
+iDo
 aaa
 aaa
 aaa
@@ -94908,6 +95448,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -94999,14 +95544,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -95033,11 +95578,11 @@ ahl
 uHp
 aic
 ahT
-ahT
-ahT
-ahT
-ahT
-ahT
+adq
+ahs
+ahO
+ajG
+adq
 ahT
 alL
 ahT
@@ -95046,17 +95591,17 @@ ahT
 ydM
 anZ
 apu
-arf
-arf
-arf
-arf
-arf
-awA
-axT
-axW
-aAl
-cHf
-aJC
+pQp
+bag
+big
+arm
+arm
+btG
+fHG
+fHG
+aAn
+pQp
+bjG
 aDR
 aFl
 kqI
@@ -95067,12 +95612,12 @@ hIL
 aKR
 wxT
 moD
-aQd
-aQa
 aKR
-elh
-wxT
-uBa
+aKR
+aKR
+aKR
+ceY
+aKR
 bac
 aJC
 aYV
@@ -95135,36 +95680,36 @@ aaa
 aaa
 aaa
 aaa
-cCQ
-aaf
-aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-eRz
+cDL
+wKh
+oRV
+oRV
+oRV
+fNG
+nki
+gXs
+gXs
+iDo
+ctv
+iDo
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -95256,14 +95801,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -95293,46 +95838,46 @@ aif
 aif
 aif
 aif
+akH
 aif
-fpz
-bkV
+aif
 jKP
-alK
+aif
 aif
 anc
-anc
+azp
 anD
 aoI
-arf
-eSe
-asN
+pQp
+bbO
+fHG
 aur
 avy
 nSt
 axS
-azk
+fHG
 aAk
-tvi
-aJC
+pQp
+bnN
 aDY
-aDY
-kqI
-aKR
+bqI
+bvW
+bxK
 aJk
 aKR
 aKR
+ceY
+cjK
+oIJ
 aKR
+crm
+cAE
 aKR
-aKR
-aKR
-aKR
-aKR
-aKR
-aKR
-aKR
+cAK
+cAQ
 bab
-aJC
-ucq
+aQg
+aYV
 aYV
 ber
 bfF
@@ -95392,58 +95937,58 @@ aaa
 aaa
 czN
 aaa
-cCQ
-aaf
-aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-jAD
+cDL
+xEb
+xqH
+iRp
+grT
+uvQ
+nki
+gXs
+gXs
+iDo
+ctv
+iDo
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -95520,7 +96065,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -95551,44 +96096,44 @@ ahn
 aiA
 ahn
 grc
+anF
+ahn
 anE
+arp
+avD
 aod
 ahn
-apx
+ast
 ahn
-ahn
-ahn
-ahn
-ahn
-arf
-oAB
-eQb
-aut
-arf
-aXF
-awr
-awr
-aAn
-rqk
-aJC
+pQp
+bdL
+fHG
+lUS
+azk
+bHC
+aBA
+bVA
+axq
+pQp
+aCh
 aEc
 aFk
 aGw
-aKR
+byQ
 aJC
 aKr
 aKR
-aKR
-sLj
-sLj
-vcN
-aKR
-aKR
-aKR
+eJa
+coh
 sLj
 aKR
-aKR
-bbx
+hIL
+hIL
+cAH
+cAK
+dce
+ewu
+aJC
 aYV
 aYV
 tkB
@@ -95649,58 +96194,58 @@ aaa
 aaa
 aaa
 aaa
-cCQ
-aaf
+cDL
+qOZ
+iRp
+oiX
+nrL
+wEa
+nki
+gXs
 aaa
-aaa
-aaf
-aaf
-cso
-aaf
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-eRz
+iDo
+ctv
+iDo
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -95777,7 +96322,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -95800,52 +96345,52 @@ wdv
 afp
 wdv
 abp
-aaa
-aaa
+gXs
+gXs
 ahn
 nQi
 ahn
 uei
 ahn
-grc
-anE
-aod
-aoK
+alK
+anF
 oyX
-aqp
-ahn
+anG
+aqA
+anF
+aod
 tzQ
 pgf
 gzf
-eQb
-eQb
-eQb
+pQp
+beZ
+fHG
 lUS
-aun
+aXF
 avz
-awr
-awr
-aAn
-jGW
-aJC
-aJC
+aBA
+bVB
+bWz
+pQp
+aCr
+boV
 plC
-oAb
-aJC
+aGv
+aCr
 aJC
 aKq
-aKR
-aNF
-hOv
+aSH
+eJa
+wxT
 oax
-oxm
+aKR
 aSH
 aKR
-rmN
-eJa
-hSZ
 aKR
-aQg
+eJa
+aKR
+aKR
+bbx
 aYV
 aYV
 bes
@@ -95906,58 +96451,58 @@ aaa
 aaa
 aaa
 aaa
-cCQ
-aaf
+cDL
+xEb
+grT
+iRp
+xqH
+uvQ
+nki
 aaa
 aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-eRz
+iDo
+ctv
+iDo
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -96034,7 +96579,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -96065,23 +96610,23 @@ ahn
 anF
 ahn
 eMs
-anG
-aoe
-aoL
-apy
-aqq
-ahn
+anF
+anE
+arj
+atZ
+awC
+ask
 qLR
 oIW
-arf
-kmS
-ast
-eQb
+asN
+pQp
+bgN
+fHG
 auv
-arf
 avA
+bPX
 axW
-azo
+arm
 aAp
 uxY
 aBC
@@ -96091,16 +96636,16 @@ aGz
 aIb
 aJC
 aKN
-aKR
-aKR
+ccd
+chI
 aOJ
 oIJ
-unA
 aKR
-akH
+cAy
+aKR
 aUg
-bFC
-hSZ
+eJa
+aKR
 aKR
 bbx
 aYV
@@ -96163,58 +96708,58 @@ aoV
 aoV
 aoV
 aoV
-cCQ
-aoV
-aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-quT
+cDL
+nWM
+rIH
+rIH
+rIH
+fBg
+nki
+gXs
+gXs
+jUU
+ctv
+iDo
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -96291,7 +96836,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -96314,10 +96859,10 @@ aaa
 aaa
 aaa
 gXs
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
 ahn
 chO
 ahn
@@ -96331,30 +96876,30 @@ ahn
 arf
 arf
 arf
-asd
-arf
-arf
-arf
-arf
-hlV
-oHB
-azf
+pQp
+bgO
+fHG
+bij
+bnV
+bPY
+azg
+bVE
 aAo
-vyp
+bXy
 aBB
 aBB
 aBB
 aGy
 aIa
 cNE
-aKM
 aMu
-aMu
-feG
-tif
+ccZ
+chK
 aMu
 aMu
 aMu
+cAA
+pqe
 jgA
 aSq
 aKR
@@ -96420,58 +96965,58 @@ aoV
 aoV
 aaa
 aaa
-cCQ
-aoV
+cDL
+nki
+nki
+nki
+nki
+nki
+nki
 aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-eRz
+gXs
+iDo
+ctv
+aaT
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -96548,7 +97093,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -96574,13 +97119,13 @@ gXs
 aaa
 aaa
 aaa
-aaa
+gXs
 gJi
 gJi
 dFX
 wWW
-dqb
-lCo
+wcR
+xZL
 ohq
 wXl
 iou
@@ -96589,26 +97134,26 @@ xZL
 wig
 str
 rrM
-clO
-ahC
-ahP
+oZl
+oZl
+oZl
 oZl
 awB
 att
 azh
-fHG
-fHG
-kxf
-ufD
+bWA
+bYt
+pQp
+aaa
 alP
 aGI
 aId
 aJD
 aKP
 aMx
-aMx
+ciT
 aQe
-aOL
+aMx
 aMx
 aMx
 aMx
@@ -96678,57 +97223,57 @@ aaa
 aaa
 aaa
 cCQ
-aaf
-aaf
-aaf
-aaf
-aaf
-cso
-aaf
-aaf
-aag
+aaa
+aaa
+gXs
+aaa
+gXs
+aaa
+aaa
+gXs
+iDo
+iDo
+aaT
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-quT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -96805,7 +97350,7 @@ cNd
 cNd
 cNd
 cNd
-aaa
+cNd
 aaa
 aaa
 aaa
@@ -96830,33 +97375,33 @@ aaa
 oyN
 aaa
 aaa
-aaa
-aaa
+gXs
+gXs
 aaa
 aaa
 uEx
-ulM
+wWW
 wcR
-uzs
-uzs
-uzs
-uzs
-uzs
+wcR
+wcR
+auz
+ecg
+ecg
 ecg
 jLT
 veS
 arm
-fHG
+arm
 aya
 fHG
 fHG
 auB
-atZ
-azg
-azp
 fHG
-aCu
-qOc
+azg
+fHG
+bYu
+pQp
+ktS
 alP
 aGH
 aIc
@@ -96864,15 +97409,15 @@ aJC
 aKO
 aMw
 aNI
-aKR
-aKR
+cqK
+crl
 acN
 acN
 acN
 acN
 acN
-aKR
-aKR
+acN
+eAJ
 aJC
 bcr
 aYV
@@ -96935,57 +97480,57 @@ dCt
 dCt
 dCt
 imk
-aoV
+gXs
+gXs
+gXs
 aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-quT
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -97062,14 +97607,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -97088,32 +97633,32 @@ efO
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
+gXs
 aaa
 uEx
 azm
-gvX
+wcR
 qWV
 con
 oVo
 con
 con
-eVJ
+wcR
 ujS
 aqs
-coh
 fHG
-fHG
-fHG
-fHG
+bhJ
+bih
+bkC
+bnW
 pPi
-fHG
+bUv
 ayb
 hWd
-fHG
-aCv
-mbU
+pQp
+pQp
+aaa
 alP
 aGJ
 aIe
@@ -97126,12 +97671,12 @@ aJC
 aXj
 aVy
 aSY
-aVy
+cAJ
 xqG
-acN
+elh
 bah
 aJC
-aYV
+feG
 bdo
 beu
 bvk
@@ -97192,22 +97737,14 @@ aoV
 aoV
 aae
 gXs
-aoV
 aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-jAD
+iDo
+iDo
+iDo
+iDo
+iDo
+gXs
+gXs
 aaa
 aaa
 aaa
@@ -97215,34 +97752,42 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -97319,14 +97864,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -97342,35 +97887,35 @@ gJi
 gXs
 gJi
 gJi
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
 aaa
 aaa
 uEx
-stF
-gvX
+wcR
+wcR
 con
 con
 con
 con
 con
-eVJ
-dqb
+wcR
+aCu
 qeA
 ahm
-fHG
-fHG
-fHG
-fHG
-pPi
-fHG
-ayb
-hWd
-fHG
+ahm
+bii
+bkD
+bph
+bph
+bkD
+bVF
+bVG
+bVG
 sci
-sEi
+gXs
 alP
 aGJ
 aIe
@@ -97384,9 +97929,9 @@ egt
 aQc
 aSZ
 aQc
-qaY
-acN
-bag
+aQc
+aQc
+aQc
 aJC
 aYV
 aYV
@@ -97449,46 +97994,13 @@ aoV
 aoV
 aoV
 gXs
-aoV
-aaa
-aaa
-aaf
-aaa
-csn
-aaa
-aaf
-aag
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-ctZ
-ctZ
-ctZ
-ctZ
-ctZ
-aaf
-aaa
-aaf
-cvF
-aaf
-aaa
-aaa
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-cAU
-aaf
+gXs
+iDo
+ctv
+ctv
+ctv
+iDo
+gXs
 aaa
 aaa
 aaa
@@ -97497,9 +98009,42 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -97576,14 +98121,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -97601,32 +98146,32 @@ gXs
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
+gXs
 dFX
 lnk
-gvX
+wcR
 wQg
 con
-con
+avC
 con
 fyS
-eVJ
-dqb
-veS
-ahs
-sJI
-ahO
-fHG
-eAJ
-rvr
-nLu
-hcA
-ryr
-fHG
-aCu
+wcR
+wHk
+aqu
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aCw
 puh
 alP
 aGA
@@ -97641,8 +98186,8 @@ aRz
 aSF
 aQc
 aQc
-aXl
-aKR
+aQc
+aQc
 bai
 aJC
 aYV
@@ -97706,49 +98251,12 @@ mfI
 mfI
 mfI
 mfI
-mfI
-mfI
-mfI
-mfI
-mfI
-csM
-mfI
-mfI
-ctd
-mfI
-mfI
-mfI
-mfI
-vOC
-ctZ
-ctZ
-cuo
-cuA
-cuM
-ctZ
-cvk
-cvk
-cvk
-cvk
-aaf
-aaf
-aaf
-aaf
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
+aaa
+iDo
+iDo
+iDo
+iDo
+iDo
 aaa
 aaa
 aaa
@@ -97756,7 +98264,44 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -97833,14 +98378,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -97858,33 +98403,33 @@ xLX
 aaa
 aaa
 aaa
-aaa
+gXs
 aaa
 aaa
 aaa
 uEx
-dqb
-gvX
+unR
+wcR
 con
 con
 con
 con
 con
-eVJ
+wcR
 iBv
-lZK
-fZm
-jmV
-epD
-ghD
-hBA
-xbn
-fHG
-reA
-lsk
-xXi
-jAN
-jEc
+aqu
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aCw
+gXs
 alP
 aGL
 aHM
@@ -97899,8 +98444,8 @@ aQc
 aac
 aQc
 aXk
-aKR
-aKR
+aQc
+eCr
 aJC
 aYV
 aYV
@@ -97954,7 +98499,7 @@ cjp
 chh
 ciy
 cke
-cjr
+cfv
 pzG
 uHc
 aoV
@@ -97964,56 +98509,56 @@ aoV
 aoV
 aoV
 aoV
-aoV
-aaa
-aaf
-aaa
-csn
-aag
-aag
-aag
-aag
 aaa
 aaa
-aaa
-nFj
-ctY
-cuh
-cun
-cuz
-cuL
-cuY
-cvj
-cvs
-cvD
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvX
-cvX
-cvX
-cvX
-cwq
-cwq
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
+gXs
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -98090,19 +98635,19 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -98120,7 +98665,7 @@ aaa
 aaa
 aaa
 uEx
-dqb
+wag
 kdO
 con
 con
@@ -98129,19 +98674,19 @@ con
 con
 akE
 wHk
-ewu
-pQp
-pQp
-oqj
-jBi
-fpl
-fpl
-jBi
-oDN
-sEM
-sEM
-pRs
-arj
+aqu
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aro
+aCw
+aaa
 alP
 aGL
 aIe
@@ -98196,7 +98741,7 @@ bLT
 bLT
 bUY
 bWe
-bWe
+bnt
 bWe
 bWe
 bWe
@@ -98204,14 +98749,14 @@ cdE
 bAw
 bzs
 bAw
-caK
+bYr
 uHc
 ciB
 ckh
 chj
 ciA
 dQD
-cjr
+cfv
 clh
 uHc
 aoV
@@ -98223,54 +98768,54 @@ aoV
 aoV
 aoV
 aaa
-aaf
-aaa
-csn
-csD
-cta
-csD
-cua
-aaa
-aaa
-aaa
-aaf
-ctZ
-cui
-cuq
-cuC
-cuO
-cuz
-cvm
-cvt
-cvt
-cvt
-cvL
-cvQ
-cvX
-cvX
-cvX
-cvX
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cvx
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -98347,21 +98892,21 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gDl
 aaa
 aaa
 aaa
@@ -98377,15 +98922,15 @@ aaa
 aaa
 aaa
 uEx
-dqb
-gvX
+unR
+wag
 con
 con
 con
 con
 con
-eVJ
-wHk
+wcR
+aCy
 aqu
 aro
 aro
@@ -98398,7 +98943,7 @@ aro
 aro
 aro
 aCw
-aaa
+gXs
 alP
 aGL
 aIg
@@ -98480,54 +99025,54 @@ czJ
 aaf
 aoV
 aaa
-aaf
-aaa
-csn
-csD
-csX
-ctg
-cua
-cua
-cua
-cua
-cua
-ctZ
-ctZ
-cup
-cuB
-cuN
-cuZ
-cvj
-cvj
-cvj
-cvj
-cvj
-cvP
-cvj
-cvj
-cvj
-cvj
-cva
-cva
-cva
-cva
-cvp
-cwv
-cvr
-cvp
-cvl
-cvr
-cwv
-cvp
-cva
-cva
-cva
-aaf
 aaa
 aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -98604,14 +99149,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -98635,14 +99180,14 @@ aaa
 aaa
 dFX
 jMW
-gvX
+unR
 wQg
 con
 con
 con
 fyS
-eVJ
-wHk
+wcR
+aKM
 aqu
 aro
 aro
@@ -98655,7 +99200,7 @@ aro
 aro
 aro
 aCw
-aaf
+aoV
 alP
 aGL
 aIe
@@ -98724,8 +99269,8 @@ cfZ
 cjr
 cld
 cjr
-cjr
-cjr
+cfv
+cfv
 csq
 xJC
 wHz
@@ -98737,54 +99282,54 @@ aag
 aag
 aag
 aaa
-aaf
-csD
-csO
-csD
-czk
-cti
-cua
-cua
-ctw
-ctH
-ctQ
-cuc
-cuj
-cuj
-cuE
-cuQ
-cuj
-cvk
-cvw
-cvw
-cvG
-cvM
-cvS
-cvZ
-cvG
-cvw
-cvw
-cvf
-cwh
-cwm
-cwr
-cvp
-cwx
-cwj
-cwu
-cAV
-cAZ
-cvl
-cvl
-cva
-cva
-cva
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -98861,14 +99406,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -98891,28 +99436,28 @@ aaa
 aaa
 aaa
 uEx
-sth
-gvX
+unR
+wag
 con
 con
 con
 con
 con
-eVJ
-wHk
-aqu
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aCw
-aaa
+wcR
+aOL
+aQb
+ahm
+ahm
+ahm
+bkV
+bph
+bph
+bVx
+bVG
+bVG
+bVG
+bYv
+gXs
 alP
 aGN
 aIh
@@ -98978,7 +99523,7 @@ cdF
 ceD
 cfk
 cfY
-cjr
+cfv
 ckj
 cle
 cle
@@ -98994,54 +99539,54 @@ cqs
 aaa
 aag
 aaa
-aaf
-csD
-csN
-csV
-ctb
-cth
-cua
-ctr
-ctu
-ctG
-ctP
-cub
-cuj
-cur
-cuD
-cuP
-cvc
-cvk
-cvu
-cvu
-cvu
-cvu
-cvR
-cvY
-cwb
-cvu
-cvu
-cva
-cwg
-cwl
-cwr
-cvl
-cww
-cwD
-cvv
-cvv
-cAY
-cBb
-cBd
-cva
-cva
-cva
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -99118,14 +99663,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -99149,27 +99694,27 @@ aaa
 aaa
 uEx
 wag
-gvX
+unR
 con
 con
 voW
 con
 con
-eVJ
-wHk
-aqu
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aCw
-aaf
+wcR
+aQa
+uEx
+gXs
+gXs
+pQp
+bkZ
+bqD
+bRh
+azg
+alP
+alP
+alP
+aaa
+aoV
 alP
 aGB
 aIf
@@ -99185,7 +99730,7 @@ aVD
 aVE
 aXm
 aVz
-juG
+bak
 bbz
 aYV
 bdp
@@ -99251,54 +99796,54 @@ cqt
 aaa
 aag
 aaa
-aaf
-csD
-csU
-csW
-ctc
-ctc
-cto
-ctt
-cty
-ctJ
-ctT
-cue
-cul
-cuu
-cuG
-cuS
-cve
-cvo
-cvz
-cvz
-cvI
-cvz
-cvT
-cBS
-cwc
-cvz
-cwd
-cwf
-cwj
-cwo
-cwt
-cwu
-cwA
-cAR
-cAS
-cvv
-cBa
-cBc
-cBe
-cva
-cva
-cva
-cBf
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -99375,14 +99920,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -99406,27 +99951,27 @@ aaa
 aaa
 uEx
 tAC
-uAH
+wag
 unR
-unR
+wag
 dCr
+wag
 unR
-unR
-hzK
+wcR
 iYE
-aqu
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aro
-aCw
-aaa
+uEx
+gXs
+gXs
+pQp
+bnT
+bij
+bUt
+bVy
+alP
+bXw
+alP
+alP
+alP
 alP
 aGL
 aHY
@@ -99508,54 +100053,54 @@ cqs
 aaa
 aag
 aaa
-aaf
-csD
-ctb
-csV
-ctb
-ctj
-ctk
-cts
-ctx
-ctI
-ctS
-cud
-cuk
-cus
-cuF
-cuR
-cvd
-cvn
-cvy
-cvy
-cvH
-cvy
-cvy
-cvy
-cvy
-cvy
-cvy
-cwe
-cwi
-cwn
-cws
-cwn
-cwz
-cwE
-cvv
-cvv
-cvv
-cvp
-cvl
-cva
-cva
-cva
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -99632,14 +100177,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -99663,27 +100208,27 @@ aaa
 aaa
 dFX
 xaB
-mgF
-mgF
-mgF
+unR
+wag
+unR
 vAl
 meb
-meb
+awE
 meb
 iMv
-vmQ
-pQp
-pQp
+dFX
+gXs
+gXs
 pQp
 grA
-fpl
-fpl
+grA
+alP
 gbh
-sEM
-sEM
-sEM
-aCy
-arj
+alP
+anf
+anf
+iYL
+auD
 alP
 aGL
 avI
@@ -99699,7 +100244,7 @@ aTO
 cCq
 aVz
 aVz
-qus
+bak
 bbz
 aYV
 bdp
@@ -99765,54 +100310,54 @@ aag
 aag
 aag
 aaa
-aaf
-csD
-csD
-csD
-csD
-cti
-ctq
-cua
-ctA
-cuy
-ctV
-cug
-cuj
-cuj
-cuE
-cuU
-cuj
-cvk
-cvw
-cvw
-cvJ
-cvw
-cvV
-cwa
-cvJ
-cvw
-cvw
-cvb
-cwk
-cwp
-cwr
-cvp
-cwC
-cwn
-cAT
-cAW
-cvl
-cvl
-cvl
-cva
-cva
-cva
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -99889,14 +100434,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -99917,30 +100462,30 @@ aaS
 aaS
 aaS
 aaS
+gXs
+dFX
+dFX
+uEx
+uEx
+uEx
+dFX
+uEx
+uEx
+uEx
+dFX
+dFX
+gXs
+gXs
+gXs
 aaa
-dFX
-dFX
-uEx
-uEx
-uEx
-dFX
-uEx
-uEx
-uEx
-dFX
-dFX
 aaa
-aaa
-arj
-fCx
-avD
-awC
-ayb
-eCr
-jvd
-cEo
-xZD
-vpY
+alP
+anf
+alP
+jSZ
+iWx
+anf
+anf
 alP
 aGJ
 avI
@@ -100006,13 +100551,13 @@ cdJ
 bzs
 cfm
 cgc
-bAw
+cgo
 ciF
 cjw
 ckl
 clk
 clk
-bAw
+lFn
 bzs
 aaf
 aaa
@@ -100024,52 +100569,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-ctp
-cua
-ctz
-ctK
-ctU
-cuf
-cuf
-cuv
-cuH
-cuT
-cvg
-cvj
-cvj
-cvj
-cvj
-cvj
-cvU
-cvj
-cvj
-cvj
-cvj
-cva
-cva
-cva
-cva
-cvp
-cwB
-cvr
-cvp
-cvl
-cvr
-cwB
-cvp
-cva
-cva
-cva
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -100146,14 +100691,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -100176,6 +100721,7 @@ aaf
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
@@ -100184,21 +100730,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+gXs
 aaf
 aaf
-arj
-auz
-avC
-vHz
-aya
-fHG
-fHG
+aaa
+aaa
+gXs
+alP
+anf
+alP
+bXx
 xkd
-fHG
-fHG
-gOZ
+bYw
+anf
+gbh
 aGJ
 avI
 aJL
@@ -100260,11 +100805,11 @@ caO
 cbN
 ccI
 cdL
-ceI
+bzs
 cfo
-bAw
-bAw
-bAw
+cdR
+cgq
+ckS
 cjz
 ceJ
 clm
@@ -100281,52 +100826,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-cua
-ctF
-ctM
-ctX
-cuf
-cum
-cuw
-cuJ
-cuW
-cvi
-cvq
-cvC
-cvC
-cvC
-cvN
-cvW
-cvX
-cvX
-cvX
-cvX
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cvA
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -100403,14 +100948,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -100445,11 +100990,11 @@ gXs
 aaf
 aaf
 alO
-arj
-arj
-arj
-pBp
-gOZ
+alO
+alO
+alP
+alP
+anf
 cVb
 cVb
 cVb
@@ -100520,7 +101065,7 @@ cdK
 ceH
 cfn
 cgd
-ceJ
+cgu
 ccM
 cjy
 ceJ
@@ -100538,52 +101083,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-cua
-ctE
-ctL
-ctW
-cuf
-cum
-cuw
-cuI
-cuV
-cvh
-cvj
-cvB
-cvE
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvX
-cvX
-cvX
-cvX
-cwq
-cwq
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -100660,19 +101205,19 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -100700,7 +101245,7 @@ aaa
 gJi
 alO
 alO
-arp
+alO
 alO
 anf
 anf
@@ -100777,7 +101322,7 @@ ccM
 ceJ
 ceJ
 cgf
-ceJ
+cgy
 ccM
 ccM
 ceJ
@@ -100795,52 +101340,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-cua
-cua
-cua
-cua
-cuf
-cuf
-cux
-cuK
-cuX
-cuf
-cvk
-cvk
-cvk
-cvk
-aaf
-aaf
-aaf
-aaf
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -100917,14 +101462,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -100959,11 +101504,11 @@ cyG
 anf
 anf
 aqv
-ayf
-dce
-uua
-awE
-tRB
+anf
+anf
+anf
+anf
+anf
 cVb
 vCb
 wUY
@@ -101034,7 +101579,7 @@ bLS
 bLS
 cfp
 cge
-cbK
+chC
 ciG
 bLS
 ckm
@@ -101052,52 +101597,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-cuf
-cuf
-cuf
-cuf
-cuf
-aaf
-aaa
-aaf
-cvK
-aaf
-aaa
-aaa
-aaf
-aaf
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-cAX
-aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -101174,14 +101719,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -101213,14 +101758,14 @@ aaf
 aaf
 cxW
 alO
-anf
-anf
+aQd
+aXl
 alO
-mAH
+anf
 jaF
 alP
+alP
 anf
-aCG
 cVb
 cVb
 cVb
@@ -101269,7 +101814,7 @@ bFG
 bCY
 bFP
 bBN
-bKQ
+bcM
 bMb
 bNd
 bOt
@@ -101291,13 +101836,13 @@ ccM
 ceL
 ceJ
 cgh
-ceJ
-ceJ
+chH
 ccM
+clv
 ceJ
 cAe
 cmj
-cne
+cdN
 bHd
 bPn
 aaa
@@ -101309,52 +101854,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -101431,14 +101976,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -101476,11 +102021,11 @@ alP
 alP
 alP
 alP
-awF
-aCG
+nbM
+anf
 alP
-nhY
-aBE
+oyc
+anf
 aCz
 vEp
 aCJ
@@ -101548,8 +102093,8 @@ bFr
 ceK
 ceJ
 cgg
-ccM
-ccM
+ciK
+clq
 cjA
 ceJ
 ccM
@@ -101566,52 +102111,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -101688,17 +102233,17 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gDl
 aaa
 aaa
 aaS
@@ -101733,14 +102278,14 @@ itK
 atv
 auD
 alP
-aoQ
+awR
 cqM
-ayg
-ayg
-ayg
+asw
+asw
+asw
 aCA
-aFn
-aFp
+anf
+aCG
 aGW
 anf
 aIp
@@ -101804,13 +102349,13 @@ ccN
 bHd
 bzs
 bzs
-bKT
-bAw
-bAw
-bFr
+bKw
+bzs
+bzs
+clw
 ceJ
 ccM
-ccM
+cou
 cng
 bzs
 bzs
@@ -101823,52 +102368,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -101945,14 +102490,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -102061,13 +102606,13 @@ ccM
 cdN
 bzs
 cfq
-bKT
-bAw
+cdV
+ciL
 ciH
 bHd
 bzs
 bAw
-cmk
+bAw
 cnf
 bzs
 aaf
@@ -102080,52 +102625,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -102202,14 +102747,14 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -102247,11 +102792,11 @@ anf
 anf
 auF
 alP
-awH
+ksg
 auF
 alP
-aAr
-aBF
+kMr
+anf
 alP
 aaa
 aFq
@@ -102292,10 +102837,10 @@ bon
 bAw
 bzg
 bLS
-bLS
-bLS
-cbQ
-bLS
+ajM
+aZs
+baN
+gRP
 bLS
 bKE
 caU
@@ -102314,13 +102859,13 @@ bNc
 bLS
 caU
 cbQ
-cNY
-cNY
-cNY
-cNY
+cOb
+cOb
+cOb
+cOb
 cgj
-cNY
-cNY
+cOb
+cOb
 chp
 bzs
 clp
@@ -102337,52 +102882,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -102462,11 +103007,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -102500,15 +103045,15 @@ aof
 aof
 aof
 vCy
-aoP
 atw
+iMZ
 auF
 alP
-aoP
+lYT
 auF
 azr
-jez
-atw
+anf
+anf
 alP
 alP
 aFo
@@ -102571,10 +103116,10 @@ bLT
 bLT
 caT
 cbP
+cdO
+cdO
+bYs
 ccO
-cdO
-cdO
-cdO
 cnH
 czH
 czT
@@ -102594,52 +103139,52 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -102719,11 +103264,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -102747,21 +103292,21 @@ adW
 aeG
 aaf
 aaf
+gXs
+gXs
+gXs
+gXs
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-apC
-aqy
+gXs
+awF
+anf
+anf
 anf
 anf
 aty
-auF
+jDq
 alP
-aAt
+alP
 jZT
 alP
 alP
@@ -102849,33 +103394,33 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -102976,11 +103521,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -103007,22 +103552,22 @@ aaf
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaa
-apC
+awF
 anf
-jez
+alP
+rFy
 alP
 atx
 auF
 alP
 auD
 auF
-apE
-aAs
-vbi
+alP
+xCt
+anf
 alP
 aCG
 aFr
@@ -103093,7 +103638,7 @@ aaa
 cNW
 cQB
 czY
-cOT
+cNW
 aaa
 aaa
 gXs
@@ -103108,31 +103653,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -103233,11 +103778,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -103264,23 +103809,23 @@ aaf
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
 aaa
-aaa
-apC
+awF
 anf
 alP
 alP
-apE
+alP
+alP
 auG
 alP
-iWx
+eyH
 auF
 apE
 anf
-anf
-noF
+jeG
+alP
 aCG
 aDZ
 aFu
@@ -103349,7 +103894,7 @@ ccQ
 aaa
 cOT
 cQB
-czY
+cmk
 cOT
 aaa
 aaa
@@ -103365,24 +103910,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -103490,11 +104035,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -103518,15 +104063,15 @@ adY
 aeG
 aaa
 aaS
+gXs
+gXs
+gXs
+gXs
 aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-aaf
-apC
-arA
+gXs
+awF
+oOl
+anf
 anf
 asx
 anf
@@ -103622,24 +104167,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -103747,11 +104292,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -103781,8 +104326,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-apC
+awF
+alP
 alP
 alP
 alP
@@ -103879,24 +104424,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -104004,11 +104549,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -104034,14 +104579,14 @@ aaS
 aaS
 aaf
 aaa
-aaa
-aaf
-aaf
-aaf
-aaf
+gXs
+gXs
+gXs
+gXs
 alO
-aqz
-aru
+eGC
+gmC
+anf
 alP
 anf
 anf
@@ -104124,36 +104669,36 @@ czY
 cNW
 aaa
 aaa
-aaa
-aaa
-aaH
-eFW
-nwX
-weM
-aaa
-aaa
-aaa
-aaa
+cOx
+cPA
+cOx
+cPA
+cOx
+cOx
+cOx
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -104261,11 +104806,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -104290,21 +104835,21 @@ aaa
 aaa
 aaf
 aaf
-aaa
 aaa
 aaa
 aaa
 aaa
 aaa
 alO
+wgA
 anf
 anf
-asy
+atB
 anf
 anf
 alP
 alP
-rtU
+anf
 alP
 alP
 alP
@@ -104380,37 +104925,37 @@ cQB
 cAa
 cOT
 gXs
-rnK
-kWp
-aaa
-aaa
-aaH
-aaH
-aaH
-weM
-aaa
-aaa
-aaa
+cOx
+cOx
+mJo
+qnr
+oEZ
+tvs
+yay
+iyv
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -104518,11 +105063,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -104550,12 +105095,12 @@ aaf
 aaf
 aaa
 aaa
-aaa
-aaf
-aaf
+gXs
+gXs
 alO
-aqA
-arz
+eGC
+uNv
+anf
 alP
 anf
 anf
@@ -104563,8 +105108,8 @@ alP
 awJ
 anf
 alP
-aAv
-tJS
+hWV
+anf
 aCE
 aDZ
 aFu
@@ -104637,37 +105182,37 @@ czU
 czZ
 cOT
 aaa
-gJi
-aaH
-aaH
-aaH
-aaH
-aaH
-aaH
-eFW
+cPA
+lZl
+oEZ
+sLv
+oEZ
+kKe
+yay
+qZj
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -104775,11 +105320,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -104808,7 +105353,7 @@ aaf
 aaf
 aaa
 aaa
-aaa
+alP
 alP
 alP
 alP
@@ -104894,37 +105439,37 @@ cgm
 czY
 cOT
 gXs
-rnK
-kWp
-kaq
-aaH
-aaH
-aaa
-aaa
-kaq
-aaa
-aaa
-aaa
+cOx
+cOx
+rmX
+sLv
+oEZ
+xkI
+yay
+lvZ
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -105032,11 +105577,11 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -105063,14 +105608,14 @@ aaa
 aaa
 aaa
 aaf
-aaf
-aaa
+gXs
 aaa
 alP
-apD
-aEl
+awH
 anf
-arx
+anf
+iWx
+anf
 anf
 anf
 alP
@@ -105145,43 +105690,43 @@ bDb
 bDb
 bDb
 bDb
-aaa
+cNW
 cNW
 cgm
 czY
 cNW
 aaa
 aaa
-aaa
-kaq
-kaq
-eFW
-aaH
-gXs
-aaa
-aaa
-aaa
+cOx
+cPA
+xFf
+cPA
+cOx
+cOx
+cOx
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -105289,46 +105834,46 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaa
+gXs
+gXs
 alO
 anf
 anf
+aAs
 arw
 nuw
-uve
+anf
 anf
 alP
 awL
@@ -105399,13 +105944,13 @@ bZX
 aqB
 cbU
 bDb
-aaf
-aaf
-aaa
-aaa
+bNB
+cac
+cOe
+ceN
 cNW
 cgm
-czY
+oUt
 cNW
 aaa
 aaa
@@ -105421,24 +105966,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -105546,6 +106091,31 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -105553,39 +106123,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
+gXs
 alO
-aoQ
+awR
 anf
+aAt
 arv
 asz
-atA
+anf
 anf
 alP
 awK
@@ -105656,11 +106201,11 @@ bEm
 amo
 bRU
 bDb
-aaf
-aaa
-aaa
-aaa
-cOT
+bNC
+cad
+cOe
+ceO
+cNW
 cgm
 czY
 cOT
@@ -105678,24 +106223,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -105803,6 +106348,31 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -105811,39 +106381,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-gXs
 alP
-jkx
+alP
 ayf
+aAv
 xAk
 mHU
-aFn
-aFn
+mHU
+mHU
 aBB
 awM
 ayg
@@ -105913,11 +106458,11 @@ bEm
 ano
 bRU
 bDb
-aaf
-aaa
-aaa
-aaa
-cOT
+bPO
+cae
+cOe
+ceS
+cNW
 cgm
 czY
 cOT
@@ -105935,24 +106480,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -106062,29 +106607,29 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -106095,12 +106640,12 @@ aaa
 nsA
 nsA
 nsA
-nsA
+tan
 qVP
 nsA
 nsA
-atB
 alP
+atB
 alP
 awx
 aye
@@ -106170,14 +106715,14 @@ bEm
 abz
 bUi
 bDb
-aaf
-aaf
-aaa
-aaa
-cOT
+bSm
+cOe
+ccV
+ceT
+cNW
 cgm
 czY
-cOT
+cNW
 aaa
 aaa
 aaa
@@ -106192,24 +106737,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -106319,42 +106864,42 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 nsA
-cQF
-ndq
-rIA
-fBy
-hRI
+nsA
+nsA
+nsA
+nsA
+pSG
+aAA
+cRJ
+qGl
+lhg
 jaH
 hHQ
 feE
@@ -106364,7 +106909,7 @@ wHT
 asA
 apE
 dPk
-aCG
+cKP
 aEf
 aFw
 aGU
@@ -106428,7 +106973,7 @@ bDb
 bDb
 bDb
 cNW
-cNW
+cbi
 cNW
 cNW
 cNW
@@ -106449,24 +106994,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -106576,46 +107121,46 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-wKe
+wFG
+aru
 ndq
 ndq
 ndq
 ndq
-oLl
+ndq
+utX
+uKt
+nQR
 asB
 asB
 asB
-avo
+asB
 awx
 avH
 asB
@@ -106692,8 +107237,8 @@ czR
 czW
 cAb
 cko
-clq
-cmq
+qxC
+jqa
 ciI
 cnJ
 cri
@@ -106706,24 +107251,24 @@ gJi
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -106833,50 +107378,50 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-wKe
+nsA
+nsA
+nsA
+nsA
+nsA
 ndq
 ndq
-ndq
-ndq
-qeb
+utX
+cwE
+fFr
+hWK
 asB
-atD
-auJ
+spD
 asB
-awQ
-avK
-azt
-aAy
+gfj
+rKj
+auI
+jAE
 asB
 aCN
 aEf
@@ -106943,13 +107488,13 @@ bTl
 bQZ
 bNB
 ceM
-ccU
-cgo
-czS
-cOb
-cAd
 cNW
-cOx
+cgm
+iWD
+cOb
+hIn
+cNW
+naf
 cBL
 cOe
 cvO
@@ -106963,24 +107508,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -107090,29 +107635,29 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -107123,17 +107668,17 @@ aaa
 nsA
 ndq
 ndq
+utX
 ndq
 ndq
-ndq
+auI
 asB
-atC
+cyY
+asB
+gfj
+asB
+jcx
 auI
-auI
-awP
-avJ
-awO
-awO
 asB
 aCM
 aEg
@@ -107199,10 +107744,10 @@ caY
 cbV
 bQZ
 blQ
-cPA
-cfs
+cOe
+iQX
 cgm
-cQw
+ckr
 cNW
 cNW
 cNW
@@ -107210,7 +107755,7 @@ cNW
 cNW
 cOe
 fup
-csy
+kQK
 cko
 cAf
 aaa
@@ -107235,9 +107780,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -107347,6 +107892,29 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -107354,43 +107922,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-wKe
+nsA
 ndq
 ndq
+utX
 ndq
 ndq
-ndq
+auI
 asB
-atE
-auI
-auI
-awT
-avM
-azv
-aAA
+asB
+asB
+pLq
+asB
+asB
+asB
 asB
 aCE
 aEi
@@ -107455,19 +108000,19 @@ bTl
 cbc
 bTl
 bQZ
-cdR
-ceO
 cNW
-cgm
+cNW
+cNW
+flK
 chw
-ciK
+cNY
 cjC
 ckp
 cls
 cmr
 cOe
+pfd
 cOe
-cou
 cNW
 aaf
 aaf
@@ -107484,7 +108029,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -107492,9 +108037,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -107604,6 +108149,29 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -107611,44 +108179,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-wKe
+nsA
 ndq
 ndq
+xDj
 ndq
 ndq
-ndq
-asB
-asB
-asB
-avL
-awR
-hiV
-azu
-aAz
-asB
+aAB
+azF
+oXR
+sJv
+fej
+oqz
+sJv
+azF
+aFz
 aCO
 aEh
 aFz
@@ -107712,19 +108257,19 @@ bTl
 cbb
 bTl
 bQZ
-cdR
-ceN
+eMH
 cNW
+ccW
 cgp
 chv
-ciJ
+cbv
+cmo
 cbf
-diq
-clr
-bnt
+ihF
+cQw
+cNW
 cOe
-cOe
-bMB
+oMF
 cOT
 aaa
 aaa
@@ -107749,9 +108294,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -107861,29 +108406,29 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -107892,20 +108437,20 @@ aaa
 aaa
 aaa
 nsA
-lGV
+axi
 ndq
-pou
 ndq
-srG
-asB
-atG
-auL
-avN
-axa
+ndq
+ndq
 auI
-azw
-aAA
-asB
+azF
+sJv
+mwo
+saO
+sJv
+sJv
+wFF
+aFz
 aCQ
 aEk
 aFB
@@ -107917,8 +108462,8 @@ aLr
 aFB
 aPn
 aQy
-aPn
-aTi
+qOe
+aVU
 aUK
 aVU
 aWg
@@ -107972,14 +108517,14 @@ bQZ
 bQZ
 bQZ
 bQZ
-cgr
+clt
 chx
 cNW
-cNW
-cNW
+cmq
+eaJ
 clt
-cQw
-cOe
+iyT
+cNW
 cOe
 bNA
 cOT
@@ -108006,9 +108551,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -108118,29 +108663,29 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -108149,20 +108694,20 @@ aaa
 aaa
 aaa
 nsA
-nsA
-nsA
-nsA
-nsA
-nsA
-asB
-atF
-auK
-auJ
-awS
+ndq
+ndq
+ndq
+ndq
+ndq
 auI
-awO
-awO
-asB
+azF
+sKb
+sJv
+fej
+sJv
+sKb
+azF
+aFz
 aCP
 aEj
 aFA
@@ -108229,17 +108774,17 @@ ccR
 cdS
 ceP
 bQZ
-cgq
-chx
-cNW
-aaa
-cNW
 clt
-cQw
+vbt
 cNW
-mJo
+cDY
+bMB
+clt
+ckr
+cfs
+cOe
+xcp
 cNW
-cNW
 aaf
 aaf
 aaf
@@ -108263,9 +108808,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -108375,29 +108920,29 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aae
 aaa
@@ -108405,21 +108950,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaf
-aaf
-aaa
-aaa
-asB
-atH
-auM
-avO
-awU
-ayj
-azx
-aAB
-asB
+nsA
+nsA
+nsA
+nsA
+azF
+azF
+azF
+azF
+ojo
+xmc
+joq
+sJv
+drQ
+azF
+azF
 aCR
 aEm
 aCR
@@ -108488,14 +109033,14 @@ ceP
 bQZ
 cgt
 chx
-cOT
-aaa
-cOT
-clt
-cQw
-oEZ
+vxh
+cDY
+tJu
+mCU
+dBm
+cNW
 cOe
-cOe
+sOs
 cNW
 aaa
 aaa
@@ -108517,12 +109062,12 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -108632,6 +109177,29 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -108643,40 +109211,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-asB
-asB
-asB
-asB
-asB
-asB
-asB
-asB
-asB
+azF
+jez
+pou
+pou
+sJv
+sJv
+idG
+sJv
+sJv
+fyI
+azF
 aCR
 bfb
 aCR
@@ -108745,14 +109290,14 @@ ceQ
 cft
 cgs
 chy
-cOT
-aaa
-cOT
-clt
-cQw
+sOs
+cDY
+iXH
+cne
+pKk
+cNW
+pfd
 ttL
-cOe
-cOe
 cNW
 aaa
 fIs
@@ -108777,9 +109322,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -108889,6 +109434,29 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -108900,40 +109468,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-atS
-aaf
-aoV
-aoV
-atS
-aaf
-aaf
-aaf
-atS
+aBE
+jkx
+qeb
+qeb
+sJv
+sJv
+oPb
+sJv
+sJv
+vww
+azF
 aCR
 aEn
 aCR
@@ -109000,16 +109545,16 @@ ccT
 bSc
 bSc
 cfu
-cgu
+pYp
 chA
 cNW
-aaa
+cDY
 cNW
-clt
+cgr
 cQw
-ajM
+cNW
 cOe
-cOe
+vxh
 cNW
 ktS
 aaS
@@ -109034,9 +109579,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -109146,6 +109691,29 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -109157,40 +109725,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atS
-aoV
-aoV
-aoV
-atS
-aoV
-aoV
-aaf
-atS
+aBE
+lGV
+qeb
+qeb
+sJv
+sJv
+sJv
+sJv
+sJv
+sYA
+azF
 aaf
 aaa
 aaf
@@ -109259,14 +109804,14 @@ bQZ
 bQZ
 cNW
 chz
-cNW
-cNW
-cNW
+cOe
+cOe
+pfd
 clt
-cQw
+kAJ
 cCt
 cOe
-cOe
+cNW
 cNW
 aaa
 aaS
@@ -109291,9 +109836,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -109408,6 +109953,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -109419,35 +109982,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atS
-aoV
-aoV
-aoV
-aaH
-aoV
-aoV
-aaf
-atS
+aBE
+jkx
+qeb
+tJS
+smW
+sJv
+sJv
+sJv
+wqm
+mYJ
+azF
 aaf
 aaa
 aaf
@@ -109511,20 +110056,20 @@ bTo
 eaI
 cbZ
 bSl
-cmo
+jGR
+lZL
+dYR
 cNW
-lZl
+eeV
 cNW
-chC
-ciL
-cOe
-cOe
-clv
+eoU
+cNW
+hbU
 cQw
 cNW
 cNW
 cNW
-cNW
+xIa
 aaa
 aba
 aaf
@@ -109548,9 +110093,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -109665,6 +110210,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -109676,35 +110239,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atS
-aoV
-aoV
-aoV
-aaH
-aoV
-aoV
-aoV
-atS
+aBE
+aBE
+azF
+aBE
+aBE
+tza
+tza
+tza
+aBE
+aBE
+azF
 aaf
 aaa
 aaf
@@ -109768,14 +110313,14 @@ bXs
 sSW
 cbY
 bSl
-cOe
-cNW
-cNW
+vAA
+htl
+lsX
 cNW
 ccp
-cbf
-cbf
-cbf
+cbv
+cbv
+cbv
 clu
 cmt
 aaa
@@ -109805,9 +110350,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -109922,6 +110467,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -109935,33 +110498,15 @@ aaa
 aaa
 aaa
 aaa
+azF
 aaa
+aBE
+aBE
+azF
+aBE
+aBE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaH
-aoV
-aoV
-aoV
-atS
-aoV
-aoV
-aoV
-atS
+azF
 aaf
 aaa
 aaf
@@ -110025,15 +110570,15 @@ itG
 cbe
 wvX
 bSl
-cOe
-ceS
-cae
-cNW
+urN
+htl
+fxh
+pSC
 ccq
-cdq
-cjE
-ckr
-clw
+czS
+cOb
+cOb
+cOb
 cmu
 aaf
 aaf
@@ -110062,9 +110607,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -110179,6 +110724,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -110192,33 +110755,15 @@ aaa
 aaa
 aaa
 aaa
+vmQ
 aaa
 aaa
 aaa
+vmQ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-atS
-aoV
-aoV
-aoV
-atS
-aoV
-aoV
-aoV
-aaf
+azF
 aaf
 aaa
 aaf
@@ -110282,10 +110827,10 @@ bXs
 bXs
 bXs
 bSl
-cOe
+vAA
 ceR
-cbf
-cbv
+mtc
+pcW
 uVS
 cQw
 cjD
@@ -110319,9 +110864,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -110436,6 +110981,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -110447,35 +111010,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
-aaa
-atS
 aoV
-aoV
-aoV
-atS
-aoV
-aoV
-aoV
-aoV
+aaa
+azF
+aaa
+aaa
+aaa
+vmQ
+aaa
+aaa
+aaa
+gXs
 aaf
 aaa
 aaf
@@ -110516,14 +111061,14 @@ bzO
 bzO
 bzO
 bqe
-bEF
+xed
 bky
 bEO
 bGK
 bKc
 cNW
-bMB
-bNA
+ttL
+vxh
 cOe
 bSl
 bUq
@@ -110539,9 +111084,9 @@ vPE
 jrE
 saK
 bSl
-cOx
-sLv
-ckS
+jIM
+sWZ
+iyD
 cNW
 jVl
 cds
@@ -110576,9 +111121,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -110693,6 +111238,24 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -110706,33 +111269,15 @@ aaa
 aaa
 aaa
 aaa
+azF
+aaa
+aaa
+aaa
+azF
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aoV
-aoV
-aoV
-atS
-aoV
-aoV
-aoV
-aoV
 aaf
 aaa
 aaf
@@ -110833,9 +111378,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -110960,6 +111505,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -110973,23 +111526,15 @@ aaa
 aaa
 aaa
 aaa
+azF
+aaa
+aaa
+aaa
+azF
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aoV
-aoV
-aoV
-aaf
-aoV
-aoV
-aoV
-aoV
 aaf
 aaa
 aaf
@@ -111036,12 +111581,12 @@ bHs
 bGL
 bKd
 cNY
-bMC
+cjE
 cOb
 jHt
-bPO
 kob
-bSm
+kob
+kob
 bTr
 bTr
 bTr
@@ -111058,7 +111603,7 @@ nGt
 cbg
 bTr
 cct
-cdu
+cAd
 cjG
 cku
 clz
@@ -111090,9 +111635,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -111217,6 +111762,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -111230,26 +111783,18 @@ aaa
 aaa
 aaa
 aaa
+gXs
+aaa
+aaa
+aaa
+azF
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aoV
-aoV
-aoV
-aoV
-aaf
-aoV
-aoV
-aoV
-aoV
-aaa
-aaa
-aaf
+cxn
 aaa
 aaa
 aaa
@@ -111295,7 +111840,7 @@ bEs
 bEs
 bEs
 cNW
-sOs
+eUX
 cNW
 cNW
 cNW
@@ -111311,7 +111856,7 @@ cNW
 cNW
 cNW
 cNW
-clt
+jAY
 cNW
 cNW
 cNW
@@ -111347,9 +111892,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -111474,6 +112019,14 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -111487,19 +112040,11 @@ aaa
 aaa
 aaa
 aaa
+gXs
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -111551,7 +112096,7 @@ bIV
 bKf
 bLk
 bEs
-bNC
+tLQ
 nRG
 cbf
 cbf
@@ -111560,18 +112105,18 @@ cbf
 cbf
 cbf
 cbf
-bYr
+gMQ
 cbf
 clr
-cad
-cbi
+kfk
+joB
 cNW
-ccW
-cdV
+wpa
+wYQ
 clt
 cNW
-cgy
-ccV
+jGs
+wYQ
 cNW
 aaa
 aaa
@@ -111604,9 +112149,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -111731,32 +112276,32 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gXs
 aaa
 aaa
 aaa
@@ -111808,8 +112353,8 @@ bIU
 bKe
 bLj
 bEs
-bNB
-cac
+dEM
+cOe
 bPP
 cNW
 cNW
@@ -111818,15 +112363,15 @@ cNW
 cNW
 cNW
 cNW
-kAJ
-clt
-cac
-cbh
 cNW
-ccV
+clt
+cOe
+lqt
+cNW
+wYQ
 cOe
 clt
-cfv
+cfs
 cBL
 cOe
 cNW
@@ -111861,9 +112406,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aae
-aaa
+cNd
+naI
+cNd
 cNd
 cNd
 cNd
@@ -111988,26 +112533,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -112057,7 +112602,7 @@ bvQ
 bxt
 cNT
 bCm
-bDh
+pmY
 bEs
 ydD
 bHv
@@ -112065,9 +112610,9 @@ bIW
 bKe
 vHY
 bEs
-rmX
-xIa
-vxh
+cxz
+ohA
+miU
 cNW
 aaa
 aaa
@@ -112075,17 +112620,17 @@ aaf
 aaa
 aaf
 cNW
-bYs
+vnq
 nRG
 ciJ
 cbf
 cbf
 cbf
 cbf
-ceT
+iur
 cNW
-dBm
-chH
+qtE
+tBK
 cNW
 aaf
 aaf
@@ -112118,9 +112663,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -112245,26 +112790,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -112308,13 +112853,13 @@ aaa
 aaa
 aaa
 bZi
-bqg
+ohs
 brG
 brG
 cNR
 brG
 brG
-bDg
+oLy
 bEs
 bGd
 poc
@@ -112375,9 +112920,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -112502,6 +113047,26 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -112511,27 +113076,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -112565,7 +113110,7 @@ aaa
 aaa
 aaa
 bZi
-btq
+lBf
 brI
 bvR
 cNS
@@ -112631,10 +113176,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+gDl
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -112759,26 +113304,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aoW
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -112889,9 +113434,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -113016,26 +113561,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -113146,9 +113691,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -113273,26 +113818,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -113403,9 +113948,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -113530,26 +114075,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -113660,9 +114205,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -113787,26 +114332,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -113893,7 +114438,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -114044,26 +114589,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -114165,7 +114710,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aoV
 aaa
 aaa
 aaa
@@ -114301,26 +114846,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -114404,33 +114949,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -114558,26 +115103,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -114661,33 +115206,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+aoW
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -114815,26 +115360,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -114918,33 +115463,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -115072,26 +115617,26 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -115173,35 +115718,35 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -115338,17 +115883,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -115417,48 +115962,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -115595,17 +116140,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -115663,7 +116208,7 @@ aaa
 aaf
 aaa
 aaf
-aae
+aoV
 aaa
 aaa
 aaa
@@ -115674,48 +116219,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -115852,17 +116397,17 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -115931,48 +116476,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -116109,19 +116654,19 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gDl
 aaa
 aaa
 aaa
@@ -116179,6 +116724,7 @@ aaa
 aaf
 aaa
 aaa
+gDl
 aaa
 aaa
 aaa
@@ -116187,49 +116733,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -116445,48 +116990,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -116654,7 +117199,6 @@ aaa
 aaa
 aaa
 aaa
-aae
 aaa
 aaa
 aaa
@@ -116682,6 +117226,7 @@ aaa
 aaa
 aaa
 aaa
+gDl
 aaa
 aaa
 aaa
@@ -116702,48 +117247,48 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -116959,20 +117504,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -117216,20 +117761,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -117442,7 +117987,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gDl
 aaa
 aaa
 aaa
@@ -117473,20 +118018,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -117680,7 +118225,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gDl
 aaa
 aaa
 aaa
@@ -117730,20 +118275,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -117919,17 +118464,17 @@ cNd
 cNd
 cNd
 cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117987,20 +118532,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -118176,17 +118721,17 @@ cNd
 cNd
 cNd
 cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118244,20 +118789,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -118433,17 +118978,17 @@ cNd
 cNd
 cNd
 cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
-cNd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118501,20 +119046,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -118701,38 +119246,38 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -118758,20 +119303,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -118958,38 +119503,38 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -119015,13 +119560,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -119215,38 +119760,38 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -119272,13 +119817,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -119501,9 +120046,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -119529,13 +120074,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -119758,9 +120303,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -119786,13 +120331,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -120015,9 +120560,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -120043,13 +120588,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -120272,9 +120817,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -120300,13 +120845,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -120529,9 +121074,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -120557,13 +121102,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 cNd
 cNd
 cNd
@@ -120633,7 +121171,14 @@ cNd
 cNd
 cNd
 cNd
-xUn
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+naI
 cNd
 cNd
 cNd
@@ -120786,9 +121331,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -120814,13 +121359,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -121043,9 +121588,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -121071,13 +121616,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -121300,9 +121845,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -121328,13 +121873,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -121557,9 +122102,9 @@ cNd
 cNd
 cNd
 cNd
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -121585,13 +122130,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -121814,6 +122359,9 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -121839,16 +122387,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd
@@ -122071,6 +122616,9 @@ cNd
 cNd
 cNd
 cNd
+cNd
+cNd
+cNd
 aaa
 aaa
 aaa
@@ -122096,16 +122644,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
+cNd
 cNd
 cNd
 cNd

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57962,9 +57962,6 @@
 /turf/open/space,
 /area/solar/port/aft)
 "qVP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -73,11 +73,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
-"o" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "p" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
@@ -162,7 +157,7 @@
 (1,1,1) = {"
 a
 B
-o
+d
 d
 d
 B


### PR DESCRIPTION
## About The Pull Request

The main feature of this PR is that box maintenance has mostly been redone. It keeps the spirit of box maintenance, but hopefully makes it a lot less barren in terms of loot, rooms, and hiding places. It should be much more on par with Meta maintenance while still keeping and even bringing back some of the classic box flavor. 

Another major change is that the AI core has been moved to the center of the station and the AI sat is gone entirely. Vault and some other command areas were moved around to fit it. This is a very experimental change and will require testing. May be reverted if necessary.

Additionally, all cameras have been standardized in their "tags" which should make using camera consoles a lot less painful. 

Relatively small changes have been made to dorms, engineering, bar, and security, mostly in making better use of space.

Caps of new version here: https://imgur.com/a/Yn5n6rs

## Why It's Good For The Game

Box is stale, and a lot of people have gripes with it. Maintenance is generally unliked in its current state especially when it comes to assistant and antag interactions, some areas feel awkwardly taped on or do not fit the overall station design. There was also some qol issues that needed to be addressed. This PR attacks these issues, though they will not fix them entirely. 

The AI relocation is a lot more experimental, but was done based both on the nostalgia factor, and on the experimental idea that while the AI is more accessible, it should also make the AI less helpless to threats, as it has full control over atmosphere of the central primary hall which surrounds it, and bombings and EMPs are generally more risky.

## Changelog
:cl: Tupinambis
add: Many new rooms and areas in box maintenance to explore, as well as more loot to gather. Replaces and moves old maintenance areas.
add: Connects box cargo maint to port aft maint via space bridge.
add: Adds a goon inspired garden area adjacent to box chapel.
del: Box AI Satellite is gone.
tweak: Moved the box AI core to the central command area. Conference room is now where theater used to be. (Experimental)
tweak: Moved box gravity generator to where the AI sat access point used to be.
tweak: Box dorms and security have both had rooms and areas shuffled to allow for better spacing and to resolve certain issues with space overexposure.
tweak: Small box decal changes.
tweak: Box vault has been moved below HoP office and now has a more compound design. It is additionally accessible via maintenance. (Somewhat experimental)
tweak: The box boxing ring has returned to dorms!
tweak: Box bar now has its theater again, and has had its layout changed somewhat.
tweak: double firedoors in the main halls are now directional, so they do their job better.
tweak: Box security cameras now use a much more consistent naming scheme for QOL. (Department - Room/Area - Direction)
fix: A random window structure among window spawners in the box arrivals shuttle has been made into a spawner.
/:cl:
