### PR TITLE
THROWING A CLOWN INTO THE SUPERMATTER ENGINE NOW RANDOMLY ADJUSTS ENERGY AND DAMAGE

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -928,8 +928,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		var/mob/living/user = AM
 		if(user.status_flags & GODMODE)
 			return
-		message_admins("[src] has consumed [key_name_admin(user)] [ADMIN_JMP(src)].")
-		investigate_log("has consumed [key_name(user)].", INVESTIGATE_SUPERMATTER)
+		var/add
+		if(user.mind?.assigned_role == "Clown")
+			var/denergy = rand(-1000, 1000)
+			var/ddamage = rand(-150, clamp(150, 0, (explosion_point - damage) + 150))
+			add = ", adding [denergy] energy and [ddamage] damage to the crystal"
+		message_admins("[src] has consumed [key_name_admin(user)] [ADMIN_JMP(src)][add].")
+		investigate_log("has consumed [key_name(user)][add].", INVESTIGATE_SUPERMATTER)
 		user.dust(force = TRUE)
 		if(power_changes)
 			matter_power += 200

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -932,6 +932,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(user.mind?.assigned_role == "Clown")
 			var/denergy = rand(-1000, 1000)
 			var/ddamage = rand(-150, clamp(150, 0, (explosion_point - damage) + 150))
+			energy += denergy
+			damage += ddamage
 			add = ", adding [denergy] energy and [ddamage] damage to the crystal"
 		message_admins("[src] has consumed [key_name_admin(user)] [ADMIN_JMP(src)][add].")
 		investigate_log("has consumed [key_name(user)][add].", INVESTIGATE_SUPERMATTER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just like the singularity
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's not but 🤡 funny
oh and it's capped to 150 below explosion point so you can't instantly blow an engine by touching it and rolling right
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Clowns now have unpredictable effects on supermatter crystals when dusting from contact.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
