### PR TITLE
Zeolites tweaks

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -591,21 +591,21 @@
 /datum/chemical_reaction/fermi/zeolites
 	name = "Zeolites"
 	id = /datum/reagent/fermi/zeolites
-	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot! - But it's now somewhat dangerous, and needs a bit of uranium to catalyze the reaction
+	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot! - But it's now somewhat dangerous, and needs a bit of gold to catalyze the reaction
 	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
-	required_catalysts = list(/datum/reagent/uranium = 5)
+	required_catalysts = list(/datum/reagent/gold = 5)
 	//FermiChem vars:
 	OptimalTempMin 	= 500
 	OptimalTempMax 	= 750
 	ExplodeTemp 	= 850
-	OptimalpHMin 	= 2.8
-	OptimalpHMax 	= 5 //2.2 ph levels of optimal ph zone - centered at 3.9 - ph of ingredients mixed at equal values is 9.55; ph of result is 8.
-	ReactpHLim 		= 4
+	OptimalpHMin 	= 4.8
+	OptimalpHMax 	= 7
+	ReactpHLim 		= 5
 	//CatalystFact 	= 0
 	CurveSharpT 	= 1.5
 	CurveSharppH 	= 3
-	ThermicConstant = 7
+	ThermicConstant = 5
 	HIonRelease 	= -0.15
 	RateUpLim 		= 4
-	PurityMin 		= 0.5 //Good luck.
+	PurityMin 		= 0.4
 	FermiChem 		= TRUE

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -607,5 +607,5 @@
 	ThermicConstant = 5
 	HIonRelease 	= -0.15
 	RateUpLim 		= 4
-	PurityMin 		= 0.4
+	PurityMin 		= 0.5 //Good luck!
 	FermiChem 		= TRUE


### PR DESCRIPTION
## About The Pull Request
After tweaks that made the chemical "to hard to make" I was asked by 
K0oshy#5075 
To tweak it back a bit as it was to hard to make + needed babysitting for the only game in the game that clears contamination 
## Why It's Good For The Game

The tweakers here make it so you can more easy produce the chemical to fix peoples rads well also refecting more of the IRL sci behind the "Zeolites" as they are based off a real chemical.

## Changelog
:cl:
tweak: Zeolites now use gold rather then uranium for catalyst
tweak: Zeolites are not as hard to make ph wise
tweak: Making Zeolites heats up the beaker less allowing for better control
/:cl:

