### PR TITLE
Nerfs combat knife damage

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -150,8 +150,8 @@
 	item_state = "knife"
 	desc = "A military combat utility survival knife."
 	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
-	force = 20
-	throwforce = 20
+	force = 16
+	throwforce = 16
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
 	bayonet = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Tanks the force damage from 20force to 16 force, to move it more in-line with other knives.

## Why It's Good For The Game

For the low, low, price of 800 credits, you can get a weapon that's stronger than a two handed plasma spear that can be used in one hand, and has the same embed chance.
It's too good, and I'd rather not just remove the cargo box itself, rather, move it in line with the other knives, see the picture below:
![image](https://user-images.githubusercontent.com/48370570/97488386-8ed13080-1934-11eb-80be-1bd04e57acd3.png)


## Changelog
:cl:
balance: Nerf combat knife damage
/:cl: