### PR TITLE
the snow taxi is no longer the slow taxi

### DIFF
--- a/_maps/shuttles/snow_taxi.dmm
+++ b/_maps/shuttles/snow_taxi.dmm
@@ -39,6 +39,7 @@
 	name = "Mining Shuttle Airlock"
 	},
 /obj/docking_port/mobile{
+	callTime = 5;
 	dwidth = 3;
 	height = 4;
 	id = "snow_taxi";


### PR DESCRIPTION

## About The Pull Request

the shuttle now takes about 1/2 a second in transit after a 6 second warmup to travel, and is therefore only slightly slower than the pads
## Why It's Good For The Game

nobody fucking uses the taxi the map is named after.

## Changelog
:cl:
tweak: the snow taxi is no longer the slow taxi
/:cl:
