### PR TITLE
Scarp Changes and Bundle

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -134,6 +134,28 @@
 		return BULLET_ACT_FORCE_PIERCE
 	return BULLET_ACT_HIT
 
+/datum/block_parry_data/sleeping_carp
+	parry_time_windup = 0
+	parry_time_active = 25
+	parry_time_spindown = 0
+	// we want to signal to players the most dangerous phase, the time when automatic counterattack is a thing.
+	parry_time_windup_visual_override = 1
+	parry_time_active_visual_override = 3
+	parry_time_spindown_visual_override = 12
+	parry_flags = PARRY_DEFAULT_HANDLE_FEEDBACK		//can attack while
+	parry_time_perfect = 2.5		// first ds isn't perfect
+	parry_time_perfect_leeway = 1.5
+	parry_imperfect_falloff_percent = 5
+	parry_efficiency_to_counterattack = 100
+	parry_efficiency_considered_successful = 65		// VERY generous
+	parry_efficiency_perfect = 100
+	parry_failed_stagger_duration = 4 SECONDS
+	parry_cooldown = 0.5 SECONDS
+
+/mob/living/carbon/human/UseStaminaBuffer(amount, warn = FALSE, considered_action = TRUE)
+	amount *= physiology? physiology.stamina_buffer_mod : 1
+	return ..()
+
 /datum/martial_art/the_sleeping_carp/teach(mob/living/carbon/human/H, make_temporary = FALSE)
 	. = ..()
 	if(!.)
@@ -144,12 +166,12 @@
 	ADD_TRAIT(H, TRAIT_TASED_RESISTANCE, SLEEPING_CARP_TRAIT)
 	H.physiology.brute_mod *= 0.4 //brute is really not gonna cut it
 	H.physiology.burn_mod *= 0.7 //burn is distinctly more useful against them than brute but they're still resistant
-	H.physiology.stamina_mod *= 0.5 //You take less stamina damage overall, but you do not reduce the damage from stun batons
+	H.physiology.stamina_mod *= 0.4 //You take less stamina damage overall, but you do not reduce the damage from stun batons as much
 	H.physiology.stun_mod *= 0.3 //for those rare stuns
 	H.physiology.pressure_mod *= 0.3 //go hang out with carp
 	H.physiology.cold_mod *= 0.3 //cold mods are different to burn mods, they do stack however
 	H.physiology.heat_mod *= 2 //this is mostly so sleeping carp has a viable weakness. Cooking them alive. Setting them on fire and heating them will be their biggest weakness. The reason for this is....filet jokes.
-
+	H.physiology.stamina_buffer_mod *= 0.75 //to help with some stamina
 	H.faction |= "carp" //:D
 
 /datum/martial_art/the_sleeping_carp/on_remove(mob/living/carbon/human/H)
@@ -165,7 +187,7 @@
 	H.physiology.pressure_mod = initial(H.physiology.pressure_mod) //no more carpies
 	H.physiology.cold_mod = initial(H.physiology.cold_mod)
 	H.physiology.heat_mod = initial(H.physiology.heat_mod)
-
+	H.physiology.stamina_buffer_mod = initial(H.physiology.stamina_buffer_mod)
 	H.faction -= "carp" //:(
 
 /mob/living/carbon/human/proc/sleeping_carp_help()

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -520,3 +520,9 @@
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter(src)
 
+/obj/item/storage/box/syndie_kit/scarp
+
+/obj/item/storage/box/syndie_kit/scarp/PopulateContents()
+	new /obj/item/book/granter/martial/carp(src)
+	new /obj/item/clothing/suit/hooded/carp_costume(src)
+	new /obj/item/staff/bostaff(src)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -280,7 +280,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS|FEET
 	cold_protection = CHEST|GROIN|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT	//Space carp like space, so you should too
-	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/gun/ballistic/automatic/speargun)
+	allowed = list(/obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/gun/ballistic/automatic/speargun, /obj/item/staff/bostaff)
 	hoodtype = /obj/item/clothing/head/hooded/carp_hood
 
 /obj/item/clothing/head/hooded/carp_hood

--- a/code/modules/mob/living/carbon/human/physiology.dm
+++ b/code/modules/mob/living/carbon/human/physiology.dm
@@ -7,6 +7,7 @@
 	var/oxy_mod = 1     	// % of oxygen damage taken from all sources
 	var/clone_mod = 1   	// % of clone damage taken from all sources
 	var/stamina_mod = 1 	// % of stamina damage taken from all sources
+	var/stamina_buffer_mod = 1 // % of stamina buffer
 	var/brain_mod = 1   	// % of brain damage taken from all sources
 
 	var/pressure_mod = 1	// % of brute damage taken from low or high pressure (stacks with brute_mod)

--- a/code/modules/uplink/uplink_items/uplink_bundles.dm
+++ b/code/modules/uplink/uplink_items/uplink_bundles.dm
@@ -52,6 +52,15 @@
 	cost = 20
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
 
+/datum/uplink_item/bundles_TC/scarp_bundle
+	name = "Sleeping Carp Bundle"
+	desc = "Become one with your inner carp!  Your ancient fish masters leave behind their legacy, and bestow to you their teachings, sacred uniform, and staff. \
+	Please be aware that you will not be able to use dishonerable ranged weapons."
+	item = /obj/item/storage/box/syndie_kit/scarp
+	cost = 20
+	player_minimum = 20
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
+
 /datum/uplink_item/suits/infiltrator_bundle
 	name = "Insidious Infiltration Gear Case"
 	desc = "Developed by Roseus Galactic in conjunction with the Gorlex Marauders to produce a functional suit for urban operations, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This tweaks Sleeping Carp a bit to deal with stamina a TINY bit more but not a lot. It gives them a parry also.

There's also a separate bundle that gives you the Bo Staff and a Carp Costume.

Huge thanks to Augments, Kevin, and Teak for helping me through this.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

SCarp is in a very lackluster place after taking a few nerfs and it can't deal with stamina combat that much. Despite being stun resistant, it isn't that much stamina resistant. So the changes should reflect the cost of TC now.

## Changelog
:cl:
add: Adds a reduced stamina buffer for SCarp users
add: Gives SCarp users a better parry
add: Adds the SCarp bundle which includes a bo staff
add: Lets Carp costumes carry Bo Staffs
balance: reduces the stamina damage of scarp slightly
balance: reduced the blockchance of the bo staff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
