### PR TITLE
you can choose your blood colour on customization

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -476,7 +476,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if(pref_species.can_choose_blood_color)
 				var/button_color = features["bloodcolor"]
 				if(!button_color || button_color == "None")
-					button_color = "#" + pref_species.exotic_blood_color //if no option is given, then we just accept it as the species default
+					button_color = pref_species.exotic_blood_color //if no option is given, then we just accept it as the species default
 				dat += "<h3>Blood Color</h3>"
 				dat += "<span style='border: 1px solid #161616; background-color: [button_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=bloodcolor;task=input'>Change</a><BR>"
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -104,6 +104,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/features = list("mcolor" = "FFFFFF",
 		"mcolor2" = "FFFFFF",
 		"mcolor3" = "FFFFFF",
+		"bloodcolor" = "None" //this means dont change it
 		"tail_lizard" = "Smooth",
 		"tail_human" = "None",
 		"snout" = "Round",
@@ -471,6 +472,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				dat += "<b>Tertiary Color:</b><BR>"
 				dat += "<span style='border: 1px solid #161616; background-color: #[features["mcolor3"]];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=mutant_color3;task=input'>Change</a><BR>"
 				mutant_colors = TRUE
+
+			if(pref_species.can_choose_blood_color)
+				var/button_color = features["bloodcolor"]
+				if(!button_color || button_color == "None")
+					button_color = "#" + pref_species.exotic_blood_color //if no option is given, then we just accept it as the species default
+				dat += "<h3>Blood Color<\h3>"
+				dat += "<span style='border: 1px solid #161616; background-color: [button_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=bloodcolor;task=input'>Change</a><BR>"
 
 			if (CONFIG_GET(number/body_size_min) != CONFIG_GET(number/body_size_max))
 				dat += "<b>Sprite Size:</b> <a href='?_src_=prefs;preference=body_size;task=input'>[features["body_size"]*100]%</a><br>"
@@ -1668,6 +1676,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							features["mcolor3"] = sanitize_hexcolor(new_mutantcolor, 6)
 						else
 							to_chat(user, "<span class='danger'>Invalid color. Your color is not bright enough.</span>")
+
+				if("bloodcolor")
+					var/button_color = features["bloodcolor"]
+					if(!button_color || button_color == "None")
+						button_color = pref_species.exotic_blood_color //if no option is given, then we just accept it as the species default
+					var/new_bloodcolor = input(user, "Choose your character's blood color", "Character Preference", button_color) as color|null
+					if(new_bloodcolor)
+						features["bloodcolor"] = "#" + sanitize_hexcolor(new_bloodcolor, 6)
 
 				if("mismatched_markings")
 					show_mismatched_markings = !show_mismatched_markings

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//Job preferences 2.0 - indexed by job title , no key or value implies never
 	var/list/job_preferences = list()
 
-		// Want randomjob if preferences already filled - Donkie
+	// Want randomjob if preferences already filled - Donkie
 	var/joblessrole = BERANDOMJOB  //defaults to 1 for fewer assistants
 
 	// 0 = character settings, 1 = game preferences

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/list/features = list("mcolor" = "FFFFFF",
 		"mcolor2" = "FFFFFF",
 		"mcolor3" = "FFFFFF",
-		"bloodcolor" = "None" //this means dont change it
+		"bloodcolor" = "None", //this means dont change it
 		"tail_lizard" = "Smooth",
 		"tail_human" = "None",
 		"snout" = "Round",
@@ -477,7 +477,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/button_color = features["bloodcolor"]
 				if(!button_color || button_color == "None")
 					button_color = "#" + pref_species.exotic_blood_color //if no option is given, then we just accept it as the species default
-				dat += "<h3>Blood Color<\h3>"
+				dat += "<h3>Blood Color</h3>"
 				dat += "<span style='border: 1px solid #161616; background-color: [button_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=bloodcolor;task=input'>Change</a><BR>"
 
 			if (CONFIG_GET(number/body_size_min) != CONFIG_GET(number/body_size_max))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	37
+#define SAVEFILE_VERSION_MAX	39
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -216,6 +216,13 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 				eye_type = "moth"
 			else
 				eye_type = "insect"
+
+	if(current_version < 39) //sets everyones blood color back to the species default
+		if(S["species"])
+			var/current_species = GLOB.species_list[S["species"]]
+			if(current_species)
+				var/datum/species/the_species = current_species
+				features["bloodcolor"] = initial(the_species.exotic_blood_color)
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)
@@ -722,7 +729,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	jumpsuit_style					= sanitize_inlist(jumpsuit_style, GLOB.jumpsuitlist, initial(jumpsuit_style))
 	uplink_spawn_loc				= sanitize_inlist(uplink_spawn_loc, GLOB.uplink_spawn_loc_list, initial(uplink_spawn_loc))
 	features["mcolor"]				= sanitize_hexcolor(features["mcolor"], 6, FALSE)
-	features["bloodcolor"]			= sanitize_hexcolor(features["bloodcolor"], 6, FALSE)
+	if(features["bloodcolor"] != "None")
+		features["bloodcolor"]			= sanitize_hexcolor(features["bloodcolor"], 6, FALSE)
 	features["tail_lizard"]			= sanitize_inlist(features["tail_lizard"], GLOB.tails_list_lizard)
 	features["tail_human"]			= sanitize_inlist(features["tail_human"], GLOB.tails_list_human)
 	features["snout"]				= sanitize_inlist(features["snout"], GLOB.snouts_list)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -591,6 +591,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_genitals_use_skintone"]	>> features["genitals_use_skintone"]
 	S["feature_mcolor2"]				>> features["mcolor2"]
 	S["feature_mcolor3"]				>> features["mcolor3"]
+	S["feature_bloodcolor"]				>> features["bloodcolor"]
 	S["feature_mam_body_markings"]		>> features["mam_body_markings"]
 	S["feature_mam_tail"]				>> features["mam_tail"]
 	S["feature_mam_ears"]				>> features["mam_ears"]
@@ -721,6 +722,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	jumpsuit_style					= sanitize_inlist(jumpsuit_style, GLOB.jumpsuitlist, initial(jumpsuit_style))
 	uplink_spawn_loc				= sanitize_inlist(uplink_spawn_loc, GLOB.uplink_spawn_loc_list, initial(uplink_spawn_loc))
 	features["mcolor"]				= sanitize_hexcolor(features["mcolor"], 6, FALSE)
+	features["bloodcolor"]			= sanitize_hexcolor(features["bloodcolor"], 6, FALSE)
 	features["tail_lizard"]			= sanitize_inlist(features["tail_lizard"], GLOB.tails_list_lizard)
 	features["tail_human"]			= sanitize_inlist(features["tail_human"], GLOB.tails_list_human)
 	features["snout"]				= sanitize_inlist(features["snout"], GLOB.snouts_list)
@@ -858,6 +860,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["medical_records"]			, medical_records)
 
 	WRITE_FILE(S["feature_mcolor"]					, features["mcolor"])
+	WRITE_FILE(S["feature_bloodcolor"]				, features["bloodcolor"])
 	WRITE_FILE(S["feature_lizard_tail"]				, features["tail_lizard"])
 	WRITE_FILE(S["feature_human_tail"]				, features["tail_human"])
 	WRITE_FILE(S["feature_lizard_snout"]			, features["snout"])

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -72,6 +72,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	var/list/special_step_sounds //Sounds to override barefeet walkng
 	var/grab_sound //Special sound for grabbing
 	var/datum/outfit/outfit_important_for_life // A path to an outfit that is important for species life e.g. plasmaman outfit
+	var/can_choose_blood_color = TRUE
 
 	// species-only traits. Can be found in DNA.dm
 	var/list/species_traits = list(HAS_FLESH,HAS_BONE) //by default they can scar and have bones/flesh unless set to something else
@@ -317,6 +318,11 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 	if(exotic_bloodtype && C.dna.blood_type != exotic_bloodtype)
 		C.dna.blood_type = exotic_bloodtype
+
+	if(can_choose_blood_color)
+		var/chosen_blood = C.dna.features["bloodcolor"]
+		if(chosen_blood != "None")
+			exotic_blood_color = chosen_blood
 
 	if(old_species.mutanthands)
 		for(var/obj/item/I in C.held_items)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -14,6 +14,7 @@
 	exotic_blood = /datum/reagent/blood/jellyblood
 	exotic_bloodtype = "GEL"
 	exotic_blood_color = "BLOOD_COLOR_SLIME"
+	can_choose_blood_color = FALSE //you cant choose it because it will always be set to your body colour as a slime
 	damage_overlay_type = ""
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 	var/datum/action/innate/slime_change/slime_change	//CIT CHANGE


### PR DESCRIPTION
## About The Pull Request
we went through the cbt of detaching blood colour from blood type so we might as well use it for more than slime blood
[insert white blood = cum joke here]

this is pretty uninvasive as far as customization changes go because it starts as "None" which means it acts like your blood colour is your species default blood colour

which means absolutely no change is made to anyones savefiles, including no required migrations

here's an example where i made my blood orange as a human
![image](https://user-images.githubusercontent.com/59849408/95615841-c731cd00-0a60-11eb-8140-d5dfa7bd119e.png)

as an extra note: this option is not enabled for slimes because a slimes blood colour is already their body colour
and once again yes i spelt it as 'color' in the code instead of 'colour' you damn americans ruining words

## Why It's Good For The Game
all heil customization

## Changelog
:cl:
add: blood colour is now an option on the customization menu
/:cl:
