### PR TITLE
Fixes cloning computer UI not updating when pressing certain buttons - also adds extra check for names to update a message

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -196,7 +196,7 @@
 					dat += "[scanner_occupant] => Scanning..."
 				else
 					if(use_records)
-						if(scanner_occupant.name != scantemp_name || scanner_occupant.ckey != scantemp_ckey)
+						if(scanner_occupant.ckey != scantemp_ckey || scanner_occupant.name != scantemp_name)
 							scantemp = "Ready to Scan"
 							scantemp_ckey = scanner_occupant.ckey
 							scantemp_name = scanner_occupant.name
@@ -298,17 +298,18 @@
 				autoprocess = FALSE
 				STOP_PROCESSING(SSmachines, src)
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+		src.updateUsrDialog()
 		. = TRUE
 
 	else if ((href_list["scan"]) && !isnull(scanner) && scanner.is_operational())
 		scantemp = ""
 
 		loading = TRUE
-		src.updateUsrDialog()
 		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 		say("Initiating scan...")
 		var/prev_locked = scanner.locked
 		scanner.locked = TRUE
+		src.updateUsrDialog()
 		addtimer(CALLBACK(src, .proc/finish_scan, scanner.occupant, prev_locked), 2 SECONDS)
 		. = TRUE
 
@@ -320,6 +321,7 @@
 		else
 			scanner.locked = FALSE
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+		src.updateUsrDialog()
 		. = TRUE
 
 
@@ -461,7 +463,6 @@
 	if(!scanner || !L)
 		return
 	src.add_fingerprint(usr)
-	src.updateUsrDialog()
 
 	if(use_records)
 		scan_occupant(L)
@@ -469,9 +470,10 @@
 		clone_occupant(L)
 
 	loading = FALSE
+	scanner.locked = prev_locked
 	src.updateUsrDialog()
 	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-	scanner.locked = prev_locked
+	
 
 /obj/machinery/computer/cloning/proc/scan_occupant(occupant)
 	var/mob/living/mob_occupant = get_mob_or_brainmob(occupant)

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -12,6 +12,7 @@
 	var/list/pods //Linked cloning pods
 	var/temp = "Inactive"
 	var/scantemp_ckey
+	var/scantemp_name
 	var/scantemp = "Ready to Scan"
 	var/menu = 1 //Which menu screen to display
 	var/datum/data/record/active_record = null
@@ -195,9 +196,10 @@
 					dat += "[scanner_occupant] => Scanning..."
 				else
 					if(use_records)
-						if(scanner_occupant.ckey != scantemp_ckey)
+						if(scanner_occupant.name != scantemp_name || scanner_occupant.ckey != scantemp_ckey)
 							scantemp = "Ready to Scan"
 							scantemp_ckey = scanner_occupant.ckey
+							scantemp_name = scanner_occupant.name
 					else
 						scantemp = "Ready to Clone"
 					dat += "[scanner_occupant] => [scantemp]"
@@ -340,6 +342,7 @@
 				src.menu = 3
 		else
 			src.temp = "Record missing."
+		src.updateUsrDialog()
 		. = TRUE
 
 	else if (href_list["del_rec"])
@@ -348,6 +351,7 @@
 		if (src.menu == 3) //If we are viewing a record, confirm deletion
 			src.temp = "Delete record?"
 			src.menu = 4
+			src.updateUsrDialog()
 			playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 
 		else if (src.menu == 4)
@@ -357,12 +361,14 @@
 					src.temp = "[src.active_record.fields["name"]] => Record deleted."
 					src.records.Remove(active_record)
 					active_record = null
+					src.updateUsrDialog()
 					playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 					src.menu = 2
 					var/obj/item/circuitboard/computer/cloning/board = circuit
 					board.records = records
 				else
 					src.temp = "<font class='bad'>Access Denied.</font>"
+					src.updateUsrDialog()
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		. = TRUE
 
@@ -384,6 +390,7 @@
 				for(var/key in diskette.fields)
 					src.active_record.fields[key] = diskette.fields[key]
 				src.temp = "Load successful."
+				src.updateUsrDialog()
 				var/obj/item/circuitboard/computer/cloning/board = circuit
 				board.records = records
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
@@ -403,6 +410,7 @@
 				diskette.fields = active_record.fields.Copy()
 				diskette.name = "data disk - '[src.diskette.fields["name"]]'"
 				src.temp = "Save successful."
+				src.updateUsrDialog()
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 		. = TRUE
 
@@ -431,17 +439,21 @@
 				if(active_record == C)
 					active_record = null
 				menu = 1
+				src.updateUsrDialog()
 			else
 				temp = "[C.fields["name"]] => <font class='bad'>Initialisation failure.</font>"
+				src.updateUsrDialog()
 				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 
 		else
 			temp = "<font class='bad'>Data corruption.</font>"
+			src.updateUsrDialog()
 			playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		. = TRUE
 
 	else if (href_list["menu"] && use_records)
 		menu = text2num(href_list["menu"])
+		src.updateUsrDialog()
 		playsound(src, "terminal_type", 25, 0)
 		. = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bug fix until someone here randomly decides to update the cloner to newest TGUI setup - which would require acting of their own since TG removed cloning after all, and it wouldn't be on their top priority.

The extra check is in case someone decides to shove a mob that doesn't have a ckey attached into the scanner. Provides better feedback if you want to use a monkeyman or something in the experimental version of the cloner.

## Why It's Good For The Game

Don't you just love having to press either the refresh button or the console itself when you're trying to clone someone, or toggling the lock on the scanner or something like that?

Too bad, you don't have to press it anymore.

## Changelog
:cl:
fix: Fixes cloning computer UI not updating when pressing certain buttons - also adds extra check for names to update a message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
