### PR TITLE
Altclick gasmasks and any subtypes like mime/clown masks to toggle facial visibility. Now with toggleable plasmaman helmets too.

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -11,6 +11,44 @@
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH
 	resistance_flags = NONE
 	mutantrace_variation = STYLE_MUZZLE
+	var/held_flags_inv = 0
+	var/held_visor_flags_inv = 0
+	var/face_shown = FALSE
+
+/obj/item/clothing/mask/gas/AltClick(mob/user)
+	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+		return
+	toggle_face_visibility(user)
+	return TRUE
+
+/obj/item/clothing/mask/gas/proc/toggle_face_visibility()
+	set src in usr
+
+	if(!can_use(usr))
+		return 0
+
+	src.face_shown = !src.face_shown
+	if(src.face_shown)
+		src.held_flags_inv = src.flags_inv
+		src.held_visor_flags_inv = src.visor_flags_inv
+		if(src.mask_adjusted) //is it one of those toggleable masks like the sechailer?
+			src.held_flags_inv |= src.held_visor_flags_inv //make sure we're not missing anything in that case.
+		src.flags_inv &= HIDEEYES|HIDEFACIALHAIR //still obstruct eyes and facial hair if gas mask subtype is hiding them, otherwise don't.
+		src.visor_flags_inv &= HIDEEYES|HIDEFACIALHAIR
+	else
+		src.flags_inv = src.held_flags_inv
+		src.visor_flags_inv = src.held_visor_flags_inv
+		if(src.mask_adjusted) //is it one of those toggleable masks like the sechailer?
+			src.flags_inv &= ~src.visor_flags_inv //woosh
+	to_chat(usr, "<span class='notice'>You adjust [src], [src.face_shown?"reveal":"obscur"]ing facial details while worn.</span>")
+	usr.update_inv_wear_mask()
+
+/obj/item/clothing/mask/gas/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>The mask is currently adjusted to [src.face_shown?"reveal":"obscure"] facial details.</span>"
+	. += "<span class='notice'>Alt-click on [src] to toggle facial obscurity.</span>"
+
 
 /obj/item/clothing/mask/gas/glass
 	name = "glass gas mask"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -90,7 +90,7 @@
 	src.face_shown = !src.face_shown
 	if(src.face_shown)
 		src.held_flags_inv = src.flags_inv
-		src.flags_inv &= HIDEEYES|HIDEFACIALHAIR //imagine if plasmemes could get facial hair.
+		src.flags_inv &= HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT //imagine if plasmemes could get facial hair.
 	else
 		src.flags_inv = src.held_flags_inv
 	to_chat(usr, "<span class='notice'>You adjust [src], [src.face_shown?"reveal":"obscur"]ing facial details while worn.</span>")

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -50,7 +50,6 @@
 	var/held_flags_inv = 0
 	var/face_shown = FALSE
 
-
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	if(!light_overlay)
 		return

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -47,6 +47,9 @@
 	var/light_overlay = "envirohelm-light"
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	mutantrace_variation = NONE
+	var/held_flags_inv = 0
+	var/face_shown = FALSE
+
 
 /obj/item/clothing/head/helmet/space/plasmaman/attack_self(mob/user)
 	if(!light_overlay)
@@ -71,6 +74,33 @@
 	. = ..()
 	if(!isinhands && on)
 		. += mutable_appearance(icon_file, light_overlay)
+
+/obj/item/clothing/head/helmet/space/plasmaman/AltClick(mob/user)
+	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
+		return
+	toggle_face_visibility(user)
+	return TRUE
+
+/obj/item/clothing/head/helmet/space/plasmaman/proc/toggle_face_visibility()
+	set src in usr
+
+	if(!can_use(usr))
+		return 0
+
+	src.face_shown = !src.face_shown
+	if(src.face_shown)
+		src.held_flags_inv = src.flags_inv
+		src.flags_inv &= HIDEEYES|HIDEFACIALHAIR //imagine if plasmemes could get facial hair.
+	else
+		src.flags_inv = src.held_flags_inv
+	to_chat(usr, "<span class='notice'>You adjust [src], [src.face_shown?"reveal":"obscur"]ing facial details while worn.</span>")
+	usr.update_inv_head()
+
+/obj/item/clothing/head/helmet/space/plasmaman/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>The helmet is currently adjusted to [src.face_shown?"reveal":"obscure"] facial details.</span>"
+	. += "<span class='notice'>Alt-click on [src] to toggle facial obscurity.</span>"
 
 /obj/item/clothing/head/helmet/space/plasmaman/security
 	name = "security plasma envirosuit helmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This was requested, and not the first time I heard about this suggestion before.
![you got your wish](https://user-images.githubusercontent.com/57083662/96212088-cac6c780-0f2a-11eb-89c6-8e2f8b27fcf5.png)

This enables mimes, clowns, and gas-mask obsessed assistants to choose whether or not their facial details are obstructed when wearing a mask.

This, in essence, allows wearers of said mask to no longer be hidden on examine, and allows their flavor text to be read.

You can examine a gas mask/gas mask subtype to determine whether or not obscurity is currently toggled on or not.

If this forms some sort of salty meta somehow (I.E. security getting uppity about someone obscuring their face), I can probably move all clown/mime/costume related things to a costume subtype where these procs will be applied there instead but for now, this applies to all gas masks.

Update: 
Plasmaman helmets now have the same function. Finally, plasmamen have visible flavor text.

## Why It's Good For The Game

Allows for funny flavor text to be shown under current mechanics for masked people, particularly the mime and clown. Plasmemes also can finally show their flavortext and have a way to show their identity without an ID since they're stuck in a helmet all the time.

maybe it can be useful for masked slimepeople who don't want to get fucked over by medical people who makes quick judgements based on examine and not by health analyzer (please don't do this). In contrast it can also let antagonists know more about your nature species-wise otherwise and how to exploit it. Plantpeople do hate weed killer and goats and all that.

## Changelog
:cl:
add: You can now altclick gasmasks and subtypes like mime/clown masks to toggle facial visibility. Examine a gasmask/subtype to determine facial visibility.
add: Like gasmasks, you can altclick plasmaman helmets to toggle facial visibility.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
