### PR TITLE
Changes to void volt and the clock power_drain() proc

### DIFF
--- a/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
@@ -1,41 +1,57 @@
-//horrifying power drain proc made for clockcult's power drain in lieu of six istypes or six for(x in view) loops
-/atom/movable/proc/power_drain(clockcult_user, drain_weapons = FALSE) //This proc as of now is only in use for void volt
+/*
+horrifying power drain proc made for clockcult's power drain in lieu of six istypes or six for(x in view) loops
+args:
+clockcult_user: If the user / source has to do with clockcult stuff
+drain_weapons: If this drains weaponry, such as batons and guns
+recursive: If this recurses through mob / storage contents. ONLY USE THIS IF IT'S NOT CALLED TOO FREQUENTLY, or I'm not liable for any lag / functional issues caused
+drain_amount: Ho much is drained by default; Influenced by a multiplier on most things depending on how much power they usually hold.
+*/
+/atom/movable/proc/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER) //This proc as of now is only in use for void volt and transmission sigils
+	if(recursive)
+		var/succ = 0
+		for(var/V in contents)
+			var/atom/movable/target = V
+			succ += target.power_drain(clockcult_user, drain_weapons, recursive, drain_amount)
+		return succ
 	var/obj/item/stock_parts/cell/cell = get_cell()
 	if(cell)
-		return cell.power_drain(clockcult_user)
+		return cell.power_drain(clockcult_user, drain_weapons, recursive, drain_amount)
 	return 0 //Returns 0 instead of FALSE to symbolise it returning the power amount in other cases, not TRUE aka 1
 
-/obj/item/melee/baton/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes
+/obj/item/melee/baton/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER)	//balance memes
 	if(!drain_weapons)
 		return 0
-	return ..()
+	var/obj/item/stock_parts/cell/cell = get_cell()
+	if(cell)
+		return cell.power_drain(clockcult_user, drain_weapons, recursive, drain_amount)
+	return 0 //No need to recurse further in batons
 
-/obj/item/gun/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes
+/obj/item/gun/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER)	//balance memes
 	if(!drain_weapons)
 		return 0
 	var/obj/item/stock_parts/cell/cell = get_cell()
 	if(!cell)
 		return 0
 	if(cell.charge)
-		. = min(cell.charge, MIN_CLOCKCULT_POWER*4) //Done snowflakey because guns have far smaller cells than batons / other equipment
+		. = min(cell.charge, drain_amount*4) //Done snowflakey because guns have far smaller cells than batons / other equipment, also no need to recurse further in guns
 		cell.use(.)
 		update_icon()
 
-/obj/machinery/power/apc/power_drain(clockcult_user, drain_weapons = FALSE)
+/obj/machinery/power/apc/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER)
 	if(cell && cell.charge)
 		playsound(src, "sparks", 50, 1)
 		flick("apc-spark", src)
-		. = min(cell.charge, MIN_CLOCKCULT_POWER*4)
-		cell.use(.) //Better than a power sink!
+		. = min(cell.charge, drain_amount*4)
+		cell.use(min(cell.charge, . * 4)) //Better than a power sink!
 		if(!cell.charge && !shorted)
 			shorted = 1
 			visible_message("<span class='warning'>The [name]'s screen blurs with static.</span>")
 		update()
 		update_icon()
 
-/obj/machinery/power/smes/power_drain(clockcult_user, drain_weapons = FALSE)
+/obj/machinery/power/smes/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER)
 	if(charge)
-		. = min(charge, MIN_CLOCKCULT_POWER*4)
+		. = min(charge, drain_amount*4)
 		charge -= . * 50
 		if(!charge && !panel_open)
 			panel_open = TRUE
@@ -44,20 +60,26 @@
 			visible_message("<span class='warning'>[src]'s panel flies open with a flurry of sparks!</span>")
 		update_icon()
 
-/obj/item/stock_parts/cell/power_drain(clockcult_user, drain_weapons = FALSE)
+/obj/item/stock_parts/cell/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER)
 	if(charge)
-		. = min(charge, MIN_CLOCKCULT_POWER * 4) //Done like this because normal cells are usually quite a bit bigger than the ones used in guns / APCs
+		. = min(charge, drain_amount * 4) //Done like this because normal cells are usually quite a bit bigger than the ones used in guns / APCs
 		use(min(charge, . * 10)) //Usually cell-powered equipment that is not a gun has at least ten times the capacity of a gun / 5 times the amount of an APC. This adjusts the drain to account for that.
 		update_icon()
 
-/mob/living/silicon/robot/power_drain(clockcult_user, drain_weapons = FALSE)
+/mob/living/silicon/robot/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER)
 	if((!clockcult_user || !is_servant_of_ratvar(src)) && cell && cell.charge)
-		. = min(cell.charge, MIN_CLOCKCULT_POWER*4)
+		. = min(cell.charge, drain_amount*8) //Silicons are very susceptible to Ratvar's might
 		cell.use(.)
 		spark_system.start()
 
-/obj/mecha/power_drain(clockcult_user, drain_weapons = FALSE)
-	if((!clockcult_user || (occupant && !is_servant_of_ratvar(occupant))) && cell && cell.charge)
-		. = min(cell.charge, MIN_CLOCKCULT_POWER*4)
-		cell.use(.)
-		spark_system.start()
+/obj/mecha/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER)
+	if(!clockcult_user || (occupant && !is_servant_of_ratvar(occupant)))
+		if(recursive)
+			var/succ = 0
+			for(var/atom/movable/target in contents) //Hiding in your mech won't save you.
+				succ += target.power_drain(clockcult_user, drain_weapons, recursive, drain_amount)
+			. = succ
+		else if(cell && cell.charge)
+			. = min(cell.charge, drain_amount*4)
+			cell.use(.)
+			spark_system.start()

--- a/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
@@ -4,7 +4,7 @@ args:
 clockcult_user: If the user / source has to do with clockcult stuff
 drain_weapons: If this drains weaponry, such as batons and guns
 recursive: If this recurses through mob / storage contents. ONLY USE THIS IF IT'S NOT CALLED TOO FREQUENTLY, or I'm not liable for any lag / functional issues caused
-drain_amount: Ho much is drained by default; Influenced by a multiplier on most things depending on how much power they usually hold.
+drain_amount: How much is drained by default; Influenced by a multiplier on most things depending on how much power they usually hold.
 */
 /atom/movable/proc/power_drain(clockcult_user, drain_weapons = FALSE, recursive = FALSE, drain_amount = MIN_CLOCKCULT_POWER) //This proc as of now is only in use for void volt and transmission sigils
 	if(recursive)

--- a/code/modules/antagonists/clockcult/clock_scripture.dm
+++ b/code/modules/antagonists/clockcult/clock_scripture.dm
@@ -167,7 +167,7 @@ Judgement 5 converts
 	set waitfor = FALSE
 	chanting = TRUE
 	for(var/invocation in invocations)
-		sleep(channel_time / invocations.len)
+		sleep(channel_time / (invocations.len + 1)) //So it always finishes the invocation
 		if(QDELETED(src) || QDELETED(slab) || !chanting)
 			return
 		if(multiple_invokers_used)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As of now, void volt is a rather mixed bag as a spell, mostly because while it does drain cells / weaponry on the ground, it does not touch anything on a person / in a container. Issue with changing it to do that in general was that void volt was channeled, means it called the proc in a weak version repeatedly, which would be rather processing-intentive to do with all the contents of everything in the scripture's range.
Therefore, I changed them a bit:
Firstly, void volt is no longer channeled, instead releasing a singular powerful power-drain pulse (Not EMP) after 13 seconds cast time. The pulse has a base range of 12 tiles (+2 per additional invoker), and a drain strength of 250 (as opposed to 25 base), further modified during the item-specific drain procs.
This amount to a full drain for guns, a very strong (possibly full) drain for batons / power cells, and about 4000 charge drain for APCs, aswell as going through contents of things it affects.

The drain proc itself has been modified accordingly to support this, adding the parameters recursive (defaults to FALSE), and drain_amount (Defaults to MIN_CLOCKCULT_POWER, which is 25 as of now)
Additionally, the effect of the power drain proc in general on APCs and silicons has been increased

Another thing done is that some measures are added to protect part of the invocation of scripture from being eaten due to it not having been finished when the scripture gets qdel()d
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Void volt as of now is rather weak, due to it's main speciality (draining weapons) only working on dropped weapons, plus it having no recursiveness. These changes should make it more effective, while keeping its drawback and time consumption.

Scripture always having enough time to finish the invocations is a fluff fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Scripture no longer sometimes eats part of its invocation.
balance: APCs and silicons are now more susceptible to powerdrains (by the power_drain() proc, which is rare)
balance: Void Volt has been modified from a chant to a singular pulse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
