### PR TITLE
[s] Fixes a tiny Neovgre edge case

### DIFF
--- a/code/game/mecha/combat/neovgre.dm
+++ b/code/game/mecha/combat/neovgre.dm
@@ -64,6 +64,8 @@
 
 /obj/mecha/combat/neovgre/process()
 	..()
+	if(!obj_integrity) //Integrity is zero but we would heal out of that state if we went into this before it recognises it being zero
+		return
 	if(GLOB.ratvar_awakens) // At this point only timley intervention by lord singulo could hope to stop the superweapon
 		cell.charge = INFINITY
 		max_integrity = INFINITY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out, sometimes, or well, commonly even, Neovgre's process() is called after it takes damage, but before it gets destroyed from having 0 object integrity, allowing it to heal out of those 0 hp, and be effectively invincible as long as He is on clock tiles. 
Oops!
This PR fixes that problem.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Neovgre can no longer become invincible on clock tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
