### PR TITLE
Makes cryo pods no longer replace already-won objectives.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -355,23 +355,23 @@
 		cryo_items -= I
 
 	//Update any existing objectives involving this mob.
-	for(var/datum/objective/O in GLOB.objectives)
+	for(var/i in GLOB.objectives)
+		var/datum/objective/O = i
 		// We don't want revs to get objectives that aren't for heads of staff. Letting
 		// them win or lose based on cryo is silly so we remove the objective.
 		if(istype(O,/datum/objective/mutiny) && O.target == mob_occupant.mind)
 			qdel(O)
-		else if(O.target && istype(O.target, /datum/mind))
-			if(O.target == mob_occupant.mind)
-				if(O.owner && O.owner.current)
-					to_chat(O.owner.current, "<BR><span class='userdanger'>You get the feeling your target is no longer within reach. Time for Plan [pick("A","B","C","D","X","Y","Z")]. Objectives updated!</span>")
-				O.target = null
-				spawn(10) //This should ideally fire after the occupant is deleted.
-					if(!O)
-						return
-					O.find_target()
-					O.update_explanation_text()
-					if(!(O.target))
-						qdel(O)
+		else if(O.target && istype(O.target, /datum/mind) && !O.check_completion())
+			if(O.target == mob_occupant.mind && O.owner?.current)
+				to_chat(O.owner.current, "<BR><span class='userdanger'>You get the feeling your target is no longer within reach. Time for Plan [pick("A","B","C","D","X","Y","Z")]. Objectives updated!</span>")
+			O.target = null
+			spawn(10) //This should ideally fire after the occupant is deleted.
+				if(!O)
+					return
+				O.find_target()
+				O.update_explanation_text()
+				if(!(O.target))
+					qdel(O)
 
 	if(mob_occupant.mind)
 		//Handle job slot/tater cleanup.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. It's kinda bullshit that you can finish an objective then WHOOPS the target you've *already dealt with* cryos and now you've lost.

## Why It's Good For The Game

This is kinda a bug anyway.

## Changelog
:cl:
tweak: Cryoing no longer unwins already-won objectives.
/:cl: