### PR TITLE
Buffs rad collectors

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -1,7 +1,7 @@
 // stored_power += (pulse_strength-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
 #define RAD_COLLECTOR_EFFICIENCY 80 	// radiation needs to be over this amount to get power
-#define RAD_COLLECTOR_COEFFICIENT 100
-#define RAD_COLLECTOR_STORED_OUT 0.04	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
+#define RAD_COLLECTOR_COEFFICIENT 125
+#define RAD_COLLECTOR_STORED_OUT 0.05	// (this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
 #define RAD_COLLECTOR_MINING_CONVERSION_RATE 0.00001 //This is gonna need a lot of tweaking to get right. This is the number used to calculate the conversion of watts to research points per process()
 #define RAD_COLLECTOR_OUTPUT min(stored_power, (stored_power*RAD_COLLECTOR_STORED_OUT)+1000) //Produces at least 1000 watts if it has more than that stored
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Increased the power-from-radiation by 1.25x and increased power output by 1.25x, leading to a total increase of 56.25% buff.

## Why It's Good For The Game

With the way power is now, you need to set up the supermatter AND solars to get even a chance of powering the whole station. The supermatter's power output has been severely lacking historically anyway, so here's a patch to that.

## Changelog
:cl:
balance: Rad collectors now get 1.25x as much energy from radiation
balance: Rad collectors now put out 1.25x as much stored energy per tick
balance: Above two rad collector changes give a total 56.25% power output increase
/:cl: