### PR TITLE
fixes space ninjas being able to hardstun with their gloves

### DIFF
--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -261,9 +261,9 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		spark_system.set_up(5, 0, loc)
 		playsound(src, "sparks", 50, 1)
 		visible_message("<span class='danger'>[H] electrocutes [src] with [H.p_their()] touch!</span>", "<span class='userdanger'>[H] electrocutes you with [H.p_their()] touch!</span>")
-		electrocute_act(15, H)
+		electrocute_act(15, H, flags = SHOCK_NOSTUN)
 
-		DefaultCombatKnockdown(G.stunforce)
+		DefaultCombatKnockdown(G.stunforce, override_hardstun = 0)
 		apply_effect(EFFECT_STUTTER, G.stunforce)
 		SEND_SIGNAL(src, COMSIG_LIVING_MINOR_SHOCK)
 

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -254,7 +254,7 @@ They *could* go in their appropriate files, but this is supposed to be modular
 	. = DRAIN_MOB_SHOCK_FAILED
 
 	//Default cell = 10,000 charge, 10,000/1000 = 10 uses without charging/upgrading
-	if(S.cell && S.cell.charge && S.cell.use(1000))
+	if(S.cell && S.cell.charge && S.cell.use(500))
 		. = DRAIN_MOB_SHOCK
 		//Got that electric touch
 		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

reduced usage to 500 to compensate

who wrote this shit

bug

(the real reason is all spammable hardstuns were supposed to be out given that we took hardstuns away from security LITERALLY 2 years ago)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: ninja gloves no longer hardstun
balance: ninja gloves now cost half as much to use to compensate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
