### PR TITLE
A bunch of blacksmithing fixes / tweaks

### DIFF
--- a/code/datums/skills/_skill.dm
+++ b/code/datums/skills/_skill.dm
@@ -171,6 +171,7 @@ GLOBAL_LIST_INIT_TYPED(skill_datums, /datum/skill, init_skill_datums())
 				continue
 			max_assoc = levels[lvl-1]
 			levels["[max_assoc] +[max_assoc_start++]"] = value
+			continue
 		levels[key] = value
 
 /datum/skill/level/sanitize_value(new_value)

--- a/code/datums/skills/blacksmithing.dm
+++ b/code/datums/skills/blacksmithing.dm
@@ -1,6 +1,7 @@
-/datum/skill/level/dorfy/blacksmithing
+/datum/skill/level/dwarfy/blacksmithing
 	name = "Blacksmithing"
 	desc = "Making metal into fancy shapes using heat and force. Higher levels increase both your working speed at an anvil as well as the quality of your works."
 	name_color = COLOR_FLOORTILE_GRAY
 	skill_traits = list(SKILL_SANITY, SKILL_INTELLIGENCE, SKILL_USE_TOOL, SKILL_TRAINING_TOOL)
 	ui_category = SKILL_UI_CAT_MISC
+	standard_xp_lvl_up = 100 //Effectively 200xp for level 1 because of how this code works. 300 more for 2, Etc,

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -35,7 +35,7 @@
 			if(G.max_heat_protection_temperature)
 				prot = (G.max_heat_protection_temperature > 360)
 		else
-			prot = 1
+			prot = 0
 	if(prot > 0 || HAS_TRAIT(user, TRAIT_RESISTHEAT) || HAS_TRAIT(user, TRAIT_RESISTHEATHANDS))
 		to_chat(user, "<span class='notice'>You pick up the [src].</span>")
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does a few things:
1.) It fixes up the blacksmithing skill, which wasn't actually a dwarfy skill because of a typo.
2.) It blocks anvils from having multiple actions going on at one time / people opening the window beforehand, to prevent a bunch of issues.
3.) People without gloves now are counted as having no heat protection, instead of always counting as protected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the blacksmithing skill now works properly
tweak: Anvils cannot be interacted with with hammers whilst they are already being used
tweak: If someone has no gloves when interacting with heated ingots, they no longer ignore their effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
