### PR TITLE
Adds peculiar plushies, which are made by failing to make plushmium

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -204,6 +204,11 @@
 	mood_change = -1
 	timeout = 2 MINUTES
 
+/datum/mood_event/plush_bite
+	description = "<span class='warning'>IT BIT ME!! OW!</span>\n"
+	mood_change = -3
+	timeout = 2 MINUTES
+
 //Cursed stuff below
 
 /datum/mood_event/emptypred

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -255,7 +255,7 @@
 /obj/item/choice_beacon/box/plushie/generate_display_names()
 	var/list/plushie_list = list()
 	//plushie set 1: just subtypes of /obj/item/toy/plush
-	var/list/plushies_set_one = subtypesof(/obj/item/toy/plush) - list(/obj/item/toy/plush/narplush, /obj/item/toy/plush/awakenedplushie, /obj/item/toy/plush/random_snowflake, /obj/item/toy/plush/random) //don't allow these special ones (you can still get narplush/hugbox)
+	var/list/plushies_set_one = subtypesof(/obj/item/toy/plush) - list(/obj/item/toy/plush/narplush, /obj/item/toy/plush/awakenedplushie, /obj/item/toy/plush/random_snowflake, /obj/item/toy/plush/plushling, /obj/item/toy/plush/random) //don't allow these special ones (you can still get narplush/hugbox)
 	for(var/V in plushies_set_one)
 		var/atom/A = V
 		plushie_list[initial(A.name)] = A

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -167,7 +167,7 @@
 					return
 			log_game("[key_name(user)] activated a hidden grenade in [src].")
 			grenade.preprime(user, msg = FALSE, volume = 10)
-			SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT,"plushpet", /datum/mood_event/plushpet)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT,"plushpet", /datum/mood_event/plushpet)
 	else
 		to_chat(user, "<span class='notice'>You try to pet [src], but it has no stuffing. Aww...</span>")
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT,"plush_nostuffing", /datum/mood_event/plush_nostuffing)
@@ -754,8 +754,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	attack_verb = list("headbutt", "scritched", "bit")
 	squeak_override = list('modular_citadel/sound/voice/nya.ogg' = 1)
 	can_random_spawn = FALSE
-	
-	
+
+
 /obj/item/toy/plush/hairball
 	name = "Hairball"
 	desc = "A bundle of undigested fibers and scales. Yuck."
@@ -765,3 +765,80 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	squeak_override = list('sound/misc/splort.ogg'=1)
 	attack_verb = list("sploshed", "splorted", "slushed")
 	can_random_spawn = FALSE
+
+/obj/item/toy/plush/plushling
+	name = "peculiar plushie"
+	desc = "An adorable stuffed toy- wait, did it just move?"
+	can_random_spawn = FALSE
+	var/absorb_cooldown = 100 //ticks cooldown between absorbs
+	var/next_absorb = 0 //When can it absorb another plushie
+	var/check_interval = 20
+	var/next_check = 0
+
+/obj/item/toy/plush/plushling/attack_self(mob/user)
+	. = ..()
+	if(!user) //hmmmmm
+		return
+	to_chat(user, "<span class='warning'>You try to pet the plushie, but recoil as it bites your hand instead! OW!</span>")
+	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT,"plush_bite", /datum/mood_event/plush_bite)
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(!H)
+		return //Too much type safety? There is no such thing as too much type safety.
+	H.apply_damage(5, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+	addtimer(CALLBACK(H, /mob/living/carbon/human.proc/dropItemToGround, src, TRUE), 1)
+
+/obj/item/toy/plush/plushling/New()
+	var/initial_state = pick("plushie_lizard", "plushie_snake", "plushie_slime", "fox")
+	icon_state = initial_state
+	item_state = initial_state
+	START_PROCESSING(SSobj, src)
+	. = ..()
+
+/obj/item/toy/plush/plushling/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
+
+/obj/item/toy/plush/plushling/process()
+	if(world.time < next_absorb || world.time < next_check)
+		return
+	next_check = world.time + check_interval
+	var/obj/item/toy/plush/target
+	for(var/obj/item/toy/plush/possible_target in loc) //First, it tries to get anything in its same location, be it a tile or a backpack
+		if(possible_target == src || istype(possible_target, /obj/item/toy/plush/plushling))
+			continue
+		target = possible_target
+		break
+	if(!target)
+		if(!isturf(loc))
+			return
+		for(var/obj/item/toy/plush/P in oview(1, src)) //If that doesn't work, it hunts for plushies adjacent to its own tile
+			if(istype(P, /obj/item/toy/plush/plushling)) //These do not hunt their own kind
+				continue
+			src.throw_at(P, 1, 2)
+			visible_message("<span class='danger'>[src] leaps at [P]!</span>")
+			break
+		return
+	if(istype(target, /obj/item/toy/plush/plushling)) //These do not consume their own.
+		return
+	next_absorb = world.time + absorb_cooldown
+	plushie_absorb(target)
+
+/obj/item/toy/plush/plushling/proc/plushie_absorb(obj/item/toy/plush/victim)
+	if(!victim)
+		return
+	visible_message("<span class='warning'>[src] gruesomely mutilliates [victim], leaving nothing more than dust!</span>")
+	name = victim.name
+	desc = victim.desc + " Wait, did it just move..?"
+	icon_state = victim.icon_state
+	item_state = victim.item_state
+	squeak_override = victim.squeak_override
+	attack_verb = victim.attack_verb
+	new /obj/effect/decal/cleanable/ash(get_turf(victim))
+	qdel(victim)
+
+/obj/item/toy/plush/plushling/love(obj/item/toy/plush/Kisser, mob/living/user) //You shouldn't have come here, poor plush.
+	if(!Kisser)
+		return
+	plushie_absorb(Kisser)

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -775,8 +775,8 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	var/check_interval = 20
 	var/next_check = 0
 
+//Overrides parent proc
 /obj/item/toy/plush/plushling/attack_self(mob/user)
-	. = ..()
 	if(!user) //hmmmmm
 		return
 	to_chat(user, "<span class='warning'>You try to pet the plushie, but recoil as it bites your hand instead! OW!</span>")

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -781,11 +781,9 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 		return
 	to_chat(user, "<span class='warning'>You try to pet the plushie, but recoil as it bites your hand instead! OW!</span>")
 	SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT,"plush_bite", /datum/mood_event/plush_bite)
-	if(!ishuman(user))
-		return
 	var/mob/living/carbon/human/H = user
 	if(!H)
-		return //Too much type safety? There is no such thing as too much type safety.
+		return //Type safety.
 	H.apply_damage(5, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 	addtimer(CALLBACK(H, /mob/living/carbon/human.proc/dropItemToGround, src, TRUE), 1)
 

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -501,7 +501,10 @@
 	PurityMin		= 0.6
 
 /datum/chemical_reaction/fermi/plushmium/FermiExplode(datum/reagents, var/atom/my_atom, volume, temp, pH)
-	new /obj/item/toy/plush/random(get_turf(my_atom))
+	if(volume < 20) //It creates a normal plush at low volume.. at higher amounts, things get slightly more interesting.
+		new /obj/item/toy/plush/random(get_turf(my_atom))
+	else
+		new /obj/item/toy/plush/plushling(get_turf(my_atom))
 	my_atom.visible_message("<span class='warning'>The reaction suddenly zaps, creating a plushie!</b></span>")
 	my_atom.reagents.clear_reagents()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds peculiar plushies, or well, plushlings, to the game, which are created by failing to make plushmium with at least 20u of volume (everything below just creates a normal plushie)
It will start out with one of a few possible appearances, but has a few special things about it.
This plushie will violently retalliate to being pet, aswell as brutally murdering any plushie it shares its place with, stealing their appearance, name and other custom special stuff with just a small tell to it not being the real one. If on the ground, it will also hunt for plushies very close to it, leaping at them if they get as close as one tile.
(disclaimer, it doesn't hunt actual player-controlled-plush-mobs, that'd be rude)

Oh, this PR also fixes the 'I pet a plushie' mood buff only showing up if the plushie had a grenade in it. Funny, but still nonintentional.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A shapeshifting plushie feels pretty fitting for failing a plush-fermichem-reaction. Mostly just fluff, but shouldn't cause anything bad for the game either.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Failing the plushmium reaction can now create peculiar plushies, depending on reaction volume.
fix: The mood-buff from petting a plushie now works properly again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
