### PR TITLE
adds empty() proc to pipelines that purges all connected airs to avoid sdql2 and proccall torture (SPT) whenever atmos breaks and the station is -#1.IND degrees hot

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -208,7 +208,11 @@
 		stack_trace("[src]([REF(src)]) has one or more null gas mixtures, which may cause bugs. Null mixtures will not be considered in reconcile_air().")
 		return listclearnulls(.)
 
-/datum/pipeline/proc/reconcile_air()
+/datum/pipeline/proc/empty()
+	for(var/datum/gas_mixture/GM in get_all_connected_airs()
+		GM.empty()
+
+/datum/pipeline/proc/get_all_connected_airs()
 	var/list/datum/gas_mixture/GL = list()
 	var/list/datum/pipeline/PL = list()
 	PL += src
@@ -233,6 +237,10 @@
 				var/obj/machinery/atmospherics/components/unary/portables_connector/C = atmosmch
 				if(C.connected_device)
 					GL += C.portableConnectorReturnAir()
+	return GL
+
+/datum/pipeline/proc/reconcile_air()
+	var/list/datum/gas_mixture/GL = get_all_connected_airs()
 
 	var/total_thermal_energy = 0
 	var/total_heat_capacity = 0

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -210,7 +210,7 @@
 
 /datum/pipeline/proc/empty()
 	for(var/datum/gas_mixture/GM in get_all_connected_airs())
-		GM.empty()
+		GM.clear()
 
 /datum/pipeline/proc/get_all_connected_airs()
 	var/list/datum/gas_mixture/GL = list()

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -209,7 +209,7 @@
 		return listclearnulls(.)
 
 /datum/pipeline/proc/empty()
-	for(var/datum/gas_mixture/GM in get_all_connected_airs()
+	for(var/datum/gas_mixture/GM in get_all_connected_airs())
 		GM.empty()
 
 /datum/pipeline/proc/get_all_connected_airs()


### PR DESCRIPTION
also useful for grief fixing