### PR TITLE
Cogstation Fixes and Improvements

### DIFF
--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -64,8 +64,8 @@
 /turf/closed/wall,
 /area/maintenance/port/fore)
 "aam" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -90,15 +90,13 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
 "aap" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/closed/wall,
+/area/crew_quarters/observatory)
 "aaq" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/observatory)
 "aar" = (
 /obj/machinery/conveyor/auto{
 	dir = 8;
@@ -664,14 +662,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
-"abF" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "sb_out";
-	name = "Router Driver"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "abG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -709,13 +699,6 @@
 /obj/item/paper/fluff/cogstation/cluwne,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/clown)
-"abJ" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "sb_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "abK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -819,17 +802,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"abZ" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "sb_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "aca" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 5;
-	id = "pb_off"
+	id = "pb"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -858,17 +834,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "ace" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "pb_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
-"acf" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "pb_out";
-	name = "Router Driver"
+	id = "pb"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -898,9 +866,9 @@
 	name = "Medical Booth"
 	})
 "acj" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "solar_off"
+	id = "solar"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -973,8 +941,8 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/machinery/conveyor{
-	id = "solar_off"
+/obj/machinery/conveyor/auto{
+	id = "solar"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -1052,25 +1020,10 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"acz" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "sb_in";
-	name = "Router Driver"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
-"acA" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "sb_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "acB" = (
 /obj/machinery/conveyor{
 	dir = 6;
-	id = "sb_off"
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -1109,9 +1062,9 @@
 /turf/closed/wall,
 /area/crew_quarters/lounge)
 "acG" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "pb_off"
+	id = "pb"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -1142,8 +1095,8 @@
 /area/crew_quarters/lounge)
 "acJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/conveyor{
-	id = "solar_off"
+/obj/machinery/conveyor/auto{
+	id = "solar"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -1297,18 +1250,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/brig)
-"adc" = (
-/obj/machinery/conveyor{
-	id = "sb_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "add" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/crew_quarters/observatory)
 "ade" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on,
@@ -1332,11 +1278,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/lounge)
 "adh" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/crew_quarters/observatory)
 "adi" = (
 /turf/open/floor/plasteel,
@@ -1349,8 +1294,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/conveyor{
-	id = "solar_off"
+/obj/machinery/conveyor/auto{
+	id = "solar"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -1494,9 +1439,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/observatory)
 "adG" = (
-/obj/machinery/mass_driver{
-	id = "serv_in";
-	name = "Router Driver"
+/obj/machinery/mass_driver/pressure_plate{
+	id = "hydro_in"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -1535,13 +1479,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/stairs/medium,
 /area/security/brig)
-"adL" = (
-/obj/machinery/mass_driver{
-	id = "starboard_in";
-	name = "Router Driver"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "adM" = (
 /turf/closed/wall,
 /area/crew_quarters/observatory)
@@ -2671,8 +2608,9 @@
 /turf/open/floor/plating,
 /area/construction)
 "agy" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/table,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "agz" = (
@@ -4478,6 +4416,7 @@
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
+	id = "security_out";
 	name = "Security Router"
 	},
 /turf/open/floor/plating,
@@ -4661,7 +4600,7 @@
 "als" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	id = "sec_out";
+	id = "security_out";
 	name = "Router Driver"
 	},
 /turf/open/floor/plating,
@@ -5525,15 +5464,14 @@
 	dir = 8
 	},
 /obj/item/destTagger,
-/obj/machinery/button/door{
-	id = "secblock";
-	name = "Router Access Control";
-	pixel_x = 8;
-	pixel_y = 24;
-	req_access_txt = "1"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/button/massdriver{
+	id = "security_out";
+	name = "Security Driver Control";
+	pixel_x = 8;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/router/sec)
@@ -5817,9 +5755,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "anW" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "sec_off"
+	id = "sec"
 	},
 /turf/open/floor/plating,
 /area/router/sec)
@@ -6276,12 +6214,12 @@
 "aoS" = (
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
-/obj/machinery/conveyor{
-	id = "serv_off"
-	},
 /obj/machinery/door/poddoor{
-	id = "servblock";
+	id = "hydro_in";
 	name = "Service Router"
+	},
+/obj/machinery/conveyor/auto{
+	id = "service"
 	},
 /turf/open/floor/plating,
 /area/router/service)
@@ -6289,7 +6227,7 @@
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
-	id = "servblock";
+	id = "hydro_out";
 	name = "Service Router"
 	},
 /turf/open/floor/plating,
@@ -6477,11 +6415,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/machinery/button/massdriver{
-	id = "sec_out";
-	pixel_x = 24;
-	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/router/sec)
@@ -6792,8 +6725,8 @@
 	},
 /area/chapel/main)
 "aqe" = (
-/obj/machinery/conveyor{
-	id = "serv_off"
+/obj/machinery/conveyor/auto{
+	id = "service"
 	},
 /turf/open/floor/plating,
 /area/router/service)
@@ -6933,7 +6866,7 @@
 "aqy" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	id = "serv_out";
+	id = "hydro_out";
 	name = "Router Driver"
 	},
 /turf/open/floor/plating,
@@ -7497,11 +7430,6 @@
 	light_color = "#ffc1c1"
 	},
 /obj/item/destTagger,
-/obj/machinery/button/massdriver{
-	id = "serv_out";
-	pixel_x = 8;
-	pixel_y = -4
-	},
 /obj/machinery/requests_console{
 	department = "Service Router";
 	name = "Service Router RC";
@@ -7510,9 +7438,9 @@
 /turf/open/floor/plasteel,
 /area/router/service)
 "arL" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "serv_off"
+	id = "service"
 	},
 /turf/open/floor/plating,
 /area/router/service)
@@ -7962,12 +7890,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/button/door{
-	id = "servblock";
-	name = "Router Access Control";
+/obj/machinery/button/massdriver{
+	id = "hydro_out";
+	name = "Service Driver Control";
 	pixel_x = 8;
-	pixel_y = 24;
-	req_one_access_txt = "12;25;26;28;35;46"
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/router/service)
@@ -8538,7 +8465,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/dorms/purple)
 "atZ" = (
@@ -9047,9 +8973,9 @@
 	dir = 8
 	},
 /obj/machinery/turnstile{
-	name = "Genpop Entrance Turnstile";
-	icon_state = "turnstile_map";
 	dir = 8;
+	icon_state = "turnstile_map";
+	name = "Genpop Entrance Turnstile";
 	req_access_txt = "69"
 	},
 /turf/open/floor/plasteel,
@@ -9730,9 +9656,9 @@
 	name = "Brig Lockdown"
 	},
 /obj/machinery/turnstile{
-	name = "Genpop Entrance Turnstile";
-	icon_state = "turnstile_map";
 	dir = 8;
+	icon_state = "turnstile_map";
+	name = "Genpop Entrance Turnstile";
 	req_access_txt = "69"
 	},
 /turf/open/floor/plasteel,
@@ -10134,9 +10060,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "axt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -10472,12 +10395,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter{
@@ -11341,10 +11258,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "azO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/hydroponics/lobby)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "azP" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/vending/cola/random,
@@ -11515,6 +11431,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "aAj" = (
@@ -12941,9 +12858,6 @@
 "aCZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/electricshock,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plating,
 /area/engine/supermatter{
 	name = "Thermo-Electric Generator"
@@ -15408,7 +15322,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/central";
+	areastring = "/area/security/main";
 	dir = 1;
 	name = "Security Office APC";
 	pixel_y = 24
@@ -18668,6 +18582,9 @@
 	})
 "aOl" = (
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/engine/supermatter{
 	name = "Thermo-Electric Generator"
@@ -18988,6 +18905,9 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/cogpool)
 "aOV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/stairs,
 /area/engine/supermatter{
 	name = "Thermo-Electric Generator"
@@ -19401,7 +19321,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/crew_quarters/fitness/cogpool)
 "aPO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
@@ -19667,16 +19587,10 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/crew_quarters/fitness/cogpool)
 "aQq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/crew_quarters/fitness/cogpool)
 "aQr" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment{
@@ -19689,7 +19603,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/crew_quarters/lounge/jazz)
 "aQs" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -20145,6 +20059,9 @@
 /area/crew_quarters/heads/hop)
 "aRp" = (
 /obj/structure/sign/warning/fire,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter{
 	name = "Thermo-Electric Generator"
@@ -20304,7 +20221,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/engine,
 /area/engine/supermatter{
 	name = "Thermo-Electric Generator"
@@ -21439,6 +21358,9 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering{
 	name = "Engine Room"
@@ -21744,10 +21666,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "aUR" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8;
-	icon_state = "intact"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -21936,19 +21854,14 @@
 	dir = 8;
 	pixel_y = -22
 	},
-/obj/machinery/button/massdriver{
-	id = "public_out";
-	pixel_x = 24;
-	pixel_y = -6
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "pubblock";
-	name = "Router Access Control";
+/obj/machinery/button/massdriver{
+	id = "public_out";
+	name = "Public Router Control";
 	pixel_x = 24;
-	pixel_y = 24
+	pixel_y = -8
 	},
 /turf/open/floor/plasteel,
 /area/router/public)
@@ -25118,9 +25031,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bcc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 8
+	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/crew_quarters/lounge/jazz)
 "bcd" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-14"
@@ -25134,8 +25049,8 @@
 	id = "public"
 	},
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "cargoblock";
+/obj/machinery/door/poddoor{
+	id = "public_in";
 	name = "Public Router"
 	},
 /turf/open/floor/plating,
@@ -25148,8 +25063,8 @@
 "bcg" = (
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "cargoblock";
+/obj/machinery/door/poddoor{
+	id = "public_out";
 	name = "Public Router"
 	},
 /turf/open/floor/plating,
@@ -25426,7 +25341,7 @@
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/crew_quarters/fitness/cogpool)
 "bcP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25447,9 +25362,6 @@
 /area/hallway/primary/central)
 "bcS" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom"
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -25492,9 +25404,11 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "bcY" = (
-/obj/machinery/power/smes,
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -25775,15 +25689,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bdE" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8;
-	icon_state = "intact"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/grass,
+/area/hydroponics/garden{
+	name = "Nature Preserve"
+	})
 "bdF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -26013,6 +25923,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bel" = (
@@ -26079,7 +25990,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/crew_quarters/fitness/cogpool)
 "bet" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -26128,7 +26039,7 @@
 	dir = 8
 	},
 /turf/closed/wall/r_wall/rust,
-/area/space/nearstation)
+/area/crew_quarters/fitness/cogpool)
 "bez" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26165,7 +26076,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/crew_quarters/lounge/jazz)
 "beE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -26173,6 +26084,10 @@
 	},
 /obj/structure/fans/tiny,
 /obj/structure/plasticflaps,
+/obj/machinery/door/poddoor{
+	id = "starboardbelthell_in";
+	name = "Belt Hell"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "beF" = (
@@ -26874,11 +26789,15 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bgi" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bgj" = (
 /obj/structure/table,
 /obj/item/weldingtool/mini,
@@ -27474,6 +27393,7 @@
 	id = "sec"
 	},
 /obj/machinery/door/poddoor{
+	id = "security_in";
 	name = "Security Router"
 	},
 /turf/open/floor/plating,
@@ -27570,8 +27490,12 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/chapel)
 "bhI" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bhJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -27847,12 +27771,6 @@
 /area/quartermaster/storage)
 "bim" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/massdriver{
-	id = "router_in";
-	name = "mass driver button (Router)";
-	pixel_x = 24;
-	pixel_y = -8
-	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bin" = (
@@ -27966,9 +27884,6 @@
 /area/quartermaster/storage)
 "bix" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -28112,9 +28027,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "biO" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/solars/starboard/fore)
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "biP" = (
 /obj/machinery/light{
 	dir = 4;
@@ -28721,6 +28637,11 @@
 	dir = 9;
 	id = "mail"
 	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "bkc" = (
@@ -29041,6 +28962,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering{
@@ -29936,10 +29860,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmz" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/storage/primary)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bmA" = (
 /obj/item/stack/tile/plasteel{
 	pixel_x = 10;
@@ -30321,6 +30248,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bng" = (
@@ -30448,6 +30378,9 @@
 /area/crew_quarters/lounge/jazz)
 "bnp" = (
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bnq" = (
@@ -30608,7 +30541,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "bnI" = (
@@ -31542,7 +31474,7 @@
 	})
 "bpL" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes{
@@ -31555,10 +31487,7 @@
 "bpN" = (
 /obj/structure/grille,
 /obj/machinery/power/terminal,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
@@ -32182,9 +32111,9 @@
 	},
 /area/maintenance/central)
 "brf" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
+/obj/machinery/atmospherics/pipe/manifold/green/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "brg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -32770,7 +32699,6 @@
 	name = "Station Intercom (Common)";
 	pixel_x = 26
 	},
-/obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -33277,8 +33205,8 @@
 "bts" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/light_construct/small{
-	icon_state = "bulb-construct-stage1";
-	dir = 1
+	dir = 1;
+	icon_state = "bulb-construct-stage1"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/aft)
@@ -33519,17 +33447,21 @@
 "btZ" = (
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "public_in";
+	name = "Public Router"
+	},
 /turf/open/floor/plating,
 /area/router)
 "bua" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
 "bub" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "buc" = (
@@ -33542,6 +33474,10 @@
 /obj/structure/fans/tiny,
 /obj/machinery/conveyor{
 	id = "router_off"
+	},
+/obj/machinery/door/poddoor{
+	id = "public_out";
+	name = "Public Router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -33644,10 +33580,9 @@
 /area/maintenance/department/chapel)
 "bus" = (
 /obj/structure/window/reinforced/spawner/east,
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 1;
-	id = "public_in";
-	name = "Router Driver"
+	id = "public_in"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -34430,17 +34365,6 @@
 	name = "Routing Depot RC";
 	pixel_y = 28
 	},
-/obj/machinery/button/massdriver{
-	id = "eva_in";
-	name = "mass driver button (EVA)";
-	pixel_x = -24
-	},
-/obj/machinery/button/massdriver{
-	id = "public_in";
-	name = "mass driver button (Public)";
-	pixel_x = -24;
-	pixel_y = 8
-	},
 /turf/open/floor/plasteel,
 /area/router)
 "bwi" = (
@@ -34783,9 +34707,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "router_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -35059,6 +34983,12 @@
 	pixel_x = 3;
 	pixel_y = 1
 	},
+/obj/machinery/button/massdriver{
+	id = "trash";
+	name = "Trash Driver";
+	pixel_x = -24;
+	pixel_y = -8
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bxt" = (
@@ -35105,7 +35035,6 @@
 /area/tcommsat/computer)
 "bxy" = (
 /obj/item/trash/candle,
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -35122,6 +35051,9 @@
 	dir = 1
 	},
 /obj/item/paper/guides/cogstation/letter_eng,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bxA" = (
@@ -35536,7 +35468,6 @@
 /area/maintenance/starboard/central)
 "byu" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -35616,11 +35547,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/button/massdriver{
-	id = "eva_out";
-	pixel_x = 24;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 9
 	},
@@ -35633,7 +35559,7 @@
 	},
 /obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "EVA"
+	id = "eva"
 	},
 /turf/open/floor/plating,
 /area/router/eva)
@@ -35954,7 +35880,7 @@
 	dir = 4;
 	id = "MiningConveyer"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bzv" = (
 /obj/effect/turf_decal/stripes/line,
@@ -35966,7 +35892,7 @@
 	id = "MiningConveyer"
 	},
 /obj/structure/plasticflaps,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "bzw" = (
 /obj/structure/disposalpipe/segment{
@@ -36032,8 +35958,8 @@
 "bzD" = (
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "evablock";
+/obj/machinery/door/poddoor{
+	id = "eva_out";
 	name = "EVA Router"
 	},
 /turf/open/floor/plating,
@@ -36041,17 +35967,21 @@
 "bzE" = (
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
-/obj/machinery/conveyor{
+/obj/machinery/door/poddoor{
+	id = "eva_out";
+	name = "EVA Router"
+	},
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "router_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
 "bzF" = (
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "router_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -36067,6 +35997,7 @@
 "bzH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/grille/broken,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bzI" = (
@@ -37032,8 +36963,11 @@
 "bBE" = (
 /obj/structure/grille,
 /obj/machinery/power/terminal,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plating,
 /area/engine/engine_smes{
@@ -37392,6 +37326,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/button/massdriver{
+	id = "eva_out";
+	name = "EVA Driver Control";
+	pixel_x = 24;
+	pixel_y = -22
+	},
 /turf/open/floor/plasteel,
 /area/router/eva)
 "bCv" = (
@@ -37433,9 +37373,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/clothing/under/misc/overalls,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bCA" = (
@@ -37471,8 +37410,8 @@
 	},
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "evablock";
+/obj/machinery/door/poddoor{
+	id = "eva_in";
 	name = "EVA Router"
 	},
 /turf/open/floor/plating,
@@ -37561,10 +37500,9 @@
 "bCR" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 8;
-	id = "airbridge_in";
-	name = "Router Driver"
+	id = "eva_in"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -37580,9 +37518,9 @@
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/sorting/mail/flip,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "router_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -37636,12 +37574,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bCZ" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "router_off"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -37909,14 +37847,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "router_off"
-	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	id = "router"
+	},
 /turf/open/floor/plating,
 /area/router)
 "bDE" = (
@@ -38139,12 +38077,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "router_off"
-	},
 /obj/structure/disposalpipe/sorting/mail{
-	dir = 4
+	dir = 4;
+	sortType = 9
+	},
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -38167,9 +38106,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "router_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -38359,9 +38298,9 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "router_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -38491,7 +38430,9 @@
 /area/crew_quarters/bar)
 "bEK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/machinery/space_heater,
+/obj/machinery/space_heater{
+	anchored = 1
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -39424,18 +39365,6 @@
 	pixel_x = 26
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/massdriver{
-	id = "eng_in";
-	name = "mass driver button (Engineering)";
-	pixel_x = 24;
-	pixel_y = -8
-	},
-/obj/machinery/button/massdriver{
-	id = "router_out";
-	name = "mass driver button (Other)";
-	pixel_x = 24;
-	pixel_y = 12
-	},
 /turf/open/floor/plasteel,
 /area/router)
 "bGz" = (
@@ -39527,12 +39456,6 @@
 /obj/item/clothing/gloves/color/grey,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"bGK" = (
-/obj/machinery/conveyor{
-	id = "starboard_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "bGL" = (
 /obj/structure/chair{
 	dir = 1
@@ -39574,14 +39497,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"bGP" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "secserv";
-	name = "Router Driver"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "bGQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -39695,13 +39610,6 @@
 	dir = 4;
 	name = "EVA Router APC";
 	pixel_x = 24
-	},
-/obj/machinery/button/door{
-	id = "evablock";
-	name = "Router Access Control";
-	pixel_x = 24;
-	pixel_y = 10;
-	req_access_txt = "19"
 	},
 /turf/open/floor/plasteel,
 /area/router/eva)
@@ -40583,8 +40491,9 @@
 /area/maintenance/department/chapel)
 "bIY" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden,
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "bIZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -42717,20 +42626,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 4;
-	id = "router_out";
-	name = "Router Driver"
+	id = "starboardbelthell_out"
 	},
 /turf/open/floor/plating,
 /area/router)
-"bNo" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "starboard_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "bNp" = (
 /obj/machinery/light{
 	dir = 1
@@ -42756,6 +42657,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNr" = (
@@ -43726,7 +43628,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bPB" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
@@ -43736,12 +43637,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPC" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Waste In"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -43963,7 +43863,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail{
-	sortType = 1
+	sortType = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/open/floor/plasteel,
@@ -44382,7 +44282,6 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/landmark/start/atmospheric_technician,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -45195,6 +45094,7 @@
 /area/science/mixing)
 "bSm" = (
 /obj/machinery/modular_computer/console/preset/engineering,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes{
 	name = "Power Monitoring"
@@ -45207,12 +45107,12 @@
 	name = "Power Monitoring"
 	})
 "bSo" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/engine/engine_smes{
-	name = "Power Monitoring"
+/turf/open/floor/engine,
+/area/engine/supermatter{
+	name = "Thermo-Electric Generator"
 	})
 "bSp" = (
 /obj/structure/cable{
@@ -45325,7 +45225,7 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
-	sortType = 11
+	sortType = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -45837,6 +45737,7 @@
 "bTF" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/router)
 "bTG" = (
@@ -46008,14 +45909,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bUa" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Entrance"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -47053,10 +46954,10 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bVY" = (
@@ -47260,9 +47161,6 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "bWq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/airalarm{
 	dir = 8;
@@ -47414,12 +47312,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bWG" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWH" = (
@@ -48037,9 +47933,9 @@
 /area/maintenance/aft)
 "bXM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "router_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -48060,11 +47956,11 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bXP" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bXQ" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/tile/purple,
@@ -48117,11 +48013,12 @@
 	name = "Research Sector"
 	})
 "bXV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Mix"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bXW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48197,11 +48094,9 @@
 	name = "Research Sector"
 	})
 "bYd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bYe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -48220,6 +48115,10 @@
 	id = "router"
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "starboardbelthell_in";
+	name = "Belt Hell"
+	},
 /turf/open/floor/plating,
 /area/router)
 "bYg" = (
@@ -48576,14 +48475,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Distro to Waste"
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/atmos)
 "bYQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -49034,12 +48934,22 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "bZQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -30
+	},
+/obj/structure/tank_dispenser{
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "bZR" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -49174,6 +49084,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cai" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
@@ -49194,7 +49105,7 @@
 "cak" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cal" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 10
@@ -49206,7 +49117,7 @@
 "cam" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "can" = (
 /obj/machinery/power/turbine{
 	dir = 8
@@ -49215,7 +49126,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cao" = (
 /obj/machinery/power/compressor{
 	dir = 4
@@ -49227,7 +49138,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cap" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49238,7 +49149,7 @@
 	},
 /obj/machinery/igniter/incinerator_atmos,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "caq" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_exterior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -49249,7 +49160,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "car" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
@@ -49263,7 +49174,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "cat" = (
@@ -49273,7 +49183,7 @@
 "cau" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cav" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -49545,6 +49455,7 @@
 "cbe" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/gas,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/explab)
 "cbf" = (
@@ -49926,13 +49837,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"cbS" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "starboard_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "cbT" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 4
@@ -49940,28 +49844,28 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -2;
-	pixel_y = -27
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cbU" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Air to Distro"
-	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/engine/atmos";
 	name = "Atmospherics APC";
-	pixel_y = -28
+	pixel_y = -24
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/supplymain/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cbV" = (
 /obj/structure/disposalpipe/segment,
@@ -50055,9 +49959,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "starboard_off"
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -50084,9 +49988,8 @@
 /area/router)
 "cci" = (
 /obj/structure/window/reinforced/spawner/west,
-/obj/machinery/mass_driver{
-	id = "workshop_in";
-	name = "Router Driver"
+/obj/machinery/mass_driver/pressure_plate{
+	id = "portbelthell_out"
 	},
 /turf/open/floor/plating,
 /area/router)
@@ -50184,9 +50087,9 @@
 /area/router/aux)
 "ccs" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "starboard_off"
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -50247,6 +50150,10 @@
 	id = "router"
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "portbelthell_in";
+	name = "Airbridge Router"
+	},
 /turf/open/floor/plating,
 /area/router)
 "ccz" = (
@@ -50320,11 +50227,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ccE" = (
-/obj/machinery/mass_driver{
-	id = "eng_in";
-	name = "Router Driver"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/mass_driver/pressure_plate{
+	id = "engi_in"
+	},
 /turf/open/floor/plating,
 /area/router)
 "ccF" = (
@@ -50349,10 +50255,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ccH" = (
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 8;
-	id = "disposal_in";
-	name = "Router Driver"
+	id = "recycle_in"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -50368,13 +50273,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"ccJ" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "starboard_off"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "ccK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
@@ -50409,7 +50307,8 @@
 "ccO" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/sorting/mail{
-	dir = 8
+	dir = 8;
+	sortType = 21
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -50673,10 +50572,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cdq" = (
-/obj/machinery/mass_driver{
-	id = "sq_in";
-	name = "Router Driver"
-	},
+/obj/machinery/mass_driver/pressure_plate,
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cdr" = (
@@ -50820,8 +50716,8 @@
 "cdG" = (
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "engblock";
+/obj/machinery/door/poddoor{
+	id = "engi_out";
 	name = "Engineering Router"
 	},
 /turf/open/floor/plating,
@@ -50961,8 +50857,8 @@
 	id = "eng"
 	},
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "engblock";
+/obj/machinery/door/poddoor{
+	id = "engi_in";
 	name = "Engineering Router"
 	},
 /turf/open/floor/plating,
@@ -51172,7 +51068,7 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/machinery/mass_driver{
 	dir = 1;
-	id = "eng_out";
+	id = "engi_out";
 	name = "Router Driver"
 	},
 /obj/structure/window/reinforced/spawner/west,
@@ -51391,16 +51287,10 @@
 	dir = 1
 	},
 /obj/machinery/button/massdriver{
-	id = "eng_out";
+	id = "engi_out";
+	name = "Engineering Driver Control";
 	pixel_x = -24;
 	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "engblock";
-	name = "Router Access Control";
-	pixel_x = -24;
-	pixel_y = 32;
-	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -51483,11 +51373,11 @@
 /turf/open/floor/plasteel,
 /area/router/eng)
 "ceU" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
 /obj/structure/fireaxecabinet{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -51888,14 +51778,14 @@
 	name = "Canister Storage"
 	})
 "cfM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supplymain/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -51921,13 +51811,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "cfP" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Distro"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cfQ" = (
@@ -51954,9 +51845,15 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cfT" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Air to Mix"
+	},
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -52061,6 +51958,10 @@
 	id = "disposal"
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "starboardbelthell_out";
+	name = "Belt Hell"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cge" = (
@@ -52097,20 +51998,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cgg" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cgh" = (
 /obj/machinery/pipedispenser,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
@@ -52260,9 +52155,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/teg_hot)
 "cgx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -52271,10 +52168,10 @@
 /turf/closed/wall/rust,
 /area/maintenance/solars/starboard/aft)
 "cgz" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Filter"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cgA" = (
@@ -52629,37 +52526,23 @@
 	name = "Nature Preserve"
 	})
 "chn" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal/incinerator";
-	dir = 8;
-	name = "Incinerator APC";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cho" = (
 /turf/closed/wall/r_wall/rust,
 /area/maintenance/department/eva)
 "chp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chq" = (
@@ -52712,10 +52595,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "chx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chy" = (
@@ -52826,20 +52709,20 @@
 /turf/open/floor/plating,
 /area/engine/teg_cold)
 "chL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chM" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -52919,11 +52802,13 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "chS" = (
-/obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "chT" = (
@@ -53102,12 +52987,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "router_in";
-	name = "Router Driver"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/mass_driver/pressure_plate{
+	dir = 8;
+	id = "starboardbelthell_in"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cil" = (
@@ -53127,7 +53011,7 @@
 "cim" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
-	sortType = 11
+	sortType = 9
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -53150,11 +53034,10 @@
 /turf/closed/wall,
 /area/science/robotics/mechbay)
 "cip" = (
-/obj/machinery/mass_driver{
-	id = "cargo_in";
-	name = "Router Driver"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/mass_driver/pressure_plate{
+	id = "cargo_in"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ciq" = (
@@ -53187,6 +53070,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ciu" = (
@@ -53242,7 +53126,7 @@
 "ciB" = (
 /obj/structure/frame/computer,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ciC" = (
 /obj/structure/table,
@@ -53280,12 +53164,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "ciG" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "disposal_off"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/closed/wall/r_wall,
+/area/engine/engineering{
+	name = "Engine Room"
+	})
 "ciH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 6
@@ -53351,10 +53236,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/kitchen)
 "ciO" = (
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 4;
-	id = "disposal_out";
-	name = "Router Driver"
+	id = "recycle_out"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -53487,7 +53371,8 @@
 /obj/structure/fans/tiny,
 /obj/structure/plasticflaps,
 /obj/machinery/door/poddoor{
-	name = "Disposal Router"
+	id = "recycle_out";
+	name = "Belt Hell"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -53538,6 +53423,10 @@
 /obj/machinery/conveyor/auto{
 	dir = 1;
 	id = "disposal"
+	},
+/obj/machinery/door/poddoor{
+	id = "cargo_out";
+	name = "Cargo Router"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -53897,9 +53786,6 @@
 /area/engine/teg_cold)
 "cjV" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Engineering Sector"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53929,8 +53815,8 @@
 /obj/machinery/button/door{
 	id = "hos";
 	name = "HoS Office Shutters";
-	pixel_y = -32;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
@@ -55207,8 +55093,8 @@
 "cmH" = (
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "cargoblock";
+/obj/machinery/door/poddoor{
+	id = "cargo_out";
 	name = "Cargo Router"
 	},
 /turf/open/floor/plating,
@@ -55275,14 +55161,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cmL" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/light,
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "cmM" = (
 /obj/structure/sign/poster/official/safety_internals{
 	pixel_x = -32
 	},
-/obj/effect/landmark/blobstart,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cmN" = (
@@ -55421,6 +55311,9 @@
 /area/quartermaster/qm)
 "cmX" = (
 /obj/machinery/light/small,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/engine/supermatter{
 	name = "Thermo-Electric Generator"
@@ -55535,9 +55428,11 @@
 /turf/open/floor/plasteel,
 /area/engine/teg_cold)
 "cni" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Port to Fuel Pipe"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cnj" = (
 /obj/machinery/camera{
 	c_tag = "Research - Observatory";
@@ -55570,7 +55465,6 @@
 	dir = 1;
 	pixel_x = 5
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cnm" = (
@@ -55646,7 +55540,8 @@
 	id = "disposal"
 	},
 /obj/machinery/door/poddoor{
-	name = "Disposal Router"
+	id = "recycle_in";
+	name = "Belt Hell"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -55815,14 +55710,6 @@
 /obj/item/target/clown,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cnM" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "pb_in";
-	name = "Router Driver"
-	},
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "cnN" = (
 /obj/structure/bookcase/random/fiction,
 /obj/effect/turf_decal/tile/neutral,
@@ -56008,12 +55895,14 @@
 	name = "Electrical Substation"
 	})
 "coh" = (
-/obj/machinery/power/smes,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
 /turf/open/floor/plating,
 /area/engine/storage_shared{
@@ -56203,8 +56092,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/orange/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -56248,7 +56137,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/orange/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/orange/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "coE" = (
@@ -56679,8 +56568,8 @@
 	id = "cargo"
 	},
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/preopen{
-	id = "cargoblock";
+/obj/machinery/door/poddoor{
+	id = "cargo_in";
 	name = "Cargo Router"
 	},
 /turf/open/floor/plating,
@@ -56792,6 +56681,10 @@
 "cpE" = (
 /obj/structure/fans/tiny,
 /obj/structure/plasticflaps,
+/obj/machinery/door/poddoor{
+	id = "cargo_in";
+	name = "Cargo Router"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cpF" = (
@@ -56901,12 +56794,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cpO" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/item/cartridge/atmos,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cpP" = (
@@ -56917,14 +56816,12 @@
 /turf/open/floor/plasteel/white,
 /area/gateway)
 "cpQ" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6;
 	layer = 2.03
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/orange/visible,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cpR" = (
@@ -57238,6 +57135,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cqt" = (
@@ -57260,6 +57160,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cqv" = (
@@ -57272,6 +57175,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -57616,11 +57522,6 @@
 /obj/structure/sign/warning{
 	name = "\improper KEEP CLEAR: HIGH SPEED DELIVERIES";
 	pixel_y = 32
-	},
-/obj/machinery/button/massdriver{
-	id = "cargo_out";
-	pixel_x = -8;
-	pixel_y = -4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -58608,9 +58509,9 @@
 /obj/machinery/button/door{
 	id = "robotics";
 	name = "Shutters Control Button";
+	pixel_x = -24;
 	pixel_y = 8;
-	req_access_txt = "29";
-	pixel_x = -24
+	req_access_txt = "29"
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
@@ -58648,8 +58549,6 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/effect/landmark/blobstart,
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
 "ctc" = (
@@ -58998,12 +58897,20 @@
 /area/science/explab)
 "ctJ" = (
 /obj/structure/plasticflaps,
+/obj/machinery/door/poddoor{
+	id = "portbelthell_in";
+	name = "Airbridge Router"
+	},
 /turf/open/floor/plating,
 /area/engine/workshop)
 "ctK" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
 	id = "workshop_off"
+	},
+/obj/machinery/door/poddoor{
+	id = "portbelthell_out";
+	name = "Airbridge Router"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
@@ -59474,7 +59381,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/crew_quarters/fitness/cogpool)
 "cuy" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -59685,17 +59592,16 @@
 /area/router/air)
 "cuS" = (
 /obj/structure/window/reinforced/spawner/east,
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 1;
-	id = "workshop_out";
-	name = "Router Driver"
+	id = "portbelthell_in"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
 "cuT" = (
 /obj/structure/window/reinforced/spawner/west,
-/obj/machinery/conveyor{
-	id = "workshop_off"
+/obj/machinery/conveyor/auto{
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
@@ -59908,9 +59814,9 @@
 /area/router/air)
 "cvq" = (
 /obj/structure/window/reinforced/spawner/east,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "workshop_off"
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
@@ -60422,12 +60328,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/button/door{
-	id = "cargoblock";
-	name = "Router Access Control";
+/obj/machinery/button/massdriver{
+	id = "cargo_out";
+	name = "Cargo Driver Control";
 	pixel_x = -24;
-	pixel_y = 24;
-	req_access_txt = "31"
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -60587,6 +60492,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes{
 	name = "Power Monitoring"
@@ -60894,6 +60802,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes{
 	name = "Power Monitoring"
@@ -66167,15 +66076,16 @@
 	},
 /obj/machinery/button/massdriver{
 	id = "airbridge_out";
+	name = "Airbridge Driver Control";
 	pixel_x = -8;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
 /area/router/air)
 "cGa" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "airbridge_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router/air)
@@ -66261,9 +66171,9 @@
 /area/medical/medbay/central)
 "cGf" = (
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "airbridge_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router/air)
@@ -66273,9 +66183,9 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "airbridge_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/router/air)
@@ -66287,7 +66197,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/machinery/mass_driver{
 	dir = 4;
-	id = "airbridge_in";
+	id = "airbridge_out";
 	name = "Router Driver"
 	},
 /turf/open/floor/plating,
@@ -66730,7 +66640,6 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "cGW" = (
-/obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -67029,7 +66938,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
 	},
@@ -67284,6 +67192,7 @@
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
+	id = "airbridge_out";
 	name = "Airbridge Router"
 	},
 /turf/open/floor/plating,
@@ -67326,7 +67235,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cId" = (
-/obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 5
 	},
@@ -67363,17 +67271,21 @@
 /area/medical/genetics)
 "cIh" = (
 /obj/structure/plasticflaps,
-/obj/machinery/conveyor{
+/obj/machinery/door/poddoor{
+	id = "airbridge_out";
+	name = "Airbridge Router"
+	},
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "workshop_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
 "cIi" = (
 /obj/structure/window/reinforced/spawner,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "workshop_off"
+	id = "router"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
@@ -67473,9 +67385,9 @@
 "cIq" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "workshop_off"
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
@@ -67502,13 +67414,13 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cIt" = (
@@ -67737,9 +67649,6 @@
 /area/hallway/primary/aft)
 "cIN" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Engineering Sector"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68040,17 +67949,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cJo" = (
-/obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
-/area/engine/atmos)
 "cJp" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -68103,14 +68001,10 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "cJu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Engine"
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cJv" = (
@@ -68256,14 +68150,9 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "cJH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+	dir = 9
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cJI" = (
@@ -68982,11 +68871,12 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Unfiltered & Air to Mix"
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -69016,10 +68906,10 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/violet/visible,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
 	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cLh" = (
@@ -69075,7 +68965,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "cLn" = (
@@ -69262,8 +69151,8 @@
 /area/router/air)
 "cLK" = (
 /obj/structure/window/reinforced/spawner/north,
-/obj/machinery/conveyor{
-	id = "airbridge_off"
+/obj/machinery/conveyor/auto{
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/router/air)
@@ -69289,9 +69178,9 @@
 /area/medical/virology)
 "cLO" = (
 /obj/structure/window/reinforced/spawner/north,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "airbridge_off"
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/router/air)
@@ -69328,6 +69217,7 @@
 	id = "airbridge_off"
 	},
 /obj/machinery/door/poddoor{
+	id = "airbridge_in";
 	name = "Airbridge Router"
 	},
 /turf/open/floor/plating,
@@ -69338,10 +69228,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 8;
-	id = "workshop_in";
-	name = "Router Driver"
+	id = "airbridge_in"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
@@ -69363,8 +69252,8 @@
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "cLV" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -69381,19 +69270,13 @@
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cLY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/incinerator_output{
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
-"cLZ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cMa" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -69404,20 +69287,16 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cMb" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "cMc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -69451,9 +69330,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cMi" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
 /area/engine/atmos)
 "cMj" = (
 /obj/structure/cable{
@@ -69463,7 +69343,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cMk" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -69527,7 +69407,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cMu" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -69535,7 +69415,7 @@
 	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
+/area/engine/atmos)
 "cMv" = (
 /obj/machinery/button/door/incinerator_vent_atmos_main{
 	pixel_x = -24;
@@ -69545,28 +69425,26 @@
 	pixel_x = -40;
 	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cMw" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	name = "Waste Release"
-	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cMx" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -69659,14 +69537,20 @@
 /turf/open/floor/plasteel/white/corner,
 /area/engine/atmos)
 "cMG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cMH" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/closed/wall/r_wall,
+/obj/machinery/suit_storage_unit/atmos,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cMI" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -69717,13 +69601,12 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cMP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/engine/atmos)
 "cMQ" = (
 /obj/structure/lattice,
@@ -69755,16 +69638,16 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "workshop_off"
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
 "cMV" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "workshop_off"
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
@@ -69943,17 +69826,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/router/air)
-"cNm" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "airbridge_off"
-	},
-/turf/open/floor/plating,
-/area/router/air)
 "cNn" = (
-/obj/machinery/conveyor{
-	dir = 10;
-	id = "airbridge_off"
+/obj/machinery/conveyor/auto{
+	dir = 8;
+	id = "airbridge"
 	},
 /turf/open/floor/plating,
 /area/router/air)
@@ -70359,6 +70235,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cOr" = (
@@ -70499,6 +70376,12 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/machinery/button/massdriver{
+	id = "research_out";
+	name = "Medsci Driver Control";
+	pixel_x = -24;
+	pixel_y = -24
+	},
 /turf/open/floor/plasteel,
 /area/router/medsci)
 "cOF" = (
@@ -70527,8 +70410,8 @@
 /turf/closed/wall/r_wall,
 /area/router/medsci)
 "cOJ" = (
-/obj/machinery/conveyor{
-	id = "medsci_off"
+/obj/machinery/conveyor/auto{
+	id = "medsci"
 	},
 /turf/open/floor/plating,
 /area/router/medsci)
@@ -70538,11 +70421,6 @@
 /obj/item/hand_labeler,
 /obj/item/destTagger,
 /obj/machinery/light,
-/obj/machinery/button/massdriver{
-	id = "medsci_out";
-	pixel_x = -8;
-	pixel_y = 8
-	},
 /obj/machinery/requests_console{
 	department = "MedSci Router";
 	name = "MedSci Router RC";
@@ -70551,9 +70429,9 @@
 /turf/open/floor/plating,
 /area/router/medsci)
 "cOL" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "medsci_off"
+	id = "medsci"
 	},
 /turf/open/floor/plating,
 /area/router/medsci)
@@ -70579,7 +70457,7 @@
 /area/janitor/aux)
 "cOP" = (
 /obj/machinery/mass_driver{
-	id = "medsci_out";
+	id = "research_out";
 	name = "Router Driver"
 	},
 /turf/open/floor/plating,
@@ -70649,6 +70527,7 @@
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
+	id = "research_out";
 	name = "MedSci Router"
 	},
 /turf/open/floor/plating,
@@ -70657,11 +70536,12 @@
 /obj/structure/plasticflaps,
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
+	id = "research_in";
 	name = "MedSci Router"
 	},
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "medsci_off"
+	id = "medsci"
 	},
 /turf/open/floor/plating,
 /area/router/medsci)
@@ -70691,6 +70571,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/janitor/aux)
 "cOX" = (
@@ -70768,100 +70649,88 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "cPd" = (
-/obj/machinery/conveyor{
-	id = "sq_off"
+/obj/machinery/conveyor/auto{
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPe" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "sq_out";
-	name = "Router Driver"
+/obj/machinery/mass_driver/pressure_plate{
+	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
-"cPf" = (
-/obj/machinery/conveyor/auto,
-/turf/open/floor/plating/airless,
-/area/router/aux)
 "cPg" = (
-/obj/machinery/mass_driver{
+/obj/machinery/mass_driver/pressure_plate{
 	dir = 1;
-	id = "medsci_in";
-	name = "Router Driver"
+	id = "research_in"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPh" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "sq_off"
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPi" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 1;
-	id = "viro_off"
+	id = "pq"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPj" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 9;
-	id = "viro_off"
+	id = "medsci"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPk" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "viro_off"
+	id = "medsci"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPl" = (
-/obj/machinery/mass_driver{
-	dir = 8;
-	id = "viro_in";
-	name = "Router Driver"
+/obj/machinery/mass_driver/pressure_plate{
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPm" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 8;
-	id = "sq_off"
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPn" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 10;
-	id = "sq_off"
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPo" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "viro_off"
+/obj/machinery/conveyor/auto{
+	id = "pq"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPp" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "viro_out";
-	name = "Router Driver"
+/obj/machinery/mass_driver/pressure_plate{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
 "cPq" = (
-/obj/machinery/conveyor{
+/obj/machinery/conveyor/auto{
 	dir = 4;
-	id = "sq_off"
+	id = "starboard"
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
@@ -71867,7 +71736,7 @@
 	id = "MiningConveyorBlastDoor";
 	name = "Asteroid Mining Load Door"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "cRb" = (
 /obj/machinery/computer/cloning,
@@ -71932,13 +71801,7 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "cRh" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
@@ -71972,8 +71835,8 @@
 /obj/item/stock_parts/cell/high{
 	charge = 100;
 	maxcharge = 15000;
-	pixel_y = 3;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /obj/item/stock_parts/cell/high{
 	charge = 100;
@@ -72137,29 +72000,41 @@
 	name = "Medbay Treatment Center"
 	})
 "cVq" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/hallway/primary/aft)
 "cVO" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dpO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dwH" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor/auto{
+	dir = 1;
+	id = "router"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "engi_out";
+	name = "Engineering Router"
+	},
+/turf/open/floor/plating,
+/area/router)
 "dVR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dYm" = (
@@ -72170,11 +72045,11 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "eCy" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -72194,13 +72069,15 @@
 	},
 /area/engine/atmos)
 "eKM" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -30
-	},
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eSd" = (
+/obj/machinery/mass_driver/pressure_plate{
+	id = "security_in"
+	},
+/turf/open/floor/plating/airless,
+/area/router/aux)
 "eTZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -72208,10 +72085,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eUF" = (
@@ -72238,24 +72114,25 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fkx" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/hallway/primary/aft)
 "fti" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fui" = (
-/obj/machinery/atmospherics/pipe/simple/violet/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fuE" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -72271,32 +72148,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"fIw" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "guK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/space/basic,
 /area/space)
 "gDY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Fuel Pipe to Incinerator"
-	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gGG" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -72330,24 +72197,15 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "hlo" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/quartermaster/miningdock/airless)
 "hlV" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supplymain/visible{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/storage/tech)
 "hDz" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hFa" = (
@@ -72358,19 +72216,10 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "hKC" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"hMZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Pure to Port"
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hXk" = (
@@ -72384,17 +72233,10 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
-"iAW" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "iQY" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
 	},
-/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jiZ" = (
@@ -72403,19 +72245,8 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"jml" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	layer = 2.4
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jon" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72435,16 +72266,6 @@
 /area/engine/secure_construction{
 	name = "Engineering Construction Area"
 	})
-"jXo" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
-"kxw" = (
-/obj/machinery/atmospherics/pipe/simple/violet/visible,
-/turf/open/space/basic,
-/area/space)
 "kzb" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
@@ -72455,16 +72276,12 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Engine"
-	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "lcD" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Air to Port"
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -72472,8 +72289,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Mix to Filter"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -72487,7 +72305,10 @@
 	name = "Engine Room"
 	})
 "mqB" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Air to Ports"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mxW" = (
@@ -72497,13 +72318,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"mBP" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "mEa" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mIm" = (
@@ -72530,36 +72350,14 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"mNN" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"ntC" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Fuel Pipe"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "nvn" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "nAF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Port"
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "nBM" = (
@@ -72570,26 +72368,9 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"nEX" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"nLV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "ony" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+/obj/machinery/atmospherics/pipe/manifold/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -72618,6 +72399,13 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pZq" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	sortType = 12
+	},
+/turf/open/floor/plating/airless,
+/area/router/aux)
 "qeq" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -72625,41 +72413,72 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"qgO" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "qlJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
-"qvB" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
+"qGi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes{
+	name = "Power Monitoring"
+	})
 "qHL" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"qWY" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste In"
+"qMN" = (
+/obj/structure/plasticflaps,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "starboardbelthell_out";
+	name = "Belt Hell"
 	},
+/turf/open/floor/plating,
+/area/router)
+"qWY" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rdF" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rke" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes{
+	name = "Power Monitoring"
+	})
+"rqk" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes{
+	name = "Power Monitoring"
+	})
+"rOE" = (
+/obj/structure/plasticflaps,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "eva_in";
+	name = "EVA Router"
+	},
+/turf/open/floor/plating,
+/area/router)
 "rTW" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/visible{
@@ -72673,22 +72492,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"sdp" = (
-/obj/structure/reagent_dispensers/foamtank,
-/turf/open/floor/engine,
-/area/engine/secure_construction{
-	name = "Engineering Construction Area"
-	})
-"sHB" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
+"sky" = (
+/obj/machinery/conveyor/auto{
+	dir = 4;
+	id = "pq"
 	},
+/turf/open/floor/plating/airless,
+/area/router/aux)
+"sAm" = (
+/obj/structure/plasticflaps,
+/obj/machinery/door/poddoor{
+	id = "airbridge_out";
+	name = "Airbridge Router"
+	},
+/turf/open/floor/plating,
+/area/engine/workshop)
+"sHB" = (
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sRD" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sVC" = (
@@ -72699,6 +72524,15 @@
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"tff" = (
+/obj/structure/plasticflaps,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "portbelthell_out";
+	name = "Airbridge Router"
+	},
+/turf/open/floor/plating,
+/area/router)
 "tjb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -72714,12 +72548,15 @@
 /obj/machinery/atmospherics/pipe/simple/violet/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
-"tuF" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
+"tsU" = (
+/obj/structure/plasticflaps,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "engi_in";
+	name = "Engineering Router"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/turf/open/floor/plating,
+/area/router)
 "tyI" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
 	dir = 4
@@ -72728,36 +72565,28 @@
 /area/engine/atmos)
 "tXV" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	layer = 2.4
+	name = "Pure to Ports"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tZj" = (
-/obj/structure/tank_dispenser{
-	pixel_x = -1
-	},
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tZC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/orange/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "urj" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 8;
-	icon_state = "intact"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "uwK" = (
@@ -72778,26 +72607,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uVD" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/brown/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vcb" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"vsO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/closed/wall/r_wall,
 /area/engine/atmos)
 "vxU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -72818,7 +72638,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "wWH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xcO" = (
@@ -72828,24 +72650,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 0;
-	name = "Mix Outlet Pump"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"xjk" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"xkC" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+	name = "Mix to Ports"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -72862,9 +72668,8 @@
 /turf/closed/wall,
 /area/quartermaster/storage)
 "xCy" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/violet/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -92048,7 +91853,7 @@ aaa
 aaa
 bcy
 bdf
-mBP
+bdf
 crJ
 blT
 bqJ
@@ -92763,7 +92568,7 @@ auL
 aAc
 aGq
 aJX
-bdE
+cQQ
 cen
 aGq
 cvK
@@ -95885,7 +95690,7 @@ bhS
 beJ
 beJ
 bGI
-bXP
+aaU
 aaa
 aaa
 aaa
@@ -96142,7 +95947,7 @@ bdg
 beJ
 beJ
 bGI
-bXV
+aaU
 aaa
 aaa
 aaa
@@ -96399,7 +96204,7 @@ bdg
 beJ
 ceI
 bGI
-bXV
+aaU
 aaa
 aaa
 aaa
@@ -96656,7 +96461,7 @@ bdg
 cmd
 beT
 bGI
-bXV
+aaU
 aaa
 aaa
 aaa
@@ -96913,7 +96718,7 @@ bdg
 beJ
 bfd
 bdg
-bXV
+aaU
 aaa
 aaa
 ceD
@@ -97170,7 +96975,7 @@ bdg
 beJ
 bfd
 bdg
-bXV
+aaU
 aaa
 bdg
 buB
@@ -97427,7 +97232,7 @@ bdg
 caW
 bJy
 bdg
-bXV
+aaU
 aaU
 bdg
 bjg
@@ -97684,7 +97489,7 @@ bdg
 beJ
 bfd
 bGI
-bYd
+bGI
 bGI
 bGI
 bzb
@@ -97941,7 +97746,7 @@ beJ
 beJ
 bfd
 blc
-bYP
+beJ
 coS
 aXc
 aXc
@@ -98116,7 +97921,7 @@ aak
 aak
 aak
 aak
-aak
+eSd
 aaa
 aaa
 aaa
@@ -98198,7 +98003,7 @@ bzB
 bgA
 bWf
 bXm
-bZQ
+bgA
 bWq
 ccN
 cei
@@ -98263,10 +98068,10 @@ aaa
 aaa
 aaa
 aaa
-cPf
-cPf
-cPf
-cPf
+cPo
+cPo
+cPo
+cPo
 cPo
 abp
 aaa
@@ -98524,7 +98329,7 @@ abM
 abR
 abM
 abM
-cPo
+sky
 aaU
 aaa
 aaa
@@ -98781,7 +98586,7 @@ cPg
 cPi
 cPj
 abR
-cPo
+sky
 aaU
 aaa
 aaa
@@ -99038,7 +98843,7 @@ aaa
 aaa
 cPk
 abR
-cPo
+sky
 aaU
 aaa
 aaa
@@ -99399,7 +99204,7 @@ aaa
 aaU
 aar
 abM
-acf
+cPp
 aaU
 aaa
 aaa
@@ -99661,12 +99466,12 @@ aaU
 aaa
 aaa
 aaa
+adM
 adj
 adj
 adj
 adj
-adj
-adj
+adM
 aaU
 aaU
 aaa
@@ -99918,12 +99723,12 @@ aaU
 aaa
 aaa
 aaa
-adj
+adM
 aeC
 afv
 adF
 agM
-adj
+adM
 aaa
 aaU
 aaU
@@ -100175,12 +99980,12 @@ aaU
 aaa
 aaa
 aaa
-adj
+adM
 aeR
 afx
 aga
 afI
-adj
+adM
 aaa
 aaa
 aaU
@@ -100432,20 +100237,20 @@ aaU
 add
 adC
 adC
-adC
+aap
 aeS
 adj
 adj
 agN
+aiX
 ahL
 ahL
-ahL
-ahL
+aaq
 afD
 afQ
 age
 age
-agy
+age
 age
 age
 afC
@@ -100697,8 +100502,8 @@ aad
 aad
 aad
 aad
-adM
-aaj
+aiM
+agy
 aaI
 ami
 akX
@@ -100955,7 +100760,7 @@ aad
 aad
 aad
 aiM
-aaj
+azO
 aaI
 aco
 akX
@@ -101020,7 +100825,7 @@ bRf
 cCG
 cCH
 cCG
-bUw
+bgi
 bVJ
 cCG
 bWF
@@ -101277,7 +101082,7 @@ bcf
 bcf
 bCs
 bcf
-bwU
+bhI
 bCD
 bcf
 bcf
@@ -101469,7 +101274,7 @@ aad
 aad
 aad
 aiM
-aap
+aco
 abd
 abT
 akX
@@ -101725,8 +101530,8 @@ aad
 aad
 aad
 aad
-adM
-aaq
+aiM
+aco
 aaI
 acF
 akX
@@ -101982,7 +101787,7 @@ agO
 adj
 adj
 adj
-adM
+aiM
 aat
 abf
 acF
@@ -103105,7 +102910,7 @@ aaa
 cuR
 cGa
 cuR
-cNm
+cNn
 cuR
 cIH
 cgv
@@ -103927,7 +103732,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cpB
 ckl
 ckl
 ckl
@@ -105619,7 +105424,7 @@ aYi
 baU
 bdh
 aOJ
-aog
+bdE
 aog
 axV
 aHV
@@ -106149,7 +105954,7 @@ aaU
 aaa
 btT
 bzE
-btZ
+rOE
 btT
 aaa
 aaa
@@ -106188,7 +105993,7 @@ aaa
 aaa
 ctG
 cIh
-ctJ
+sAm
 ctG
 cIy
 bjm
@@ -106925,7 +106730,7 @@ bKl
 bQW
 bUp
 cci
-btZ
+tff
 aSq
 bgh
 bIY
@@ -107163,7 +106968,7 @@ bdP
 bfF
 bha
 bdP
-abp
+aOJ
 aPN
 bes
 aaU
@@ -107208,8 +107013,8 @@ aPg
 aPg
 cet
 bpL
-bBO
-bBO
+bpL
+rqk
 bBO
 bBO
 ctG
@@ -107228,7 +107033,7 @@ bZq
 bZh
 cEE
 bpD
-cmL
+bpD
 cyS
 byQ
 byQ
@@ -107420,7 +107225,7 @@ bdW
 bfJ
 bhc
 bdP
-abp
+aOJ
 aPN
 bes
 aaU
@@ -107466,7 +107271,7 @@ cdV
 cdV
 bpN
 bCa
-bSo
+bSp
 bSv
 cfl
 ctX
@@ -107677,7 +107482,7 @@ bdY
 bfM
 bhg
 bdP
-abp
+aOJ
 aPN
 bey
 aaU
@@ -107934,7 +107739,7 @@ bdP
 bdP
 bhl
 bdP
-abp
+aOJ
 aPN
 bes
 aaU
@@ -107978,7 +107783,7 @@ cmf
 cnK
 cnK
 cdV
-bBO
+rke
 bUB
 bSq
 bVf
@@ -108191,7 +107996,7 @@ aaU
 aaU
 cuA
 cuy
-bcc
+blD
 bcO
 bes
 aaU
@@ -108448,7 +108253,7 @@ aaa
 aaa
 aaa
 aaU
-brs
+aQq
 aPR
 cux
 aaU
@@ -108492,7 +108297,7 @@ cmE
 cok
 cok
 cdV
-bBO
+rke
 bPv
 cBd
 cfi
@@ -108705,7 +108510,7 @@ aaa
 aaa
 aaa
 aaU
-brs
+aQq
 aQp
 cux
 aaU
@@ -108749,7 +108554,7 @@ cmG
 coT
 cpL
 cpZ
-bBO
+qGi
 cxd
 cBd
 cfj
@@ -108962,9 +108767,9 @@ aaU
 aaU
 aaU
 aaU
-abp
-aQq
-bes
+aUq
+bmO
+bcc
 aaU
 aaa
 aaa
@@ -109006,7 +108811,7 @@ cmY
 cdV
 cdV
 cdV
-bBO
+qGi
 bSm
 cBk
 cfk
@@ -109066,7 +108871,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cpB
 aaa
 ckl
 ckl
@@ -109219,9 +109024,9 @@ aaa
 aaa
 aaa
 aaU
-abp
+aUq
 aQr
-bes
+bcc
 aaU
 aaa
 aaa
@@ -109239,7 +109044,7 @@ bBv
 bXM
 ccn
 ccA
-ccy
+dwH
 aTl
 bsz
 cdG
@@ -109263,7 +109068,7 @@ cks
 crv
 crx
 aeI
-bBO
+rke
 bSn
 cBl
 bSn
@@ -109476,7 +109281,7 @@ aaa
 aaa
 aaa
 aaU
-abp
+aUq
 aQr
 beD
 cuy
@@ -109496,7 +109301,7 @@ bUc
 bXM
 cco
 ccE
-btZ
+tsU
 aTl
 bsz
 cdU
@@ -109534,7 +109339,7 @@ cNt
 beZ
 cIS
 coz
-bty
+fkx
 bBl
 aaU
 aaU
@@ -110046,9 +109851,9 @@ cJy
 cNg
 cNs
 cIB
-cIM
-bXX
-bty
+cMG
+cVq
+fui
 bBl
 aaU
 bIm
@@ -110262,7 +110067,7 @@ aaa
 btT
 bBX
 btT
-btZ
+qMN
 btT
 aaa
 aaU
@@ -110303,9 +110108,9 @@ cvi
 cuN
 cNv
 bhT
-cIM
-bXX
-bty
+cMG
+cVq
+fui
 bzr
 byT
 cfc
@@ -110799,12 +110604,12 @@ aCZ
 aRG
 aOl
 aOV
-avQ
+bSo
 cmX
 aRp
 bkJ
 aUf
-aeI
+ciG
 bnp
 cmO
 cfU
@@ -112870,7 +112675,7 @@ biV
 cKg
 cLn
 cLz
-bmz
+cLz
 biV
 cdP
 bXX
@@ -113177,7 +112982,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+cpB
 aaa
 aaa
 ckl
@@ -113336,7 +113141,7 @@ cAM
 bCP
 boA
 aYC
-brf
+att
 att
 att
 att
@@ -114066,7 +113871,7 @@ aaa
 aaU
 aio
 akZ
-biO
+aKe
 bEt
 bEA
 aik
@@ -114643,7 +114448,7 @@ aaa
 bsz
 anr
 bcI
-sdp
+bgw
 bUX
 bgw
 uwK
@@ -116226,7 +116031,7 @@ btz
 bPm
 bxH
 bSf
-bzd
+hlV
 bQD
 bxH
 bxH
@@ -116873,7 +116678,7 @@ aaa
 aaa
 aaa
 aaU
-cnM
+cPl
 abM
 acj
 aaU
@@ -117470,8 +117275,8 @@ aaa
 aaa
 aaa
 aaa
-bgi
-fui
+bMp
+bJv
 aaa
 cwK
 aaa
@@ -117727,8 +117532,8 @@ aZG
 aaa
 aaa
 aaa
-bgi
-fui
+bMp
+bJv
 aaa
 cwI
 aaa
@@ -117984,8 +117789,8 @@ aaa
 aaa
 aaa
 aaa
-bgi
-fui
+bMp
+bJv
 aaa
 cwK
 aaa
@@ -118026,7 +117831,7 @@ bYh
 bYn
 bYn
 bYE
-cni
+bYn
 cyf
 cgy
 bIz
@@ -118488,16 +118293,16 @@ bzO
 caD
 bzn
 bjz
-ciG
+ciq
 bAK
 ciV
 aMI
 aaa
 bJj
 bLS
-kxw
-kxw
-kxw
+bHg
+bHg
+bHg
 bPA
 wPS
 aaa
@@ -118931,7 +118736,7 @@ aaa
 aaU
 aav
 abM
-acz
+cPp
 aaU
 aaa
 aaa
@@ -118961,7 +118766,7 @@ avz
 awx
 axU
 ayL
-azO
+azU
 aAu
 awp
 aCP
@@ -119533,10 +119338,10 @@ cPD
 bVE
 cbT
 cww
-bhI
-bhI
+cww
+cww
 can
-bhI
+cww
 aaa
 anr
 aaa
@@ -119786,15 +119591,15 @@ bNb
 bPL
 cwB
 cwB
-cwB
+hDz
 bVX
 eKM
+bZQ
 cww
-bhI
-bhI
+cww
 cao
-bhI
-bhI
+cww
+cww
 anr
 aaa
 aaU
@@ -120041,13 +119846,13 @@ cww
 bjE
 bNq
 bQK
-qgO
+cwB
 chO
 cpN
 bWG
 cRg
-jiZ
-bhI
+cmL
+cww
 cLY
 cap
 cMt
@@ -120301,14 +120106,14 @@ bNd
 bNE
 cww
 cpO
-bWG
-cJo
+bYP
+cRg
 cMH
-bhI
-cLZ
+cww
+cMb
 caq
-cLZ
-bhI
+cMb
+cww
 anr
 aaa
 aaU
@@ -120557,15 +120362,15 @@ cww
 cww
 cww
 cww
-cww
+cLm
 cIs
 tyI
-cMJ
+cww
 cLX
 cMa
 cMj
 cMu
-cMG
+jiZ
 anr
 aaU
 aaU
@@ -120812,17 +120617,17 @@ pgu
 pgu
 pgu
 gGG
-vsO
+cww
 chS
 cpQ
 cfM
 cbU
-jXo
+cww
 cLm
 cMb
 cas
 cMb
-cMH
+cMJ
 anr
 aaa
 aaa
@@ -121069,9 +120874,9 @@ aXx
 aXx
 aXx
 bfW
-tuF
+cww
 lRy
-fti
+cMl
 cfP
 mEa
 cLV
@@ -121326,7 +121131,7 @@ bca
 cat
 cKX
 bQN
-nLV
+cLb
 cLd
 fti
 cfT
@@ -121337,7 +121142,7 @@ chx
 chM
 gDY
 jiZ
-hlV
+anr
 aaa
 aaa
 aaU
@@ -121595,7 +121400,7 @@ rUl
 cMw
 cfs
 cMP
-aaa
+cMi
 aaa
 aaU
 aaa
@@ -121838,14 +121643,14 @@ aXx
 bca
 bca
 cKQ
-cKY
-bQO
+biO
+bmz
 ony
 xcO
 hKC
 cVO
-sRD
-cMe
+nAF
+cni
 cai
 rdF
 cMk
@@ -122099,12 +121904,12 @@ aXx
 bfW
 cww
 bUa
-cMr
+brf
 sRD
-cMo
+nAF
 cgz
-cai
-fkx
+cJH
+cwB
 cMl
 cMx
 cMJ
@@ -122356,13 +122161,13 @@ cKX
 bQN
 cLb
 cLe
-cMo
-hMZ
+bXP
+sRD
 nAF
 lcD
-cai
-fkx
-mNN
+cwB
+cwB
+cwB
 cLo
 nBM
 cfD
@@ -122613,12 +122418,12 @@ bZR
 bfW
 cwA
 cLf
-cMo
-iAW
-fIw
+bXV
+sRD
+nAF
 wWH
-ntC
-nEX
+cwB
+cwB
 hDz
 cLp
 oMB
@@ -122870,11 +122675,11 @@ cKY
 bQO
 cLc
 eIh
-car
+bYd
 tXV
 tZj
-jml
-cVq
+cwB
+cwB
 cMc
 cMm
 cMy
@@ -123128,10 +122933,10 @@ bfW
 cww
 bhJ
 cMo
-iAW
+cwB
 cJu
-iAW
-cJH
+cwB
+cwB
 cMd
 cMn
 cMz
@@ -123385,10 +123190,10 @@ bQN
 cLb
 cLh
 cMo
-iAW
-cJu
-hlo
-cJH
+cwB
+jon
+cwB
+cwB
 cMe
 cMo
 cLq
@@ -123643,9 +123448,9 @@ bWK
 cLi
 xKr
 nvn
-cJu
-iAW
-cJH
+jon
+cwB
+cwB
 cMe
 cMo
 cMA
@@ -123899,10 +123704,10 @@ cLa
 cLc
 fgS
 car
-iAW
+cwB
 jon
-xjk
-cai
+cwB
+cwB
 cMg
 cMq
 cMB
@@ -124159,7 +123964,7 @@ kOG
 dVR
 xCy
 sHB
-xkC
+cwB
 cMe
 cMr
 cMC
@@ -124413,7 +124218,7 @@ bQS
 cLb
 cLj
 cMo
-qvB
+cwB
 cgh
 cgA
 chq
@@ -124931,7 +124736,7 @@ prx
 vxU
 cLW
 ccG
-cMi
+prx
 iQY
 cMF
 cMO
@@ -125728,7 +125533,7 @@ cNB
 cNB
 cNB
 cNG
-cNN
+hlo
 cNT
 cNy
 cNX
@@ -125941,7 +125746,7 @@ aaa
 aaa
 aaa
 aaU
-cbS
+cPq
 abM
 ccH
 aaU
@@ -126125,9 +125930,9 @@ aaa
 aaa
 aaa
 aaU
-abF
+cPl
 abM
-acA
+cPq
 aaU
 aaa
 aaa
@@ -126198,9 +126003,9 @@ aaa
 aaa
 aaa
 aaU
-cbS
+cPq
 abR
-ccJ
+cPm
 aaU
 aaa
 aaa
@@ -126382,9 +126187,9 @@ aaa
 aaa
 aaa
 aaU
-abJ
+cPm
 abR
-acA
+cPq
 aaU
 aaU
 aaU
@@ -126639,12 +126444,12 @@ aaa
 aaa
 aaa
 aaU
-abJ
+cPm
 abR
 acB
-adc
-adc
-adL
+cPd
+cPd
+cdq
 aaa
 aaa
 aaa
@@ -126709,14 +126514,14 @@ aaU
 aaa
 aaa
 aaa
-bGK
-bGK
+cPd
+cPd
 bUe
 ccc
 abR
-aaY
+pZq
 cdb
-bGK
+cPd
 cdq
 aaa
 aaa
@@ -126896,7 +126701,7 @@ aaa
 aaa
 aaa
 aaU
-abJ
+cPm
 abM
 abR
 abM
@@ -127153,12 +126958,12 @@ aaa
 aaa
 aaa
 abp
-abJ
-abZ
-abZ
-abZ
-abZ
-abZ
+cPm
+cPh
+cPh
+cPh
+cPh
+cPh
 aaa
 aaa
 aaa
@@ -127223,15 +127028,15 @@ aaU
 aaa
 aaa
 aaa
-bGP
-bNo
-bNo
+cPe
+cPh
+cPh
 ccf
 ccs
 ccP
 cdi
-bNo
-bNo
+cPh
+cPh
 aaa
 aaa
 aaa

--- a/code/game/machinery/mass_driver.dm
+++ b/code/game/machinery/mass_driver.dm
@@ -38,3 +38,14 @@
 	if(stat & (BROKEN|NOPOWER))
 		return
 	drive()
+
+/obj/machinery/mass_driver/pressure_plate
+	name = "pressure plated mass driver"
+	var/drive_delay = 10
+
+/obj/machinery/mass_driver/pressure_plate/Crossed(atom/movable/O)
+	. = ..()
+	if(isliving(O))
+		var/mob/living/L = O
+		to_chat(L, "<span class='warning'>You feel something click beneath you!</span>")
+	addtimer(CALLBACK(src, .proc/drive), drive_delay)


### PR DESCRIPTION
## About The Pull Request

Guess who's back.

This is a collection of fixes for cogstation to make it a more functional map. Atmos has been redone somewhat and belt hell has been prepared for when mass drivers finally work as fully intended.

## Why It's Good For The Game

Cog is a fun new map I spent a lot of time on and I want it to get into rotation already. This PR should put it into a fully playable state, doubly so if someone helps with mass driver code.

## Changelog
:cl: Tupinambis
tweak: Redid Cogstation atmos pipes to make it less cluttered. 
tweak: Removed a few doors from the main hallway to mitigate chokepoint issues
fix: All belt hell conveyers are now on by default, so that belt hell actually works.
fix: IDs for poddoors and belts and the like. Everything is now properly hooked and should work as expected (except for the pressure triggered mass drivers)
fix: addresses most if not all roundstart active turfs.
fix: Issue where wires were connected to the SMES improperly, and SMES were not properly precharged, resulting in power failure earlier than intended.
fix: various rogue turfs and wirings.
fix: security office APC being hooked to maintenance for some reason.
fix: TEG is now directly wired to the SMES.
code: adds a subtype of mass drivers that is triggered by things being on it. TODO: Make these mass drivers trigger poddoors, to make belt hell fully functional.
/:cl: