### PR TITLE
Quick clown/mime masks designs fix.

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -74,7 +74,7 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	visor_flags_inv = HIDEFACE
 	dog_fashion = /datum/dog_fashion/head/clown
-	var/static/list/clownmask_designs = list()
+	var/static/list/clownmask_designs
 
 /obj/item/clothing/mask/gas/clown_hat/Initialize(mapload)
 	.=..()
@@ -131,7 +131,7 @@
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	visor_flags_inv = HIDEFACE
-	var/static/list/mimemask_designs = list()
+	var/static/list/mimemask_designs
 
 /obj/item/clothing/mask/gas/mime/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
The masks' designs static lists must be null to be generated on initialize.

## Why It's Good For The Game
Fixing a mistake with their alt clicking PR.

## Changelog
:cl:
fix: You can access the mime / clown mask skins radial menu once again.
/:cl:
