### PR TITLE
turrets will now break instead of magically poofing out of existence

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -381,6 +381,7 @@ Class Procs:
 /obj/machinery/obj_break(damage_flag)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		stat |= BROKEN
+		return TRUE
 
 /obj/machinery/contents_explosion(severity, target)
 	if(occupant)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -300,6 +300,7 @@
 				else
 					to_chat(user, "<span class='notice'>You remove the turret but did not manage to salvage anything.</span>")
 				qdel(src)
+				return
 
 	else if((istype(I, /obj/item/wrench)) && (!on))
 		if(raised)

--- a/code/game/machinery/porta_turret/portable_turret_construct.dm
+++ b/code/game/machinery/porta_turret/portable_turret_construct.dm
@@ -151,6 +151,7 @@
 					turret.installation = installed_gun.type
 					turret.setup(installed_gun)
 					qdel(src)
+					return
 
 			else if(istype(I, /obj/item/crowbar))
 				I.play_tool_sound(src, 75)


### PR DESCRIPTION
## About The Pull Request
title (it was checking if the machine/object successfully got broken but the proc never returned anything)

also fixes a runtime which would occur when making turrets because it would delete the construction turret obj to replace it with an actual turret and then attack the turret with the welding tool because it didnt return, meaning it tried to attack something that was not there

closes #13328 

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: turrets can once again be broken
/:cl:
