### PR TITLE
[WIP] Adds the ability to respawn via cryo

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -24,6 +24,8 @@ SUBSYSTEM_DEF(ticker)
 	var/round_end_sound_sent = TRUE			//If all clients have loaded it
 
 	var/list/datum/mind/minds = list()		//The characters in the game. Used for objective tracking.
+	var/list/cryo_occupants = list()		//List of all cryo occupants that are currently in the lobby. Keyed list containing references to mobs in nullspace and the cryopods they exited from
+	var/list/cryo_deepstorage = list()		//List of all cryo occupants that have abandoned the round via ghosting.
 
 	var/list/syndicate_coalition = list()	//list of traitor-compatible factions
 	var/list/factions = list()				//list of all factions

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -102,7 +102,7 @@
 			if(dbflags & DB_FLAG_AGE_CONFIRMATION_INCOMPLETE) //they have not completed age verification
 				var/age_verification = askuser(src, "Are you 18+", "Age Verification", "I am 18+", "I am not 18+", null, TRUE, null)
 				if(age_verification != 1)
-					//add_system_note("Automated-Age-Verification", "Failed automatic age verification")
+					add_system_note("Automated-Age-Verification", "Failed automatic age verification")
 					qdel(client) //kick the user
 					return FALSE
 				else
@@ -213,6 +213,7 @@
 		new_character = L
 		SSticker.cryo_occupants -= "[ckey(key)]"
 		L.status_flags &= ~GODMODE
+		close_spawn_windows()
 		transfer_character()
 		return
 


### PR DESCRIPTION
This is a heavy, **heavy** WIP. this has been made a draft PR to allow collaboration from other maintainers

Current progress:
- [x] Proof-of-concept for core functionality (use cryopods to return to lobby, exit lobby at any time via new, fancy button)
- [ ] Make it so that observing while in the cryo lobby sends you to deep storage (in laymen's terms, fully cryo's you like exactly how cryopods currently do on live)
- [ ] Remove the cooldown before someone can be cryo'd by another person
- [ ] Make it so that your job slot is properly freed up once you're in a cryopod
- [ ] Make it so that attempting to rejoin while your job slot is full instead reassigns you to the overflow slot (with the same exact character you cryo'd out with)
- [ ] Make it so that you actually get moved to the cryopod you used to re-enter the lobby when you exit cryosleep
- [ ] Make cryopods keep track of every preservable item that an individual has while entering cryosleep.
- [ ] Make it so that those preservable items are displayed in the cryo console, and allow retrieval directly from the cryo occupant's inventory while they're in the pod
- [ ] Make currently cryo'd occupants show up in the cryo console (along with a list of all occupants in deep storage (in laymen's terms, those who ghosted out))
- [ ] Make the station announcer actually inform the crew when people enter/exit cryo (and allow this text to be adjusted via the physical announcement machine like latejoin messages allow)
- [ ] Properly account for high-priority edge cases like AIs and cyborgs cryo'ing out
- [ ] Make it so that targeted objectives use a list instead of a single ref for their targets, and allow any target in that list that's outside of nullspace to count towards that objective.
- [ ] Make it so that cryo'ing out adds a new valid target to the target lists of any objectives that only have cryo'd individuals as targets

Optional progress:
- [ ] Add some help text when you cryo out, stating that you can safely close your client, and that your character will remain exactly as they are until you exit cryo
- [ ] Maybe allow cosmetic character adjustments while you're in the lobby? No changes to loadouts, quirks, species, name, or anything that could genuinely affect gameplay, but maybe allow changing colors and sprite accessories
- [ ] Maybe allow players to return to lobby via the arrivals shuttle (maybe add a new console to the arrivals shuttle? and if the player hasn't stepped foot outside of the arrivals shuttle at all, maybe allow them to choose a different character or job instead of hard-locking them to that specific character/job)
- [ ] Maybe add a feature to the cryo console that allows cryo occupants outside of deep storage to be pinged if possible (either through discord account linking or by making a noise in the lobby)
- [ ] Make it so that cryo'ing out puts you in the sleeper, and displays the lobby splash screen fadein, before actually moving you back to lobby
- [ ] Make the lobby splash screen do the fadeout animation when you exit the lobby via cryo

### What this PR is and why it's good for the game
This PR allows players to return to the round if they cryo out. One of the more common sentiments we hear among staff and players alike, is that joining a round feels like a huge time commitment due to the sheer length of individual rounds. Cryo was originally ported as an attempt to help alleviate this by allowing players to drop out of rounds as they please.
However, when the round length was made longer, it started becoming more and more obvious that cryo did not alleviate this much at all, as it only allowed players to drop out of rounds, but doesn't allow them to drop back in. This means rounds still feel like huge time commitments, as the only way to voluntarily exit the round within the server's ruleset stops you from returning to the game until the round is over.
On servers where cryo is present, respawn is usually enabled, and cryo is usually given a shorter respawn timer to allow players to drop back in, but since we have respawn disabled due to the amount of administration overhead it'd require to stay balanced, simply enabling respawn to resolve these issues is not an option at all. Simply enabling respawn usually results in issues of metagaming (both conscious and not), since this entails being able to observe the round freely before you re-enter the round as a fresh character.
So this PR directly tackles the issue of rounds feeling like huge time commitments, by allowing players to drop back in after cryoing out, while avoiding the issues associated with traditional respawning. This is a good alternative to simply enabling respawn, as the way this PR handles respawning from cryo inherently prevents metagaming, since you can only cryo while you're alive, you're prevented from interacting with deadchat and all forms of IC communication while you're in cryo, and you're restricted to a view of the lobby while in cryo. With this PR, entering cryo more or less becomes equivalent to stepping into a locker and closing your client, albeit with your job slot being freed until you get back, and your character being put into stasis until you return.
This PR will hopefully increase player retention, as this will allow cryo to actually be used as the drop-in/drop-out mechanic it was designed to be, and having such a mechanic is crucial for the health of a server with long rounds.

## Changelog
:cl: Bhijn and Citadel Station 13 maintainers
add: Cryopods now return you to the lobby, allowing you to seamlessly rejoin the round after cryoing out.
/:cl:
