### PR TITLE
Removes pyroclastic slimes, but makes the anomaly fire way bigger

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -285,13 +285,7 @@
 /obj/effect/anomaly/pyro/proc/makepyroslime()
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
-		T.atmos_spawn_air("o2=500;plasma=500;TEMP=1000") //Make it hot and burny for the new slime
-	var/new_colour = pick("red", "orange")
-	var/mob/living/simple_animal/slime/S = new(T, new_colour)
-	S.rabid = TRUE
-	S.amount_grown = SLIME_EVOLUTION_THRESHOLD
-	S.Evolve()
-	offer_control(S,POLL_IGNORE_SENTIENCE_POTION)
+		T.atmos_spawn_air("o2=750;plasma=1500;TEMP=1000") //Make it hot and burny for the new slime
 
 /////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Makes no slime spawn from the pyroclastic anomaly explosion, but makes its plasma fire FAR hotter, by multiplying the oxygen content by 1.5 and the plasma content by 3. This essentially makes it equivalent to a highly above-average plasmaflood in terms of effectiveness.

Mutually exclusive with #13455.

## Why It's Good For The Game

This is approximately the same danger level as a flux anomaly, I'd say--which is to say, a few minutes with the tools given to engineering, and not much more than that.

## Changelog
:cl:
del: Sentient pyroclastic anomaly slimes removed
balance: Pyroclastic anomaly explosion buffed massively
/:cl: