### PR TITLE
projectile process invoke async because people keep breaking shit and trying to enforce do not sleep on it is a moot point because people keep breaking shit

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -460,6 +460,7 @@
 	return TRUE	//Bullets don't drift in space
 
 /obj/item/projectile/process(wait)
+	set waitfor = FALSE
 	if(!loc || !fired || !trajectory)
 		fired = FALSE
 		return PROCESS_KILL


### PR DESCRIPTION
fixes projectiles