### PR TITLE
Giving science a space loop on every map

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -9502,6 +9502,9 @@
 	name = "Medbay";
 	req_access_txt = "5"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "asV" = (
@@ -9528,6 +9531,9 @@
 	id_tag = "MedbayFoyer";
 	name = "Medbay";
 	req_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -28539,8 +28545,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bqg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bqh" = (
@@ -29181,17 +29188,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "brH" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/space/basic,
+/area/space)
 "brI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -29843,10 +29850,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "btq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Space Loop Out"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -30971,14 +30977,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bvQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/space/basic,
+/area/space)
 "bvR" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -31632,10 +31638,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bxt" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -42935,6 +42942,9 @@
 /area/science/circuit)
 "bZi" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bZj" = (
@@ -52756,6 +52766,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNS" = (
@@ -52768,15 +52781,19 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNT" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cNU" = (
@@ -55020,6 +55037,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hTw" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop In"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hWd" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -56229,6 +56252,12 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/bar)
+"lpH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "lsk" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
@@ -56596,6 +56625,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mBg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -58287,6 +58322,15 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
+"rNM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rPU" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -59283,6 +59327,10 @@
 "uGI" = (
 /turf/open/floor/grass,
 /area/security/prison)
+"uGQ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space)
 "uHc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60334,6 +60382,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xlp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space)
 "xmo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -93272,9 +93326,9 @@ aZV
 aZV
 aZV
 aZV
-bmx
-bmx
-bmx
+aZV
+aZV
+aZV
 bqH
 bqH
 btM
@@ -112033,15 +112087,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+brH
+lpH
+brH
+lpH
 aaa
 bky
 btp
-brH
-bvQ
+btp
+btp
 bxt
 cNT
 bCm
@@ -112290,15 +112344,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bvQ
+xlp
+mBg
+xlp
+uGQ
 bZi
 bqg
-brG
-brG
+hTw
+bvR
 cNR
 brG
 brG
@@ -112547,18 +112601,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xlp
+uGQ
+uGQ
+uGQ
+uGQ
 bZi
 btq
 brI
 bvR
 cNS
 byx
-brI
+rNM
 bky
 bky
 bEs

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -26758,7 +26758,6 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "blS" = (
@@ -29845,6 +29844,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btp" = (
+/obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "btq" = (
@@ -29852,7 +29852,9 @@
 	dir = 1;
 	name = "Space Loop Out"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
 /area/maintenance/starboard)
 "btr" = (
 /obj/machinery/camera{
@@ -30975,11 +30977,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bvQ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bvR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -53533,12 +53532,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dyO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "dyS" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -54046,6 +54039,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"eXL" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fbp" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot,
@@ -54969,15 +54969,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"hNW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "hOv" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -55208,12 +55199,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"ixi" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "izg" = (
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plating,
@@ -55645,6 +55630,13 @@
 	},
 /turf/open/space,
 /area/solar/starboard/fore)
+"jIy" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jJF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -55817,6 +55809,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
+"kgk" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
 "kgr" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -55903,12 +55900,6 @@
 /obj/structure/window,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"krp" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Space Loop In"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ktP" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -56226,12 +56217,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"lht" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space)
 "lhQ" = (
 /obj/machinery/power/floodlight,
 /obj/structure/cable{
@@ -56979,6 +56964,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nJP" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nJQ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
@@ -57354,6 +57346,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"oBQ" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop In"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "oDm" = (
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/plasteel,
@@ -57418,12 +57416,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"oRg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "oSl" = (
 /obj/machinery/door/airlock/security{
 	name = "Firing Range";
@@ -57477,12 +57469,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"oZE" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space)
 "pem" = (
 /obj/machinery/button/door{
 	desc = "Bolts the doors to the Private Study.";
@@ -57903,6 +57889,13 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/toilet)
+"qtH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qus" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -58017,6 +58010,13 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qXJ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59529,10 +59529,11 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
-"vds" = (
+"vdo" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "vdu" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -60045,6 +60046,15 @@
 /obj/item/instrument/recorder,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"wkc" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "wkN" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -60106,6 +60116,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"wqW" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "wrp" = (
 /obj/machinery/light{
 	dir = 8
@@ -112097,16 +112115,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bvQ
-oRg
-bvQ
-oRg
-aaa
+gXs
+jIy
+nJP
+jIy
+nJP
+gXs
 bky
-btp
+kgk
 brH
-btp
+bvQ
 bxt
 cNT
 bCm
@@ -112355,15 +112373,15 @@ aaa
 aaa
 aaa
 aaa
-ixi
-lht
-oZE
-lht
-vds
+qtH
+eXL
+qXJ
+eXL
+vdo
 bZi
 bqg
-krp
-dyO
+oBQ
+wqW
 cNR
 brG
 brG
@@ -112612,18 +112630,18 @@ aaa
 aaa
 aaa
 aaa
-lht
-vds
-vds
-vds
-vds
+eXL
+vdo
+vdo
+vdo
+vdo
 bZi
 btq
 brI
 bvR
 cNS
 byx
-hNW
+wkc
 bky
 bky
 bEs
@@ -112873,7 +112891,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gXs
 bky
 bky
 bky

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -29188,11 +29188,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "brH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/item/cigbutt/cigarbutt,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "brI" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30978,7 +30976,7 @@
 /area/science/explab)
 "bvQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+	dir = 6
 	},
 /turf/open/space/basic,
 /area/space)
@@ -30986,6 +30984,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bvS" = (
@@ -53534,6 +53533,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dyO" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "dyS" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -54964,6 +54969,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"hNW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hOv" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -55037,12 +55051,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"hTw" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Space Loop In"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "hWd" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -55200,6 +55208,12 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ixi" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "izg" = (
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plating,
@@ -55889,6 +55903,12 @@
 /obj/structure/window,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"krp" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop In"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ktP" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -56206,6 +56226,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"lht" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space)
 "lhQ" = (
 /obj/machinery/power/floodlight,
 /obj/structure/cable{
@@ -56252,12 +56278,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/bar)
-"lpH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "lsk" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plasteel,
@@ -56625,12 +56645,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mBg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -57404,6 +57418,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"oRg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "oSl" = (
 /obj/machinery/door/airlock/security{
 	name = "Firing Range";
@@ -57457,6 +57477,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"oZE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space)
 "pem" = (
 /obj/machinery/button/door{
 	desc = "Bolts the doors to the Private Study.";
@@ -58322,15 +58348,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
-"rNM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "rPU" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -59327,10 +59344,6 @@
 "uGI" = (
 /turf/open/floor/grass,
 /area/security/prison)
-"uGQ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space/basic,
-/area/space)
 "uHc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59516,6 +59529,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/range)
+"vds" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space)
 "vdu" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -60382,12 +60399,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xlp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space)
 "xmo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -112087,14 +112098,14 @@ aaa
 aaa
 aaa
 aaa
-brH
-lpH
-brH
-lpH
+bvQ
+oRg
+bvQ
+oRg
 aaa
 bky
 btp
-btp
+brH
 btp
 bxt
 cNT
@@ -112344,15 +112355,15 @@ aaa
 aaa
 aaa
 aaa
-bvQ
-xlp
-mBg
-xlp
-uGQ
+ixi
+lht
+oZE
+lht
+vds
 bZi
 bqg
-hTw
-bvR
+krp
+dyO
 cNR
 brG
 brG
@@ -112601,18 +112612,18 @@ aaa
 aaa
 aaa
 aaa
-xlp
-uGQ
-uGQ
-uGQ
-uGQ
+lht
+vds
+vds
+vds
+vds
 bZi
 btq
 brI
 bvR
 cNS
 byx
-rNM
+hNW
 bky
 bky
 bEs

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -125265,6 +125265,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden/abandoned)
+"esD" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "etO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -125641,11 +125647,6 @@
 	dir = 10
 	},
 /area/science/circuit)
-"hkh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
 "hnq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -125733,6 +125734,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"hLf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "hNZ" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -125952,6 +125960,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jdR" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jeu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -126511,13 +126525,6 @@
 	dir = 1
 	},
 /area/science/circuit)
-"mcn" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
 "mkm" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
@@ -126550,6 +126557,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"mtj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -126645,6 +126659,17 @@
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"nMo" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"nNN" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space/nearstation)
 "nOz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -126839,12 +126864,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
-"pcv" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "pcK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -126920,6 +126939,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
+"pwx" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "pxR" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -127057,12 +127083,6 @@
 	dir = 9
 	},
 /area/science/circuit)
-"rmS" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "rCv" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 6
@@ -127248,6 +127268,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"tzM" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
 "tCh" = (
 /turf/closed/wall,
 /area/science/misc_lab)
@@ -127298,12 +127325,6 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/chapel/office)
-"tQc" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space)
 "tRT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -127314,13 +127335,6 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tWM" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "tYG" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -127415,13 +127429,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uGS" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "uNP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -127474,13 +127481,6 @@
 /obj/item/clothing/under/color/grey,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"vjn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/mixing)
 "voA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -127582,13 +127582,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
-"vGO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/mixing)
 "vHN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -127761,6 +127754,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"xmL" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "xok" = (
 /obj/machinery/light{
 	dir = 1
@@ -155127,7 +155127,7 @@ dAt
 djs
 dhQ
 atI
-rmS
+jdR
 aaa
 aaa
 aad
@@ -155383,8 +155383,8 @@ dAt
 dBX
 dDl
 dhQ
-uGS
-uGS
+pwx
+pwx
 aad
 aad
 abj
@@ -155640,8 +155640,8 @@ dhQ
 dhQ
 dhQ
 dhQ
-uGS
-pcv
+pwx
+esD
 aaa
 aaa
 aad
@@ -155895,10 +155895,10 @@ djw
 fRT
 dAu
 caE
-tQc
-hkh
-tWM
-uGS
+nMo
+nNN
+xmL
+pwx
 aad
 aad
 abj
@@ -156152,10 +156152,10 @@ drH
 dzn
 cLt
 caE
-uGS
+pwx
 drP
 dEn
-vjn
+hLf
 drP
 dEn
 drP
@@ -156409,7 +156409,7 @@ djA
 cJT
 cLx
 cOj
-pcv
+esD
 dEn
 dFz
 dGY
@@ -156666,7 +156666,7 @@ djA
 cJS
 cLu
 cOj
-uGS
+pwx
 dEn
 dFA
 dGZ
@@ -156923,7 +156923,7 @@ djA
 dzo
 cLt
 caE
-pcv
+esD
 drP
 dFB
 dHa
@@ -157180,8 +157180,8 @@ djA
 dzp
 cLy
 cOj
-mcn
-vGO
+tzM
+mtj
 dFC
 dHb
 dIm

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -110277,9 +110277,6 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
 "dFz" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = -26;
@@ -110288,11 +110285,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dFA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -110311,25 +110315,28 @@
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dFC" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"dFD" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"dFD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop Out";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "dFE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
@@ -110337,9 +110344,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dFF" = (
@@ -111237,20 +111245,16 @@
 /turf/open/floor/plating,
 /area/science/test_area)
 "dGY" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/toxins{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dGZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dHa" = (
@@ -111267,9 +111271,6 @@
 	},
 /area/science/mixing)
 "dHb" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -111279,22 +111280,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"dHc" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "dHd" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -111995,16 +111981,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIm" = (
@@ -112012,14 +111994,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIo" = (
@@ -112030,7 +112010,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dIp" = (
@@ -112918,6 +112897,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJM" = (
@@ -112930,6 +112912,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJN" = (
@@ -112938,6 +112923,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/rd,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJO" = (
@@ -112950,6 +112938,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJP" = (
@@ -125650,6 +125641,11 @@
 	dir = 10
 	},
 /area/science/circuit)
+"hkh" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space/nearstation)
 "hnq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -126515,6 +126511,13 @@
 	dir = 1
 	},
 /area/science/circuit)
+"mcn" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
 "mkm" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
@@ -126836,6 +126839,12 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
+"pcv" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "pcK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -127048,6 +127057,12 @@
 	dir = 9
 	},
 /area/science/circuit)
+"rmS" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space)
 "rCv" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 6
@@ -127283,6 +127298,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/chapel/office)
+"tQc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space)
 "tRT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -127293,6 +127314,13 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tWM" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "tYG" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -127387,6 +127415,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uGS" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "uNP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -127439,6 +127474,13 @@
 /obj/item/clothing/under/color/grey,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"vjn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "voA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -127540,6 +127582,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
+"vGO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "vHN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -155077,8 +155126,8 @@ dmy
 dAt
 djs
 dhQ
-aad
-aaa
+atI
+rmS
 aaa
 aaa
 aad
@@ -155334,8 +155383,8 @@ dAt
 dBX
 dDl
 dhQ
-aad
-aad
+uGS
+uGS
 aad
 aad
 abj
@@ -155591,8 +155640,8 @@ dhQ
 dhQ
 dhQ
 dhQ
-aad
-aaa
+uGS
+pcv
 aaa
 aaa
 aad
@@ -155846,10 +155895,10 @@ djw
 fRT
 dAu
 caE
-aaa
-aad
-aad
-aad
+tQc
+hkh
+tWM
+uGS
 aad
 aad
 abj
@@ -156103,10 +156152,10 @@ drH
 dzn
 cLt
 caE
-aad
+uGS
 drP
 dEn
-dEn
+vjn
 drP
 dEn
 drP
@@ -156360,7 +156409,7 @@ djA
 cJT
 cLx
 cOj
-aaa
+pcv
 dEn
 dFz
 dGY
@@ -156617,7 +156666,7 @@ djA
 cJS
 cLu
 cOj
-aad
+uGS
 dEn
 dFA
 dGZ
@@ -156874,7 +156923,7 @@ djA
 dzo
 cLt
 caE
-aaa
+pcv
 drP
 dFB
 dHa
@@ -157131,8 +157180,8 @@ djA
 dzp
 cLy
 cOj
-aad
-dEn
+mcn
+vGO
 dFC
 dHb
 dIm
@@ -157391,7 +157440,7 @@ cOj
 aaa
 dEn
 dFD
-dHc
+dHd
 dIn
 dJN
 dEn

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -84519,24 +84519,9 @@
 	icon_state = "wood-broken"
 	},
 /area/security/vacantoffice)
-"diX" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "dky" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"dkY" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space/basic,
 /area/space/nearstation)
 "dlg" = (
 /obj/machinery/light,
@@ -84695,11 +84680,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"fBR" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space/basic,
-/area/space/nearstation)
 "fXq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -84768,6 +84748,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gwE" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "gxY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -84826,21 +84813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iek" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"igu" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "ikw" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Cell 4";
@@ -84889,6 +84861,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"iPI" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "iSg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -84898,6 +84877,13 @@
 /mob/living/simple_animal/hostile/retaliate/ghost,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"iXU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "iZo" = (
 /turf/closed/wall/r_wall/rust,
 /area/medical/virology)
@@ -85152,6 +85138,10 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/maintenance/port/fore)
+"kWO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/maintenance/starboard)
 "kXo" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -85163,6 +85153,10 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/port/fore)
+"lht" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space/nearstation)
 "llm" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall,
@@ -85189,6 +85183,14 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/warden)
+"lVT" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "mbs" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/item/pickaxe,
@@ -85252,9 +85254,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
-"npg" = (
+"nHl" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+	dir = 10
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -85296,10 +85298,6 @@
 	dir = 8
 	},
 /area/hallway/primary/fore)
-"oPw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall,
-/area/maintenance/starboard)
 "oTy" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -85319,17 +85317,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"oXQ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ppP" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
 /area/security/vacantoffice)
-"pBE" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "pCe" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/asteroid/airless,
@@ -85360,6 +85358,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
+"qlK" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qvS" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=W CPH";
@@ -85383,13 +85388,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
-"qIO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "qIR" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Cell 6";
@@ -85414,12 +85412,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qLG" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qPY" = (
 /obj/machinery/vr_sleeper{
 	dir = 1
@@ -85439,6 +85431,13 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
+"rnD" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ruL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -85446,15 +85445,25 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"rvN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"rwy" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rNm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/entry)
-"sfw" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space/basic,
-/area/space/nearstation)
 "swG" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = 4;
@@ -85484,7 +85493,18 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/rust,
 /area/space/nearstation)
-"sJR" = (
+"tog" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space/nearstation)
+"tCi" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/maintenance/port/fore)
+"tJC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -85495,19 +85515,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard)
-"tBn" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"tCi" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/maintenance/port/fore)
 "uda" = (
 /turf/closed/wall/rust,
 /area/security/warden)
@@ -85516,6 +85523,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uhv" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ukP" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/bot/cleanbot{
@@ -85553,13 +85567,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"urw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "uxQ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/closed/mineral/random/labormineral,
@@ -85571,6 +85578,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"uOT" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "uRM" = (
 /turf/open/floor/wood,
 /area/security/vacantoffice)
@@ -85593,13 +85607,6 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"vNn" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "whZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -85617,20 +85624,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"wSA" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"xfL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "xqv" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -85709,6 +85702,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"ygZ" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ykB" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -129015,9 +129016,9 @@ ava
 bkd
 bkd
 bkd
-sJR
-xfL
-oPw
+tJC
+iXU
+kWO
 bBX
 bkd
 cwC
@@ -129272,8 +129273,8 @@ bkd
 aeu
 aeu
 bkd
-qIO
-qIO
+rvN
+rvN
 bkd
 aaa
 bkd
@@ -129529,8 +129530,8 @@ bkd
 aeu
 alm
 acm
-igu
-iek
+iPI
+ygZ
 aeo
 acm
 bkd
@@ -129786,9 +129787,9 @@ bkd
 aeu
 aeU
 aaa
-igu
-vNn
-urw
+iPI
+rwy
+uhv
 aaa
 acm
 acK
@@ -130042,10 +130043,10 @@ aaa
 bhq
 aeu
 aUz
-npg
-dkY
-diX
-wSA
+oXQ
+lVT
+rnD
+gwE
 aaa
 acm
 aaa
@@ -130299,10 +130300,10 @@ aaa
 akA
 aeu
 aeU
-pBE
+qlK
 aeo
-vNn
-urw
+rwy
+uhv
 aaa
 acm
 aaa
@@ -130556,10 +130557,10 @@ aaa
 cko
 aeu
 aeu
-qLG
-fBR
-sfw
-tBn
+nHl
+tog
+lht
+uOT
 acm
 acK
 aaa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -27414,10 +27414,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -27448,11 +27446,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/medbay/central)
 "aSZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -73372,6 +73369,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -84288,7 +84286,9 @@
 /area/maintenance/starboard)
 "cOo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cOx" = (
@@ -84519,9 +84519,24 @@
 	icon_state = "wood-broken"
 	},
 /area/security/vacantoffice)
+"diX" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dky" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
+/area/space/nearstation)
+"dkY" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "dlg" = (
 /obj/machinery/light,
@@ -84680,6 +84695,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"fBR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fXq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -84806,6 +84826,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iek" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"igu" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "ikw" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Cell 4";
@@ -85217,6 +85252,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
+"npg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nJw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -85255,6 +85296,10 @@
 	dir = 8
 	},
 /area/hallway/primary/fore)
+"oPw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/maintenance/starboard)
 "oTy" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -85279,6 +85324,12 @@
 	icon_state = "wood-broken7"
 	},
 /area/security/vacantoffice)
+"pBE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pCe" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/asteroid/airless,
@@ -85332,6 +85383,13 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"qIO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "qIR" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Cell 6";
@@ -85356,6 +85414,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qLG" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "qPY" = (
 /obj/machinery/vr_sleeper{
 	dir = 1
@@ -85387,6 +85451,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/entry)
+"sfw" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space/nearstation)
 "swG" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = 4;
@@ -85415,6 +85483,24 @@
 "sDw" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/rust,
+/area/space/nearstation)
+"sJR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop Out";
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard)
+"tBn" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "tCi" = (
 /obj/effect/decal/cleanable/glass,
@@ -85467,6 +85553,13 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"urw" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "uxQ" = (
 /obj/effect/decal/cleanable/ash,
 /turf/closed/mineral/random/labormineral,
@@ -85500,6 +85593,13 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"vNn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "whZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -85517,6 +85617,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"wSA" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"xfL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xqv" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -128901,9 +129015,9 @@ ava
 bkd
 bkd
 bkd
-avA
-avA
-bkd
+sJR
+xfL
+oPw
 bBX
 bkd
 cwC
@@ -129157,10 +129271,10 @@ avA
 bkd
 aeu
 aeu
-aeu
-acm
-aaa
-acm
+bkd
+qIO
+qIO
+bkd
 aaa
 bkd
 cwD
@@ -129415,8 +129529,8 @@ bkd
 aeu
 alm
 acm
-aaQ
-aeo
+igu
+iek
 aeo
 acm
 bkd
@@ -129672,9 +129786,9 @@ bkd
 aeu
 aeU
 aaa
-acm
-aaa
-acm
+igu
+vNn
+urw
 aaa
 acm
 acK
@@ -129928,10 +130042,10 @@ aaa
 bhq
 aeu
 aUz
-aaa
-aaQ
-aaa
-acm
+npg
+dkY
+diX
+wSA
 aaa
 acm
 aaa
@@ -130185,10 +130299,10 @@ aaa
 akA
 aeu
 aeU
-aaa
+pBE
 aeo
-aaa
-acm
+vNn
+urw
 aaa
 acm
 aaa
@@ -130442,10 +130556,10 @@ aaa
 cko
 aeu
 aeu
-aeU
-acm
-aaa
-acK
+qLG
+fBR
+sfw
+tBn
 acm
 acK
 aaa

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -391,8 +391,12 @@
 /turf/open/space,
 /area/solar/port/fore)
 "abk" = (
-/turf/closed/wall/r_wall,
-/area/asteroid/nearstation)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "abl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -720,9 +724,6 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 1
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
 /obj/item/radio/intercom{
 	dir = 8;
 	pixel_x = -28
@@ -742,13 +743,16 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "acf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/button/massdriver{
 	id = "toxinsdriver";
 	pixel_x = 24;
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -1137,12 +1141,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "adb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -1153,13 +1157,9 @@
 "add" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ade" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -4424,7 +4424,6 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "ajC" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -63554,6 +63553,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dZH" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "dZS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/snack/random,
@@ -65741,6 +65747,15 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"hvW" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "hwx" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
@@ -66614,6 +66629,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jxL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/plating,
+/area/science/mixing)
 "jEf" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -67005,6 +67025,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
+"keL" = (
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "kgv" = (
 /obj/structure/railing{
 	icon_state = "railing";
@@ -67187,6 +67210,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kEr" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "kEv" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -67311,6 +67341,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"kXa" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "kXf" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/stripes/line{
@@ -68138,6 +68177,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"mmb" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop In"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "mmA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -69166,6 +69214,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"oAa" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "oBc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -70090,6 +70144,13 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"qzd" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "qzu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile,
@@ -70625,6 +70686,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/chief/private)
+"rJx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "rMo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70661,6 +70729,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rRp" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "rUH" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -72188,6 +72262,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
+"viN" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "vja" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72313,6 +72391,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"vvz" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "vyb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -72825,6 +72908,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wyb" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "wyC" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -73262,6 +73354,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xyH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xzj" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -73505,6 +73606,15 @@
 "ycq" = (
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
+"yex" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "yfq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -99141,7 +99251,7 @@ aaA
 aaA
 aaA
 abY
-aUL
+xyH
 afP
 afB
 acw
@@ -100418,11 +100528,11 @@ aaA
 aaA
 aaA
 aaA
-abk
-abk
-abk
-abk
-abk
+aaQ
+aaQ
+aaQ
+aaQ
+aaQ
 aaA
 aaA
 abY
@@ -103763,8 +103873,8 @@ aAY
 aAY
 aAY
 aAY
-aAY
-aAY
+aaA
+aaA
 abJ
 acb
 acF
@@ -104009,20 +104119,20 @@ aab
 aab
 aab
 aab
-aab
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
+aaa
+aaa
+aaa
+abk
+vvz
+vvz
+vvz
+dZH
+viN
+rRp
 aAY
 abK
+abK
+abJ
 acc
 acG
 adb
@@ -104268,19 +104378,19 @@ aab
 aab
 aab
 aaa
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-abK
-ace
+aaa
+qzd
+vvz
+vvz
+vvz
+rJx
+aac
+oAa
+viN
+jxL
+kXa
+yex
+keL
 acH
 ajC
 abJ
@@ -104525,19 +104635,19 @@ aab
 aab
 aab
 aaa
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
+aac
+abk
+vvz
+vvz
+vvz
+kEr
+aac
 aAY
 aAY
 abK
-ace
+hvW
+keL
+keL
 acI
 add
 adv
@@ -104781,19 +104891,19 @@ aab
 aab
 aab
 aab
-aaa
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-aAY
-abK
+aac
+aac
+qzd
+vvz
+vvz
+vvz
+dZH
+viN
+viN
+viN
+jxL
+mmb
+wyb
 acf
 adH
 ade
@@ -105048,8 +105158,8 @@ aaA
 aaA
 aaA
 aaA
-aaA
-aaA
+abJ
+abJ
 abJ
 abK
 abK

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -10503,6 +10503,10 @@
 "atH" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
+"atI" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "atJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -63553,13 +63557,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"dZH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "dZS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/snack/random,
@@ -63637,10 +63634,26 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"egV" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "ehl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/paramedic)
+"ehs" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "eia" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -64010,6 +64023,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"eLb" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "eMH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -64441,6 +64460,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"fvD" = (
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fvI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -65465,6 +65487,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"hbf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hbS" = (
 /obj/machinery/button/door{
 	id = "engstorage";
@@ -65747,15 +65778,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"hvW" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "hwx" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
@@ -66212,6 +66234,13 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/aft)
+"iIs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "iJd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
@@ -66629,11 +66658,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jxL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/floor/plating,
-/area/science/mixing)
+"jwN" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "jEf" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -67025,9 +67055,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
-"keL" = (
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "kgv" = (
 /obj/structure/railing{
 	icon_state = "railing";
@@ -67132,6 +67159,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"krP" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "krZ" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -67210,13 +67242,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kEr" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "kEv" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -67244,6 +67269,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"kFO" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "kJN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/table,
@@ -67341,15 +67375,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"kXa" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "kXf" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/stripes/line{
@@ -68177,12 +68202,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"mmb" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Space Loop In"
+"mkV" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -69214,12 +69239,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"oAa" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
-	},
-/turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation)
 "oBc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -70144,13 +70163,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"qzd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "qzu" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile,
@@ -70227,6 +70239,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"qPP" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "qSJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable{
@@ -70471,6 +70490,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"rsU" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "rtC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -70686,13 +70712,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/chief/private)
-"rJx" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "rMo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70729,12 +70748,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rRp" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation)
 "rUH" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -71687,6 +71700,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"ucV" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "ufs" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -72262,10 +72281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
-"viN" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/floor/plating/asteroid/airless,
-/area/asteroid/nearstation)
 "vja" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72391,11 +72406,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vvz" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "vyb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -72767,6 +72777,15 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"wgn" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop In"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "wgU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxins_mixing_output,
 /turf/open/floor/engine/vacuum,
@@ -72908,15 +72927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wyb" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "wyC" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -73080,6 +73090,15 @@
 "wPh" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
+"wPU" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "wQP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -73354,15 +73373,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"xyH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "xzj" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -73371,6 +73381,11 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"xzG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/turf/open/floor/plating,
+/area/science/mixing)
 "xAN" = (
 /turf/closed/wall,
 /area/maintenance/department/electrical)
@@ -73606,15 +73621,6 @@
 "ycq" = (
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
-"yex" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "yfq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -99251,7 +99257,7 @@ aaA
 aaA
 aaA
 abY
-xyH
+hbf
 afP
 afB
 acw
@@ -104123,12 +104129,12 @@ aaa
 aaa
 aaa
 abk
-vvz
-vvz
-vvz
-dZH
-viN
-rRp
+krP
+krP
+krP
+qPP
+atI
+ucV
 aAY
 abK
 abK
@@ -104379,18 +104385,18 @@ aab
 aab
 aaa
 aaa
-qzd
-vvz
-vvz
-vvz
-rJx
+rsU
+krP
+krP
+krP
+iIs
 aac
-oAa
-viN
-jxL
-kXa
-yex
-keL
+jwN
+atI
+xzG
+kFO
+mkV
+eLb
 acH
 ajC
 abJ
@@ -104637,17 +104643,17 @@ aab
 aaa
 aac
 abk
-vvz
-vvz
-vvz
-kEr
+krP
+krP
+krP
+egV
 aac
 aAY
 aAY
 abK
-hvW
-keL
-keL
+wPU
+fvD
+fvD
 acI
 add
 adv
@@ -104893,17 +104899,17 @@ aab
 aab
 aac
 aac
-qzd
-vvz
-vvz
-vvz
-dZH
-viN
-viN
-viN
-jxL
-mmb
-wyb
+rsU
+krP
+krP
+krP
+qPP
+atI
+atI
+atI
+xzG
+wgn
+ehs
 acf
 adH
 ade

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -76185,6 +76185,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"cYI" = (
+/obj/machinery/camera{
+	c_tag = "Research Division Circuitry Lab";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "cYJ" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -79847,12 +79855,12 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "dka" = (
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/turf/open/space,
+/area/space/nearstation)
 "dlI" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -81295,6 +81303,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"etb" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "etr" = (
 /obj/machinery/vr_sleeper,
 /turf/open/floor/plasteel,
@@ -81335,6 +81351,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"faU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fdr" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -81515,6 +81536,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"idz" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -81532,6 +81558,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"izh" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "izu" = (
 /obj/machinery/autolathe{
 	name = "public autolathe"
@@ -81674,6 +81706,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"jDS" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jKK" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -81907,6 +81946,16 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"lUv" = (
+/obj/structure/noticeboard{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "lWL" = (
 /obj/machinery/smartfridge/organ/preloaded,
 /turf/closed/wall,
@@ -82010,6 +82059,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mIJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/space,
+/area/space/nearstation)
 "mSd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82105,6 +82161,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage/wing)
+"nKU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/circuit)
 "nLT" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82325,6 +82388,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pDn" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pEv" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -82397,6 +82467,12 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"qaK" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "qhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -82442,6 +82518,11 @@
 "qBq" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
+"qEc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/plating,
+/area/science/circuit)
 "qJZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -82459,13 +82540,12 @@
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
 "qRM" = (
-/obj/machinery/camera{
-	c_tag = "Research Division Circuitry Lab";
-	dir = 1;
-	network = list("ss13","rd")
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/turf/open/space,
+/area/space/nearstation)
 "qVR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -82623,6 +82703,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"sqe" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space/nearstation)
 "stP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Fuel Pipe"
@@ -82708,6 +82792,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"tfs" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "tre" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -82756,6 +82847,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tID" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop Out";
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "tUa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -82871,6 +82969,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"vda" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "vgd" = (
 /obj/item/taperecorder,
 /obj/item/camera,
@@ -82935,6 +83040,11 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"vYs" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space,
+/area/space/nearstation)
 "wdu" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -83006,6 +83116,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/closed/wall,
 /area/science/circuit)
+"wNQ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wOE" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -83135,6 +83252,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xHA" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop In";
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "xIi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83161,6 +83285,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/security/vacantoffice)
+"xUO" = (
+/turf/open/space,
+/area/space/nearstation)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -83186,6 +83313,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"yfk" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "yfW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -83209,9 +83343,12 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "ykE" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/space,
+/area/space/nearstation)
 
 (1,1,1) = {"
 oRp
@@ -120387,9 +120524,9 @@ kOt
 gRS
 oUA
 cxO
-qRM
+cxO
+cYI
 krD
-aaf
 aaf
 aaf
 anS
@@ -120644,9 +120781,9 @@ oLW
 gGT
 wPk
 dGH
-dka
+cxO
+lUv
 krD
-aaf
 aaa
 aaf
 aaf
@@ -120901,9 +121038,9 @@ ocT
 xkG
 uTS
 cxO
-ykE
+cxO
+tfs
 krD
-aaa
 aaa
 aaa
 aaa
@@ -121159,9 +121296,9 @@ llb
 uTS
 cxO
 cxO
-krD
-aaa
-aaa
+tID
+noG
+lMJ
 aaa
 aaa
 aaf
@@ -121415,13 +121552,13 @@ lsv
 txj
 eEe
 cxO
-cxO
-krD
-aaa
-aaa
-aaa
-aaf
-aaf
+izh
+qaK
+qEc
+idz
+idz
+vYs
+mIJ
 aaa
 anT
 aaf
@@ -121672,13 +121809,13 @@ jyv
 ohj
 nnK
 cxO
+xHA
 cxO
 krD
 aaa
 aaa
 aaa
-aaa
-aaf
+qRM
 aaa
 anT
 aaf
@@ -121929,13 +122066,13 @@ krD
 noG
 krD
 noG
+nKU
 krD
 krD
-aaa
-aaa
-aaa
-aaa
-aaf
+yfk
+idz
+idz
+vda
 aaa
 aqB
 aaa
@@ -122181,18 +122318,18 @@ dvY
 dvY
 dvY
 aaf
-aaf
-aaf
+dka
+vYs
+idz
+idz
+idz
+jDS
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
+wNQ
+idz
+vYs
+mIJ
 aaf
 anT
 aaa
@@ -122438,18 +122575,18 @@ crc
 aaf
 ctl
 aaa
-aaf
-aaf
+qRM
+xUO
 anT
 anT
 anT
-aaf
-aaf
-aaf
-lMJ
-lMJ
-aaf
-aaa
+ake
+ake
+ake
+pDn
+faU
+vYs
+jDS
 aaf
 anT
 aaf
@@ -122695,17 +122832,17 @@ crd
 ack
 ack
 aaf
-aaf
+ykE
+idz
+sqe
+sqe
+idz
+idz
+idz
+idz
+etb
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+ake
 aaf
 aaf
 anT

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -39574,6 +39574,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"boE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "bpj" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -39590,6 +39597,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"bpo" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "bpB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -40577,10 +40590,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/security/checkpoint)
-"bBq" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/plating,
-/area/science/storage)
 "bGL" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -41125,6 +41134,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"eXV" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "eYe" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass{
@@ -41237,6 +41252,10 @@
 /obj/item/wrench,
 /turf/open/space,
 /area/space/nearstation)
+"foz" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "fsl" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -41530,6 +41549,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"gZk" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "heQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/navbeacon{
@@ -41584,6 +41609,13 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/engine/atmos)
+"hyX" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hAy" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing";
@@ -41824,6 +41856,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"iOL" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iUq" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -42035,6 +42074,13 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/engine/atmos)
+"jEK" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jFP" = (
 /turf/open/space/basic,
 /area/space/station_ruins)
@@ -42047,6 +42093,11 @@
 	pixel_y = 5
 	},
 /obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"jIu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "jLF" = (
@@ -42072,6 +42123,13 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"jYq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kaA" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -42083,6 +42141,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
+"kcN" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "kit" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/small{
@@ -42101,6 +42165,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kpi" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kqH" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -42110,6 +42179,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"kuK" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "kwF" = (
@@ -42210,10 +42283,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"leB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "leU" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/storage)
@@ -42388,6 +42457,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mdx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "meo" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/mixing)
@@ -42436,12 +42512,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"mrS" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "msG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -42456,12 +42526,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mtU" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "mvB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -42534,22 +42598,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nbT" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Space Loop Out"
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "ndg" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"nfS" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating,
+/area/science/storage)
+"ngY" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "nhU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"njJ" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "nty" = (
 /obj/machinery/button/massdriver{
 	id = "toxinsdriver";
@@ -42735,6 +42810,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"oys" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "oyD" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet/restrooms)
@@ -42812,6 +42891,12 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oXz" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "pbT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -43003,6 +43088,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"pMh" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "pNE" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -43196,12 +43287,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"rxk" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "rzn" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -43338,10 +43423,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"ssf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel,
-/area/science/mixing)
 "svX" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -44044,6 +44125,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"sIm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "sIu" = (
 /turf/closed/wall/r_wall/rust,
 /area/engine/gravity_generator)
@@ -46417,6 +46505,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"uDp" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
+"uEu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uGq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -46675,6 +46776,10 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"vKE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "vMb" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -46733,10 +46838,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"wbg" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "wbV" = (
@@ -46823,6 +46924,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wRY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wUF" = (
 /obj/machinery/door/airlock/atmos/glass/critical{
 	heat_proof = 1;
@@ -46893,13 +47001,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"xmE" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Space Loop Out"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -97671,10 +97772,10 @@ meo
 uiT
 bfq
 bpj
-wbg
-wbg
-wbg
-wbg
+oys
+oys
+oys
+oys
 fjN
 iio
 aad
@@ -97932,8 +98033,8 @@ hVE
 hVE
 hVE
 hVE
-mrS
-leB
+pMh
+kuK
 aac
 aaa
 aaa
@@ -98185,15 +98286,15 @@ ucd
 vZb
 iiW
 bOJ
-ssf
-xmE
-njJ
-rxk
-mtU
-leB
-aac
-aaa
-aaa
+foz
+nbT
+ngY
+oXz
+bpo
+jIu
+vKE
+kpi
+mdx
 aaa
 aaa
 aaa
@@ -98437,7 +98538,7 @@ aac
 aad
 eGm
 lmq
-bBq
+nfS
 sVt
 iio
 upN
@@ -98445,12 +98546,12 @@ iio
 iio
 iio
 iio
-leB
-leB
+sIm
+boE
 iio
 aac
-aaa
-aaa
+sdX
+jEK
 aaa
 aaa
 aaa
@@ -98703,11 +98804,11 @@ gGq
 iio
 aad
 aac
-aac
-aac
-aaa
-aaa
-aaa
+gZk
+uDp
+uEu
+hyX
+jEK
 jFP
 jFP
 jFP
@@ -98961,10 +99062,10 @@ iio
 aad
 aac
 aac
-aac
-aaa
-aaa
-aaa
+eXV
+wRY
+wRY
+jEK
 jFP
 jFP
 jFP
@@ -99218,10 +99319,10 @@ iio
 aad
 aac
 aac
-aac
-aaa
-aaa
-aaa
+kcN
+wRY
+wRY
+jEK
 jFP
 jFP
 jFP
@@ -99475,10 +99576,10 @@ iio
 aac
 aac
 aac
-aaa
-aaa
-aaa
-aaa
+jEK
+wRY
+wRY
+jEK
 jFP
 jFP
 jFP
@@ -99732,10 +99833,10 @@ sdX
 aac
 aac
 aac
-aaa
-aaa
-aaa
-aaa
+jEK
+wRY
+wRY
+jEK
 jFP
 jFP
 jFP
@@ -99989,10 +100090,10 @@ sdX
 aaa
 aac
 aaa
-aaa
-aaa
-aaa
-aaa
+jEK
+wRY
+wRY
+jEK
 jFP
 jFP
 jFP
@@ -100246,10 +100347,10 @@ sdX
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+jYq
+iOL
+jYq
+iOL
 jFP
 jFP
 jFP

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1741,7 +1741,7 @@
 	pixel_x = 12
 	},
 /obj/machinery/shower{
-	pixel_y = 26
+	pixel_y = 16
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -39578,6 +39578,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Toxins Launch Room Access";
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bpn" = (
@@ -40573,6 +40577,10 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
 /area/security/checkpoint)
+"bBq" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating,
+/area/science/storage)
 "bGL" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
@@ -40604,10 +40612,6 @@
 	},
 /area/engine/atmos)
 "bOJ" = (
-/obj/machinery/camera{
-	c_tag = "Toxins Launch Room Access";
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -42065,6 +42069,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "kaA" = (
@@ -42205,11 +42210,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"leB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "leU" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/storage)
 "lmq" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plating,
 /area/science/storage)
 "low" = (
@@ -42427,6 +42436,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"mrS" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "msG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -42441,6 +42456,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mtU" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "mvB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -42523,6 +42544,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"njJ" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "nty" = (
 /obj/machinery/button/massdriver{
 	id = "toxinsdriver";
@@ -43169,6 +43196,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"rxk" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "rzn" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -43305,6 +43338,10 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"ssf" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "svX" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -46249,6 +46286,9 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ujg" = (
@@ -46695,6 +46735,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"wbg" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "wbV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/hydroponics/soil,
@@ -46849,6 +46893,13 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
+"xmE" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Space Loop Out"
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -97368,7 +97419,7 @@ meo
 sVt
 sVt
 sVt
-aad
+iio
 aad
 aad
 aad
@@ -97620,12 +97671,12 @@ meo
 uiT
 bfq
 bpj
+wbg
+wbg
+wbg
+wbg
+fjN
 iio
-aad
-aad
-aad
-aad
-aad
 aad
 aaa
 aaa
@@ -97877,12 +97928,12 @@ sVt
 kQn
 lFm
 fjN
-iio
-aad
-aad
-aad
-aad
-aad
+hVE
+hVE
+hVE
+hVE
+mrS
+leB
 aac
 aaa
 aaa
@@ -98134,12 +98185,12 @@ ucd
 vZb
 iiW
 bOJ
-iio
-aad
-aad
-aad
-aad
-aad
+ssf
+xmE
+njJ
+rxk
+mtU
+leB
 aac
 aaa
 aaa
@@ -98386,17 +98437,17 @@ aac
 aad
 eGm
 lmq
-lmq
+bBq
 sVt
 iio
 upN
 iio
 iio
 iio
-aad
-aad
-aad
-aac
+iio
+leB
+leB
+iio
 aac
 aaa
 aaa
@@ -98651,8 +98702,8 @@ uTF
 gGq
 iio
 aad
-aad
-aad
+aac
+aac
 aac
 aaa
 aaa
@@ -98908,8 +98959,8 @@ msG
 ogL
 iio
 aad
-aad
-aad
+aac
+aac
 aac
 aaa
 aaa
@@ -99165,7 +99216,7 @@ msG
 diQ
 iio
 aad
-aad
+aac
 aac
 aac
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -34077,9 +34077,13 @@
 /turf/closed/wall,
 /area/science/mixing)
 "bAG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/science/mixing)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/science)
 "bAH" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -37242,12 +37246,15 @@
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
 "bGB" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bGD" = (
@@ -37753,12 +37760,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bHD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -38317,11 +38324,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bIP" = (
-/obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/department/science)
 "bIQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38331,11 +38339,9 @@
 /area/maintenance/department/science)
 "bIR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "bIT" = (
 /obj/structure/window/reinforced{
@@ -39403,7 +39409,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40359,11 +40365,12 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "bNq" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Toxins Launch Maintenance";
+	req_access_txt = "8"
 	},
-/turf/open/floor/plating/airless,
-/area/science/mixing)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "bNr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40798,11 +40805,10 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "bOu" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
 	},
-/turf/open/space,
+/turf/open/floor/plating/airless,
 /area/science/mixing)
 "bOv" = (
 /obj/structure/window/reinforced{
@@ -54165,11 +54171,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "fwr" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/science/mixing)
+/obj/machinery/door/airlock/maintenance/abandoned,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "fwI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -54258,6 +54263,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "fBZ" = (
@@ -54461,6 +54467,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"gjv" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Space Loop In";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "gjN" = (
 /obj/item/weldingtool,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -54810,10 +54823,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gMm" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+	dir = 5
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/science/mixing)
 "gMO" = (
 /obj/structure/plasticflaps/opaque,
@@ -55085,6 +55099,13 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hxI" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space/nearstation)
 "hyh" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -55189,6 +55210,12 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"hMx" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/science)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -55450,6 +55477,13 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ilE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "imE" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -57131,6 +57165,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"mhK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/space/basic,
+/area/space/nearstation)
 "miw" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/structure/cable/yellow{
@@ -57383,6 +57422,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"mJp" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -59579,12 +59625,10 @@
 /turf/open/floor/plating,
 /area/chapel/asteroid/monastery)
 "rBh" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/plating,
 /area/maintenance/department/science)
 "rEh" = (
 /obj/structure/table/glass,
@@ -60153,6 +60197,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"tfx" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "tfP" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -60207,6 +60257,13 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"tlp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tlw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -61929,6 +61986,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"xlg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "xlA" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating,
@@ -62181,6 +62243,13 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/freezer,
 /area/storage/emergency/port)
+"xQk" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space/nearstation)
 "xSd" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -105349,7 +105418,7 @@ bHy
 bHy
 bHy
 bOs
-aht
+mZE
 aaa
 aaa
 aaa
@@ -105606,7 +105675,7 @@ bCV
 bCV
 bCV
 bOu
-bNq
+aht
 aaa
 aaa
 aaa
@@ -106115,7 +106184,7 @@ bFt
 bGy
 bHD
 fBz
-bCV
+gMm
 bCV
 bCV
 bCV
@@ -106627,17 +106696,17 @@ bwm
 bAF
 bAF
 bGA
-bAG
-fwr
-gMm
 bAF
 bAF
-aht
-aht
-abI
-abI
-abI
-abI
+bAF
+bAF
+bAF
+uaO
+dsz
+xQk
+hxI
+xQk
+hxI
 abI
 abI
 abI
@@ -106883,18 +106952,18 @@ cDB
 lWy
 tSL
 lWy
-cDB
+bAG
 bwm
 rBh
-bwm
-aht
-aht
-aht
-aaa
-aht
-aaa
-aaa
-aaa
+gjv
+tfx
+xlg
+mJp
+nqu
+mJp
+nqu
+tlp
+ilE
 aaa
 aaa
 aaa
@@ -107140,18 +107209,18 @@ cDB
 hxn
 uvq
 bFx
-tSL
-bwm
 bIP
-bwm
-aht
-aaa
-aht
-aaa
-aht
-aht
-aht
-aht
+bNq
+tSL
+hMx
+tfx
+xlg
+mhK
+wIo
+mhK
+mhK
+mhK
+hyh
 aht
 aaa
 aaa
@@ -107399,16 +107468,16 @@ obP
 bFy
 bGB
 bwm
-bIQ
 bwm
-aht
+bwm
+rNB
 bwm
 bwm
 rNB
 bwm
 rNB
 bwm
-aaa
+cdm
 aby
 aaa
 aaa
@@ -107654,9 +107723,9 @@ rKL
 lWy
 lWy
 bFz
-lWy
-xlA
 bIR
+fwr
+eMC
 bwm
 aht
 bwm


### PR DESCRIPTION
## About The Pull Request

Says what's on the tin, gives a space loop on every map, and some extremely minor updates and fixes. Listing them all would be a bit much.

EDIT: THIS DOES INCLUDE A BALANCE THING I FORGOT TO MENTION.
On boxstation, I made the outside wall of the captain-teleporter hallway/maint an r-wall. This should have been done a long time ago.

## Why It's Good For The Game

@silicons said they wanted to redo freezers to not break the laws of thermodynamics, but, needed there to be space loops in science so they can complete toxins. Well, here it is.

## Changelog
:cl:
add: Adds a space loop to every map in toxins
/:cl:
