### PR TITLE
Makes the slimeperson swap-body UI stay open when you switch bodies

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -242,8 +242,7 @@
 
 	H.mob_transforming = FALSE
 
-/datum/action/innate/split_body/proc/make_
-()
+/datum/action/innate/split_body/proc/make_dupe()
 	var/mob/living/carbon/human/H = owner
 	CHECK_DNA_AND_SPECIES(H)
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -242,7 +242,8 @@
 
 	H.mob_transforming = FALSE
 
-/datum/action/innate/split_body/proc/make_dupe()
+/datum/action/innate/split_body/proc/make_
+()
 	var/mob/living/carbon/human/H = owner
 	CHECK_DNA_AND_SPECIES(H)
 
@@ -278,7 +279,7 @@
 		// transfer the swap-body ui if it's open
 		var/datum/action/innate/swap_body/this_swap = origin_datum.swap_body
 		var/datum/action/innate/swap_body/other_swap = spare_datum.swap_body
-		var/datum/tgui/ui = SStgui.get_open_ui(old, this_swap, "main") || SStgui.get_open_ui(dupe, this_swap, "main")
+		var/datum/tgui/ui = SStgui.get_open_ui(H, this_swap, "main") || SStgui.get_open_ui(spare, this_swap, "main")
 		if(ui)
 			SStgui.on_close(ui) // basically removes it from lists is all this proc does.
 			ui.user = spare

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -274,7 +274,17 @@
 		\"steps out\" of [H.p_them()].</span>",
 		"<span class='notice'>...and after a moment of disorentation, \
 		you're besides yourself!</span>")
-
+	if(H != spare && isslimeperson(spare) && isslimeperson(H))
+		// transfer the swap-body ui if it's open
+		var/datum/action/innate/swap_body/this_swap = origin_datum.swap_body
+		var/datum/action/innate/swap_body/other_swap = spare_datum.swap_body
+		var/datum/tgui/ui = SStgui.get_open_ui(old, this_swap, "main") || SStgui.get_open_ui(dupe, this_swap, "main")
+		if(ui)
+			SStgui.on_close(ui) // basically removes it from lists is all this proc does.
+			ui.user = spare
+			ui.src_object = other_swap
+			SStgui.on_open(ui) // stick it back on the lists
+			ui.process(force = TRUE)
 
 /datum/action/innate/swap_body
 	name = "Swap Body"
@@ -327,6 +337,8 @@
 				stat = "Conscious"
 			if(UNCONSCIOUS)
 				stat = "Unconscious"
+			if(SOFT_CRIT)
+				stat = "Barely Conscious"
 			if(DEAD)
 				stat = "Dead"
 		var/occupied
@@ -373,7 +385,6 @@
 			var/mob/living/carbon/human/selected = locate(params["ref"]) in SS.bodies
 			if(!can_swap(selected))
 				return
-			SStgui.close_uis(src)
 			swap_to_dupe(H.mind, selected)
 
 /datum/action/innate/swap_body/proc/can_swap(mob/living/carbon/human/dupe)
@@ -407,6 +418,7 @@
 /datum/action/innate/swap_body/proc/swap_to_dupe(datum/mind/M, mob/living/carbon/human/dupe)
 	if(!can_swap(dupe)) //sanity check
 		return
+	var/mob/living/carbon/human/old = M.current
 	if(M.current.stat == CONSCIOUS)
 		M.current.visible_message("<span class='notice'>[M.current] \
 			stops moving and starts staring vacantly into space.</span>",
@@ -418,7 +430,20 @@
 	dupe.visible_message("<span class='notice'>[dupe] blinks and looks \
 		around.</span>",
 		"<span class='notice'>...and move this one instead.</span>")
-
+	if(old != M.current && dupe == M.current && isslimeperson(dupe))
+		var/datum/species/jelly/slime/other_spec = dupe.dna.species
+		var/datum/action/innate/swap_body/other_swap = other_spec.swap_body
+		// theoretically the transfer_to proc is supposed to transfer the ui from the mob.
+		// so I try to get the UI from one of the two mobs and schlump it over to the new action button
+		var/datum/tgui/ui = SStgui.get_open_ui(old, src, "main") || SStgui.get_open_ui(dupe, src, "main")
+		if(ui)
+			// transfer the UI over. This code is slightly hacky but it fixes the problem
+			// I'd use SStgui.on_transfer but that doesn't let you transfer the src_object as well s
+			SStgui.on_close(ui) // basically removes it from lists is all this proc does.
+			ui.user = dupe
+			ui.src_object = other_swap
+			SStgui.on_open(ui) // stick it back on the lists
+			ui.process(force = TRUE)
 
 ////////////////////////////////////////////////////////Round Start Slimes///////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so the swap-body UI is transferred instead of closed upon switching bodies. Port of https://github.com/yogstation13/Yogstation/pull/4411

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a nice QOL change

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak:  The slimeperson swap-body UI stays open when you switch bodies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
