### PR TITLE
Added policy config for sentient pyro slimes (no actual policy yet)

### DIFF
--- a/code/__DEFINES/configuration.dm
+++ b/code/__DEFINES/configuration.dm
@@ -18,3 +18,5 @@
 #define POLICYCONFIG_ON_DEFIB_INTACT "ON_DEFIB_INTACT"
 /// Displayed to defibbed/revival surgery'd patients after the memory loss time threshold
 #define POLICYCONFIG_ON_DEFIB_LATE "ON_DEFIB_LATE"
+/// Displayed to pyroclastic slimes on spawn
+#define POLICYCONFIG_ON_PYROCLASTIC_SENTIENT "PYROCLASTIC_SLIME"

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -291,7 +291,19 @@
 	S.rabid = TRUE
 	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
 	S.Evolve()
-	offer_control(S,POLL_IGNORE_SENTIENCE_POTION)
+	var/list/candidates = pollCandidatesForMob("Do you want to play as a pyroclastic anomaly slime?",ROLE_SENTIENCE,null,ROLE_SENTIENCE,100,S,POLL_IGNORE_SENTIENCE_POTION)
+	if(length(candidates))
+		var/mob/C = pick(candidates)
+		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(S)])")
+		C.transfer_ckey(S, FALSE)
+		var/list/policies = CONFIG_GET(keyed_list/policyconfig)
+		var/policy = policies[POLICYCONFIG_ON_PYROCLASTIC_SENTIENT]
+		if(policy)
+			to_chat(S,policy)
+		return TRUE
+	else
+		message_admins("No ghosts were willing to take control of [ADMIN_LOOKUPFLW(S)])")
+		return FALSE
 
 /////////////////////
 


### PR DESCRIPTION
##  About The Pull Request

As title. Adds a config option for explicit flavor text for pyroclastic anomaly sentient-spawned slimes. No actual policy is suggested here and would need to be added manually into the config.

Mutually exclusive with #13456.

## Why It's Good For The Game

People have veeeeeeeery different ideas as to what these should be, and some of those ideas make pyroclastic anomalies the most deadly by far, unless you wanna pretend that a 1/4/16 explosion is more deadly than a low pop round being ended because everyone's dead.

## Changelog
:cl:
add: New policy config for pyroclastic slimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
