### PR TITLE
new radial menu for adjacent emotes

### DIFF
--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -342,20 +342,22 @@
 		to_chat(src, "<span class='warning'>You can't do that so fast, slow down.</span>")
 		return
 
-	var/list/choices
+	DelayNextAction(CLICK_CD_MELEE, flush = TRUE)
+
+	var/list/lickable = list()
 	for(var/mob/living/L in view(1))
 		if(L != src && (!L.ckey || L.client?.prefs.vore_flags & LICKABLE) && Adjacent(L))
-			LAZYADD(choices, L)
+			LAZYADD(lickable, L)
+	for(var/mob/living/listed in lickable)
+		lickable[listed] = getFlatIcon(listed) // forgive me for what I must do.
 
-	if(!choices)
+	if(!lickable)
 		return
 
-	var/mob/living/tasted = input(src, "Who would you like to lick? (Excluding yourself and those with the preference disabled)", "Licking") as null|anything in choices
+	var/mob/living/tasted = show_radial_menu(src, src, lickable, radius = 40, require_near = TRUE)
 
 	if(QDELETED(tasted) || (tasted.ckey && !(tasted.client?.prefs.vore_flags & LICKABLE)) || !Adjacent(tasted) || incapacitated(ignore_restraints = TRUE))
 		return
-
-	DelayNextAction(CLICK_CD_MELEE)
 
 	visible_message("<span class='warning'>[src] licks [tasted]!</span>","<span class='notice'>You lick [tasted]. They taste rather like [tasted.get_taste_message()].</span>","<b>Slurp!</b>")
 

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -349,7 +349,7 @@
 		if(L != src && (!L.ckey || L.client?.prefs.vore_flags & LICKABLE) && Adjacent(L))
 			LAZYADD(lickable, L)
 	for(var/mob/living/listed in lickable)
-		lickable[listed] = getFlatIcon(listed) // forgive me for what I must do.
+		lickable[listed] = new /mutable_appearance(listed)
 
 	if(!lickable)
 		return


### PR DESCRIPTION
## About The Pull Request

I have slain another cringe dropdown in my radial conquest, now with licc.

## Why It's Good For The Game
radial licking enables a high level of competitive gameplay by allowing you to use your monkey brain's quick recognition of images to reflexively 360 noscope quickshot your licks on the correct target, creating an enhanced experience for pro players.

## Changelog
:cl:
add: Lick radial
/:cl:
