### PR TITLE
Makes dynamic no longer show "none" in the vote.

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -391,6 +391,8 @@ Example config:
 	for(var/T in storyteller_cache)
 		var/datum/dynamic_storyteller/S = T
 		var/config_tag = initial(S.config_tag)
+		if(!config_tag)
+			continue
 		var/probability = (config_tag in probabilities) ? probabilities[config_tag] : initial(S.weight)
 		var/min_players = (config_tag in min_player_counts) ? min_player_counts[config_tag] : initial(S.min_players)
 		if(probability <= 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Coder's idiocy indeed

## Why It's Good For The Game

If people vote for "none" i have literally no idea what happens so it'd better not happen

## Changelog
:cl:
fix: Dynamic vote no longer shows the none-storyteller.
/:cl: