### PR TITLE
buffs stands in general, adds gravitokinetic stand type from tg, fixes broken protector shield

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	icon_state = "magicbase"
 	icon_living = "magicbase"
 	icon_dead = "magicbase"
-	speed = 0
+	speed = -0.5
 	blood_volume = 0
 	a_intent = INTENT_HARM
 	stop_automated_movement = 1
@@ -511,7 +511,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	var/used_message = "<span class='holoparasite'>All the cards seem to be blank now.</span>"
 	var/failure_message = "<span class='holoparasite bold'>..And draw a card! It's...blank? Maybe you should try again later.</span>"
 	var/ling_failure = "<span class='holoparasite bold'>The deck refuses to respond to a souless creature such as you.</span>"
-	var/list/possible_guardians = list("Assassin", "Chaos", "Charger", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
+	var/list/possible_guardians = list("Assassin", "Chaos", "Gravitokinetic", "Charger", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
 	var/random = TRUE
 	var/allowmultiple = FALSE
 	var/allowling = TRUE
@@ -558,6 +558,9 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 
 		if("Chaos")
 			pickedtype = /mob/living/simple_animal/hostile/guardian/fire
+
+		if("Gravitokinetic")
+			pickedtype = /mob/living/simple_animal/hostile/guardian/gravitokinetic
 
 		if("Standard")
 			pickedtype = /mob/living/simple_animal/hostile/guardian/punch
@@ -615,10 +618,10 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	random = FALSE
 
 /obj/item/guardiancreator/choose/dextrous
-	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
+	possible_guardians = list("Assassin", "Chaos", "Gravitokinetic", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
 
 /obj/item/guardiancreator/choose/wizard
-	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard")
+	possible_guardians = list("Assassin", "Chaos", "Gravitokinetic", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard")
 	allowmultiple = TRUE
 
 /obj/item/guardiancreator/tech
@@ -634,7 +637,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	ling_failure = "<span class='holoparasite bold'>The holoparasites recoil in horror. They want nothing to do with a creature like you.</span>"
 
 /obj/item/guardiancreator/tech/choose/traitor
-	possible_guardians = list("Assassin", "Chaos", "Charger", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
+	possible_guardians = list("Assassin", "Chaos", "Gravitokinetic", "Charger", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
 	allowling = FALSE
 
 /obj/item/guardiancreator/tech/choose/traitor/check_uplink_validity()
@@ -644,10 +647,10 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	random = FALSE
 
 /obj/item/guardiancreator/tech/choose/dextrous
-	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
+	possible_guardians = list("Assassin", "Chaos", "Gravitokinetic", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
 
 /obj/item/guardiancreator/tech/choose/nukie // lacks support and protector as encouraging nukies to play turtle isnt fun and dextrous is epic
-	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Ranged", "Standard")
+	possible_guardians = list("Assassin", "Chaos", "Gravitokinetic", "Charger", "Dextrous", "Explosive", "Lightning", "Ranged", "Standard")
 
 /obj/item/guardiancreator/tech/choose/nukie/check_uplink_validity()
 	return !used
@@ -665,6 +668,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
  <b>Charger</b>: Moves extremely fast, does medium damage on attack, and can charge at targets, damaging the first target hit and forcing them to drop any items they are holding.<br>
  <br>
  <b>Explosive</b>: High damage resist and medium power attack that may explosively teleport targets. Can turn any object, including objects too large to pick up, into a bomb, dealing explosive damage to the next person to touch it. The object will return to normal after the trap is triggered or after a delay.<br>
+ <br>
+ <b>Gravitokinetic</b>: Attacks will apply crushing gravity to the target. Can target the ground as well to slow targets advancing on you, but this will affect the user.<br>
  <br>
  <b>Lightning</b>: Attacks apply lightning chains to targets. Has a lightning chain to the user. Lightning chains shock everything near them, doing constant damage.<br>
  <br>
@@ -695,6 +700,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
  <br>
  <b>Explosive</b>: High damage resist and medium power attack that may explosively teleport targets. Can turn any object, including objects too large to pick up, into a bomb, dealing explosive damage to the next person to touch it. The object will return to normal after the trap is triggered or after a delay.<br>
  <br>
+ <b>Gravitokinetic</b>: Attacks will apply crushing gravity to the target. Can target the ground as well to slow targets advancing on you, but this will affect the user.<br>
+ <br>
  <b>Lightning</b>: Attacks apply lightning chains to targets. Has a lightning chain to the user. Lightning chains shock everything near them, doing constant damage.<br>
  <br>
  <b>Protector</b>: Causes you to teleport to it when out of range, unlike other parasites. Has two modes; Combat, where it does and takes medium damage, and Protection, where it does and takes almost no damage but moves slightly slower.<br>
@@ -719,6 +726,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
  <b>Dextrous</b>: Does low damage on attack, but is capable of holding items and storing a single item within it. It will drop items held in its hands when it recalls, but it will retain the stored item.<br>
  <br>
  <b>Explosive</b>: High damage resist and medium power attack that may explosively teleport targets. Can turn any object, including objects too large to pick up, into a bomb, dealing explosive damage to the next person to touch it. The object will return to normal after the trap is triggered or after a delay.<br>
+ <br>
+ <b>Gravitokinetic</b>: Attacks will apply crushing gravity to the target. Can target the ground as well to slow targets advancing on you, but this will affect the user.<br>
  <br>
  <b>Lightning</b>: Attacks apply lightning chains to targets. Has a lightning chain to the user. Lightning chains shock everything near them, doing constant damage.<br>
  <br>

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -1,5 +1,7 @@
 //Assassin
 /mob/living/simple_animal/hostile/guardian/assassin
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -1,8 +1,11 @@
 //Charger
 /mob/living/simple_animal/hostile/guardian/charger
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	ranged = 1 //technically
 	ranged_message = "charges"
 	ranged_cooldown_time = 20
+	speed = -1
 	damage_coeff = list(BRUTE = 0.2, BURN = 0.5, TOX = 0.5, CLONE = 0.5, STAMINA = 0, OXY = 0.5)
 	playstyle_string = "<span class='holoparasite'>As a <b>charger</b> type you do medium damage, take half damage, have near immunity to brute damage, move very fast, and can charge at a location, damaging any target hit and forcing them to drop any items they are holding.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Hunter, an alien master of rapid assault.</span>"

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -1,5 +1,7 @@
 //Bomb
 /mob/living/simple_animal/hostile/guardian/bomb
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	damage_coeff = list(BRUTE = 0.6, BURN = 0.6, TOX = 0.6, CLONE = 0.6, STAMINA = 0, OXY = 0.6)
 	playstyle_string = "<span class='holoparasite'>As an <b>explosive</b> type, you have moderate close combat abilities, take half damage, may explosively teleport targets on attack, and are capable of converting nearby items and objects into disguised bombs via alt click.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Scientist, master of explosive death.</span>"

--- a/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/gravitokinetic.dm
@@ -1,0 +1,73 @@
+//gravitokinetic
+/mob/living/simple_animal/hostile/guardian/gravitokinetic
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	damage_coeff = list(BRUTE = 0.75, BURN = 0.75, TOX = 0.75, CLONE = 0.75, STAMINA = 0, OXY = 0.75)
+	playstyle_string = "<span class='holoparasite'>As a <b>gravitokinetic</b> type, you can alt click to make the gravity on the ground stronger, and punching applies this effect to a target.</span>"
+	magic_fluff_string = "<span class='holoparasite'>..And draw the Singularity, an anomalous force of terror.</span>"
+	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Gravitokinetic modules loaded. Holoparasite swarm online.</span>"
+	carp_fluff_string = "<span class='holoparasite'>CARP CARP CARP! Caught one! It's a gravitokinetic carp! Now do you understand the gravity of the situation?</span>"
+	var/list/gravito_targets = list()
+	var/gravity_power_range = 10 //how close the stand must stay to the target to keep the heavy gravity
+
+///Removes gravity from affected mobs upon guardian death to prevent permanent effects
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/death()
+	. = ..()
+	for(var/i in gravito_targets)
+		remove_gravity(i)
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/AttackingTarget()
+	. = ..()
+	if(isliving(target) && target != src && target != summoner)
+		to_chat(src, "<span class='danger'><B>Your punch has applied heavy gravity to [target]!</span></B>")
+		add_gravity(target, 5)
+		to_chat(target, "<span class='userdanger'>Everything feels really heavy!</span>")
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/AltClickOn(atom/A)
+	if(isopenturf(A) && is_deployed() && stat != DEAD && in_range(src, A) && !incapacitated())
+		var/turf/T = A
+		if(isspaceturf(T))
+			to_chat(src, "<span class='warning'>You cannot add gravity to space!</span>")
+			return
+		visible_message("<span class='danger'>[src] slams their fist into the [T]!</span>", "<span class='notice'>You modify the gravity of the [T].</span>")
+		do_attack_animation(T)
+		add_gravity(T, 3)
+		return
+	return ..()
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/Recall(forced)
+	. = ..()
+	to_chat(src, "<span class='danger'><B>You have released your gravitokinetic powers!</span></B>")
+	for(var/i in gravito_targets)
+		remove_gravity(i)
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/Manifest(forced)
+	. = ..()
+	//just make sure to reapply a gravity immunity wherever you summon. it can be overridden but not by you at least
+	summoner.AddElement(/datum/element/forced_gravity, 1)
+	AddElement(/datum/element/forced_gravity, 1)
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/Moved(oldLoc, dir)
+	. = ..()
+	for(var/i in gravito_targets)
+		if(get_dist(src, i) > gravity_power_range)
+			remove_gravity(i)
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/proc/add_gravity(atom/A, new_gravity = 3)
+	if(gravito_targets[A])
+		return
+	A.AddElement(/datum/element/forced_gravity, new_gravity)
+	gravito_targets[A] = new_gravity
+	RegisterSignal(A, COMSIG_MOVABLE_MOVED, .proc/__distance_check)
+	playsound(src, 'sound/effects/gravhit.ogg', 100, TRUE)
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/proc/remove_gravity(atom/target)
+	if(isnull(gravito_targets[target]))
+		return
+	UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
+	target.RemoveElement(/datum/element/forced_gravity, gravito_targets[target])
+	gravito_targets -= target
+
+/mob/living/simple_animal/hostile/guardian/gravitokinetic/proc/__distance_check(atom/movable/AM, OldLoc, Dir, Forced)
+	if(get_dist(src, AM) > gravity_power_range)
+		remove_gravity(AM)

--- a/code/modules/mob/living/simple_animal/guardian/types/protector.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/protector.dm
@@ -1,5 +1,7 @@
 //Protector
 /mob/living/simple_animal/hostile/guardian/protector
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	range = 15 //worse for it due to how it leashes
 	damage_coeff = list(BRUTE = 0.4, BURN = 0.4, TOX = 0.4, CLONE = 0.4, STAMINA = 0, OXY = 0.4)
 	playstyle_string = "<span class='holoparasite'>As a <b>protector</b> type you cause your summoner to leash to you instead of you leashing to them and have two modes; Combat Mode, where you do and take medium damage, and Protection Mode, where you do and take almost no damage, but move slightly slower.</span>"
@@ -31,9 +33,10 @@
 	cooldown = world.time + 10
 	if(toggle)
 		cut_overlays()
-		melee_damage_lower = 15
-		melee_damage_upper = 15
-		speed = 0
+		add_overlay(cooloverlay) //readd the guardian's colors
+		melee_damage_lower = initial(melee_damage_lower)
+		melee_damage_upper = initial(melee_damage_upper)
+		speed = initial(speed)
 		damage_coeff = list(BRUTE = 0.4, BURN = 0.4, TOX = 0.4, CLONE = 0.4, STAMINA = 0, OXY = 0.4)
 		to_chat(src, "<span class='danger'><B>You switch to combat mode.</span></B>")
 		toggle = FALSE

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -4,6 +4,8 @@
 	friendly_verb_continuous = "heals"
 	friendly_verb_simple = "heal"
 	damage_coeff = list(BRUTE = 0.7, BURN = 0.7, TOX = 0.7, CLONE = 0.7, STAMINA = 0, OXY = 0.7)
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	playstyle_string = "<span class='holoparasite'>As a <b>support</b> type, you have 30% damage reduction and may toggle your basic attacks to a healing mode. In addition, Alt-Clicking on an adjacent object or mob will warp them to your bluespace beacon after a short delay.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the CMO, a potent force of life... and death.</span>"
 	carp_fluff_string = "<span class='holoparasite'>CARP CARP CARP! You caught a support carp. It's a kleptocarp!</span>"
@@ -43,15 +45,15 @@
 	if(src.loc == summoner)
 		if(toggle)
 			a_intent = INTENT_HARM
-			speed = 0
+			speed = initial(speed)
 			damage_coeff = list(BRUTE = 0.7, BURN = 0.7, TOX = 0.7, CLONE = 0.7, STAMINA = 0, OXY = 0.7)
-			melee_damage_lower = 15
-			melee_damage_upper = 15
+			melee_damage_lower = initial(melee_damage_lower)
+			melee_damage_upper = initial(melee_damage_upper)
 			to_chat(src, "<span class='danger'><B>You switch to combat mode.</span></B>")
 			toggle = FALSE
 		else
 			a_intent = INTENT_HELP
-			speed = 1
+			speed = initial(speed)
 			damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 			melee_damage_lower = 0
 			melee_damage_upper = 0

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2677,6 +2677,7 @@
 #include "code\modules\mob\living\simple_animal\guardian\types\dextrous.dm"
 #include "code\modules\mob\living\simple_animal\guardian\types\explosive.dm"
 #include "code\modules\mob\living\simple_animal\guardian\types\fire.dm"
+#include "code\modules\mob\living\simple_animal\guardian\types\gravitokinetic.dm"
 #include "code\modules\mob\living\simple_animal\guardian\types\lightning.dm"
 #include "code\modules\mob\living\simple_animal\guardian\types\protector.dm"
 #include "code\modules\mob\living\simple_animal\guardian\types\ranged.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ok so
Can we all agree that holoparasites/stands/punchghosts FUCKING SUCK? They're slower than run speed, do fairly poor damage if they're not one of a few very specific types, and are worst of all. Controlled by another person, a person which is going to march into that warden brandishing a shotgun, and is going to die for it also.
This PR does a few things:
It (should if this works) increase the speed of all stands by a good bit so they're not all helplessly walking.
Remove the slowdown support stands got when they were in heal mode for whatever reason.
Give charger the F A S T speed it has on TG so they are more than just standard with less offensive capabilities.
Fix the bug where guardian stands cleared all of their overlays and became partially invisible when turning on and off their shield.
Add the Gravitokinetic stand from TG; a combat stand which excels in trapping and preventing escapes by slowing down its victims and creating speed traps in the form of intense gravity. All effects are lost upon exiting range of the stand and it can do nothing at all outside of melee combat.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
stands are unbalanced in the bad way that they fucking suck so can we please make stands somewhat worth having to compete with the second hitbox actively trying to kill you

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: gravitokinetic stands from tg
balance: buffs stands overall
fix: protector stands no longer become tposing invisible apes sometimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
