### PR TITLE
Makes toilet loot not exist to cause bad GC bugs.

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -133,7 +133,7 @@
 /obj/structure/toilet/secret
 	var/secret_type = null
 
-/obj/structure/toilet/secret/PopulateContents()
+/obj/structure/toilet/secret/Initialize()
 	. = ..()
 	if (secret_type)
 		new secret_type(src)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -131,15 +131,12 @@
 		return ..()
 
 /obj/structure/toilet/secret
-	var/obj/item/secret
 	var/secret_type = null
 
-/obj/structure/toilet/secret/Initialize(mapload)
+/obj/structure/toilet/secret/PopulateContents()
 	. = ..()
 	if (secret_type)
-		secret = new secret_type(src)
-		secret.desc += "" //In case you want to add something to the item that spawns
-		contents += secret
+		new secret_type(src)
 
 /obj/structure/toilet/secret/LateInitialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Whoever wrote toilet loot somehow didn't notice that they were using spawners, which delete themselves, and for some reason decided to keep a reference to the item spawned inside itself, which in this case is a loot spawner that instantly qdels itself. This was causing the description addition not to work at all (not that it was ever used) and to cause all the spawners to force hard del cause the toilets kept a reference to what the original code writer must have assumed would be the item spawned by the loot spawner but was actually the spawner itself. For no reason.

## Why It's Good For The Game

You may have noticed I typed a lot up there saying "why is this code like this". I'd rather it not be.

## Changelog
:cl:
fix: Toilet loot spawners don't lag the server on server start with forced hard dels.
/:cl: