### PR TITLE
Fixes APC recharge power use

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1373,7 +1373,7 @@
 	// next: take from or charge to the cell, depending on how much is left
 	if(cell && !shorted)
 		if(cur_excess > 0)
-			var/charging_cell = min(cur_excess*GLOB.CELLRATE, cell.maxcharge * GLOB.CHARGELEVEL)
+			var/charging_cell = min(min(cur_excess*GLOB.CELLRATE, cell.maxcharge * GLOB.CHARGELEVEL), cell.maxcharge - cell.charge)
 			cell.give(charging_cell)
 			add_load(charging_cell/GLOB.CELLRATE)
 			lastused_total += charging_cell

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1373,9 +1373,9 @@
 	// next: take from or charge to the cell, depending on how much is left
 	if(cell && !shorted)
 		if(cur_excess > 0)
-			var/charging_cell = min(cur_excess, cell.maxcharge * GLOB.CHARGELEVEL)
+			var/charging_cell = min(cur_excess*GLOB.CELLRATE, cell.maxcharge * GLOB.CHARGELEVEL)
 			cell.give(charging_cell)
-			add_load(charging_cell)
+			add_load(charging_cell/GLOB.cellrate)
 			lastused_total += charging_cell
 			longtermpower = min(10,longtermpower + 1)
 			if(chargemode && !charging)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1375,7 +1375,7 @@
 		if(cur_excess > 0)
 			var/charging_cell = min(cur_excess*GLOB.CELLRATE, cell.maxcharge * GLOB.CHARGELEVEL)
 			cell.give(charging_cell)
-			add_load(charging_cell/GLOB.cellrate)
+			add_load(charging_cell/GLOB.CELLRATE)
 			lastused_total += charging_cell
 			longtermpower = min(10,longtermpower + 1)
 			if(chargemode && !charging)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Soo, back when APCs got somewhat reworked (using power from the net first then cell and being able to work without cell), the one making that PR forgot to make cell recharge take into account the cellrate ratio (0.002)
This makes it that when for example an APC should be using 2.5(1% of its cell max) * 500 (1250 generic powernet units), it'd only be using those 2.5 units instead. This fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Recharging APCs no longer use 0.2% of the power they should be using.
fix: APCs no longer always use as much power as they can for their cell, even if it is full.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
