### PR TITLE
Minesweeper no longer blows up your ears when you select "Play on the same board"

### DIFF
--- a/code/game/machinery/computer/arcade/minesweeper.dm
+++ b/code/game/machinery/computer/arcade/minesweeper.dm
@@ -178,9 +178,12 @@
 								table[y1][x1] += 10
 				if(href_list["same_board"])	//Reset the board... kinda
 					if(game_status != MINESWEEPER_GAME_PLAYING)
+						mine_sound = TRUE
 						game_status = MINESWEEPER_GAME_PLAYING
 					if(table[y1][x1] >= 10)	//If revealed, become unrevealed!
-						playsound(loc, 'sound/arcade/minesweeper_menuselect.ogg', 50, 0, extrarange = -3, falloff = 10)
+						if(mine_sound)
+							playsound(loc, 'sound/arcade/minesweeper_menuselect.ogg', 50, 0, extrarange = -3, falloff = 10)
+							mine_sound = FALSE
 						table[y1][x1] -= 10
 				if(table[y1][x1] > 10 && !reset_board)
 					safe_squares_revealed += 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

BEFORE (volume warning):
https://lambda.sx/eCW.webm
AFTER:
https://lambda.sx/PUP1.webm

To put it into words, it played "minesweeper_menuselect.ogg" every single time it was unrevealing a box on the minesweeper grid according to its code. Which meant it could be played over 50 times in a single instance. This pull makes it so it only plays once.

## Why It's Good For The Game

Your ears will thank you.

## Changelog
:cl:
fix: Minesweeper will no longer blow up the player's ears when they select "Play on the same board"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
