### PR TITLE
Fixes subtle hotkey, adds subtler anti-ghost hotkey

### DIFF
--- a/code/modules/keybindings/keybind/mob.dm
+++ b/code/modules/keybindings/keybind/mob.dm
@@ -107,7 +107,18 @@
 
 /datum/keybinding/living/subtle/down(client/user)
 	var/mob/living/L = user.mob
-	L.subtle_keybind()
+	L.subtle()
+	return TRUE
+
+/datum/keybinding/living/subtler
+	hotkey_keys = list("6")
+	classic_keys = list()
+	name = "subtler_emote"
+	full_name = "Subtler Anti-Ghost Emote"
+
+/datum/keybinding/living/subtler/down(client/user)
+	var/mob/living/L = user.mob
+	L.subtler()
 	return TRUE
 
 /datum/keybinding/mob/whisper

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -83,7 +83,6 @@ proc/get_top_level_mob(var/mob/S)
 	message = null
 	mob_type_blacklist_typecache = list(/mob/living/brain)
 
-
 /datum/emote/living/subtler/proc/check_invalid(mob/user, input)
 	if(stop_bad_mime.Find(input, 1, 1))
 		to_chat(user, "<span class='danger'>Invalid emote.</span>")
@@ -129,12 +128,6 @@ proc/get_top_level_mob(var/mob/S)
 		user.visible_message(message=message,self_message=message,vision_distance=1, ignored_mobs = GLOB.dead_mob_list)
 
 ///////////////// VERB CODE
-/mob/living/proc/subtle_keybind()
-	var/message = input(src, "", "subtle") as text|null
-	if(!length(message))
-		return
-	return subtle(message)
-
 /mob/living/verb/subtle()
 	set name = "Subtle"
 	set category = "IC"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The behavior of the subtle hotkey, triggered by pressing 5 was the following:
- Created a prompt for the input supposedly to subtle
- Type in a message
- The message doesn't get sent, and instead it just pops up Subtle.

Looking at the code, it probably was supposed to call the subtle verb with the message but... _there's no parameter available for it to be put into._ 

My change just makes the hotkey go for subtle directly, much like the "me" hotkey.

I also added a new Subtler hotkey that follows the same behavior as the other hotkey. Default key is 6, respective to subtle's 5.

## Why It's Good For The Game
Fixed horny button, easier horny buttons

## Changelog
:cl:
fix: Fixed the subtle hotkey being weird with its input prompts.
add: Adds a subtler anti-ghost hotkey. Default key is 6.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
