### PR TITLE
copying prefs always regenerates icons now (attempt to stop preview icons being outright wrong)

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2634,8 +2634,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				new_limb.replace_limb(character)
 			qdel(old_part)
 
-	if(length(modified_limbs))
-		character.regenerate_icons()
+	character.regenerate_icons()
 
 	SEND_SIGNAL(character, COMSIG_HUMAN_PREFS_COPIED_TO, src, icon_updates, roundstart_checks)
 


### PR DESCRIPTION
## About The Pull Request
title
yes it's an expensive proc but it's necessary when you're making constant changes to a character
if this becomes an issue somehow i'll look into a more efficient way of handling character previews by making dummies into simplemobs that can still wear clothes

## Why It's Good For The Game
attempts to make preview icons slightly more consistent


## Changelog
:cl:
tweak: character previews should be more consistent now
/:cl:
