### PR TITLE
this one line broke atmos more at 10

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -206,7 +206,7 @@
 	. = other_airs + air
 	if(null in .)
 		stack_trace("[src]([REF(src)]) has one or more null gas mixtures, which may cause bugs. Null mixtures will not be considered in reconcile_air().")
-		return listclearnulls(.)
+		listclearnulls(.)
 
 /datum/pipeline/proc/empty()
 	for(var/datum/gas_mixture/GM in get_all_connected_airs())


### PR DESCRIPTION
i'd say "who had the idea of using listclearnulls as a return value given that it returns 1/0 based on if it cleared nulls" but it's probably me i don't know check git blame of master

the fact there's nulls in it is a problem in of itself but it doesn't help when atmos bricks because of it