### PR TITLE
warp implant is now infinite use and now actually reverts your position to 10 seconds before in time rather than use a snowflake chemical to teleport you 5 seconds later

### DIFF
--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -40,11 +40,11 @@
 //What does the implant do upon injection?
 //return 1 if the implant injects
 //return 0 if there is no room for implant / it fails
-/obj/item/implant/proc/implant(mob/living/target, mob/user, silent = FALSE)
+/obj/item/implant/proc/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	if(SEND_SIGNAL(src, COMSIG_IMPLANT_IMPLANTING, args) & COMPONENT_STOP_IMPLANTING)
 		return
 	LAZYINITLIST(target.implants)
-	if(!target.can_be_implanted() || !can_be_implanted_in(target))
+	if(!force && (!target.can_be_implanted() || !can_be_implanted_in(target)))
 		return FALSE
 	for(var/X in target.implants)
 		var/obj/item/implant/imp_e = X

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -40,13 +40,17 @@
 
 /obj/item/implant/warp
 	name = "warp implant"
-	desc = "Saves your position somewhere, and then warps you back to it after five seconds."
+	desc = "Warps you to where you were 10 seconds before when activated."
 	icon_state = "warp"
 	uses = -1
 	var/total_delay = 10 SECONDS
 	var/cooldown = 10 SECONDS
 	var/last_use = 0
 	var/list/positions = list()
+
+/obj/item/implant/warp/Destroy()
+	positions = null
+	return ..()
 
 /obj/item/implant/warp/implant(mob/living/target, mob/user, silent, force)
 	. = ..()

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -75,7 +75,7 @@
 
 /obj/item/implant/warp/proc/get_tele_position()
 	prune()
-	return positions[positions[positions.len]]
+	return positions[positions[1]]
 
 /obj/item/implant/warp/proc/do_teleport_effects()
 	var/safety = 100
@@ -99,6 +99,7 @@
 	if(last_use + cooldown > world.time)
 		to_chat(imp_in, "<span class=warning'>[src] is still recharging!</span>")
 		return
+	last_use = world.time
 	prune()
 	do_teleport_effects()		//first.
 	do_teleport(imp_in, get_tele_position(), 0, TRUE, null, null, null, null, null, TELEPORT_CHANNEL_QUANTUM, TRUE)

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -47,6 +47,7 @@
 	var/cooldown = 10 SECONDS
 	var/last_use = 0
 	var/list/positions = list()
+	var/next_prune = 0
 
 /obj/item/implant/warp/Destroy()
 	positions = null
@@ -65,9 +66,11 @@
 /obj/item/implant/warp/proc/update_position(datum/source)
 	if(!isatom(imp_in.loc))
 		return
-	var/time = text2num(world.time)
+	var/time = num2text(world.time)
 	positions.Insert(time, 1)
 	positions[time] = imp_in.loc
+	if(!((++next_prune) % 10))
+		prune()
 
 /obj/item/implant/warp/proc/clear_positions()
 	positions = list()

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -42,15 +42,65 @@
 	name = "warp implant"
 	desc = "Saves your position somewhere, and then warps you back to it after five seconds."
 	icon_state = "warp"
-	uses = 15
+	uses = -1
+	var/total_delay = 10 SECONDS
+	var/cooldown = 10 SECONDS
+	var/last_use = 0
+	var/list/positions = list()
+
+/obj/item/implant/warp/implant(mob/living/target, mob/user, silent, force)
+	. = ..()
+	if(.)
+		update_position()
+		RegisterSignal(imp_in, COMSIG_MOVABLE_MOVED, .proc/update_position)
+
+/obj/item/implant/warp/removed(mob/living/source, silent, special)
+	. = ..()
+	clear_positions()
+
+/obj/item/implant/warp/proc/update_position(datum/source)
+	if(!isatom(imp_in.loc))
+		return
+	var/time = text2num(world.time)
+	positions.Insert(time, 1)
+	positions[time] = imp_in.loc
+
+/obj/item/implant/warp/proc/clear_positions()
+	positions = list()
+
+/obj/item/implant/warp/proc/get_tele_position()
+	prune()
+	return positions[positions[positions.len]]
+
+/obj/item/implant/warp/proc/do_teleport_effects()
+	var/safety = 100
+	var/list/done = list()
+	for(var/i in 1 to positions.len)
+		if(!--safety)
+			break
+		var/turf/target = positions[positions[i]]
+		if(done[target])
+			continue
+		done[target] = TRUE
+		if(!istype(target))
+			continue
+		new /obj/effect/temp_visual/dir_setting/ninja(target)
 
 /obj/item/implant/warp/activate()
 	. = ..()
-	uses--
-	imp_in.do_adrenaline(20, TRUE, 0, 0, TRUE, list(/datum/reagent/fermi/eigenstate = 1.2), "<span class='boldnotice'>You feel an internal prick as as the bluespace starts ramping up!</span>")
-	to_chat(imp_in, "<span class='notice'>You feel an internal prick as as the bluespace starts ramping up!</span>")
-	if(!uses)
-		qdel(src)
+	if(last_use + cooldown > world.time)
+		to_chat(imp_in, "<span class=warning'>[src] is still recharging!</span>")
+		return
+	do_teleport_effects()		//first.
+	do_teleport(imp_in, get_tele_position(), 0, TRUE, null, null, null, null, null, TELEPORT_CHANNEL_QUANTUM, TRUE)
+
+/obj/item/implant/warp/proc/prune()
+	var/minimum_time = world.time - total_delay
+	for(var/i in positions.len to 1 step -1)
+		if(text2num(positions[i]) < minimum_time)
+			positions.len--
+		else
+			break
 
 /obj/item/implanter/warp
 	name = "implanter (warp)"

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -66,9 +66,7 @@
 /obj/item/implant/warp/proc/update_position(datum/source)
 	if(!isatom(imp_in.loc))
 		return
-	var/time = num2text(world.time)
-	positions.Insert(time, 1)
-	positions[time] = imp_in.loc
+	positions[num2text(world.time)] = imp_in.loc
 	if(!((++next_prune) % 10))
 		prune()
 
@@ -82,10 +80,13 @@
 /obj/item/implant/warp/proc/do_teleport_effects()
 	var/safety = 100
 	var/list/done = list()
+	var/time
+	var/turf/target
 	for(var/i in 1 to positions.len)
 		if(!--safety)
 			break
-		var/turf/target = positions[positions[i]]
+		time = positions[i]
+		target = positions[time]
 		if(done[target])
 			continue
 		done[target] = TRUE
@@ -98,16 +99,20 @@
 	if(last_use + cooldown > world.time)
 		to_chat(imp_in, "<span class=warning'>[src] is still recharging!</span>")
 		return
+	prune()
 	do_teleport_effects()		//first.
 	do_teleport(imp_in, get_tele_position(), 0, TRUE, null, null, null, null, null, TELEPORT_CHANNEL_QUANTUM, TRUE)
 
 /obj/item/implant/warp/proc/prune()
 	var/minimum_time = world.time - total_delay
-	for(var/i in positions.len to 1 step -1)
+	var/remove = 0
+	for(var/i in 1 to length(positions))
 		if(text2num(positions[i]) < minimum_time)
-			positions.len--
+			remove++
 		else
 			break
+	if(remove)
+		positions.Cut(1, remove + 1)
 
 /obj/item/implanter/warp
 	name = "implanter (warp)"

--- a/code/modules/uplink/uplink_items/uplink_implants.dm
+++ b/code/modules/uplink/uplink_items/uplink_implants.dm
@@ -31,7 +31,7 @@
 
 /datum/uplink_item/implants/warp
 	name = "Warp Implant"
-	desc = "An implant injected into the body and later activated at the user's will. It will inject eigenstasium which saves the user's location and teleports them there after five seconds. Lasts only fifteen times."
+	desc = "An implant injected into the body and later activated at the user's will. Allows the user to teleport to where they were 10 seconds ago. Has a 10 second cooldown."
 	item = /obj/item/storage/box/syndie_kit/imp_warp
 	cost = 6
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

useless implant using snowflakey chemical
this gives it some love
to make it easier to track, the user will leave a trail of ninja-teleport-visuals for you to follow.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: the warp implant now actually warps you back 10 seconds. leaves a trail, though. now unlimited us.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
