### PR TITLE
Fixes a 5+ year old bug with ghost poly's hex value that potentially causes runtimes and crashes.

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -979,6 +979,7 @@
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."
 	color = "#FFFFFF"
+	alpha = 77
 	speak_chance = 20
 	status_flags = GODMODE
 	incorporeal_move = INCORPOREAL_MOVE_BASIC

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -978,7 +978,7 @@
 /mob/living/simple_animal/parrot/Poly/ghost
 	name = "The Ghost of Poly"
 	desc = "Doomed to squawk the Earth."
-	color = "#FFFFFF77"
+	color = "#FFFFFF"
 	speak_chance = 20
 	status_flags = GODMODE
 	incorporeal_move = INCORPOREAL_MOVE_BASIC


### PR DESCRIPTION

## About The Pull Request

Tin

## Why It's Good For The Game

Fix

## Changelog
:cl: Tupinambis
fix: Ghost poly's color value is now a hex value instead of an oct value. This has been a thing for OVER FIVE YEARS
/:cl: