### PR TITLE
alters the TEG's logistic power generation

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -66,7 +66,7 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				lastgen += LOGISTIC_FUNCTION(1250000,0.0001,delta_temperature,50000)
+				lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
 
 				hot_air.set_temperature(hot_air.return_temperature() - energy_transfer/hot_air_heat_capacity)
 				cold_air.set_temperature(cold_air.return_temperature() + heat/cold_air_heat_capacity)


### PR DESCRIPTION
## About The Pull Request

I KNOW IT'S ENTICING BUT DON'T PUT EVERY GAS PUMP ON THE BOX TEG TO 4500kPa OK? OK THANKS THIS LITERALLY FIXED THE PROBLEM ALSO WHY IS THE AIR INJECTOR IN THE CHAMBER 50L. A 3x3 BURN CHAMBER IS FINE JUST BE SMART ABOUT IT
EDIT: PUNCTUATION OK

Makes the TEG bearable to use, now.
Also fixes an issue where the TEG would make 36kW with literally no temperature difference, woops. Nobody noticed!

## Why It's Good For The Game

TEG before was too difficult to supply power to the station with. Now it's fine (maybe too easy); just be smart about it.

goes without saying that this disregards fusion as an option to supply heat because fusion isn't really meant to be balanced anyways so i'm just gonna ignore it lol

## Changelog
:cl:
tweak: TEG power generation
/:cl: