### PR TITLE
Lingblood rework (Loudness is now an average, rather than a sum)

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -63,6 +63,10 @@
 #define CONTRACT_UPLINK_PAGE_CONTRACTS "CONTRACTS"
 #define CONTRACT_UPLINK_PAGE_HUB "HUB"
 
+//Lingblood stuff
+#define LINGBLOOD_DETECTION_THRESHOLD 1
+#define LINGBLOOD_EXPLOSION_MULT 2
+#define LINGBLOOD_EXPLOSION_THRESHOLD (LINGBLOOD_DETECTION_THRESHOLD * LINGBLOOD_EXPLOSION_THRESHOLD) //Hey, important to note here: the explosion threshold is explicitly more than, rather than more than or equal to. This stops a single loud ability from triggering the explosion threshold.
 
 ///Heretics --
 #define IS_HERETIC(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic))

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -66,7 +66,7 @@
 //Lingblood stuff
 #define LINGBLOOD_DETECTION_THRESHOLD 1
 #define LINGBLOOD_EXPLOSION_MULT 2
-#define LINGBLOOD_EXPLOSION_THRESHOLD (LINGBLOOD_DETECTION_THRESHOLD * LINGBLOOD_EXPLOSION_THRESHOLD) //Hey, important to note here: the explosion threshold is explicitly more than, rather than more than or equal to. This stops a single loud ability from triggering the explosion threshold.
+#define LINGBLOOD_EXPLOSION_THRESHOLD (LINGBLOOD_DETECTION_THRESHOLD * LINGBLOOD_EXPLOSION_MULT) //Hey, important to note here: the explosion threshold is explicitly more than, rather than more than or equal to. This stops a single loud ability from triggering the explosion threshold.
 
 ///Heretics --
 #define IS_HERETIC(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic))

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -38,8 +38,9 @@
 	var/mimicing = ""
 	var/canrespec = 0
 	var/changeling_speak = 0
-	var/loudfactor = 0 //Used for blood tests. At 4, blood tests will succeed. At 10, blood tests will result in an explosion.
-	var/bloodtestwarnings = 0 //Used to track if the ling has been notified that they will pass blood tests.
+	var/loudfactor = 0 //Used for blood tests. This is is the average loudness of the ling's abilities calculated with the below two vars
+	var/loudtotal = 0 //Used to keep track of the sum of the ling's loudness
+	var/totalpurchases = 0 //Used to keep track of how many purchases the ling's made after free abilities have been added
 	var/datum/dna/chosen_dna
 	var/obj/effect/proc_holder/changeling/sting/chosen_sting
 	var/datum/cellular_emporium/cellular_emporium
@@ -139,8 +140,6 @@
 /datum/antagonist/changeling/proc/reset_powers()
 	if(purchasedpowers)
 		remove_changeling_powers()
-	loudfactor = 0
-	bloodtestwarnings = 0
 	//Repurchase free powers.
 	for(var/path in all_powers)
 		var/obj/effect/proc_holder/changeling/S = new path()
@@ -148,6 +147,9 @@
 			if(!has_sting(S))
 				purchasedpowers += S
 				S.on_purchase(owner.current,TRUE)
+	loudfactor = 0
+	loudtotal = 0
+	totalpurchases = 0
 
 /datum/antagonist/changeling/proc/has_sting(obj/effect/proc_holder/changeling/power)
 	for(var/obj/effect/proc_holder/changeling/P in purchasedpowers)
@@ -192,13 +194,18 @@
 	geneticpoints -= thepower.dna_cost
 	purchasedpowers += thepower
 	thepower.on_purchase(owner.current)
-	loudfactor += thepower.loudness
-	if(loudfactor >= 4 && !bloodtestwarnings)
-		to_chat(owner.current, "<span class='warning'>Our blood is growing flammable. Our blood will react violently to heat.</span>")
-		bloodtestwarnings = 1
-	if(loudfactor >= 10 && bloodtestwarnings < 2)
-		to_chat(owner.current, "<span class='warning'>Our blood has grown extremely flammable. Our blood will react explosively to heat.</span>")
-		bloodtestwarnings = 2
+	loudtotal += thepower.loudness
+	totalpurchases++
+	var/oldloudness = loudfactor
+	loudfactor = loudtotal/max(totalpurchases,1)
+	if(loudfactor >= LINGBLOOD_DETECTION_THRESHOLD && oldloudness < LINGBLOOD_DETECTION_THRESHOLD)
+		to_chat(owner.current, "<span class='warning'>Our blood has grown flammable. Our blood will now react violently to heat.</span>")
+	else if(loudfactor < LINGBLOOD_DETECTION_THRESHOLD && oldloudness >= LINGBLOOD_DETECTION_THRESHOLD)
+		to_chat(owner.current, "<span class='notice'>Our blood has stabilized, and will no longer react violently to heat.</span>")
+	if(loudfactor > LINGBLOOD_EXPLOSION_THRESHOLD && oldloudness <= LINGBLOOD_EXPLOSION_THRESHOLD)
+		to_chat(owner.current, "<span class='warning'>Our blood has grown extremely flammable. Our blood will now react explosively to heat.</span>")
+	else if(loudfactor <= LINGBLOOD_EXPLOSION_THRESHOLD && oldloudness > LINGBLOOD_EXPLOSION_THRESHOLD)
+		to_chat(owner.current, "<span class='notice'>Our blood has slightly stabilized, and will no longer explode when exposed to heat.</span>")
 
 /datum/antagonist/changeling/proc/readapt()
 	if(!ishuman(owner.current))

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -484,12 +484,12 @@
 		return FALSE
 	var/list/D = holder.get_data("blood")
 	if(D && D["changeling_loudness"])
-		return (D["changeling_loudness"] >= 4 ? D["changeling_loudness"] : FALSE)
+		return (D["changeling_loudness"] >= LINGBLOOD_DETECTION_THRESHOLD ? D["changeling_loudness"] : FALSE)
 	else
 		return FALSE
 
 /datum/chemical_reaction/reagent_explosion/lingblood/on_reaction(datum/reagents/holder, multiplier, specialreact)
-	if(specialreact >= 10)
+	if(specialreact > LINGBLOOD_EXPLOSION_THRESHOLD)
 		return ..()
 	else
 		return FALSE


### PR DESCRIPTION
Title. A full writeup of why I'm making this change, and what I predict will come out of it, can be found here: https://hackmd.io/@deathride58/HkTyFgr8v

~~(this is currently untested because byond is just completely refusing to compile on my own hardware for some reason, but it should in theory work. theoretically.)~~ (edit: i figured out how to break byond's compiler, disregard)

## Changelog
:cl: Bhijn
tweak: Changeling loudness is now determined as an average of all their abilities, rather than the sum
tweak: To compensate for this, blood tests now require a loudness value of 1 or higher to detect ling blood. Additionally, blood test explosions are now triggered only when the loudness value is higher than 2.
/:cl:
