### PR TITLE
Fixed toggleable polychromic hoods/helmets not polychroming with their suit

### DIFF
--- a/code/datums/elements/polychromic.dm
+++ b/code/datums/elements/polychromic.dm
@@ -62,6 +62,7 @@
 			RegisterSignal(A, COMSIG_ITEM_WORN_OVERLAYS, .proc/apply_worn_overlays)
 			if(suits_with_helmet_typecache[A.type])
 				RegisterSignal(A, COMSIG_SUIT_MADE_HELMET, .proc/register_helmet)
+				register_helmet(A) //just call it directly it only needs to be called once, right?
 	else if(_flags & POLYCHROMIC_ACTION && ismob(A)) //in the event mob update icon procs are ever standarized.
 		var/datum/action/polychromic/P = new(A)
 		RegisterSignal(P, COMSIG_ACTION_TRIGGER, .proc/activate_action)
@@ -165,7 +166,20 @@
 /datum/element/polychromic/proc/on_examine(atom/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>Alt-click to recolor it.</span>"
 
-/datum/element/polychromic/proc/register_helmet(atom/source, obj/item/clothing/head/H)
+/datum/element/polychromic/proc/register_helmet(atom/source)
+	if(!isitem(source))
+		return
+
+	var/obj/item/clothing/head/H //going to just grab the headwear this way even if it may be inefficient
+	if(istype(source,/obj/item/clothing/suit/hooded)) //so how come it be like this, where toggleable headslots are named separately (helmet/hood) anyways?
+		var/obj/item/clothing/suit/hooded/sourcesuit = source
+		H = sourcesuit.hood
+	else if(istype(source,/obj/item/clothing/suit/space/hardsuit)) 
+		var/obj/item/clothing/suit/space/hardsuit/sourcesuit = source
+		H = sourcesuit.helmet
+	else
+		return
+	
 	suit_by_helmet[H] = source
 	helmet_by_suit[source] = H
 	colors_by_atom[H] = colors_by_atom[source]

--- a/code/datums/elements/polychromic.dm
+++ b/code/datums/elements/polychromic.dm
@@ -61,8 +61,7 @@
 			A.AddElement(/datum/element/update_icon_updates_onmob)
 			RegisterSignal(A, COMSIG_ITEM_WORN_OVERLAYS, .proc/apply_worn_overlays)
 			if(suits_with_helmet_typecache[A.type])
-				RegisterSignal(A, COMSIG_SUIT_MADE_HELMET, .proc/register_helmet)
-				register_helmet(A) //just call it directly it only needs to be called once, right?
+				RegisterSignal(A, COMSIG_SUIT_MADE_HELMET, .proc/register_helmet) //you better work now you slut
 	else if(_flags & POLYCHROMIC_ACTION && ismob(A)) //in the event mob update icon procs are ever standarized.
 		var/datum/action/polychromic/P = new(A)
 		RegisterSignal(P, COMSIG_ACTION_TRIGGER, .proc/activate_action)
@@ -166,20 +165,16 @@
 /datum/element/polychromic/proc/on_examine(atom/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>Alt-click to recolor it.</span>"
 
-/datum/element/polychromic/proc/register_helmet(atom/source)
-	if(!isitem(source))
-		return
-
-	var/obj/item/clothing/head/H //going to just grab the headwear this way even if it may be inefficient
-	if(istype(source,/obj/item/clothing/suit/hooded)) //so how come it be like this, where toggleable headslots are named separately (helmet/hood) anyways?
-		var/obj/item/clothing/suit/hooded/sourcesuit = source
-		H = sourcesuit.hood
-	else if(istype(source,/obj/item/clothing/suit/space/hardsuit)) 
-		var/obj/item/clothing/suit/space/hardsuit/sourcesuit = source
-		H = sourcesuit.helmet
-	else
-		return
-	
+/datum/element/polychromic/proc/register_helmet(atom/source, obj/item/clothing/head/H)
+	if(!isitem(H)) //backup in case if it messes up somehow
+		if(istype(source,/obj/item/clothing/suit/hooded)) //so how come it be like this, where toggleable headslots are named separately (helmet/hood) anyways?
+			var/obj/item/clothing/suit/hooded/sourcesuit = source
+			H = sourcesuit.hood
+		else if(istype(source,/obj/item/clothing/suit/space/hardsuit)) 
+			var/obj/item/clothing/suit/space/hardsuit/sourcesuit = source
+			H = sourcesuit.helmet
+		else
+			return
 	suit_by_helmet[H] = source
 	helmet_by_suit[source] = H
 	colors_by_atom[H] = colors_by_atom[source]

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -5,9 +5,9 @@
 	var/obj/item/clothing/head/hooded/hood
 	var/hoodtype = /obj/item/clothing/head/hooded/winterhood //so the chaplain hoodie or other hoodies can override this
 
-/obj/item/clothing/suit/hooded/New()
+/obj/item/clothing/suit/hooded/Initialize()
+	. = ..()
 	hood = MakeHelmet()
-	..()
 
 /obj/item/clothing/suit/hooded/Destroy()
 	. = ..()
@@ -48,7 +48,7 @@
 
 /obj/item/clothing/suit/hooded/update_icon_state()
 	icon_state = "[initial(icon_state)]"
-	if(ishuman(hood.loc))
+	if(ishuman(hood?.loc))
 		var/mob/living/carbon/human/H = hood.loc
 		if(H.head == hood)
 			icon_state += "_t"
@@ -131,8 +131,8 @@
 
 //Hardsuit toggle code
 /obj/item/clothing/suit/space/hardsuit/Initialize()
-	helmet = MakeHelmet()
 	. = ..()
+	helmet = MakeHelmet()
 
 /obj/item/clothing/suit/space/hardsuit/Destroy()
 	if(helmet)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**Observations when it comes to the polychromic code:**
- There was code that took toggleable hoods into account.
- However, the proc to register the helmet was never called when the polychromic element recognized that the item in question had a toggleable helmet, meaning that the hood on the polychromic winter coat was never registered to be part of the polychromables.

This is my "I'm new to BYONDcode" way of fixing this. It seems to work. If there's even better solutions to this problem, or people see any flaws with this code, people are welcome to provide input there.

I assume @Ghommie might want to provide input on this, since this is their code that I'm editing.

## Why It's Good For The Game
Fixes are good. A hoodie not polychroming with their bottom half looks ugly. This essentially fixes the polychromic winter coat.

## Changelog
:cl:
fix: The Polychromic winter coat's hoodie will now polychrome, alongside any other new polychromic items with toggleable headwear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
