### PR TITLE
Gives drones back their e button (port)

### DIFF
--- a/code/modules/keybindings/keybind/robot.dm
+++ b/code/modules/keybindings/keybind/robot.dm
@@ -59,3 +59,17 @@
 	var/mob/living/silicon/robot/R = user.mob
 	R.uneq_active()
 	return TRUE
+
+/datum/keybinding/robot/drone/can_use(client/user)
+	return isdrone(user.mob)
+
+/datum/keybinding/robot/drone/quick_equip_drone // QOL: Drone quickequip
+	hotkey_keys = list("E")
+	name = "quick_equip_drone"
+	full_name = "Quick Equip (Drone)"
+	description = "Quickly puts an item in the best slot available"
+
+/datum/keybinding/robot/drone/quick_equip_drone/down(client/user)
+	var/mob/living/simple_animal/drone/D = user.mob
+	D.quick_equip()
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

Quality copy pasta of this PR: https://github.com/Skyrat-SS13/Skyrat13/pull/3586
But just the e button, I don't agree with the other stuff, but that's neither here nor there.

## Why It's Good For The Game

My precious quickslot button, I need it.

## Changelog
:cl:
fix: Fixes drones not being able to quickslot items
/:cl: