### PR TITLE
Properly standardizes fuid production rate.

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -47,7 +47,7 @@
 #define BALLS_SIZE_DEF		2
 #define BALLS_SIZE_MAX		3
 
-#define CUM_RATE			2 // holy shit what a really shitty define name - relates to units per arbitrary measure of time?
+#define CUM_RATE			2 // units per 10 seconds
 #define CUM_RATE_MULT		1
 #define CUM_EFFICIENCY		1 //amount of nutrition required per life()
 
@@ -58,7 +58,7 @@
 
 #define DEF_BREASTS_SHAPE	"Pair"
 
-#define MILK_RATE			5
+#define MILK_RATE			3
 #define MILK_RATE_MULT		1
 #define MILK_EFFICIENCY		1
 

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -146,7 +146,7 @@
 		aroused_state = FALSE
 
 /obj/item/organ/genital/proc/generate_fluid(datum/reagents/R)
-	var/amount = clamp((fluid_rate * ((world.time - last_orgasmed) / SSmobs.wait) * fluid_mult),0,fluid_max_volume)
+	var/amount = clamp((fluid_rate * ((world.time - last_orgasmed) / (SSmobs.wait * 10)) * fluid_mult),0,fluid_max_volume)
 	R.clear_reagents()
 	R.maximum_volume = fluid_max_volume
 	if(fluid_id)

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -146,7 +146,7 @@
 		aroused_state = FALSE
 
 /obj/item/organ/genital/proc/generate_fluid(datum/reagents/R)
-	var/amount = clamp((fluid_rate * ((world.time - last_orgasmed) / (SSmobs.wait * 10)) * fluid_mult),0,fluid_max_volume)
+	var/amount = clamp((fluid_rate * ((world.time - last_orgasmed) / (10 SECONDS)) * fluid_mult),0,fluid_max_volume)
 	R.clear_reagents()
 	R.maximum_volume = fluid_max_volume
 	if(fluid_id)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fuid (sic) generation is far too fast right now cause I did some funny math way wrong and misunderstood what the constants were supposed to be. Now it bases it on a standard "every 10 seconds".

I also reduced milk generation rates to match that of goats/cows; before, it was almost twice as much to milk yourself as to milk goats/cows, which is off.

## Why It's Good For The Game

I fixed spatters being made from too small amounts a while ago, but now the amounts are always large enough. Not good.

## Changelog
:cl:
balance: G fuid production is now much lower.
/:cl: