### PR TITLE
Makes gear harness no longer cover chest/groin.

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -168,7 +168,6 @@
 	desc = "A simple, inconspicuous harness replacement for a jumpsuit."
 	icon_state = "gear_harness"
 	item_state = "gear_harness"
-	body_parts_covered = CHEST|GROIN
 	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/durathread


### PR DESCRIPTION
## About The Pull Request

They're literally invisible.

I was gonna do a player poll on this but I realized the change is easy enough that it's easier to open the PR first and let people talk about it in here. I know why it blocks for now, but I figure that it's less of a good reason since we made underwear work. It's not like the kind of person who would abuse it is going to be stopped by having to press a button.

## Why It's Good For The Game

My immersion, unironically.

## Changelog
:cl:
tweak: gear harness no longer magically covers up the body mechanically despite covering up nothing visually
/:cl: