### PR TITLE
Cleans up and fixes SDGF code a bit, consistent naked clones, transfer_ckey resets view range

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -75,6 +75,8 @@
 	if(ishuman(new_spawn))
 		var/mob/living/carbon/human/H = new_spawn
 		H.underwear = "Nude"
+		H.undershirt = "Nude"
+		H.socks = "Nude"
 		H.update_body()
 
 /obj/effect/mob_spawn/human/ash_walker/Initialize(mapload)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -249,6 +249,8 @@
 	var/mob/living/carbon/human/spare = new /mob/living/carbon/human(H.loc)
 
 	spare.underwear = "Nude"
+	spare.undershirt = "Nude"
+	spare.socks = "Nude"
 	H.dna.transfer_identity(spare, transfer_SE=1)
 	spare.dna.features["mcolor"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
 	spare.real_name = spare.dna.real_name

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -485,11 +485,13 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 	if(!ckey)
 		return
 	SEND_SIGNAL(new_mob, COMSIG_MOB_PRE_PLAYER_CHANGE, new_mob, src)
-	if (client && client.prefs && client.prefs.auto_ooc)
-		if (client.prefs.chat_toggles & CHAT_OOC && isliving(new_mob))
-			client.prefs.chat_toggles ^= CHAT_OOC
-		if (!(client.prefs.chat_toggles & CHAT_OOC) && isdead(new_mob))
-			client.prefs.chat_toggles ^= CHAT_OOC
+	if (client)
+		if(client.prefs?.auto_ooc)
+			if (client.prefs.chat_toggles & CHAT_OOC && isliving(new_mob))
+				client.prefs.chat_toggles ^= CHAT_OOC
+			if (!(client.prefs.chat_toggles & CHAT_OOC) && isdead(new_mob))
+				client.prefs.chat_toggles ^= CHAT_OOC
+		client.change_view(CONFIG_GET(string/default_view))
 	new_mob.ckey = ckey
 	if(send_signal)
 		SEND_SIGNAL(src, COMSIG_MOB_KEY_CHANGE, new_mob, src)

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -37,8 +37,8 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 */
 
 #define POLICYCONFIG_SDGF "SDGF"
-#define POLICYCONFIG_SDGF_GOOD "SDGF"
-#define POLICYCONFIG_SDGF_BAD "SDGF"
+#define POLICYCONFIG_SDGF_GOOD "SDGF_ALIGNED"
+#define POLICYCONFIG_SDGF_BAD "SDGF_UNALIGNED"
 
 
 //Clone serum #chemClone
@@ -190,7 +190,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 
 							//clone
 							var/typepath = M.type
-							var/mob/living/SM = new typepath(M.loc)
+							var/mob/living/fermi_Clone = new typepath(M.loc)
 							var/mob/living/carbon/human/SM = fermi_Clone
 
 							if(istype(SM) && istype(M))

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -36,6 +36,11 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 6. Giving this to someone without concent is against space law and gets you sent to gulag.
 */
 
+#define POLICYCONFIG_SDGF "SDGF"
+#define POLICYCONFIG_SDGF_GOOD "SDGF"
+#define POLICYCONFIG_SDGF_BAD "SDGF"
+
+
 //Clone serum #chemClone
 /datum/reagent/fermi/SDGF //vars, mostly only care about keeping track if there's a player in the clone or not.
 	name = "synthetic-derived growth factor"
@@ -45,7 +50,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 	var/unitCheck = FALSE
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "a weird chemical fleshy flavour"
-	var/list/candies = list()
+	var/list/ghosts = list()
 	var/pollStarted = FALSE
 	var/startHunger
 	impure_chem 			= /datum/reagent/impure/SDGFtox
@@ -63,10 +68,11 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 			startHunger = M.nutrition
 			if(pollStarted == FALSE)
 				pollStarted = TRUE
-				candies = pollGhostCandidates("Do you want to play as [M]'s defective clone? (Don't ERP without permission from the original)", ignore_category = POLL_IGNORE_CLONE)
+				ghosts = pollGhostCandidates("Do you want to play as [M]'s SDGF clone? (Don't ERP without permission from the original, and respect their character.)", ignore_category = POLL_IGNORE_CLONE)
 				log_reagent("FERMICHEM: [M] ckey: [M.key] has taken SDGF, and ghosts have been polled.")
+			to_chat(M,"<span class='notice'>If a ghost takes your clone, they will be identical to you. You may wish to add note (IC tab) to help them play your character better, and keep them up on the situation.</span>")
 		if(20 to INFINITY)
-			if(LAZYLEN(candies) && playerClone == FALSE) //If there's candidates, clone the person and put them in there!
+			if(LAZYLEN(ghosts) && playerClone == FALSE) //If there's candidates, clone the person and put them in there!
 				to_chat(M, "<span class='warning'>The cells reach a critical micelle concentration, nucleating rapidly within your body!</span>")
 				var/typepath = M.type
 				var/mob/living/carbon/human/fermi_Gclone = new typepath(M.loc)
@@ -74,18 +80,22 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 				if(istype(SM) && istype(M))
 					SM.real_name = M.real_name
 					M.dna.transfer_identity(SM)
+					SM.underwear = "nude"
+					SM.socks = "nude"
+					SM.undershirt = "nude"
+					M.transfer_trait_datums(SM)
 					SM.updateappearance(mutcolor_update=1)
 
 				//Process the willing ghosts, and make sure they're actually in the body when they're moved into it!
-				candies = shuffle(candies)//Shake those ghosts up!
-				for(var/mob/dead/observer/C2 in candies)
+				ghosts = shuffle(ghosts)//Shake those ghosts up!
+				for(var/mob/dead/observer/C2 in ghosts)
 					if(C2.key && C2)
 						C2.transfer_ckey(SM, FALSE)
 						message_admins("Ghost candidate found! [C2] key [C2.key] is becoming a clone of [M] key: [M.key] (They agreed to respect the character they're becoming, and agreed to not ERP without express permission from the original.)")
 						log_reagent("FERMICHEM: [M] ckey: [M.key] is creating a clone, controlled by [C2]")
 						break
 					else
-						candies -= C2
+						ghosts -= C2
 				if(!SM.mind) //Something went wrong, use alt mechanics
 					return ..()
 				SM.mind.enslave_mind_to_creator(M)
@@ -99,16 +109,27 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 					ZI.Insert(SM)
 					log_reagent("FERMICHEM: [M] ckey: [M.key]'s zombie_infection has been transferred to their clone")
 
-				to_chat(SM, "<span class='warning'>You feel a strange sensation building in your mind as you realise there's two of you, before you get a chance to think about it, you suddenly split from your old body, and find yourself face to face with your original, a perfect clone of your origin.</span>")
-
-				if(prob(50))
-					to_chat(SM, "<span class='userdanger'>While you find your newfound existence strange, you share the same memories as [M.real_name]. However, You find yourself indifferent to the goals you previously had, and take more interest in your newfound independence, but still have an indescribable care for the safety of your original.</span>")
-					log_reagent("FERMICHEM: [SM] ckey: [SM.key]'s is not bound by [M] ckey [M.key]'s will, and is free to determine their own goals, while respecting and acting as their origin.")
-				else
-					to_chat(SM, "<span class='userdanger'>While you find your newfound existence strange, you share the same memories as [M.real_name]. Your mind has not deviated from the tasks you set out to do, and now that there's two of you the tasks should be much easier.</span>")
+				var/list/policies = CONFIG_GET(keyed_list/policyconfig)
+				var/policy = policies[POLICYCONFIG_SDGF]
+				if(policy)
+					to_chat(SM,policy)
+				if(prob((purity) * 60)) // 60% chance at 100% purity, 0% chance at 0 purity
+					policy = policies[POLICYCONFIG_SDGF_GOOD]
+					if(policy)
+						to_chat(SM,policy)
+					else
+						to_chat(SM, "<span class='userdanger'>While you find your newfound existence strange, you share the same memories as [M.real_name]. Your mind has not deviated from the tasks you set out to do, and now that there's two of you the tasks should be much easier.</span>")
 					log_reagent("FERMICHEM: [SM] ckey: [SM.key]'s is bound by [M] ckey [M.key]'s objectives, and is encouraged to help them complete them.")
-
-				to_chat(M, "<span class='warning'>You feel a strange sensation building in your mind as you realise there's two of you, before you get a chance to think about it, you suddenly split from your old body, and find yourself face to face with yourself.</span>")
+				else
+					policy = policies[POLICYCONFIG_SDGF_BAD]
+					if(policy)
+						to_chat(SM,policy)
+					else
+						to_chat(SM, "<span class='userdanger'>While you find your newfound existence strange, you share the same memories as [M.real_name]. However, You find yourself indifferent to the goals you previously had, and take more interest in your newfound independence, but still have an indescribable care for the safety of your original.</span>")
+					log_reagent("FERMICHEM: [SM] ckey: [SM.key]'s is not bound by [M] ckey [M.key]'s will, and is free to determine their own goals, while respecting and acting as their origin.")
+	
+				to_chat(SM, "<span class='warning'>You feel a strange sensation building in your mind as you realise there's two of you. Before you get a chance to think about it, you suddenly split from your old body, and find yourself face to face with your original, a perfect clone of your origin.</span>")
+				to_chat(M, "<span class='warning'>You feel a strange sensation building in your mind as you realise there's two of you. Before you get a chance to think about it, a mass splits from you, and find yourself face to face with yourself.</span>")
 				M.visible_message("[M] suddenly shudders, and splits into two identical twins!")
 				SM.copy_languages(M, LANGUAGE_MIND)
 				playerClone =  TRUE
@@ -169,19 +190,23 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 
 							//clone
 							var/typepath = M.type
-							var/mob/living/fermi_Clone = new typepath(M.loc)
-							var/mob/living/carbon/C = fermi_Clone
+							var/mob/living/SM = new typepath(M.loc)
+							var/mob/living/carbon/human/SM = fermi_Clone
 
-							if(istype(C) && istype(M))
-								C.real_name = M.real_name
-								M.dna.transfer_identity(C, transfer_SE=1)
-								C.updateappearance(mutcolor_update=1)
-							C.apply_status_effect(/datum/status_effect/chem/SGDF)
-							var/datum/status_effect/chem/SGDF/S = C.has_status_effect(/datum/status_effect/chem/SGDF)
+							if(istype(SM) && istype(M))
+								SM.real_name = M.real_name
+								M.dna.transfer_identity(SM, transfer_SE=1)
+								SM.underwear = "nude"
+								SM.socks = "nude"
+								SM.undershirt = "nude"
+								SM.updateappearance(mutcolor_update=1)
+								M.transfer_trait_datums(SM)
+							SM.real_name = M.real_name
+							SM.apply_status_effect(/datum/status_effect/chem/SGDF)
+							var/datum/status_effect/chem/SGDF/S = SM.has_status_effect(/datum/status_effect/chem/SGDF)
 							S.original = M
 							S.originalmind = M.mind
 							S.status_set = TRUE
-
 							log_reagent("FERMICHEM: [M] ckey: [M.key] has created a mindless clone of themselves")
 							SSblackbox.record_feedback("tally", "fermi_chem", 1, "Braindead clones made")
 						if(87 to INFINITY)
@@ -236,6 +261,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 			SM.real_name = M.real_name
 			M.dna.transfer_identity(SM)
 			SM.updateappearance(mutcolor_update=1)
+			M.transfer_trait_datums(SM)
 		M.mind.transfer_to(SM)
 		M.visible_message("<span class='warning'>[M]'s body shudders, the growth factor rapidly splitting into a new clone of [M].</span>")
 

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -113,7 +113,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 				var/policy = policies[POLICYCONFIG_SDGF]
 				if(policy)
 					to_chat(SM,policy)
-				if(prob((purity) * 60)) // 60% chance at 100% purity, 0% chance at 0 purity
+				if(prob((purity**3) * 80)) // 80% chance at 100% purity, 0% chance at 0 purity
 					policy = policies[POLICYCONFIG_SDGF_GOOD]
 					if(policy)
 						to_chat(SM,policy)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

SDGF now has a policy config for a few of its stages; one generic, one for if the clone is aligned with the original, one for if the clone is friendly-but-unaligned.

SDGF clones now spawn naked. Just seems consistent.

Slime clones and ashwalkers now also spawn with no undershirt/socks as well as no underwear; this is simply for consistency's sake.

SDGF now has a significantly higher chance to spawn aligned clones when pure, 80% instead of the previous 50%. Since SDGF is a super easy fermichem to make, chance drops severely with purity, reaching the original chance at 80% and dropping down from there.

SDGF clones now copy traits from their original.  This one's the real point of the PR, but whatever.

Made transfer_ckey reset the view range. A bunch of ghost roles would keep ghost view range without this. Whoops!

## Why It's Good For The Game

Fixes, fixes, tweaks, balance.

## Changelog
:cl:
tweak: SDGF clones now naked.
balance: SDGF is now way more likely to make a clone that will align with the creator's goals, with purity, making it a better antagging tool.
fix: SDGF clones now have the same traits as the original.
fix: transfer_ckey now resets view, preventing things like SDGF clones with much larger view range.
config: Policy configs have been added for SDGF, currently unused: SDGF, SDGF_ALIGNED, SDGF_UNALIGNED.
/:cl: