### PR TITLE
podpeople have green blood but done correctly

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -159,6 +159,7 @@ GLOBAL_LIST_EMPTY(bloody_footprints_cache)
 #define BLOOD_COLOR_LIZARD			"#db004D"
 #define BLOOD_COLOR_UNIVERSAL		"#db3300"
 #define BLOOD_COLOR_BUG				"#a37c0f"
+#define BLOOD_COLOR_PLANT			"#3d610e"
 
 
 //suit sensors: sensor_mode defines

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -10,6 +10,7 @@
 	burnmod = 1.25
 	heatmod = 1.5
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
+	exotic_blood_color = BLOOD_COLOR_PLANT
 	disliked_food = MEAT | DAIRY
 	liked_food = VEGETABLES | FRUIT | GRAIN
 	species_language_holder = /datum/language_holder/sylvan


### PR DESCRIPTION
## About The Pull Request
gives podpeople green blood, does not make a new subtype for the blood (blood subtypes are really bad please stop making them!)
closes #13718 (it doesn't work and additionally makes a new blood subtype which means you won't even be able to replica pod podpeople)

## Why It's Good For The Game
more species flavor is good right

## Changelog
:cl:
tweak: podpeople blood colour changed to green
/:cl:
