### PR TITLE
ports "Makes changelog compile only fire if CHANGELOG_ENABLER secret is present" from tg

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -9,32 +9,47 @@ jobs:
     name: "Compile changelogs"
     runs-on: ubuntu-latest
     steps:
+      - name: "Check for CHANGELOG_ENABLER secret and pass true to output if it exists to be checked by later steps"
+        id: value_holder
+        env:
+          CHANGELOG_ENABLER: ${{ secrets.CHANGELOG_ENABLER }}
+        run: |
+          unset SECRET_EXISTS
+          if [-n $CHANGELOG_ENABLER]; then SECRET_EXISTS='true' ; fi
+          echo ::set-output name=CL_ENABLED::${SECRET_EXISTS}
       - name: "Setup python"
+        if: steps.value_holder.outputs.CL_ENABLED
         uses: actions/setup-python@v1
         with:
           python-version: '3.x'
       - name: "Install deps"
+        if: steps.value_holder.outputs.CL_ENABLED
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
           sudo apt-get install  dos2unix
       - name: "Checkout"
+        if: steps.value_holder.outputs.CL_ENABLED
         uses: actions/checkout@v1
         with:
           fetch-depth: 25
       - name: "Compile"
+        if: steps.value_holder.outputs.CL_ENABLED
         run: |
           python tools/ss13_genchangelog.py html/changelog.html html/changelogs
       - name: "Convert Lineendings"
+        if: steps.value_holder.outputs.CL_ENABLED
         run: |
           unix2dos html/changelogs/.all_changelog.yml
       - name: Commit
+        if: steps.value_holder.outputs.CL_ENABLED
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "Changelogs"
           git pull origin master
           git commit -m "Automatic changelog compile [ci skip]" -a || true
       - name: "Push"
+        if: steps.value_holder.outputs.CL_ENABLED
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Not tested yet, so please speak up if you notice anything off.

For any interested downstream/fork maintainers reading this:

You need to add CHANGELOG_ENABLER secret with some nonempty value to your repository if you want this action to continue to work as before.

https://github.com/tgstation/tgstation/pull/53845