### PR TITLE
Makes holosigns uncontaminable

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -9,6 +9,7 @@
 	armor = list("melee" = 0, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 20)
 	var/obj/item/holosign_creator/projector
 	var/init_vis_overlay = TRUE
+	rad_flags = RAD_NO_CONTAMINATE
 
 /obj/structure/holosign/Initialize(mapload, source_projector)
 	. = ..()


### PR DESCRIPTION
Mostly done in an effort to help stop some of the overhead from radiation. (Hard?)Light shouldnt be able to get contaminated regardless.
## Changelog
:cl:
tweak: Holograms made from projectors (atmos, engi, sec, medical, ect...) can no longer be contaminated by radiation
/:cl:
