### PR TITLE
Adds a line that actually saves vore prefs to the vore pref saving

### DIFF
--- a/code/modules/vore/eating/vorepanel.dm
+++ b/code/modules/vore/eating/vorepanel.dm
@@ -661,7 +661,7 @@
 	if(href_list["saveprefs"])
 		if(!(user.client?.prefs))
 			return FALSE
-		if(!user.client.prefs.save_character())
+		if(!user.copy_to_prefs_vr() || !user.client.prefs.save_character())
 			to_chat(user, "<span class='warning'>Belly Preferences not saved!</span>")
 			log_admin("Could not save vore prefs on USER: [user].")
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

we are all idiots today. whoever removed this function from ever being called needs to have a stern talking to

## Why It's Good For The Game

saving: it's supposed to work. 

## Changelog
:cl:
fix: vore prefs save now
/:cl: