### PR TITLE
More time for admins to cancel events

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -68,8 +68,8 @@
 
 	triggering = TRUE
 	if (alert_observers)
-		message_admins("Random Event triggering in 10 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
-		sleep(100)
+		message_admins("Random Event triggering in 30 seconds: [name] (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
+		sleep(300)
 		var/gamemode = SSticker.mode.config_tag
 		var/players_amt = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
 		if(!canSpawnEvent(players_amt, gamemode))


### PR DESCRIPTION
## About The Pull Request

Makes the time to cancel an event 30 seconds, instead of 10 seconds.
Semi-port of: https://github.com/Skyrat-SS13/Skyrat-tg/pull/1569

## Why It's Good For The Game

10 seconds is only good if you're actively looking for it, and, 1 minute delays it too long.
With event managers and more events, there's more reason to just stop things.

## Changelog
:cl:
admin: Canceling events gives more time to stop from 10 to 30
/:cl:
