### PR TITLE
Makes dynamic less probabilistic, keeping the desired threat level more aggressively

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -199,8 +199,8 @@
 
 #define EXP_DISTRIBUTION(desired_mean) ( -(1/(1/desired_mean)) * log(rand(1, 1000) * 0.001) )
 
-#define LORENTZ_DISTRIBUTION(x, s) ( s*tan(TODEGREES(PI*(rand()-0.5))) + x )
-#define LORENTZ_CUMULATIVE_DISTRIBUTION(x, y, s) ( (1/PI)*TORADIANS(arctan((x-y)/s)) + 1/2 )
+#define LORENTZ_DISTRIBUTION(x, s) ( s*tan((rand()-0.5)*180) + x )
+#define LORENTZ_CUMULATIVE_DISTRIBUTION(x, y, s) ( (1/180)*(arctan((x-y)/s)) + 1/2 )
 
 #define RULE_OF_THREE(a, b, x) ((a*x)/b)
 // )

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -173,7 +173,7 @@ GLOBAL_VAR_INIT(dynamic_forced_storyteller, null)
 			dat += "[DR.ruletype] - <b>[DR.name]</b><br>"
 	else
 		dat += "none.<br>"
-	dat += "<br>Injection Timers: (<b>[storyteller.get_injection_chance(TRUE)]%</b> chance)<BR>"
+	dat += "<br>Injection Timers:<BR>"
 	dat += "Latejoin: [(latejoin_injection_cooldown-world.time)>60*10 ? "[round((latejoin_injection_cooldown-world.time)/60/10,0.1)] minutes" : "[(latejoin_injection_cooldown-world.time)/10] seconds"] <a href='?src=\ref[src];[HrefToken()];injectlate=1'>\[Now!\]</a><BR>"
 	dat += "Midround: [(midround_injection_cooldown-world.time)>60*10 ? "[round((midround_injection_cooldown-world.time)/60/10,0.1)] minutes" : "[(midround_injection_cooldown-world.time)/10] seconds"] <a href='?src=\ref[src];[HrefToken()];injectmid=1'>\[Now!\]</a><BR>"
 	usr << browse(dat.Join(), "window=gamemode_panel;size=500x500")
@@ -513,7 +513,7 @@ GLOBAL_VAR_INIT(dynamic_forced_storyteller, null)
 	drafted_rules -= starting_rule
 
 	starting_rule.trim_candidates()
-	starting_rule.scale_up(extra_rulesets_amount, threat_level)
+	starting_rule.scale_up(extra_rulesets_amount, threat_level-added_threat)
 	if (starting_rule.pre_execute())
 		log_threat("[starting_rule.ruletype] - <b>[starting_rule.name]</b> [starting_rule.cost + starting_rule.scaled_times * starting_rule.scaling_cost] threat", verbose = TRUE)
 		if(starting_rule.flags & HIGHLANDER_RULESET)
@@ -675,13 +675,12 @@ GLOBAL_VAR_INIT(dynamic_forced_storyteller, null)
 		log_game("DYNAMIC: Checking for midround injection.")
 
 		update_playercounts()
-		if (prob(storyteller.get_injection_chance()))
+		if (storyteller.should_inject_antag())
 			SSblackbox.record_feedback("tally","dynamic",1,"Attempted midround injections")
 			var/list/drafted_rules = storyteller.midround_draft()
 			if (drafted_rules.len > 0)
 				SSblackbox.record_feedback("tally","dynamic",1,"Successful midround injections")
 				picking_midround_latejoin_rule(drafted_rules)
-		// get_injection_chance can do things on fail
 
 /// Updates current_players.
 /datum/game_mode/dynamic/proc/update_playercounts()
@@ -757,12 +756,11 @@ GLOBAL_VAR_INIT(dynamic_forced_storyteller, null)
 			picking_midround_latejoin_rule(list(forced_latejoin_rule), forced = TRUE)
 		forced_latejoin_rule = null
 
-	else if (latejoin_injection_cooldown < world.time && prob(storyteller.get_injection_chance()))
+	else if (storyteller.should_inject_antag())
 		SSblackbox.record_feedback("tally","dynamic",1,"Attempted latejoin injections")
 		var/list/drafted_rules = storyteller.latejoin_draft(newPlayer)
 		if (drafted_rules.len > 0 && picking_midround_latejoin_rule(drafted_rules))
 			SSblackbox.record_feedback("tally","dynamic",1,"Successful latejoin injections")
-			latejoin_injection_cooldown = storyteller.get_latejoin_cooldown() + world.time
 
 /// Increase the threat level.
 /datum/game_mode/dynamic/proc/create_threat(gain)

--- a/code/game/gamemodes/dynamic/readme.md
+++ b/code/game/gamemodes/dynamic/readme.md
@@ -1,14 +1,15 @@
 # DYNAMIC
 
+Tries to keep the round at a certain level of action, based on the round's "threat level".
+
 ## ROUNDSTART
 
 Dynamic rolls threat based on a special sauce formula:
 "dynamic_curve_width \* tan((3.1416 \* (rand() - 0.5) \* 57.2957795)) + dynamic_curve_centre"
 
-Latejoin and midround injection cooldowns are set using exponential distribution between
-5 minutes and 25 for latejoin
-15 minutes and 35 for midround
-this value is then added to world.time and assigned to the injection cooldown variables.
+Midround injection cooldowns are set using exponential distribution between 15 minutes and 35 minutes. This value is then added to world.time and assigned to the injection cooldown variables.
+
+Latejoins are aggressively assigned whenever possible, to keep the round at a certain threat level.
 
 rigged_roundstart() is called instead if there are forced rules (an admin set the mode)
 
@@ -26,8 +27,6 @@ If midround injection time is lower than world.time, it updates playercounts aga
 make_antag_chance(newPlayer) -> [For each latespawn rule...]
 -> acceptable(living players, threat_level) -> trim_candidates() -> ready(forced=FALSE)
 **If true, add to drafted rules
-**NOTE that acceptable uses threat_level not threat!
-**NOTE Latejoin timer is ONLY reset if at least one rule was drafted.
 **NOTE the new_player.dm AttemptLateSpawn() calls OnPostSetup for all roles (unless assigned role is MODE)
 [After collecting all draftble rules...]
 -> picking_latejoin_ruleset(drafted_rules) -> spend threat -> ruleset.execute()

--- a/code/game/gamemodes/dynamic/readme.md
+++ b/code/game/gamemodes/dynamic/readme.md
@@ -5,7 +5,7 @@ Tries to keep the round at a certain level of action, based on the round's "thre
 ## ROUNDSTART
 
 Dynamic rolls threat based on a special sauce formula:
-"dynamic_curve_width \* tan((3.1416 \* (rand() - 0.5) \* 57.2957795)) + dynamic_curve_centre"
+"dynamic_curve_width \* tan((rand() - 0.5) \* 180) + dynamic_curve_centre"
 
 Midround injection cooldowns are set using exponential distribution between 15 minutes and 35 minutes. This value is then added to world.time and assigned to the injection cooldown variables.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The new system doesn't spend points; it tries to keep the whole round at a certain level of action, at least for now. This will make it do so more aggressively.

## Why It's Good For The Game

I saw a whole round go by at 50 threat level with 0 antags because the probability for a midround/latejoin antag was 2% the entire time. That's dumb.

## Changelog
:cl:
balance: Dynamic is now more aggressive with adding antags.
/:cl: