### PR TITLE
Makes welder code better*

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -22,7 +22,6 @@
 	resistance_flags = FIRE_PROOF
 
 	var/self_fueling = FALSE //Do we refill ourselves or not
-	var/next_fueling = 10 //How long we wait before refilling
 	var/nextrefueltick = 0 // How long it takes before we get a new fuel unit
 
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=30)
@@ -91,7 +90,7 @@
 	//Then looks if we refuel ourselves or not.
 
 	if(get_fuel() < max_fuel && nextrefueltick < world.time && self_fueling)
-		nextrefueltick = world.time + next_fueling
+		nextrefueltick = world.time + 10
 		reagents.add_reagent(/datum/reagent/fuel, 1)
 
 /obj/item/weldingtool/suicide_act(mob/user)
@@ -385,7 +384,6 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "welder"
 	self_fueling = TRUE
-	next_fueling = 0
 	toolspeed = 0.1
 	light_intensity = 0
 	change_icons = 0
@@ -396,7 +394,6 @@
 	icon = 'icons/obj/advancedtools.dmi'
 	icon_state = "welder"
 	self_fueling = TRUE
-	next_fueling = 0
 	toolspeed = 0.2
 	light_intensity = 0
 	change_icons = 0

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -374,7 +374,6 @@
 	name = "brass welding tool"
 	desc = "A brass welder that seems to constantly refuel itself. It is faintly warm to the touch."
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	next_fueling = 5 //makes welding fuel faster than experimental ones
 	icon_state = "clockwelder"
 	item_state = "brasswelder"
 

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -21,6 +21,10 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
 	resistance_flags = FIRE_PROOF
 
+	var/self_fueling = FALSE //Do we refill areself or not
+	var/next_fueling = 10 //How long do we wait before refilling
+	var/nextrefueltick = 0 // How long it takes before we get a new fuel unit
+
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=30)
 	var/welding = 0 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)
 	var/status = TRUE 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
@@ -82,11 +86,17 @@
 	//This is to start fires. process() is only called if the welder is on.
 	open_flame()
 
+	//This handles refuelung, its looking at how much fuel the tool has, and comparing it to the how much it holds
+	//This then looks if the refuel tick has come based on world time.
+	//Then looks if we refuel areselfs are not.
+
+	if(get_fuel() < max_fuel && nextrefueltick < world.time && self_fueling)
+		nextrefueltick = world.time + next_fueling
+		reagents.add_reagent(/datum/reagent/fuel, 1)
 
 /obj/item/weldingtool/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] welds [user.p_their()] every orifice closed! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (FIRELOSS)
-
 
 /obj/item/weldingtool/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/screwdriver))
@@ -318,7 +328,6 @@
 /obj/item/weldingtool/largetank/flamethrower_screwdriver()
 	return
 
-
 /obj/item/weldingtool/mini
 	name = "emergency welding tool"
 	desc = "A miniature welder used during emergencies."
@@ -331,20 +340,6 @@
 /obj/item/weldingtool/mini/flamethrower_screwdriver()
 	return
 
-/obj/item/weldingtool/abductor
-	name = "alien welding tool"
-	desc = "An alien welding tool. Whatever fuel it uses, it never runs out."
-	icon = 'icons/obj/abductor.dmi'
-	icon_state = "welder"
-	toolspeed = 0.1
-	light_intensity = 0
-	change_icons = 0
-
-/obj/item/weldingtool/abductor/process()
-	if(get_fuel() <= max_fuel)
-		reagents.add_reagent(/datum/reagent/fuel, 1)
-	..()
-
 /obj/item/weldingtool/hugetank
 	name = "upgraded industrial welding tool"
 	desc = "An upgraded welder based of the industrial welder."
@@ -352,27 +347,6 @@
 	item_state = "upindwelder"
 	max_fuel = 80
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
-
-/obj/item/weldingtool/experimental
-	name = "experimental welding tool"
-	desc = "An experimental welder capable of self-fuel generation and less harmful to the eyes."
-	icon_state = "exwelder"
-	item_state = "exwelder"
-	max_fuel = 40
-	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
-	var/last_gen = 0
-	change_icons = 0
-	can_off_process = 1
-	light_intensity = 1
-	toolspeed = 0.5
-	var/nextrefueltick = 0
-
-/obj/item/weldingtool/experimental/brass
-	name = "brass welding tool"
-	desc = "A brass welder that seems to constantly refuel itself. It is faintly warm to the touch."
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-	icon_state = "clockwelder"
-	item_state = "brasswelder"
 
 /obj/item/weldingtool/bronze
 	name = "bronze plated welding tool"
@@ -382,24 +356,49 @@
 	icon_state = "brasswelder"
 	item_state = "brasswelder"
 
-/obj/item/weldingtool/experimental/process()
-	..()
-	if(get_fuel() < max_fuel && nextrefueltick < world.time)
-		nextrefueltick = world.time + 10
-		reagents.add_reagent(/datum/reagent/fuel, 1)
+//Self filling welders below
+
+/obj/item/weldingtool/experimental
+	name = "experimental welding tool"
+	desc = "An experimental welder capable of self-fuel generation and less harmful to the eyes."
+	icon_state = "exwelder"
+	item_state = "exwelder"
+	max_fuel = 40
+	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
+	change_icons = 0
+	self_fueling = TRUE
+	can_off_process = 1
+	light_intensity = 1
+	toolspeed = 0.5
+
+/obj/item/weldingtool/experimental/brass
+	name = "brass welding tool"
+	desc = "A brass welder that seems to constantly refuel itself. It is faintly warm to the touch."
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	next_fueling = 5 //makes welding fuel faster then experimental ones
+	icon_state = "clockwelder"
+	item_state = "brasswelder"
+
+/obj/item/weldingtool/abductor
+	name = "alien welding tool"
+	desc = "An alien welding tool. Whatever fuel it uses, it never runs out."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "welder"
+	self_fueling = TRUE
+	next_fueling = 0
+	toolspeed = 0.1
+	light_intensity = 0
+	change_icons = 0
 
 /obj/item/weldingtool/advanced
 	name = "advanced welding tool"
 	desc = "A modern welding tool combined with an alien welding tool, it never runs out of fuel and works almost as fast."
 	icon = 'icons/obj/advancedtools.dmi'
 	icon_state = "welder"
+	self_fueling = TRUE
+	next_fueling = 0
 	toolspeed = 0.2
 	light_intensity = 0
 	change_icons = 0
-
-/obj/item/weldingtool/advanced/process()
-	if(get_fuel() <= max_fuel)
-		reagents.add_reagent(/datum/reagent/fuel, 1)
-	..()
 
 #undef WELDER_FUEL_BURN_INTERVAL

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -21,8 +21,8 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 30)
 	resistance_flags = FIRE_PROOF
 
-	var/self_fueling = FALSE //Do we refill areself or not
-	var/next_fueling = 10 //How long do we wait before refilling
+	var/self_fueling = FALSE //Do we refill ourselves or not
+	var/next_fueling = 10 //How long we wait before refilling
 	var/nextrefueltick = 0 // How long it takes before we get a new fuel unit
 
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=30)
@@ -86,9 +86,9 @@
 	//This is to start fires. process() is only called if the welder is on.
 	open_flame()
 
-	//This handles refuelung, its looking at how much fuel the tool has, and comparing it to the how much it holds
+	//This handles refueling. Its looking at how much fuel the tool has and comparing that to how much it holds
 	//This then looks if the refuel tick has come based on world time.
-	//Then looks if we refuel areselfs are not.
+	//Then looks if we refuel ourselves or not.
 
 	if(get_fuel() < max_fuel && nextrefueltick < world.time && self_fueling)
 		nextrefueltick = world.time + next_fueling
@@ -375,7 +375,7 @@
 	name = "brass welding tool"
 	desc = "A brass welder that seems to constantly refuel itself. It is faintly warm to the touch."
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	next_fueling = 5 //makes welding fuel faster then experimental ones
+	next_fueling = 5 //makes welding fuel faster than experimental ones
 	icon_state = "clockwelder"
 	item_state = "brasswelder"
 


### PR DESCRIPTION

## About The Pull Request

Makes welder code just be better
Buffs Brass welder to reload itself faster, thats it

## Why It's Good For The Game

Brass welders are cult and magic should, be somewhat better imo, legit dosnt do to much in terms of active gameplay
Code wise - easier to read and more cleanly imo runs
## Changelog
:cl:
balance: Brass welders are 50% faster at refueling
code: redoes self fueling welders in the code to be less speggie
/:cl:

