### PR TITLE
mechs leave no wrecks when sold on cargo shuttle

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -60,6 +60,9 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 		if(!dry_run && (sold || delete_unsold))
 			if(ismob(thing))
 				thing.investigate_log("deleted through cargo export",INVESTIGATE_CARGO)
+			if(ismecha(thing))
+				var/obj/mecha/mech = thing
+				mech.wreckage = null // why a mech left a wreck when sold i will never know
 			qdel(thing)
 
 	return report


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
leaving a wreckage on a shuttle because you sold a mech is pretty wacky
## Changelog
:cl:
tweak: Exosuits sold on the Supply shuttle no longer leave wreckages.
/:cl:
