### PR TITLE
Fixes the Layer 3 Outlet Injector mapping asset being on the wrong layer

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -196,7 +196,7 @@
 	icon_state = "inje_map-1"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer3
-	piping_layer = 2
+	piping_layer = 3
 	icon_state = "inje_map-2"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on
@@ -207,7 +207,7 @@
 	icon_state = "inje_map-1"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3
-	piping_layer = 2
+	piping_layer = 3
 	icon_state = "inje_map-2"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -197,7 +197,7 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/layer3
 	piping_layer = 3
-	icon_state = "inje_map-2"
+	icon_state = "inje_map-3"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on
 	on = TRUE
@@ -208,7 +208,7 @@
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3
 	piping_layer = 3
-	icon_state = "inje_map-2"
+	icon_state = "inje_map-3"
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos
 	frequency = FREQ_ATMOS_STORAGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Simply fixes the layer 3 outlet to be in the correct layer. (How did no one see this?)

## Why It's Good For The Game

Example, syndicate listening post:
**From:**
![image](https://user-images.githubusercontent.com/53913550/97353655-0fc7f380-1873-11eb-94ac-43ee924e1ead.png)
**To:**
![image](https://user-images.githubusercontent.com/53913550/97353678-18202e80-1873-11eb-937f-7e47cbd658ed.png)

## Changelog
:cl:
fix: Outlet Injector Mapping Asset Layer Fix
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
