### PR TITLE
Makes superconducting turfs not get stuck at incredibly low temperatures.

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -331,6 +331,7 @@
 			var/heat = thermal_conductivity*delta_temperature* \
 				(heat_capacity*HEAT_CAPACITY_VACUUM/(heat_capacity+HEAT_CAPACITY_VACUUM))
 			temperature -= heat/heat_capacity
+			temperature = max(temperature,T0C) //otherwise we just sorta get stuck at super cold temps forever
 
 /turf/open/proc/temperature_share_open_to_solid(turf/sharer)
 	sharer.temperature = air.temperature_share(null, sharer.thermal_conductivity, sharer.temperature, sharer.heat_capacity)
@@ -344,3 +345,5 @@
 
 		temperature -= heat/heat_capacity
 		sharer.temperature += heat/sharer.heat_capacity
+		temperature = max(temperature,T0C)
+		sharer.temperature = max(sharer.temperature,T0C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that turf temperature is floored at 273.15 kelvins. This mostly prevents it from being impossible to heat up a room properly without setting fire to it.

## Why It's Good For The Game

Tedium is bad, and sometimes we gotta compromise.

## Changelog
:cl:
balance: Superconducting turfs now can't go below 0 celsius.
/:cl: