### PR TITLE
Fixes a spelling error in an armor value that caused runtimes.

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -525,7 +525,7 @@ Contains:
 	icon_state = "hunter"
 	item_state = "swat_suit"
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/kitchen/knife/combat)
-	armor = list("melee" = 60, "bullet" = 40, "laser" = 40, "energy" = 50, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "wpound" = 25)
+	armor = list("melee" = 60, "bullet" = 40, "laser" = 40, "energy" = 50, "bomb" = 100, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100, "wound" = 25)
 	strip_delay = 130
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 


### PR DESCRIPTION

## About The Pull Request

wpound

## Why It's Good For The Game

fix

## Changelog
:cl: Tupinambis
fix: fixed a mispelling in the wound armor value for the bounty hunter suit
/:cl:

