### PR TITLE
Removed the supermatter sabotage objective; reworked non-murder MI13 objective picking.

### DIFF
--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -56,7 +56,7 @@
 	<li>There are many other ways; be creative!</li>\
 	</ul>"
 
-/datum/sabotage_objective/processing/supermatter
+/*/datum/sabotage_objective/processing/supermatter
 	name = "Sabotage the supermatter so that it goes under 50% integrity. If it is delaminated, you will fail."
 	sabotage_type = "supermatter"
 	special_equipment = list(/obj/item/paper/guides/antag/supermatter_sabotage)
@@ -77,7 +77,7 @@
 
 /datum/sabotage_objective/processing/supermatter/can_run()
 	return (locate(/obj/machinery/power/supermatter_crystal) in GLOB.machines)
-/*
+
 /datum/sabotage_objective/station_integrity
 	name = "Make sure the station is at less than 80% integrity by the end. Smash walls, windows etc. to reach this goal."
 	sabotage_type = "integrity"

--- a/code/modules/antagonists/traitor/classes/subterfuge.dm
+++ b/code/modules/antagonists/traitor/classes/subterfuge.dm
@@ -23,18 +23,23 @@
 			maroon_objective.find_target()
 			T.add_objective(maroon_objective)
 	else
-		if(prob(15) && !(locate(/datum/objective/download) in T.objectives) && !(T.owner.assigned_role in list("Research Director", "Scientist", "Roboticist")))
-			var/datum/objective/download/download_objective = new
-			download_objective.owner = T.owner
-			download_objective.gen_amount_goal()
-			T.add_objective(download_objective)
-		else if(prob(90))
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = T.owner
-			steal_objective.find_target()
-			T.add_objective(steal_objective)
-		else
-			var/datum/objective/sabotage/sabotage_objective = new
-			sabotage_objective.owner = T.owner
-			sabotage_objective.find_target()
-			T.add_objective(sabotage_objective)
+		var/list/weights = list()
+		weights["sabo"] = length(subtypesof(/datum/sabotage_objective))
+		weights["steal"] = length(subtypesof(/datum/objective_item/steal))
+		weights["download"] = !(locate(/datum/objective/download) in T.objectives || (T.owner.assigned_role in list("Research Director", "Scientist", "Roboticist")))
+		switch(pickweight(weights))
+			if("sabo")
+				var/datum/objective/sabotage/sabotage_objective = new
+				sabotage_objective.owner = T.owner
+				sabotage_objective.find_target()
+				T.add_objective(sabotage_objective)
+			if("steal")
+				var/datum/objective/steal/steal_objective = new
+				steal_objective.owner = T.owner
+				steal_objective.find_target()
+				T.add_objective(steal_objective)
+			if("download")
+				var/datum/objective/download/download_objective = new
+				download_objective.owner = T.owner
+				download_objective.gen_amount_goal()
+				T.add_objective(download_objective)

--- a/code/modules/antagonists/traitor/classes/subterfuge.dm
+++ b/code/modules/antagonists/traitor/classes/subterfuge.dm
@@ -28,7 +28,7 @@
 			download_objective.owner = T.owner
 			download_objective.gen_amount_goal()
 			T.add_objective(download_objective)
-		else if(prob(70)) // cum. not counting download: 40%.
+		else if(prob(90))
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = T.owner
 			steal_objective.find_target()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed the "bring the supermatter to 50%" objective and reworked non-murder MI13 objective picking. The rework auto-scales the objective weights based on the relevant amount of each; in other words, all steal/sabotage/download objectives now have precisely equal weights, and always will no matter how many are added.

## Why It's Good For The Game

1. The supermatter sabotage objective is, frankly, kinda garbage. It relies on the engineers to be competent, but not so competent that it becomes impossible to sabotage the supermatter without completely destroying it.
2. Having to manually adjust the balance on these things is a chore and probably never done. Best to make it auto-scale.

## Changelog
:cl:
del: Supermatter sabotage objective's gone.
balance: Subterfuge objectives are now all equally likely.
/:cl: