### PR TITLE
Changes spawn rate for wittel geysers from 1 in 27 to 1 in 20

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -45,6 +45,7 @@
 /obj/structure/geyser/random
 	erupting_state = null
 	var/list/options = list(/datum/reagent/clf3 = 7, /datum/reagent/water/hollowwater = 7, /datum/reagent/medicine/omnizine/protozine = 5, /datum/reagent/wittel = 1)
+	//Currently set to 7/20 chance for clf3 and hollowater, 5/20 for protozine, and 1/20 for wittel
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/geyser/random
 	erupting_state = null
-	var/list/options = list(/datum/reagent/clf3 = 10, /datum/reagent/water/hollowwater = 10, /datum/reagent/medicine/omnizine/protozine = 6, /datum/reagent/wittel = 1)
+	var/list/options = list(/datum/reagent/clf3 = 7, /datum/reagent/water/hollowwater = 7, /datum/reagent/medicine/omnizine/protozine = 5, /datum/reagent/wittel = 1)
 
 /obj/structure/geyser/random/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes the spawn rate for wittel from 1 in 27 to 1 in 20 leaving it as still rare but means that the chemical is actually available. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it less frustrating to get wittel which is already a difficult chem to get and use as it requires a miner to find multiple geysers, use a reinforced plunger on them, and lastly collecting the chemicals and taking them to the station which can be done with a beaker or a large plumbing project.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The spawn rate of wittel has been upped to 1 in 20 up from 1 in 27.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
