### PR TITLE
Sawing down guns makes them deal 10% less damage

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -202,6 +202,7 @@
 		slot_flags &= ~ITEM_SLOT_BACK	//you can't sling it on your back
 		slot_flags |= ITEM_SLOT_BELT		//but you can wear it on your belt (poorly concealed under a trenchcoat, ideally)
 		sawn_off = TRUE
+		projectile_damage_multiplier = src.projectile_damage_multiplier - 0.1 //We lose 10% of damange if were spawn off
 		update_icon()
 		return 1
 


### PR DESCRIPTION

## About The Pull Request

sawing down guns like shotguns will deal 10% less damage per shot

## Why It's Good For The Game

Gives people a reason to not saw down all the armory guns for better space ecom.

## Changelog
:cl:
balance: Sawing down guns have shown to deal less damage
/:cl:
