### PR TITLE
Makes planetary atmos no longer superconduct

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -312,6 +312,8 @@
 	return TRUE
 
 /turf/open/consider_superconductivity(starting)
+	if(planetary_atmos)
+		return FALSE
 	if(air.return_temperature() < (starting?MINIMUM_TEMPERATURE_START_SUPERCONDUCTION:MINIMUM_TEMPERATURE_FOR_SUPERCONDUCTION))
 		return FALSE
 	if(air.heat_capacity() < M_CELL_WITH_RATIO) // Was: MOLES_CELLSTANDARD*0.1*0.05 Since there are no variables here we can make this a constant.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Planetary turfs are allowed to do superconductivity, which is mostly just wasted processing, since C++ atmos is so fast that temperature on planets ends up evened out super quickly anyway.

## Why It's Good For The Game

Lag bad, this removes a good amount of pointless processing. Plus, superconducting turfs "radiate_to_spess", which makes no sense for planetary turfs.

## Changelog
:cl:
tweak: Planetary atmos no longer does superconduction.
/:cl: