### PR TITLE
Fixes borg KA upgrade installation

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -28,8 +28,8 @@
 	return TRUE
 
 /*
-This proc gets called by upgrades after installing them. Use this for things that for example need to be moved into a specific borg module,
-as performing this in action() will cause the module to end up in the borg instead of its intended location due to forceMove() being called afterwards..
+This proc gets called by upgrades after installing them. Use this for things that for example need to be moved into a specific borg item,
+as performing this in action() will cause the upgrade to end up in the borg instead of its intended location due to forceMove() being called afterwards..
 */
 /obj/item/borg/upgrade/proc/afterInstall(mob/living/silicon/robot/R, user = usr)
 	return

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -27,6 +27,13 @@
 		return FALSE
 	return TRUE
 
+/*
+This proc gets called by upgrades after installing them. Use this for things that for example need to be moved into a specific borg module,
+as performing this in action() will cause the module to end up in the borg instead of its intended location due to forceMove() being called afterwards..
+*/
+/obj/item/borg/upgrade/proc/afterInstall(mob/living/silicon/robot/R, user = usr)
+	return
+
 /obj/item/borg/upgrade/proc/deactivate(mob/living/silicon/robot/R, user = usr)
 	if (!(src in R.upgrades))
 		return FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -454,10 +454,12 @@
 			if(U.action(src))
 				to_chat(user, "<span class='notice'>You apply the upgrade to [src].</span>")
 				if(U.one_use)
+					U.afterInstall(src)
 					qdel(U)
 				else
 					U.forceMove(src)
 					upgrades += U
+					U.afterInstall(src)
 			else
 				to_chat(user, "<span class='danger'>Upgrade error.</span>")
 				U.forceMove(drop_location())

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -105,9 +105,19 @@
 	holds_charge = TRUE
 	unique_frequency = TRUE
 
+/obj/item/gun/energy/kinetic_accelerator/cyborg/Destroy()
+	for(var/obj/item/borg/upgrade/modkit/M in modkits)
+		M.uninstall(src)
+	return ..()
+
 /obj/item/gun/energy/kinetic_accelerator/premiumka/cyborg
 	holds_charge = TRUE
 	unique_frequency = TRUE
+
+/obj/item/gun/energy/kinetic_accelerator/premiumka/cyborg/Destroy()
+	for(var/obj/item/borg/upgrade/modkit/M in modkits)
+		M.uninstall(src)
+	return ..()
 
 /obj/item/gun/energy/kinetic_accelerator/minebot
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
@@ -284,11 +294,11 @@
 	else
 		..()
 
-/obj/item/borg/upgrade/modkit/action(mob/living/silicon/robot/R)
-	. = ..()
-	if (.)
-		for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/H in R.module.modules)
-			return install(H, usr)
+/obj/item/borg/upgrade/modkit/afterInstall(mob/living/silicon/robot/R)
+	for(var/obj/item/gun/energy/kinetic_accelerator/H in R.module.modules)
+		if(install(H, R)) //It worked
+			return
+	to_chat(R, "<span class='alert'>Upgrade error - Aborting Kinetic Accelerator linking.</span>") //No applicable KA found, insufficient capacity, or some other problem.
 
 /obj/item/borg/upgrade/modkit/proc/install(obj/item/gun/energy/kinetic_accelerator/KA, mob/user)
 	. = TRUE
@@ -322,12 +332,6 @@
 	else
 		to_chat(user, "<span class='notice'>You don't have room(<b>[KA.get_remaining_mod_capacity()]%</b> remaining, [cost]% needed) to install this modkit. Use a crowbar to remove existing modkits.</span>")
 		. = FALSE
-
-/obj/item/borg/upgrade/modkit/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if (.)
-		for(var/obj/item/gun/energy/kinetic_accelerator/cyborg/KA in R.module.modules)
-			uninstall(KA)
 
 /obj/item/borg/upgrade/modkit/proc/uninstall(obj/item/gun/energy/kinetic_accelerator/KA, forcemove = TRUE)
 	KA.modkits -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
While borgs could still install these via clicking them with their KA, others installing them in the borg has been broken for ages, or well, since modkits have been a thing specifically.
The issue was that they would be moved into the KA on action(), but then immediately get pulled out again because of the forceMove() performed right after that, leading to them just being in the borg without actually doing anything. 
This PR adds a new proc for borg upgrades, afterInstall(), which gets called AFTER this forceMove(), for upgrades which need to be in a specific location in the borg instead of just the borg itself. It also cleans up the modkit code a bit.
This will close #13367
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: People installing KA modkits in miner borgs is no longer broken.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
