### PR TITLE
Maggun unifications

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -36,6 +36,7 @@
 	if(isgun(fired_from))
 		var/obj/item/gun/G = fired_from
 		BB.damage *= G.projectile_damage_multiplier
+		BB.armour_penetration *= G.projectile_armor_penitration_multiplier
 		if(HAS_TRAIT(user, TRAIT_INSANE_AIM))
 			BB.ricochets_max = max(BB.ricochets_max, 10) //bouncy!
 			BB.ricochet_chance = max(BB.ricochet_chance, 100) //it wont decay so we can leave it at 100 for always bouncing

--- a/code/modules/projectiles/ammunition/caseless/ferromagnetic.dm
+++ b/code/modules/projectiles/ammunition/caseless/ferromagnetic.dm
@@ -13,16 +13,6 @@
 	desc = "A large, specialized ferromagnetic slug designed with a less-than-lethal payload."
 	projectile_type = /obj/item/projectile/bullet/magnetic/disabler
 
-/obj/item/ammo_casing/caseless/magnetic/weak
-	desc = "A ferromagnetic slug intended to be launched out of a compatible weapon."
-	projectile_type = /obj/item/projectile/bullet/magnetic/weak
-	energy_cost = 125
-
-/obj/item/ammo_casing/caseless/magnetic/weak/disabler
-	desc = "A specialized ferromagnetic slug designed with a less-than-lethal payload."
-	projectile_type = /obj/item/projectile/bullet/magnetic/weak/disabler
-	energy_cost = 125
-
 /obj/item/ammo_casing/caseless/magnetic/hyper
 	desc = "A large block of speciallized ferromagnetic material designed to be fired out of the experimental Hyper-Burst Rifle."
 	caliber = "hypermag"

--- a/code/modules/projectiles/boxes_magazines/external/magweapon.dm
+++ b/code/modules/projectiles/boxes_magazines/external/magweapon.dm
@@ -1,4 +1,5 @@
 /obj/item/ammo_box/magazine/mmag
+	name = "magrifle magazine (non-lethal disabler)"
 	icon_state = "mediummagmag"
 	ammo_type = /obj/item/ammo_casing/caseless/magnetic/disabler
 	caliber = "mag"
@@ -12,12 +13,12 @@
 /obj/item/ammo_box/magazine/mmag/small
 	name = "magpistol magazine (non-lethal disabler)"
 	icon_state = "smallmagmag"
-	ammo_type = /obj/item/ammo_casing/caseless/magnetic/weak/disabler
+	ammo_type = /obj/item/ammo_casing/caseless/magnetic/disabler
 	max_ammo = 16
 
 /obj/item/ammo_box/magazine/mmag/small/lethal
 	name = "magpistol magazine (lethal)"
-	ammo_type = /obj/item/ammo_casing/caseless/magnetic/weak
+	ammo_type = /obj/item/ammo_casing/caseless/magnetic
 
 /obj/item/ammo_box/magazine/mhyper
 	name = "hyper-burst rifle magazine"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -88,6 +88,7 @@
 
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 	var/projectile_damage_multiplier = 1
+	var/projectile_armor_penitration_multiplier = 1
 
 	var/automatic = 0 //can gun use it, 0 is no, anything above 0 is the delay between clicks in ds
 

--- a/code/modules/projectiles/guns/ballistic/magweapon.dm
+++ b/code/modules/projectiles/guns/ballistic/magweapon.dm
@@ -77,7 +77,7 @@
 
 /obj/item/gun/ballistic/automatic/magrifle/pistol
 	name = "magpistol"
-	desc = "A handgun utilizing maglev technologies to propel a ferromagnetic slug to extreme velocities."
+	desc = "A handgun utilizing maglev technologies to propel a ferromagnetic slug to extreme velocities. Packs less of a punch."
 	icon_state = "magpistol"
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
@@ -85,7 +85,9 @@
 	mag_type = /obj/item/ammo_box/magazine/mmag/small
 	fire_delay = 2
 	inaccuracy_modifier = 0.25
-	cell_type = /obj/item/stock_parts/cell/magnetic/pistol
+	cell_type = /obj/item/stock_parts/cell/magnetic/pistol //We also hold less ammo
+	projectile_damage_multiplier = 0.8 //20% less damage then normal
+	projectile_armor_penitration_multiplier = 0.5 //50% less AP
 	automatic_burst_overlay = FALSE
 
 /obj/item/gun/ballistic/automatic/magrifle/pistol/update_overlays()

--- a/code/modules/projectiles/projectile/bullets/ferromagnetic.dm
+++ b/code/modules/projectiles/projectile/bullets/ferromagnetic.dm
@@ -14,16 +14,6 @@
 	stamina = 20
 	light_color = LIGHT_COLOR_BLUE
 
-/obj/item/projectile/bullet/magnetic/weak
-	damage = 15
-	armour_penetration = 10
-	light_range = 2
-	range = 25
-
-/obj/item/projectile/bullet/magnetic/weak/disabler
-	damage = 2
-	stamina = 20
-
 /obj/item/projectile/bullet/magnetic/hyper
 	damage = 10
 	armour_penetration = 20


### PR DESCRIPTION

## About The Pull Request

You can no longer print mag-rifle ammo and load it into a pistol for maxium damage and AP
Mag pistol ammo bullets are removed to do clearly being trash
Mag pistol itself will modife the shots to be almost the same as before

## Why It's Good For The Game

Stops the confusing ammo thing of `Why does this ammo flat out deal more then this one`
Makes the code look cleaner
Stops the abuse of loading normal mag ammo into pistols for that reason
Corrects missing name of a mag box
Likely gives mag pistol a bit more range and use as a holdout weapon as its meant to rather then duel wielding them to down people rather.
## Changelog
:cl:
balance: You can no longer print mag-rifle ammo and load it into a pistol for maxium damage and AP
fix: Corrects missing name of a mag box
/:cl:
