### PR TITLE
antagonistic items will no longer fail to be placed on you

### DIFF
--- a/code/game/gamemodes/gangs/gang.dm
+++ b/code/game/gamemodes/gangs/gang.dm
@@ -197,7 +197,7 @@
 
 	if(gangtool)//Here is where all of the text occurs when a gang boss first spawns in.
 		var/obj/item/device/gangtool/G = new()
-		var/where = H.equip_in_one_of_slots(G, slots)
+		var/where = H.equip_in_one_of_slots(G, slots, critical = TRUE)
 		if (!where)
 			to_chat(H, "Your Syndicate benefactors were unfortunately unable to get you a Gangtool.")
 		else
@@ -207,7 +207,7 @@
 
 	if(pen)
 		var/obj/item/pen/gang/T = new()
-		var/where2 = H.equip_in_one_of_slots(T, slots)
+		var/where2 = H.equip_in_one_of_slots(T, slots, critical = TRUE)
 		if (!where2)
 			to_chat(H, "Your Syndicate benefactors were unfortunately unable to get you a recruitment pen to start.")
 		else
@@ -215,7 +215,7 @@
 
 	if(spraycan)
 		var/obj/item/toy/crayon/spraycan/gang/SC = new(null,gang)
-		var/where3 = H.equip_in_one_of_slots(SC, slots)
+		var/where3 = H.equip_in_one_of_slots(SC, slots, critical = TRUE)
 		if (!where3)
 			to_chat(H, "Your Syndicate benefactors were unfortunately unable to get you a territory spraycan to start.")
 		else
@@ -223,7 +223,7 @@
 
 	if(hud)
 		var/obj/item/clothing/glasses/hud/security/chameleon/C = new(null,gang)
-		var/where4 = H.equip_in_one_of_slots(C, slots)
+		var/where4 = H.equip_in_one_of_slots(C, slots, critical = TRUE)
 		if (!where4)
 			to_chat(H, "Your Syndicate benefactors were unfortunately unable to get you a chameleon security HUD.")
 		else

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -166,7 +166,7 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 			var/list/slots = list("backpack" = SLOT_IN_BACKPACK)
 			for(var/eq_path in special_equipment)
 				var/obj/O = new eq_path
-				H.equip_in_one_of_slots(O, slots)
+				H.equip_in_one_of_slots(O, slots, critical = TRUE)
 
 /datum/objective/assassinate
 	name = "assasinate"
@@ -1152,7 +1152,7 @@ GLOBAL_LIST_EMPTY(cult_contraband)
 	I.forceMove(get_turf(owner))
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.equip_in_one_of_slots(I, list("backpack" = SLOT_IN_BACKPACK))
+		H.equip_in_one_of_slots(I, list("backpack" = SLOT_IN_BACKPACK), critical = TRUE)
 		hoarded_item = I
 
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -100,7 +100,7 @@
 
 	var/T = new item_path(mob)
 	var/item_name = initial(item_path.name)
-	var/where = mob.equip_in_one_of_slots(T, slots)
+	var/where = mob.equip_in_one_of_slots(T, slots, critical = TRUE)
 	if(!where)
 		to_chat(mob, "<span class='userdanger'>Unfortunately, you weren't able to get a [item_name]. This is very bad and you should adminhelp immediately (press F1).</span>")
 		return 0

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -75,7 +75,7 @@
 
 	var/T = new item_path(H)
 	var/item_name = initial(item_path.name)
-	var/where = H.equip_in_one_of_slots(T, slots)
+	var/where = H.equip_in_one_of_slots(T, slots, critical = TRUE)
 	if(!where)
 		to_chat(H, "<span class='userdanger'>Unfortunately, you weren't able to get a [item_name]. This is very bad and you should adminhelp immediately (press F1).</span>")
 		return FALSE

--- a/code/modules/antagonists/overthrow/overthrow.dm
+++ b/code/modules/antagonists/overthrow/overthrow.dm
@@ -131,14 +131,14 @@
 		"left pocket" = SLOT_L_STORE,
 		"right pocket" = SLOT_R_STORE
 	)
-	var/where = H.equip_in_one_of_slots(O, slots)
+	var/where = H.equip_in_one_of_slots(O, slots, critical = TRUE)
 	if (!where)
 		to_chat(H, "The Syndicate were unfortunately unable to get you the AI module.")
 	else
 		to_chat(H, "Use the AI board in your [where] to take control of the AI, as requested by the Syndicate.")
 	// Give the implant converter
 	var/obj/item/overthrow_converter/I = new(H)
-	where = H.equip_in_one_of_slots(I, slots)
+	where = H.equip_in_one_of_slots(I, slots, critical = TRUE)
 	if (!where)
 		to_chat(H, "The Syndicate were unfortunately unable to get you a converter implant.")
 	else

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -251,7 +251,7 @@
 			"left pocket" = SLOT_L_STORE,
 			"right pocket" = SLOT_R_STORE
 		)
-		var/where = H.equip_in_one_of_slots(T, slots)
+		var/where = H.equip_in_one_of_slots(T, slots, critical = TRUE)
 		if (!where)
 			to_chat(H, "The Syndicate were unfortunately unable to get you a flash.")
 		else

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -212,7 +212,7 @@
 	)
 
 	var/where = "At your feet"
-	var/equipped_slot = mob.equip_in_one_of_slots(folder, slots)
+	var/equipped_slot = mob.equip_in_one_of_slots(folder, slots, critical = TRUE)
 	if (equipped_slot)
 		where = "In your [equipped_slot]"
 	to_chat(mob, "<BR><BR><span class='info'>[where] is a folder containing <b>secret documents</b> that another Syndicate group wants. We have set up a meeting with one of their agents on station to make an exchange. Exercise extreme caution as they cannot be trusted and may be hostile.</span><BR>")

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -14,10 +14,29 @@
 			return legcuffed
 	return null
 
-/mob/living/carbon/proc/equip_in_one_of_slots(obj/item/I, list/slots, qdel_on_fail = 1)
+/mob/living/carbon/proc/equip_in_one_of_slots(obj/item/I, list/slots, qdel_on_fail = 1, critical = FALSE)
 	for(var/slot in slots)
 		if(equip_to_slot_if_possible(I, slots[slot], qdel_on_fail = 0, disable_warning = TRUE))
 			return slot
+	if(critical) //it is CRITICAL they get this item, no matter what
+		//do they have a backpack?
+		var/obj/item/backpack = get_item_by_slot(SLOT_BACK)
+		if(!backpack)
+			//nothing on their back
+			backpack = new /obj/item/storage/backpack(get_turf(src))
+			if(equip_to_slot(backpack, SLOT_BACK)) //worst-case-scenario, something that shouldnt wear a backpack gets one
+				I.forceMove(backpack)
+				return SLOT_BACK
+		else if(istype(backpack) && SEND_SIGNAL(backpack, COMSIG_CONTAINS_STORAGE))
+			//place it in here, regardless of storage capacity
+			I.forceMove(backpack)
+			return SLOT_BACK
+		else
+			//this should NEVER happen, but if it does, report it with the appropriate information
+			var/conclusion = qdel_on_fail ? "deleted" : "not moved, staying at current position [I.x], [I.y], [I.z]"
+			message_admins("User [src] failed to get item of critical importance: [I]. Result: item is [conclusion]")
+			//it's not dropped at their turf as this is generally un-safe for midround antags and we don't know their status
+
 	if(qdel_on_fail)
 		qdel(I)
 	return null


### PR DESCRIPTION
## About The Pull Request
title

works through the following process for critical items:
try adding it to any of the given slots as normal, if it fails, continue
do they have a backpack? if so, place it in
otherwise, can we forcibly give them a default backpack? if so, equip the backpack, then place the item inside
otherwise, message admins with information on the incident (this should never happen, as forcibly equipping a backpack should never fail)

## Why It's Good For The Game
no more "i didnt get my [antag tool] when i spawned in as [some antag]"

## Changelog
:cl:
tweak: antag items are now of critical importance and wont fail to be placed on the character
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
