### PR TITLE
autosurgeons from the travelling trader have uses set to 1 instead of INFINITY

### DIFF
--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -321,6 +321,7 @@ mob/living/carbon/human/dummy/travelling_trader/animal_hunter/Initialize()
 	var/new_implant = new chosen_implant
 	var/obj/item/autosurgeon/reward = new(get_turf(src))
 	reward.insert_organ(new_implant)
+	reward.uses = 1
 
 /datum/outfit/otherworldly_surgeon
 	name = "Otherworldly Surgeon"


### PR DESCRIPTION
## About The Pull Request
coder moment

## Why It's Good For The Game
please dont give out infinite use autosurgeons

## Changelog
:cl:
tweak: autosurgeons from travelling trader rewards now only have one use
/:cl: