### PR TITLE
Poly has been ghost busted. (Hex value fix)

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -977,7 +977,7 @@
 /mob/living/simple_animal/parrot/Poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."
-	color = "#FFFFFF77"
+	color = "#FFFFFF"
 	speak_chance = 20
 	status_flags = GODMODE
 	incorporeal_move = INCORPOREAL_MOVE_BASIC


### PR DESCRIPTION

## About The Pull Request

The poly ghost hex value was haunted, so I fixed it

## Why It's Good For The Game

Fix

## Changelog
:cl: Tupinambis
fix: The ghost of poly should no longer break things with an invalid color value
/:cl:
