### PR TITLE
[READY] Hybrid bodyparts - wound surgery edition

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -91,8 +91,6 @@
 	var/wound_flags = (FLESH_WOUND | BONE_WOUND | ACCEPTS_GAUZE)
 
 /datum/wound/Destroy()
-	if(attached_surgery)
-		QDEL_NULL(attached_surgery)
 	if(limb?.wounds && (src in limb.wounds)) // destroy can call remove_wound() and remove_wound() calls qdel, so we check to make sure there's anything to remove first
 		remove_wound()
 	limb = null

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -21,13 +21,13 @@
 	force = 5
 	w_class = WEIGHT_CLASS_SMALL
 	tool_behaviour = TOOL_MULTITOOL
+	item_flags = SURGICAL_TOOL
 	throwforce = 0
 	throw_range = 7
 	throw_speed = 3
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=20)
 	var/obj/machinery/buffer // simple machine buffer for device linkage
 	toolspeed = 1
-	tool_behaviour = TOOL_MULTITOOL
 	usesound = 'sound/weapons/empty.ogg'
 	var/datum/integrated_io/selected_io = null  //functional for integrated circuits.
 	var/mode = 0

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -8,6 +8,7 @@
 	usesound = 'sound/items/crowbar.ogg'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	item_flags = SURGICAL_TOOL
 	force = 5
 	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -8,6 +8,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	item_flags = SURGICAL_TOOL
 	force = 5
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -9,6 +9,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	item_flags = SURGICAL_TOOL
 	force = 3
 	throwforce = 5
 	hitsound = "swing_hit"

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -8,6 +8,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	item_flags = SURGICAL_TOOL
 	force = 6
 	throw_speed = 3
 	throw_range = 7

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -7,6 +7,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
+	item_flags = SURGICAL_TOOL
 	force = 5
 	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -15,6 +15,9 @@
 		var/obj/item/bodypart/targeted_bodypart = target.get_bodypart(user.zone_selected)
 		return(targeted_bodypart.get_wound_type(targetable_wound))
 
+/datum/surgery/repair_bone_hairline/biomech
+	requires_bodypart_type = BODYPART_HYBRID
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/repair_bone_hairline, /datum/surgery_step/mechanic_close)
 
 ///// Repair Compound Fracture (Critical)
 /datum/surgery/repair_bone_compound
@@ -24,6 +27,10 @@
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 	requires_real_bodypart = TRUE
 	targetable_wound = /datum/wound/blunt/critical
+
+/datum/surgery/repair_bone_compound/biomech
+	requires_bodypart_type = BODYPART_HYBRID
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/open_hatch, /datum/surgery_step/pry_off_plating, /datum/surgery_step/reset_compound_fracture, /datum/surgery_step/repair_bone_compound, /datum/surgery_step/add_plating, /datum/surgery_step/mechanic_close)
 
 /datum/surgery/repair_bone_compound/can_start(mob/living/user, mob/living/carbon/target)
 	if(..())

--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -16,6 +16,10 @@
 		var/datum/wound/burn/burn_wound = targeted_bodypart.get_wound_type(targetable_wound)
 		return(burn_wound && burn_wound.infestation > 0)
 
+/datum/surgery/debride/biomech
+	name = "Debride infected synthetic flesh"
+	requires_bodypart_type = BODYPART_HYBRID
+
 //SURGERY STEPS
 
 ///// Debride

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -13,7 +13,7 @@
 			"[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].",
 			"[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].")
 
-/datum/surgery_step/mechanic_incise/tool_check(mob/user, obj/item/tool)
+/datum/surgery_step/mechanic_open/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.get_sharpness())
 		return FALSE
 	return TRUE

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -38,7 +38,7 @@
 	return TRUE
 //prepare electronics
 /datum/surgery_step/prepare_electronics
-	name = "prepare electronics"
+	name = "prepare electronics (multitool)"
 	implements = list(
 		TOOL_MULTITOOL = 100,
 		TOOL_HEMOSTAT = 10) // try to reboot internal controllers via short circuit with some conductor
@@ -77,7 +77,7 @@
 
 //open hatch
 /datum/surgery_step/open_hatch
-	name = "open the hatch"
+	name = "open the hatch (empty hand)"
 	accept_hand = 1
 	time = 10
 

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -144,4 +144,4 @@
 			display_results(user, target, "<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>",
 				"[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
 				"[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!")
-	return 0
+	return 1

--- a/code/modules/surgery/repair_puncture.dm
+++ b/code/modules/surgery/repair_puncture.dm
@@ -1,5 +1,5 @@
 
-/////BURN FIXING SURGERIES//////
+/////PUNCTURE FIXING SURGERIES//////
 
 //the step numbers of each of these two, we only currently use the first to switch back and forth due to advancing after finishing steps anyway
 #define REALIGN_INNARDS 1

--- a/code/modules/surgery/repair_puncture.dm
+++ b/code/modules/surgery/repair_puncture.dm
@@ -14,6 +14,10 @@
 	requires_real_bodypart = TRUE
 	targetable_wound = /datum/wound/pierce
 
+/datum/surgery/repair_puncture/biomech
+	requires_bodypart_type = BODYPART_HYBRID
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/repair_innards, /datum/surgery_step/seal_veins, /datum/surgery_step/mechanic_close)
+
 /datum/surgery/repair_puncture/can_start(mob/living/user, mob/living/carbon/target)
 	. = ..()
 	if(.)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -81,8 +81,12 @@
 			surgery.status++
 			if(surgery.status > surgery.steps.len)
 				surgery.complete()
-	surgery.step_in_progress = FALSE
-	return advance
+		surgery.step_in_progress = FALSE
+		return advance
+	else
+		surgery.step_in_progress = FALSE
+		return TRUE //Stop the attack chain!
+
 
 /datum/surgery_step/proc/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You begin to perform surgery on [target]...</span>",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since synthetics as of now can get wounds, but the wound-fixing surgeries were locked to organics only, this gives them access to those surgeries, with some organic steps replaced with mechanic ones where applicable.
Also fixes a typo in the mechanic_open step, and clarifies the required tool for two mechanical surgery steps.

~~Pending local testing to doublecheck this working aswell as some other hybrid bodypart interactions, but should work.~~
Localtested it a bunch and it works fine, additionally also made wound surgeries not qdel() when the wound is fixed since it's kinda weird to see the close step, now being available, and the surgery then just being deleted instead. All wound-related surgeries have checks in place for their steps if there's no wound there anymore anyways.

Edit: This also fixes organs being fed to people after inserting them (was because success returned 0 instead of 1), and designates most tools (welder, wirecutter, wrench, screwdriver, multitool) as surgery tools due to the bigger amount of people requiring robotic surgeries now. (makes them not bonk people if on help intent and having a active surgery), plus it makes the initiate() proc of surgery always return true if the doafter fails as not doing so causes some annoyances (starting to forcefeed / slapping them with whatever you used for the surgery / etc.). The behaviour for axtually failing is still the same.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Synths can get wounds, they should also be able to heal them via surgery instead of only via the agonizingly slow nonsurgical means.
Also most tools are commonly needed for surgery now that we have more robotic synths, therefore they should have the safeguard normal tools have (so you don't accidentally stab your patient's eyes out)
Not having people get slapped with / forcefed whatever you were using for the surgery if you step away without finishing the step sounds like a good thing too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Biomechanical (hybrid) bodyparts now have access to wound-fixing surgeries.
tweak: A wound being fixed no longer just qdel()s surgeries connected to it.
tweak: Some robotic surgery steps are now a bit more clear.
fix: Organs no longer get fed to people after successfully being inserted into them.
tweak: Not completing the do_after of a surgery no longer causes you to attack the target with whatever you were holding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
