### PR TITLE
Makes the experimental organ replacement surgery work on robots

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_surgery.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_surgery.dm
@@ -2,22 +2,27 @@
 	name = "experimental organ replacement"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/incise, /datum/surgery_step/extract_organ, /datum/surgery_step/gland_insert)
 	possible_locs = list(BODY_ZONE_CHEST)
-	ignore_clothes = 1
+	ignore_clothes = TRUE
 
 /datum/surgery/organ_extraction/can_start(mob/user, mob/living/carbon/target)
 	if(!ishuman(user))
-		return 0
+		return FALSE
 	var/mob/living/carbon/human/H = user
 	if(H.dna.species.id == "abductor")
-		return 1
+		return TRUE
 	for(var/obj/item/implant/abductor/A in H.implants)
-		return 1
-	return 0
+		return TRUE
+	return FALSE
+
+/datum/surgery/organ_extraction/mechanic
+	name = "Prosthesis experimental organ replacement"
+	requires_bodypart_type = BODYPART_ROBOTIC
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/open_hatch, /datum/surgery_step/mechanic_unwrench, /datum/surgery_step/prepare_electronics, /datum/surgery_step/extract_organ, /datum/surgery_step/gland_insert)
 
 
 /datum/surgery_step/extract_organ
 	name = "remove heart"
-	accept_hand = 1
+	accept_hand = TRUE
 	time = 32
 	var/obj/item/organ/IC = null
 	var/list/organ_types = list(/obj/item/organ/heart)
@@ -34,10 +39,10 @@
 		user.visible_message("[user] pulls [IC] out of [target]'s [target_zone]!", "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>")
 		user.put_in_hands(IC)
 		IC.Remove()
-		return 1
+		return TRUE
 	else
 		to_chat(user, "<span class='warning'>You don't find anything in [target]'s [target_zone]!</span>")
-		return 1
+		return TRUE
 
 /datum/surgery_step/gland_insert
 	name = "insert gland"
@@ -52,4 +57,4 @@
 	user.temporarilyRemoveItemFromInventory(tool, TRUE)
 	var/obj/item/organ/heart/gland/gland = tool
 	gland.Insert(target, 2)
-	return 1
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Since we usually have more people with robotic / hybrid torsos now, this is proobably useful.
Also replaces a few 1 / 0s in there with TRUE / FALSEs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Abductors being able to use this surgery on robots does sound like a good idea.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Abductors now can use experimental organ replacement surgery on robots / synthetics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
