### PR TITLE
Fixes plushlings

### DIFF
--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -150,6 +150,7 @@
 	if(squeak_override)
 		var/datum/component/squeak/S = GetComponent(/datum/component/squeak)
 		S?.override_squeak_sounds = squeak_override
+	snowflake_id = id
 
 /obj/item/toy/plush/handle_atom_del(atom/A)
 	if(A == grenade)
@@ -827,12 +828,16 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 	if(!victim)
 		return
 	visible_message("<span class='warning'>[src] gruesomely mutilliates [victim], leaving nothing more than dust!</span>")
-	name = victim.name
-	desc = victim.desc + " Wait, did it just move..?"
-	icon_state = victim.icon_state
-	item_state = victim.item_state
-	squeak_override = victim.squeak_override
-	attack_verb = victim.attack_verb
+	if(victim.snowflake_id) //Snowflake code for snowflake plushies.
+		set_snowflake_from_config(victim.snowflake_id)
+		desc += " Wait, did it just move..?"
+	else
+		name = victim.name
+		desc = victim.desc + " Wait, did it just move..?"
+		icon_state = victim.icon_state
+		item_state = victim.item_state
+		squeak_override = victim.squeak_override
+		attack_verb = victim.attack_verb
 	new /obj/effect/decal/cleanable/ash(get_turf(victim))
 	qdel(victim)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ironically, snowflake plushies were snowflake enough to not work with the absorb proc due to their specifics. This PR fixes that, and also makes plushies actually get their snowflake id set when they use the set_snowflake_from_config proc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Plushlings no longer break when absorbing snowflake plushies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
