### PR TITLE
Fixes matrix color randomization in /proc/randomize_human

### DIFF
--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -33,7 +33,9 @@
 	H.saved_socks = H.socks
 
 	// Mutant randomizing, doesn't affect the mob appearance unless it's the specific mutant.
-	H.dna.features["mcolor"] = random_short_color()
+	H.dna.features["mcolor"] = sanitize_hexcolor(random_short_color(), 6)
+	H.dna.features["mcolor2"] = sanitize_hexcolor(random_short_color(), 6)
+	H.dna.features["mcolor3"] = sanitize_hexcolor(random_short_color(), 6)
 	H.dna.features["tail_lizard"] = pick(GLOB.tails_list_lizard)
 	H.dna.features["snout"] = pick(GLOB.snouts_list)
 	H.dna.features["horns"] = pick(GLOB.horns_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes colors applying incorrectly to matrixed body parts after calling /proc/randomize_human
Problem described in issue : https://github.com/Citadel-Station-13/Citadel-Station-13/issues/13594
## Why It's Good For The Game

Makes it less obvious that someone has used appearance changing effects like mulligan if they had matrixed parts (like Naga taur or synth lizard snouts)

## Changelog
:cl:
fix: fixed randomization of colors for things like mulligan and Stabilized green slime extract for matrixed body parts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
