### PR TITLE
Fixed species-specific drinks not giving a mood boost if right species

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2284,7 +2284,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C, method=TOUCH)
 	if(method == INGEST)
-		if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
+		if(C?.dna?.species?.species_category == species_required) //species have a species_category variable that refers to one of the drinks
 			quality = RACE_DRINK
 		else
 			C.adjust_disgust(disgust)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2279,7 +2279,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 ////////////////////
 /datum/reagent/consumable/ethanol/species_drink
 	var/species_required
-	var/disgust = 30
+	var/disgust = 26
 	boozepwr = 50
 
 /datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C, method=TOUCH)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2282,12 +2282,13 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	var/disgust = 30
 	boozepwr = 50
 
-/datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C, method=TOUCH, reac_volume)
-	if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
-		quality = RACE_DRINK
-	else
-		C.adjust_disgust(disgust)
-	return ..()
+/datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C, method=TOUCH)
+	if(method == INGEST)
+		if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
+			quality = RACE_DRINK
+		else
+			C.adjust_disgust(disgust)
+		return ..()
 
 /datum/reagent/consumable/ethanol/species_drink/coldscales
 	name = "Coldscales"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2279,10 +2279,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 ////////////////////
 /datum/reagent/consumable/ethanol/species_drink
 	var/species_required
-	var/disgust = 25
+	var/disgust = 30
 	boozepwr = 50
 
-/datum/reagent/consumable/ethanol/species_drink/on_mob_life(mob/living/carbon/C)
+/datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C, method=TOUCH, reac_volume)
 	if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
 		quality = RACE_DRINK
 	else

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2279,15 +2279,14 @@ All effects don't start immediately, but rather get worse over time; the rate is
 ////////////////////
 /datum/reagent/consumable/ethanol/species_drink
 	var/species_required
-	var/disgust = 26
+	var/disgust = 30
 	boozepwr = 50
 
-/datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C)
-	if(method == INGEST)
-		if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
-			quality = RACE_DRINK
-		else
-			C.adjust_disgust(disgust)
+/datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C, method=TOUCH, reac_volume)
+	if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
+		quality = RACE_DRINK
+	else
+		C.adjust_disgust(disgust)
 	return ..()
 
 /datum/reagent/consumable/ethanol/species_drink/coldscales

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2279,14 +2279,15 @@ All effects don't start immediately, but rather get worse over time; the rate is
 ////////////////////
 /datum/reagent/consumable/ethanol/species_drink
 	var/species_required
-	var/disgust = 30
+	var/disgust = 26
 	boozepwr = 50
 
-/datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C, method=TOUCH, reac_volume)
-	if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
-		quality = RACE_DRINK
-	else
-		C.adjust_disgust(disgust)
+/datum/reagent/consumable/ethanol/species_drink/reaction_mob(mob/living/carbon/C)
+	if(method == INGEST)
+		if(C.dna.species && C.dna.species.species_category == species_required) //species have a species_category variable that refers to one of the drinks
+			quality = RACE_DRINK
+		else
+			C.adjust_disgust(disgust)
 	return ..()
 
 /datum/reagent/consumable/ethanol/species_drink/coldscales


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There was a bug where drinking a species-special drink didn't give a mood boost like it's supposed to. I'm fixing that.

What caused this?
The reagent event used was "on_mob_life" rather than "reaction_mob". 
"on_mob_life" is triggered while the reagent is inside the character's body. "reaction_mob" is triggered upon initially taking the reagent into your body.

Initially, the drink does not count as a "DRINK_SPECIES" up until it detects an appropriate species on_mob_life.

Drink mood boosts are only applied when you initially take a sip, and only via ingestion. Dictated by "/datum/reagent/consumable/reaction_mob".

This means that after setting itself to "DRINK_SPECIES", it becomes pointless because it's already passed that point where it gives the mood boost.

This pull request will correct the code to be "reaction_mob" instead. This pull request also changes the disgust default to 26 from 25, to make the "barfy face" appear on your first sip, so you know you're drinking something bad for you immediately.

This change also means you thankfully can't weaponize species drinks (beyond the booze factor) to make people vomit horribly using a syringe gun. Because with the current code, it was making you a _horrible stunlocked vomiting mess with even just five of an incorrect species drink reagent_, **because it was applying massive chunks of disgust for each tick instead of upon one sip**.

## Why It's Good For The Game

I just wanna be a happy slimeperson that's drinking my Jell Wyrm.

also fixes are good.

## Changelog
:cl:
fix: Fixed species-specific drinks not giving a mood boost if you are that species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
