### PR TITLE
allows players in deadchat to see explosions

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_EMPTY(explosions)
 		message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)]")
 		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in [loc_name(epicenter)]")
 	
-	deadchat_broadcast("An explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) has occured at ([get_area(epicenter)])", turf_target = get_turf(epicenter))
+	deadchat_broadcast("<span class='deadsay bold'>An explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) has occured at ([get_area(epicenter)])</span>", turf_target = get_turf(epicenter))
 
 	var/x0 = epicenter.x
 	var/y0 = epicenter.y

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -89,6 +89,8 @@ GLOBAL_LIST_EMPTY(explosions)
 	if(adminlog)
 		message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)]")
 		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in [loc_name(epicenter)]")
+	
+	deadchat_broadcast("An explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) has occured at ([get_area(epicenter)])", turf_target = get_turf(epicenter))
 
 	var/x0 = epicenter.x
 	var/y0 = epicenter.y

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -10,6 +10,7 @@
 	if(log)
 		message_admins("EMP with power [power], max distance [max_distance] in area [epicenter.loc.name] ")
 	log_game("EMP with power [power], max distance [max_distance] in area [epicenter.loc.name] ")
+	deadchat_broadcast("EMP with power ([power]), max distance ([max_distance]) in [epicenter.loc.name]", turf_target = epicenter)
 
 	if(power > 100)
 		new /obj/effect/temp_visual/emp/pulse(epicenter)

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -10,7 +10,7 @@
 	if(log)
 		message_admins("EMP with power [power], max distance [max_distance] in area [epicenter.loc.name] ")
 	log_game("EMP with power [power], max distance [max_distance] in area [epicenter.loc.name] ")
-	deadchat_broadcast("EMP with power ([power]), max distance ([max_distance]) in [epicenter.loc.name]", turf_target = epicenter)
+	deadchat_broadcast("<span class='deadsay bold'>EMP with power ([power]), max distance ([max_distance]) in [epicenter.loc.name]</span>", turf_target = epicenter)
 
 	if(power > 100)
 		new /obj/effect/temp_visual/emp/pulse(epicenter)


### PR DESCRIPTION

## About The Pull Request

explosions and EMP pulses now send a deadchat message saying where it happened, the size, and a button to jump to the epicenter.

## Why It's Good For The Game

it's good to be able to jump to see the cool kabooms

## Changelog
:cl:
add: explosions now get broadcasted to deadchat.
/:cl: