### PR TITLE
[READY] Rebalances zeolites and their reaction

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -83,6 +83,16 @@
 		updateUsrDialog()
 		update_icon()
 		return
+
+	if(beaker)
+		if(istype(I, /obj/item/reagent_containers/dropper))
+			var/obj/item/reagent_containers/dropper/D = I
+			D.afterattack(beaker, user, 1)
+			return
+		if(istype(I, /obj/item/reagent_containers/syringe))
+			var/obj/item/reagent_containers/syringe/S = I
+			S.afterattack(beaker, user, 1)
+			return
 	return ..()
 
 /obj/machinery/chem_heater/on_deconstruction()

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -209,10 +209,10 @@
 /datum/reagent/fermi/zeolites/on_mob_life(mob/living/carbon/M)
 	metabolization_rate = (4 / purity) * REAGENTS_METABOLISM //Metab rate directly influenced by purity. Linear.
 	var/datum/component/radioactive/contamination = M.GetComponent(/datum/component/radioactive)
-	if(M.radiation > 0)
-		M.radiation -= min(M.radiation, round(20 ** (0.5 + purity), 0.1)) //Far more effective if more pure. Tops out at ~90 at max purity. Exponential.
+	if(M.radiation > 0) //hey so apparently pentetic literally purges 1/50 (2%) of the rad amount on someone per tick no matter the 'true' amount, sooo uhh time to tweak this some more..
+		M.radiation -= clamp(round((M.radiation / 150) * (25 ** purity), 0.1), 0, M.radiation) //Purges between ~3% and ~16% of total rad amount, per tick, depending on purity. Exponential.
 	if(contamination && contamination.strength > 0)
-		contamination.strength -= min(contamination.strength, round(25 ** (0.5 + purity), 0.1)) //Tops out at ~125 at max purity. Exponential.
+		contamination.strength -= min(contamination.strength, round(25 ** (0.5 + purity), 0.1)) //25 per tick at minimum purity; Tops out at ~125 per tick if purity is 1. Exponential.
 	..()
 
 /datum/reagent/fermi/zeolites/reaction_obj(obj/O, reac_volume)

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -200,7 +200,7 @@
 
 /datum/reagent/fermi/zeolites
 	name = "Artificial Zeolites"
-	description = "Lab made Zeolite, used to clear radiation from people and items alike! Splashing just a small amount(5u) onto any item can clear away large amounts of contamination, as long as purity is at least 0.7."
+	description = "Lab made Zeolite, used to clear radiation from people and items alike! Splashing just a small amount(5u) onto any item can clear away large amounts of contamination, as long as its purity is at least 0.7."
 	pH = 8
 	color = "#FFDADA"
 	metabolization_rate = 8 * REAGENTS_METABOLISM //Metabolizes fast but heals a lot! Lasts far longer if more pure.

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -200,22 +200,23 @@
 
 /datum/reagent/fermi/zeolites
 	name = "Artificial Zeolites"
-	description = "Lab made Zeolite, used to clear radiation from people and items alike! Splashing just a small amount(5u) onto any item can clear away large amounts of contamination."
+	description = "Lab made Zeolite, used to clear radiation from people and items alike! Splashing just a small amount(5u) onto any item can clear away large amounts of contamination, as long as purity is at least 0.7."
 	pH = 8
 	color = "#FFDADA"
-	metabolization_rate = 8 * REAGENTS_METABOLISM //Metabolizes fast but heals a lot!
-	value = REAGENT_VALUE_COMMON
+	metabolization_rate = 8 * REAGENTS_METABOLISM //Metabolizes fast but heals a lot! Lasts far longer if more pure.
+	value = REAGENT_VALUE_RARE //Relatively hard to make now, might be fine with VERY_RARE instead depending on feedback.
 
 /datum/reagent/fermi/zeolites/on_mob_life(mob/living/carbon/M)
+	metabolization_rate = (4 / purity) * REAGENTS_METABOLISM //Metab rate directly influenced by purity. Linear.
 	var/datum/component/radioactive/contamination = M.GetComponent(/datum/component/radioactive)
 	if(M.radiation > 0)
-		M.radiation -= min(M.radiation, 60)
+		M.radiation -= min(M.radiation, round(20 ** (0.5 + purity), 0.1)) //Far more effective if more pure. Tops out at ~90 at max purity. Exponential.
 	if(contamination && contamination.strength > 0)
-		contamination.strength -= min(contamination.strength, 100)
+		contamination.strength -= min(contamination.strength, round(25 ** (0.5 + purity), 0.1)) //Tops out at ~125 at max purity. Exponential.
 	..()
 
 /datum/reagent/fermi/zeolites/reaction_obj(obj/O, reac_volume)
 	var/datum/component/radioactive/contamination = O.GetComponent(/datum/component/radioactive)
-	if(contamination && reac_volume >= 5)
+	if(contamination && reac_volume >= 5 && purity >= 0.7) //you need at least 0.7 purity to instantly purge all contam on an object.
 		qdel(contamination)
 		return

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -602,7 +602,7 @@
 	OptimalpHMax 	= 5 //2.2 ph levels of optimal ph zone - centered at 3.9 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
 	ReactpHLim 		= 4
 	//CatalystFact 	= 0
-	CurveSharpT 	= 2
+	CurveSharpT 	= 1.5
 	CurveSharppH 	= 3
 	ThermicConstant = 7
 	HIonRelease 	= -0.15

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -591,19 +591,20 @@
 /datum/chemical_reaction/fermi/zeolites
 	name = "Zeolites"
 	id = /datum/reagent/fermi/zeolites
-	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot!
+	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot! - But it's now pretty dangerous, too! The ingredients are supercheap after all...
 	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 	//FermiChem vars:
-	OptimalTempMin 	= 300
-	OptimalTempMax 	= 900
-	ExplodeTemp 	= 1000 //check to see overflow doesn't happen!
-	OptimalpHMin 	= 4.0
-	OptimalpHMax 	= 6.0
+	OptimalTempMin 	= 350
+	OptimalTempMax 	= 750
+	ExplodeTemp 	= 850
+	OptimalpHMin 	= 2.8
+	OptimalpHMax 	= 5.5 //2.7 ph levels of optimal ph zone - centered at 4.15 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
 	ReactpHLim 		= 4
 	//CatalystFact 	= 0
-	CurveSharpT 	= 4
-	CurveSharppH 	= 0
-	ThermicConstant = 0
-	HIonRelease 	= 0.01
-	RateUpLim 		= 15
+	CurveSharpT 	= 2
+	CurveSharppH 	= 3
+	ThermicConstant = 5
+	HIonRelease 	= -0.1
+	RateUpLim 		= 2
+	PurityMin 		= 0.5 //Good luck.
 	FermiChem 		= TRUE

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -598,13 +598,13 @@
 	OptimalTempMax 	= 750
 	ExplodeTemp 	= 850
 	OptimalpHMin 	= 2.8
-	OptimalpHMax 	= 5.5 //2.7 ph levels of optimal ph zone - centered at 4.15 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
+	OptimalpHMax 	= 5 //2.2 ph levels of optimal ph zone - centered at 3.9 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
 	ReactpHLim 		= 4
 	//CatalystFact 	= 0
 	CurveSharpT 	= 5
 	CurveSharppH 	= 3
-	ThermicConstant = 10
+	ThermicConstant = 15
 	HIonRelease 	= -0.2
-	RateUpLim 		= 3
+	RateUpLim 		= 4
 	PurityMin 		= 0.5 //Good luck.
 	FermiChem 		= TRUE

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -591,8 +591,9 @@
 /datum/chemical_reaction/fermi/zeolites
 	name = "Zeolites"
 	id = /datum/reagent/fermi/zeolites
-	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot! - But it's now pretty dangerous, too! The ingredients are supercheap after all...
+	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot! - But it's now somewhat dangerous, and needs a bit of uranium to catalyze the reaction
 	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
+	required_catalysts = list(/datum/reagent/uranium = 5)
 	//FermiChem vars:
 	OptimalTempMin 	= 500
 	OptimalTempMax 	= 750
@@ -601,9 +602,9 @@
 	OptimalpHMax 	= 5 //2.2 ph levels of optimal ph zone - centered at 3.9 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
 	ReactpHLim 		= 4
 	//CatalystFact 	= 0
-	CurveSharpT 	= 3
+	CurveSharpT 	= 2
 	CurveSharppH 	= 3
-	ThermicConstant = 15
+	ThermicConstant = 7
 	HIonRelease 	= -0.15
 	RateUpLim 		= 4
 	PurityMin 		= 0.5 //Good luck.

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -604,7 +604,7 @@
 	CurveSharpT 	= 5
 	CurveSharppH 	= 3
 	ThermicConstant = 15
-	HIonRelease 	= -0.2
+	HIonRelease 	= -0.15
 	RateUpLim 		= 4
 	PurityMin 		= 0.5 //Good luck.
 	FermiChem 		= TRUE

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -601,7 +601,7 @@
 	OptimalpHMax 	= 5 //2.2 ph levels of optimal ph zone - centered at 3.9 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
 	ReactpHLim 		= 4
 	//CatalystFact 	= 0
-	CurveSharpT 	= 5
+	CurveSharpT 	= 3
 	CurveSharppH 	= 3
 	ThermicConstant = 15
 	HIonRelease 	= -0.15

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -594,17 +594,17 @@
 	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot! - But it's now pretty dangerous, too! The ingredients are supercheap after all...
 	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
 	//FermiChem vars:
-	OptimalTempMin 	= 350
+	OptimalTempMin 	= 500
 	OptimalTempMax 	= 750
 	ExplodeTemp 	= 850
 	OptimalpHMin 	= 2.8
 	OptimalpHMax 	= 5.5 //2.7 ph levels of optimal ph zone - centered at 4.15 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
 	ReactpHLim 		= 4
 	//CatalystFact 	= 0
-	CurveSharpT 	= 2
+	CurveSharpT 	= 5
 	CurveSharppH 	= 3
-	ThermicConstant = 5
-	HIonRelease 	= -0.1
-	RateUpLim 		= 2
+	ThermicConstant = 10
+	HIonRelease 	= -0.2
+	RateUpLim 		= 3
 	PurityMin 		= 0.5 //Good luck.
 	FermiChem 		= TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~Foreword, this might need testmerging for a while to find if this is balanced, and to tweak the values some more if it is not. I localtested it a bunch, but of course not in actual situations.~~
It's been testmerged a bunch plus I've tested it alot locally, and I'm pretty happy with it's current state. So, in my opinion this PR is ready now, unless someone has significant concerns.

As of now, zeolites are a incredibly powerful radiation purging chem - that is incredibly easy to make. Ph has no influence on the reaction, and good luck blowing it up if you don't manually set the temp over 1000, since it is temperature inert. Additionally, the ingredients are all base reagents, with the 'hardest' of them, potassium-iodine, being two clicks to make.
This PR aims at making zeolites harder to (mass) produce, while still rewarding those that manage to make them at high purities.

I'm going to try to list the most important changes, though just look at the code to see them all.
### About the reaction itself:
First and foremost, zeolites now have a optimal temp zone of 500 - 750, instead of 300 - 900. Additionally, explosion temp has been lowered from 1000 to 850. It also has a thermic constant of ~~15~~ 7, making it ~~highly~~ moderately exothermic - be careful not to let it go into a chain reaction state with higher heat causing faster reaction speed which in turn causes even more heat.
Though, edit: It's now tweaked to be slightly less brutal on the exponentialness of the reaction speed, so it's a bit more managable now - though you still need a ton of buffer.

It now requires 5u of uranium as catalyst, though that uranium will not be used up during the reaction (as is standard for catalysts)

Their optimal ph zone has been shifted and slightly expanded, from 4 - 6 to 2.8 - 5
Its ph also moves ~~0.2~~ 0.15 ph-levels towards 'acidic' for each 'unit' of reaction.
Addtionally, ph going at least 0.4 levels past the optimal ph section now influences purity, quite severely the further out.
It will fermi-explode at less than 0.5 purity, so watch the ph level and administer buffers if it starts to go past the optimal zone.

The maximum reaction speed at the highest optimal temp has been lowered from 15 to 4, making it somewhat more controllable. Good for you if you don't like exploding / getting acid smoked.

Attendum: Apparently someone accidentally removed being able to use droppers / syringes on beakers in chem heaters, so I quickly readded it since it's pretty crucial for the more difficult fermichems unless you want to pause the reaction every five seconds.

### Now, about the actual reagent:
The reagent now counts as a rare reagent sell-price-wise, which I might change to very-rare like yamerol and some other ones are if people think it is very hard to make (in actually sale-worthy quantities)

Its metabolisation speed is now inversely related to purity, with purity 1 halving metabolisation rate as opposed to the minimum purity of 0.5. (between 4 to 8 * REAGENTS_METABOLISM)
Splashing it on objects to purge any and all contamination now only works if purity is at least 0.7
Its effect in mobs is now also determined by purity, ~~purging between 25 and 125 contamination and between  20 - 90 radiation per tick, exponentially increasing the closer purity is to 1.~~
I tweaked it some more after getting some feedback on it vs the performance of pentetic, new values:
It now purges between 3.3% and 16.6% of _total_ rad amount, per tick, depending on purity, towards zero rads, whereas pentetic purges 2% per tick, and only towards the rad_mob_safe value (About 500 rads, which can be a pretty big difference especially when you are working with percentages of the rad difference to the target value)
The way it works for contam is still the same, between 25 and 125 contam removal per tick, depending on purity.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Zeolites appeared to be a very strong chemical, due to their easy to get ingredients and not actually fermi-chem worthy reaction, considering they didn't really care about ph or heat. This makes them more difficult to make, while still keeping their high usefulness, encouraging experimenting to create high-purity versions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: zeolites are now actual fermichems instead of being incredibly easy to make.
fix: Using syringes / droppers on chem heaters with beakers in them works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
