### PR TITLE
adds luminescent and stargazer sprites as selectable body sprites for slimes

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -544,7 +544,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 			if(length(pref_species.allowed_limb_ids))
 				if(!chosen_limb_id || !(chosen_limb_id in pref_species.allowed_limb_ids))
-					chosen_limb_id = pref_species.id
+					chosen_limb_id = pref_species.limbs_id || pref_species.id
 				dat += "<h3>Body sprite</h3>"
 				dat += "<a style='display:block;width:100px' href='?_src_=prefs;preference=bodysprite;task=input'>[chosen_limb_id]</a>"
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -435,6 +435,8 @@
 	heatmod = 1
 	burnmod = 1
 
+	allowed_limb_ids = list("slime","stargazer","lum")
+
 /datum/action/innate/slime_change
 	name = "Alter Form"
 	check_flags = AB_CHECK_CONSCIOUS


### PR DESCRIPTION
## About The Pull Request
title
someone asked me to and it sounded like a good idea
this is **only sprites** in all other aspects they are regular roundstart xenobiological slime hybrids

also limbs id overrides id when set so i mirrored this behaviour in what is shown on the customization screen

## Why It's Good For The Game
customization

## Changelog
:cl:
add: added luminescent and stargazer sprites as selectable body sprites for slimes
/:cl:
