### PR TITLE
Makes hyper-nob and nitryl require energy instead of temperature

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -356,7 +356,7 @@
 		/datum/gas/oxygen = 20,
 		/datum/gas/nitrogen = 20,
 		/datum/gas/nitrous_oxide = 5,
-		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST*400
+		"ENER" = NITRYL_FORMATION_ENERGY
 	)
 
 /datum/gas_reaction/nitrylformation/react(datum/gas_mixture/air)
@@ -497,7 +497,7 @@
 	min_requirements = list(
 		/datum/gas/nitrogen = 10,
 		/datum/gas/tritium = 5,
-		"TEMP" = 5000000)
+		"ENER" = NOBLIUM_FORMATION_ENERGY)
 
 /datum/gas_reaction/nobliumformation/react(datum/gas_mixture/air)
 	var/old_heat_capacity = air.heat_capacity()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -356,6 +356,7 @@
 		/datum/gas/oxygen = 20,
 		/datum/gas/nitrogen = 20,
 		/datum/gas/nitrous_oxide = 5,
+		"TEMP" = 10000
 		"ENER" = NITRYL_FORMATION_ENERGY
 	)
 
@@ -497,6 +498,7 @@
 	min_requirements = list(
 		/datum/gas/nitrogen = 10,
 		/datum/gas/tritium = 5,
+		"TEMP" = FUSION_TEMPERATURE_THRESHOLD
 		"ENER" = NOBLIUM_FORMATION_ENERGY)
 
 /datum/gas_reaction/nobliumformation/react(datum/gas_mixture/air)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -356,7 +356,7 @@
 		/datum/gas/oxygen = 20,
 		/datum/gas/nitrogen = 20,
 		/datum/gas/nitrous_oxide = 5,
-		"TEMP" = 10000
+		"TEMP" = FUSION_TEMPERATURE_THRESHOLD,
 		"ENER" = NITRYL_FORMATION_ENERGY
 	)
 

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -356,7 +356,7 @@
 		/datum/gas/oxygen = 20,
 		/datum/gas/nitrogen = 20,
 		/datum/gas/nitrous_oxide = 5,
-		"TEMP" = FUSION_TEMPERATURE_THRESHOLD,
+		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST,
 		"ENER" = NITRYL_FORMATION_ENERGY
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title.

## Why It's Good For The Game

They require energy and not temperature anyway! They have literal defines for their energy requirement! Come on.

## Changelog
:cl:
tweak: Hyper-nob and nitryl both require energy to form instead of temperature.
balance: Hyper-nob and nitryl are probably way easier to make now.
/:cl: