### PR TITLE
No harmful parry countering for pacifists.

### DIFF
--- a/code/modules/mob/living/living_active_parry.dm
+++ b/code/modules/mob/living/living_active_parry.dm
@@ -244,7 +244,14 @@
 	if((return_list[BLOCK_RETURN_MITIGATION_PERCENT] >= 100) || (damage <= 0))
 		. |= BLOCK_SUCCESS
 	var/list/effect_text
-	if(efficiency >= data.parry_efficiency_to_counterattack)
+	var/pacifist_counter_check = TRUE
+	if(HAS_TRAIT(src, TRAIT_PACIFISM))
+		switch(parrying)
+			if(ITEM_PARRY)
+				pacifist_counter_check = (!active_parry_item.force || active_parry_item.damtype == STAMINA)
+			else
+				pacifist_counter_check = FALSE //Both martial and unarmed counter attacks generally are harmful, so no need to have the same line twice.
+	if(efficiency >= data.parry_efficiency_to_counterattack && pacifist_counter_check)
 		effect_text = run_parry_countereffects(object, damage, attack_text, attack_type, armour_penetration, attacker, def_zone, return_list, efficiency)
 	if(data.parry_flags & PARRY_DEFAULT_HANDLE_FEEDBACK)
 		handle_parry_feedback(object, damage, attack_text, attack_type, armour_penetration, attacker, def_zone, return_list, efficiency, effect_text)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds a check to parrying to try and prevent pacifists from performing harmful parry counterattacks,
Feel free to suggest changes if you want this done a bit differently, for now it just allows it if the item used to parry causes stam damage or has no force, and prevents unarmed / martial parries due to them generally always being damaging.

This will close #13460 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pacifists being able to directly murder people via hitting a parry with a sword / hulk doesn't seem like a good thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Pacifists no longer counterattack on parries if that attack would be harmful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
