### PR TITLE
fixes jetpack speed and nerfs fullspeed jetpacks to be only slightly faster (~+2 instead of +5)

### DIFF
--- a/code/modules/movespeed/modifiers/items.dm
+++ b/code/modules/movespeed/modifiers/items.dm
@@ -1,13 +1,13 @@
 /datum/movespeed_modifier/jetpack
 	conflicts_with = MOVE_CONFLICT_JETPACK
 	movetypes = FLOATING
-	multiplicative_slowdown = -1
+	multiplicative_slowdown = -0.2
 
 /datum/movespeed_modifier/jetpack/cybernetic
-	multiplicative_slowdown = -1.25
+	multiplicative_slowdown = -0.27
 
 /datum/movespeed_modifier/jetpack/fullspeed
-	multiplicative_slowdown = -1.5
+	multiplicative_slowdown = -0.27
 
 /datum/movespeed_modifier/die_of_fate
 	multiplicative_slowdown = 1


### PR DESCRIPTION
woops

anyways it's at the point where we should realize fullspeed jetpacks giving people methspeed is a little op given that once you have one there's no challenge to you from anyone without one.