### PR TITLE
moar crimmas

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -554,7 +554,7 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 
 /datum/holiday/xmas
 	name = CHRISTMAS
-	begin_day = 22
+	begin_day = 10
 	begin_month = DECEMBER
 	end_day = 27
 	drone_hat = /obj/item/clothing/head/santa


### PR DESCRIPTION
## About The Pull Request

Increases the time for christmas stuff from 5 days to 17 days a year.

## Why It's Good For The Game

It only comes around once a year, it doesn't do a whole lot, but gives a bit of rng fun.
5 days is way too short, let's have more fun, we've had a shitty year.

## Changelog
:cl:
tweak: Increased christmas event from 22th to 27th to 10th to 27th
/:cl:
