### PR TITLE
Fixes a race condition in the surgery unit test that causes it to fail at random

### DIFF
--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -42,7 +42,7 @@
 
 	var/datum/surgery/organ_manipulation/surgery_for_one = new
 	
-	sleep() // if we don't have this, then the next surgery step can start *before* the previous one does, which is no good
+	sleep(0.2) // if we don't have this, then the next surgery step can start *before* the previous one does, which is no good
 
 	// Without waiting for the incision to complete, try to start a new surgery
 	TEST_ASSERT(!surgery_step.initiate(user, patient_one, BODY_ZONE_CHEST, scalpel, surgery_for_one), "Was allowed to start a second surgery without the rod of asclepius")

--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -41,6 +41,8 @@
 	TEST_ASSERT(surgery_for_zero.step_in_progress, "Surgery on patient zero was not initiated")
 
 	var/datum/surgery/organ_manipulation/surgery_for_one = new
+	
+	sleep() // if we don't have this, then the next surgery step can start *before* the previous one does, which is no good
 
 	// Without waiting for the incision to complete, try to start a new surgery
 	TEST_ASSERT(!surgery_step.initiate(user, patient_one, BODY_ZONE_CHEST, scalpel, surgery_for_one), "Was allowed to start a second surgery without the rod of asclepius")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Sometimes the second surgery step starts *before* the first one, due to the nature of INVOKE_ASYNC. This PR aims to fix that. Because it's travis-based, this is a webedit that I didn't test. This PR is the test.

## Why It's Good For The Game

Travis randomly failing... bad.

## Changelog
:cl:
fix: Multi-surgery unit test no longer fails at random.
/:cl: