### PR TITLE
character size scaling

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -519,10 +519,10 @@
 	min_val = RESIZE_DEFAULT_SIZE
 	integer = FALSE
 
-//Pun-Pun movement slowdown given to characters with a body size smaller than this value,
+//Penalties given to characters with a body size smaller than this value,
 //to compensate for their smaller hitbox.
 //To disable, just make sure the value is lower than 'body_size_min'
-/datum/config_entry/number/threshold_body_size_slowdown
+/datum/config_entry/number/threshold_body_size_penalty
 	config_entry_value = RESIZE_DEFAULT_SIZE * 0.85
 	min_val = 0
 	max_val = RESIZE_DEFAULT_SIZE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -531,8 +531,8 @@
 //multiplicative slowdown multiplier. See 'dna.update_body_size' for the operation.
 //doesn't apply to floating or crawling mobs
 /datum/config_entry/number/body_size_slowdown_multiplier
-	config_entry_value = 0.25
-	min_val = 0.1 //To encourage folks to disable the slowdown through the above config instead.
+	config_entry_value = 0
+	min_val = 0
 	integer = FALSE
 
 //Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -509,13 +509,13 @@
 
 //Body size configs, the feature will be disabled if both min and max have the same value.
 /datum/config_entry/number/body_size_min
-	config_entry_value = RESIZE_DEFAULT_SIZE
+	config_entry_value = 0.9
 	min_val = 0.1 //to avoid issues with zeros and negative values.
 	max_val = RESIZE_DEFAULT_SIZE
 	integer = FALSE
 
 /datum/config_entry/number/body_size_max
-	config_entry_value = RESIZE_DEFAULT_SIZE
+	config_entry_value = 1.25
 	min_val = RESIZE_DEFAULT_SIZE
 	integer = FALSE
 
@@ -523,7 +523,7 @@
 //to compensate for their smaller hitbox.
 //To disable, just make sure the value is lower than 'body_size_min'
 /datum/config_entry/number/threshold_body_size_penalty
-	config_entry_value = RESIZE_DEFAULT_SIZE * 0.85
+	config_entry_value = RESIZE_DEFAULT_SIZE
 	min_val = 0
 	max_val = RESIZE_DEFAULT_SIZE
 	integer = FALSE

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -704,8 +704,11 @@
 		var/penalty_threshold = CONFIG_GET(number/threshold_body_size_penalty)
 		if(features["body_size"] < penalty_threshold && old_size >= penalty_threshold)
 			C.maxHealth -= 10 //reduce the maxhealth
+			var/slowdown = (1 - round(features["body_size"] / danger, 0.1)) * CONFIG_GET(number/body_size_slowdown_multiplier)
+			holder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/small_stride, TRUE, slowdown)
 		else
 			if(old_size < penalty_threshold && features["body_size"] >= penalty_threshold)
 				C.maxHealth  += 10 //give the maxhealth back
+				holder.remove_movespeed_modifier(/datum/movespeed_modifier/small_stride) //remove the slowdown
 
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -704,7 +704,7 @@
 		var/penalty_threshold = CONFIG_GET(number/threshold_body_size_penalty)
 		if(features["body_size"] < penalty_threshold && old_size >= penalty_threshold)
 			C.maxHealth -= 10 //reduce the maxhealth
-			var/slowdown = (1 - round(features["body_size"] / danger, 0.1)) * CONFIG_GET(number/body_size_slowdown_multiplier)
+			var/slowdown = (1 - round(features["body_size"] / penalty_threshold, 0.1)) * CONFIG_GET(number/body_size_slowdown_multiplier)
 			holder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/small_stride, TRUE, slowdown)
 		else
 			if(old_size < penalty_threshold && features["body_size"] >= penalty_threshold)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -699,10 +699,11 @@
 	//new size detected
 	holder.resize = features["body_size"] / old_size
 	holder.update_transform()
-	if(features["body_size"] < 1 && old_size >= 1)
+	var/penalty_threshold = CONFIG_GET(number/threshold_body_size_penalty)
+	if(features["body_size"] < penalty_threshold && old_size >= penalty_threshold)
 		holder.maxhealth -= 10 //reduce the maxhealth
 	else
-		if(old_size < 1 && features["body_size"] >= 1)
+		if(old_size < penalty_threshold && features["body_size"] >= penalty_threshold)
 			holder.maxhealth  += 10 //give the maxhealth back
 
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -5,7 +5,7 @@
 	var/uni_identity
 	var/blood_type
 	var/datum/species/species = new /datum/species/human //The type of mutant race the player is if applicable (i.e. potato-man)
-	var/list/features = list("FFF") //first value is mutant color
+	var/list/features = list("FFF", "body_size" = RESIZE_DEFAULT_SIZE) //first value is mutant color
 	var/real_name //Stores the real name of the person who originally got this dna datum. Used primarely for changelings,
 	var/nameless = FALSE
 	var/custom_species	//siiiiigh I guess this is important

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -699,11 +699,13 @@
 	//new size detected
 	holder.resize = features["body_size"] / old_size
 	holder.update_transform()
-	var/penalty_threshold = CONFIG_GET(number/threshold_body_size_penalty)
-	if(features["body_size"] < penalty_threshold && old_size >= penalty_threshold)
-		holder.maxhealth -= 10 //reduce the maxhealth
-	else
-		if(old_size < penalty_threshold && features["body_size"] >= penalty_threshold)
-			holder.maxhealth  += 10 //give the maxhealth back
+	if(iscarbon(holder))
+		var/mob/living/carbon/C = holder
+		var/penalty_threshold = CONFIG_GET(number/threshold_body_size_penalty)
+		if(features["body_size"] < penalty_threshold && old_size >= penalty_threshold)
+			C.maxHealth -= 10 //reduce the maxhealth
+		else
+			if(old_size < penalty_threshold && features["body_size"] >= penalty_threshold)
+				C.maxHealth  += 10 //give the maxhealth back
 
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -696,11 +696,13 @@
 /datum/dna/proc/update_body_size(old_size)
 	if(!holder || features["body_size"] == old_size)
 		return
+	//new size detected
 	holder.resize = features["body_size"] / old_size
 	holder.update_transform()
-	var/danger = CONFIG_GET(number/threshold_body_size_slowdown)
-	if(features["body_size"] < danger)
-		var/slowdown = (1 - round(features["body_size"] / danger, 0.1)) * CONFIG_GET(number/body_size_slowdown_multiplier)
-		holder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/small_stride, TRUE, slowdown)
-	else if(old_size < danger)
-		holder.remove_movespeed_modifier(/datum/movespeed_modifier/small_stride)
+	if(features["body_size"] < 1 && old_size >= 1)
+		holder.maxhealth -= 10 //reduce the maxhealth
+	else
+		if(old_size < 1 && features["body_size"] >= 1)
+			holder.maxhealth  += 10 //give the maxhealth back
+
+

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2246,7 +2246,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("body_size")
 					var/new_body_size = input(user, "Choose your desired sprite size: (90-125%)\nWarning: This may make your character look distorted. Additionally, any size under 100% takes a 10% maximum health penalty", "Character Preference", features["body_size"]*100) as num|null
 					if(new_body_size)
-						body_size = clamp(new_body_size * 0.01, CONFIG_GET(number/body_size_min), CONFIG_GET(number/body_size_max))
+						features["body_size"] = clamp(new_body_size * 0.01, CONFIG_GET(number/body_size_min), CONFIG_GET(number/body_size_max))
 
 				if("tongue")
 					var/selected_custom_tongue = input(user, "Choose your desired tongue (none means your species tongue)", "Character Preference") as null|anything in GLOB.roundstart_tongues
@@ -2695,7 +2695,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/old_size = character.dna.features["body_size"]
 	if(isdwarf(character))
 		character.dna.features["body_size"] = RESIZE_DEFAULT_SIZE
-		old_size = 1
+		old_size = RESIZE_DEFAULT_SIZE
 
 	if((parent && parent.can_have_part("meat_type")) || pref_species.mutant_bodyparts["meat_type"])
 		character.type_of_meat = GLOB.meat_types[features["meat_type"]]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -482,7 +482,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				dat += "<span style='border: 1px solid #161616; background-color: #[features["mcolor3"]];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=mutant_color3;task=input'>Change</a><BR>"
 				mutant_colors = TRUE
 
-			if (CONFIG_GET(number/body_size_min) != CONFIG_GET(number/body_size_max))
 				dat += "<b>Sprite Size:</b> <a href='?_src_=prefs;preference=body_size;task=input'>[features["body_size"]*100]%</a><br>"
 
 			if(!(NOEYES in pref_species.species_traits))
@@ -2245,21 +2244,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					gender = chosengender
 
 				if("body_size")
-					var/min = CONFIG_GET(number/body_size_min)
-					var/max = CONFIG_GET(number/body_size_max)
-					var/danger = CONFIG_GET(number/threshold_body_size_slowdown)
-					var/new_body_size = input(user, "Choose your desired sprite size: ([min*100]%-[max*100]%)\nWarning: This may make your character look distorted[danger > min ? "! Additionally, a proportional movement speed penalty will be applied to characters smaller than [danger*100]%." : "!"]", "Character Preference", features["body_size"]*100) as num|null
-					if (new_body_size)
-						new_body_size = clamp(new_body_size * 0.01, min, max)
-						var/dorfy
-						if((new_body_size + 0.01) < danger) // Adding 0.01 as a dumb fix to prevent the warning message from appearing when exactly at threshold... Not sure why that happens in the first place.
-							dorfy = alert(user, "You have chosen a size below the slowdown threshold of [danger*100]%. For balancing purposes, the further you go below this percentage, the slower your character will be. Do you wish to keep this size?", "Speed Penalty Alert", "Yes", "Move it to the threshold", "No")
-							if(dorfy == "Move it to the threshold")
-								new_body_size = danger
-							if(!dorfy) //Aborts if this var is somehow empty
-								return
-						if(dorfy != "No")
-							features["body_size"] = new_body_size
+					var/new_body_size = input(user, "Choose your desired sprite size: (90-125%)\nWarning: This may make your character look distorted. Additionally, any size under 100% takes a 10% maximum health penalty", "Character Preference", features["body_size"]*100) as num|null
+					if(new_body_size)
+						body_size = clamp(new_body_size * 0.01, 90, 125)
+
 				if("tongue")
 					var/selected_custom_tongue = input(user, "Choose your desired tongue (none means your species tongue)", "Character Preference") as null|anything in GLOB.roundstart_tongues
 					if(selected_custom_tongue)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2246,7 +2246,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("body_size")
 					var/new_body_size = input(user, "Choose your desired sprite size: (90-125%)\nWarning: This may make your character look distorted. Additionally, any size under 100% takes a 10% maximum health penalty", "Character Preference", features["body_size"]*100) as num|null
 					if(new_body_size)
-						body_size = clamp(new_body_size * 0.01, 90, 125)
+						body_size = clamp(new_body_size * 0.01, CONFIG_GET(number/body_size_min), CONFIG_GET(number/body_size_max))
 
 				if("tongue")
 					var/selected_custom_tongue = input(user, "Choose your desired tongue (none means your species tongue)", "Character Preference") as null|anything in GLOB.roundstart_tongues

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2641,6 +2641,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			else if(firstspace == name_length)
 				real_name += "[pick(GLOB.last_names)]"
 
+	//reset size if applicable
+	if(character.dna.features["body_size"])
+		var/initial_old_size = character.dna.features["body_size"]
+		character.dna.features["body_size"] = RESIZE_DEFAULT_SIZE
+		character.dna.update_body_size(initial_old_size)
+
 	character.real_name = nameless ? "[real_name] #[rand(10000, 99999)]" : real_name
 	character.name = character.real_name
 	character.nameless = nameless
@@ -2695,7 +2701,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/old_size = RESIZE_DEFAULT_SIZE
 	if(isdwarf(character))
 		character.dna.features["body_size"] = RESIZE_DEFAULT_SIZE
-		old_size = RESIZE_DEFAULT_SIZE
 
 	if((parent && parent.can_have_part("meat_type")) || pref_species.mutant_bodyparts["meat_type"])
 		character.type_of_meat = GLOB.meat_types[features["meat_type"]]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2692,7 +2692,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.dna.nameless = character.nameless
 	character.dna.custom_species = character.custom_species
 
-	var/old_size = character.dna.features["body_size"]
+	var/old_size = RESIZE_DEFAULT_SIZE
 	if(isdwarf(character))
 		character.dna.features["body_size"] = RESIZE_DEFAULT_SIZE
 		old_size = RESIZE_DEFAULT_SIZE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2683,8 +2683,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		pref_species = new /datum/species/human
 		save_character()
 
-	var/old_size = character.dna.features["body_size"]
-
 	character.dna.features = features.Copy()
 	character.set_species(chosen_species, icon_update = FALSE, pref_load = TRUE)
 	character.dna.species.eye_type = eye_type
@@ -2693,6 +2691,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.dna.real_name = character.real_name
 	character.dna.nameless = character.nameless
 	character.dna.custom_species = character.custom_species
+
+	var/old_size = character.dna.features["body_size"]
+	if(isdwarf(character)
+		character.dna.features["body_size"] = 1
+		old_size = 1
 
 	if((parent && parent.can_have_part("meat_type")) || pref_species.mutant_bodyparts["meat_type"])
 		character.type_of_meat = GLOB.meat_types[features["meat_type"]]

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2693,8 +2693,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.dna.custom_species = character.custom_species
 
 	var/old_size = character.dna.features["body_size"]
-	if(isdwarf(character)
-		character.dna.features["body_size"] = 1
+	if(isdwarf(character))
+		character.dna.features["body_size"] = RESIZE_DEFAULT_SIZE
 		old_size = 1
 
 	if((parent && parent.can_have_part("meat_type")) || pref_species.mutant_bodyparts["meat_type"])

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -651,17 +651,17 @@ PENIS_MIN_INCHES_PREFS 1
 PENIS_MAX_INCHES_PREFS 20
 
 ## Body size configs, the feature will be disabled if both min and max have the same value.
-BODY_SIZE_MIN 1
-BODY_SIZE_MAX 1
+BODY_SIZE_MIN 0.9
+BODY_SIZE_MAX 1.25
 
 ## Pun-Pun movement slowdown given to characters with a body size smaller than this value,
 ## to compensate for their smaller hitbox.
 ## To disable, just make sure the value is lower than 'body_size_min'
-THRESHOLD_BODY_SIZE_SLOWDOWN 0.85
+THRESHOLD_BODY_SIZE_PENALTY 1
 
 ## Multiplier used in the smaller strides slowdown calculation.
 ## Doesn't apply to floating or crawling mobs.
-BODY_SIZE_SLOWDOWN_MULTIPLIER 0.25
+BODY_SIZE_SLOWDOWN_MULTIPLIER 0
 
 ## Allows players to set a hexadecimal color of their choice as skin tone, on top of the standard ones.
 ALLOW_CUSTOM_SKINTONES


### PR DESCRIPTION
## About The Pull Request
before you downvote this and cry because of the title, please read the pr description, please.

the size limits are 90% to 125%
these do not stack with the dwarf species, i.e. they just outright will not apply

if you go under 100% size, REGARDLESS OF BY HOW MUCH, you will lose 10 max health, meaning you can't gamer the debuff by being 99% size or 91% or something dumb in that regard

if you go above 100% size, nothing happens, you're just bigger, congratulations on having a bigger hitbox
the reason it's capped at 125% is because this is the size of the gigantism trait and id rather it not be bigger than that because i dont want people filling my screen with their size on main

note: sizes can and will get distorted, however it's not too much of an issue because the minimum size i put in is literally 90%

## Why It's Good For The Game
size customization in a sane manner when done correctly can be good

## Changelog
:cl:
add: you can now customize your size from 90% to 130%, going below 100% makes you have 10 less max health
/:cl:
