### PR TITLE
the PR I really didn't want to make - poplocks revolvers to 15 people

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -20,6 +20,7 @@
 	desc = "A sleek box containing a brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers, and an extra speedloader."
 	item = /obj/item/storage/box/syndie_kit/revolver
 	cost = 13
+	player_minimum = 20
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
 

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -20,7 +20,7 @@
 	desc = "A sleek box containing a brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers, and an extra speedloader."
 	item = /obj/item/storage/box/syndie_kit/revolver
 	cost = 13
-	player_minimum = 20
+	player_minimum = 15
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Okay. So. As it stands the revolver is undeniably one of the strongest weapons in the uplink, only outdone by its cheap cost and overall effectiveness to the stock Stetchkin, but honestly the reason I hate the revolver being allowed on lowpop is because on lowpop, there's usually no sec or command, and if there are any chances are they are not fit for proper combat.
The Stetchkin gives you good second to react if you get hit by it due to taking three to four hits to kill.
The revolver, however, will two shot anyone and three shot anyone wearing all but the most extreme of armor.
It's entirely possible for a traitor on lowpop to just buy a revolver and delete everyone with no counterplay outside of "lmao just don't get hit", and anyone who chases after them is liable to just get fucked over due to the fact this thing deals sixty damage per shot.

In short, I want to poplock it to fifteen (less than martial arts) so there's at least a chance of security officers or people able to counterplay the funny man with the two-hit-kill gun.
And before you scream at me, yeah, this is in part a salt PR, but prior to this I used this monstrosity on a medpop round after cheesing the system to print infinite ammo, and God was it fucking stupid.

(why's the desword poplocked to twenty five when we have a gun that deals 60 brute lmao)
(you can still load a stetchkin with HP to drop your assassinate target if they aren't wearing armor so don't come yelling at me if killing people quickly would now be physically impossible without the meme cannon)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Balance and hopefully less people just getting twotapped by the funny gun on deadpop.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Balance: Revolver is now poplocked down to fifteen people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
