### PR TITLE
Tweaks heretic sacrifice husking

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -247,7 +247,8 @@
 		if(LH.target && LH.target.stat == DEAD)
 			to_chat(carbon_user,"<span class='danger'>Your patrons accepts your offer...</span>")
 			var/mob/living/carbon/human/H = LH.target
-			H.become_husk()
+			H.become_husk("burn") //Husks the target with removable husking, but causes a bunch of additional burn damage to prevent it from being 'too easy' to do
+			H.adjustFireLoss(200)
 			LH.target = null
 			var/datum/antagonist/heretic/EC = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 


### PR DESCRIPTION
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## About The Pull Request
Currently, the husking caused by heretics is uncurable, as it has no specific husking 'reason' given in the become_husk proc, leading to synthflesh and co not fixing it because those only fix burn-related husking.
This PR changes this, so that sacrifices also cause burn-husking, but deal some additional burn damage to compensate for the husking now being curable and to prevent some cheese strategies.

## Why It's Good For The Game
People not having to be cloned to lose heretic-husking, but instead having the same ways available to cure it as for normal husking seems like a good thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Heretic sacrifices now husk with the reason of burn, and deal some additional damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
