### PR TITLE
Gives IPCs hair.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -5,7 +5,8 @@
 	default_color = "00FF00"
 	blacklisted = 0
 	sexes = 0
-	species_traits = list(MUTCOLORS,NOEYES,NOTRANSSTING,HAS_FLESH,HAS_BONE)
+	species_traits = list(MUTCOLORS,NOEYES,NOTRANSSTING,HAS_FLESH,HAS_BONE,HAIR)
+	hair_alpha = 210
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
 	mutant_bodyparts = list("ipc_screen" = "Blank", "ipc_antenna" = "None")
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc


### PR DESCRIPTION
## About The Pull Request

Gives IPCs the choice to have hair. I got bored waiting for Teak to do it.

## Why It's Good For The Game

This is a critical change to game balance which will put IPCs on the same level as other races. Hopefully, with this change, IPCs will start to see viability in the current meta.

## Changelog
:cl:
add: IPC's can have hair. Why wasn't this added earlier. Use the bald hairstyle for no hair.
/:cl:
