### PR TITLE
bone gauntlets bandaid nerf

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -684,10 +684,10 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	armor = list("melee" = 20, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 35, "bio" = 35, "rad" = 35, "fire" = 0, "acid" = 0)
-	enhancement = 9 // first, do harm. all of it. all of the harm. just fuck em up.
-	wound_enhancement = 9
-	var/fast_enhancement = 9
-	var/fast_wound_enhancement = 9
+	enhancement = 6 // first, do harm. all of it. all of the harm. just fuck em up.
+	wound_enhancement = 6
+	var/fast_enhancement = 6
+	var/fast_wound_enhancement = 6
 	var/slow_enhancement = 20
 	var/slow_wound_enhancement = 20
 	silent = TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1451,9 +1451,9 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			target.apply_damage(damage*1.5, attack_type, affecting, armor_block, wound_bonus = punchwoundbonus)
 			target.apply_damage(damage*0.5, STAMINA, affecting, armor_block)
 			log_combat(user, target, "kicked")
-		else if(HAS_TRAIT(user, TRAIT_MAULER)) // mauler punches deal 1.3x raw damage + 1x stam damage, and have some armor pierce
-			target.apply_damage(damage*1.3, attack_type, affecting, armor_block, wound_bonus = punchwoundbonus)
-			target.apply_damage(damage, STAMINA, affecting, armor_block)
+		else if(HAS_TRAIT(user, TRAIT_MAULER)) // mauler punches deal 1.1x raw damage + 1.3x stam damage, and have some armor pierce
+			target.apply_damage(damage*1.1, attack_type, affecting, armor_block, wound_bonus = punchwoundbonus)
+			target.apply_damage(damage*1.3, STAMINA, affecting, armor_block)
 			log_combat(user, target, "punched (mauler)")
 		else //other attacks deal full raw damage + 2x in stamina damage
 			target.apply_damage(damage, attack_type, affecting, armor_block, wound_bonus = punchwoundbonus)


### PR DESCRIPTION
## About The Pull Request
reduces bone gauntlets fast mode enhancements to +6 instead of +9,
changes TRAIT_MAULER punch damages from 1.3x brute 1x stam to 1.1x brute 1.3x stam (compare to punches 1x brute 2x stam or kicks 1.5x brute 0.5x stam)
todo:
- tweak the sprites
- functionality for sharp unarmed on fast mode, normal unarmed on brute mode (slashing and then punching the ribs out of?)
## Why It's Good For The Game
funny hands might actually be killing people too fast on fast mode, actually, whoops
## Changelog
:cl:
balance: The bone gauntlets should be slightly less murderously punchy on the fast punches mode.
/:cl: