### PR TITLE
bodypart fixes - robotic bodypart & digitigrade edition

### DIFF
--- a/code/datums/wounds/_scars.dm
+++ b/code/datums/wounds/_scars.dm
@@ -79,7 +79,7 @@
 
 /// Used to "load" a persistent scar
 /datum/scar/proc/load(obj/item/bodypart/BP, version, description, specific_location, severity=WOUND_SEVERITY_SEVERE)
-	if(!(BP.body_zone in applicable_zones) || !BP.is_organic_limb())
+	if(!(BP.body_zone in applicable_zones) || !(BP.is_organic_limb() || BP.render_like_organic))
 		qdel(src)
 		return
 

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -110,7 +110,7 @@
   * * smited- If this is a smite, we don't care about this wound for stat tracking purposes (not yet implemented)
   */
 /datum/wound/proc/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE)
-	if(!istype(L) || !L.owner || !(L.body_zone in viable_zones) || isalien(L.owner) || !L.is_organic_limb())
+	if(!istype(L) || !L.owner || !(L.body_zone in viable_zones) || isalien(L.owner) || !(L.is_organic_limb() || L.render_like_organic))
 		qdel(src)
 		return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2639,9 +2639,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//limb stuff, only done when initially spawning in
 	if(initial_spawn)
-		//delete any existing prosthetic limbs to make sure no remnant prosthetics are left over
+		//delete any existing prosthetic limbs to make sure no remnant prosthetics are left over - But DO NOT delete those that are species-related
 		for(var/obj/item/bodypart/part in character.bodyparts)
-			if(part.status == BODYPART_ROBOTIC)
+			if(part.status == BODYPART_ROBOTIC && !part.render_like_organic)
 				qdel(part)
 		character.regenerate_limbs() //regenerate limbs so now you only have normal limbs
 		for(var/modified_limb in modified_limbs)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -581,7 +581,7 @@
 		C = owner
 		no_update = FALSE
 
-	if(HAS_TRAIT(C, TRAIT_HUSK) && is_organic_limb())
+	if(HAS_TRAIT(C, TRAIT_HUSK) && (is_organic_limb() || render_like_organic))
 		species_id = "husk" //overrides species_id
 		dmg_overlay_type = "" //no damage overlay shown when husked
 		should_draw_gender = FALSE

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -434,5 +434,8 @@
 		var/datum/scar/scaries = new
 		var/datum/wound/loss/phantom_loss = new // stolen valor, really
 		scaries.generate(L, phantom_loss)
+		if(HAS_TRAIT(src, ROBOTIC_LIMBS)) //Snowflake trait moment, but needed.
+			L.render_like_organic = TRUE
+			L.change_bodypart_status(BODYPART_ROBOTIC, FALSE, TRUE) //Haha what if IPC-lings actually regenerated the right limbs instead of organic ones? That'd be pretty cool, right?
 		L.attach_limb(src, 1)
 		return TRUE

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -529,7 +529,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 					if(5) // limb squish!
 						for(var/i in C.bodyparts)
 							var/obj/item/bodypart/squish_part = i
-							if(squish_part.is_organic_limb())
+							if(squish_part.is_organic_limb() || squish_part.render_like_organic)
 								var/type_wound = pick(list(/datum/wound/blunt/critical, /datum/wound/blunt/severe, /datum/wound/blunt/moderate))
 								squish_part.force_wound_upwards(type_wound)
 							else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
HOO BOY, this PR was !!FUN!! to make.
(Hint hint, around five hours of diving through species and bodypart code)

So, a while ago I noticed synth digi legs were not working. 
Apparently, this is not because the species or anything is broken.
But, because their limbs were being deleted roundstart by a failsafe meant to remove prothetics which were not added by the new system. Which hit any robotic bodypart. Resulting in synths being horrendously scarred roundstart, and losing their digi features (+ probably some other issues, maybe, like flomping onto the ground when arriving onstation, but that one was kinda funny)

Anyways, I fixed that issue, and found some more which looked rather minor, but i fixed them regardless. Considering synths should have wounds, I made the apply_wound proc allow robotic limbs as long as they have render_like_organic is true. Same for scars. And husking sprite-changes.
Edit: Aaand also makes regenerate_limb(s) work for people with the ROBOTIC_LIMBS trait, for when we get a synth / IPC changeling.

There goes my sanity for the day.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Haha yes synths not getting all their limbs cut off and reattached roundstart might be a good idea.
also fix man good in general, for the other stuff
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Synths / IPCs are no longer wound immune.
fix: Husked IPCs / Synths should now be rendered correctly.
fix: Falling vendors now squish synths / IPCs' limbs again.
fix: Synths and IPCs now do not have some fun roundstart oversights anymore.
fix: Regenerate_limbs now works for carbons with the ROBOTIC_LIMBS trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
