### PR TITLE
Blacklists A LOT of stuff from being contaminated

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -95,6 +95,7 @@ Class Procs:
 	flags_1 = DEFAULT_RICOCHET_1
 	flags_ricochet = RICOCHET_HARD
 	ricochet_chance_mod = 0.3
+	rad_flags = RAD_NO_CONTAMINATE
 
 	anchored = TRUE
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT


### PR DESCRIPTION
Done in an effort to reduce overhead.
There are so many hardmapped bullshit machines that cant be deconstructed and rebuilt to remove the contamination, and there really isnt a good way to go about doing it, especially when some of them are full tile and cant be cleaned by zeolites. 
Please discuss a way to go about this, at a minimum I want to make everything hardmapped in contamination proof, but I really dont want to nitpick through the mess that is every machine to see which ones can and cant be built.
:cl:
tweak: Lots of things can no longer be contaminated by radiation
/:cl:
