### PR TITLE
standardizes text formatting to rp server's |one character| instead of ||two|| because why did i even do the latter

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -96,17 +96,14 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return "[say_mod(input, message_mode)][spanned ? ", \"[spanned]\"" : ""]"
 	// Citadel edit [spanned ? ", \"[spanned]\"" : ""]"
 
-#define ENCODE_HTML_EPHASIS(input, char, html, varname) \
-	var/static/regex/##varname = regex("[char]{2}(.+?)[char]{2}", "g");\
-	input = varname.Replace_char(input, "<[html]>$1</[html]>")
-
 /atom/movable/proc/say_emphasis(input)
-	ENCODE_HTML_EPHASIS(input, "\\|", "i", italics)
-	ENCODE_HTML_EPHASIS(input, "\\+", "b", bold)
-	ENCODE_HTML_EPHASIS(input, "_", "u", underline)
+	var/static/regex/italics = regex("\\|(?=\\S)(.*?)(?=\\S)\\|", "g")
+	input = replacetext_char(input, italics, "<i>$1</i>")
+	var/static/regex/bold = regex("\\+(?=\\S)(.*?)(?=\\S)\\+", "g")
+	input = replacetext_char(input, bold, "<b>$1</b>")
+	var/static/regex/underline = regex("_(?=\\S)(.*?)(?=\\S)_", "g")
+	input = replacetext_char(input, underline, "<u>$1</u>")
 	return input
-
-#undef ENCODE_HTML_EPHASIS
 
 /// Quirky citadel proc for our custom sayverbs to strip the verb out. Snowflakey as hell, say rewrite 3.0 when?
 /atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mode)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -96,13 +96,14 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return "[say_mod(input, message_mode)][spanned ? ", \"[spanned]\"" : ""]"
 	// Citadel edit [spanned ? ", \"[spanned]\"" : ""]"
 
+/// Converts specific characters, like +, |, and _ to formatted output.
 /atom/movable/proc/say_emphasis(input)
-	var/static/regex/italics = regex("\\|(?=\\S)(.*?)(?=\\S)\\|", "g")
-	input = replacetext_char(input, italics, "<i>$1</i>")
-	var/static/regex/bold = regex("\\+(?=\\S)(.*?)(?=\\S)\\+", "g")
-	input = replacetext_char(input, bold, "<b>$1</b>")
-	var/static/regex/underline = regex("_(?=\\S)(.*?)(?=\\S)_", "g")
-	input = replacetext_char(input, underline, "<u>$1</u>")
+	var/static/regex/italics = regex(@"\|(\S[\w\W]*?\S)\|", "g")
+	input = italics.Replace_char(input, "<i>$1</i>")
+	var/static/regex/bold = regex(@"\+(\S[\w\W]*?\S)\+", "g")
+	input = bold.Replace_char(input, "<b>$1</b>")
+	var/static/regex/underline = regex(@"_(\S[\w\W]*?\S)_", "g")
+	input = underline.Replace_char(input, "<u>$1</u>")
 	return input
 
 /// Quirky citadel proc for our custom sayverbs to strip the verb out. Snowflakey as hell, say rewrite 3.0 when?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

the latter is horrible

## Changelog
:cl:
tweak: text formatting now uses one character instead of two around the text to emphasize. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
