### PR TITLE
Removes the Malf AI Doomsday module

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -132,7 +132,7 @@
 	else if(T.cooldown)
 		var/seconds_left = max(0, (T.cooldown_timer - world.time) / 10)
 		return "[round(seconds_left)]"
-
+/*
 /obj/effect/countdown/doomsday
 	name = "doomsday countdown"
 
@@ -142,7 +142,7 @@
 		return
 	else if(DD.timing)
 		return "<div align='center' valign='middle' style='position:relative; top:0px; left:0px'>[DD.seconds_remaining()]</div>"
-
+*/
 /obj/effect/countdown/anomaly
 	name = "anomaly countdown"
 

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -4,7 +4,7 @@
 GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		/obj/machinery/field/containment,
 		/obj/machinery/power/supermatter_crystal,
-		/obj/machinery/doomsday_device,
+		// /obj/machinery/doomsday_device,
 		/obj/machinery/nuclearbomb,
 		/obj/machinery/nuclearbomb/selfdestruct,
 		/obj/machinery/nuclearbomb/syndicate,
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 /datum/AI_Module/large //Big, powerful stuff that can only be used once.
 /datum/AI_Module/small //Weak, usually localized stuff with multiple uses.
 
-
+/* no fun allowed.
 //Doomsday Device: Starts the self-destruct timer. It can only be stopped by killing the AI completely.
 /datum/AI_Module/large/nuke_station
 	module_name = "Doomsday Device"
@@ -408,7 +408,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		L.dust()
 	to_chat(world, "<B>The AI cleansed the station of life with the doomsday device!</B>")
 	SSticker.force_ending = 1
-
+*/
 
 //AI Turret Upgrade: Increases the health and damage of all turrets.
 /datum/AI_Module/large/upgrade_turrets

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -75,7 +75,7 @@
 	var/call_bot_cooldown = 0		//time of next call bot command
 	var/apc_override = FALSE		//hack for letting the AI use its APC even when visionless
 	var/nuking = FALSE
-	var/obj/machinery/doomsday_device/doomsday_device
+	//var/obj/machinery/doomsday_device/doomsday_device
 
 	var/mob/camera/aiEye/eyeobj
 	var/sprint = 10

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -49,8 +49,9 @@
 		for(var/obj/item/pinpointer/nuke/P in GLOB.pinpointer_list)
 			P.switch_mode_to(TRACK_NUKE_DISK) //Party's over, back to work, everyone
 			P.alert = FALSE
-
+	/*
 	if(doomsday_device)
 		doomsday_device.timing = FALSE
 		SSshuttle.clearHostileEnvironment(doomsday_device)
 		qdel(doomsday_device)
+	*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This does one thing - removes the traitor AI's ability to doomsday.

Malf AI isn't being used as a gamemode anymore, and if anyone tries doing a malf AI gamemode after this they're probably gonna run into horrible things as a result.

## Why It's Good For The Game
Alright, here we go, time for me to get into discussion about this.

Some of you may have heard about, or been involved in a round where a few players were collaborating with at least two traitors, one firmly confirmed (the AI) and one not as much, though it did make the situation all the more suspicious - in making an engineering department micronation gimmick. When a few had discovered that the AI was indeed, malf/a traitor and announced it, the round proceeded to grow into a very chaotic state.

Throughout that round there was one particularly loud person in that micronation **who wasn't an EoC** advocating that the AI was fine constantly, constantly, constantly. Stating things like the AI wasn't going to hurt anyone, the AI and their cyborgs is part of their nation, delivering threats to anyone attacking anyone part of the nation, so forth.

End result of that round was that people treated the whole situation as an emergency and there was a whole lot of walls torn down, holes blown all around either by the AI blowing or roguifying machines up or the crew trying to make a path to the AI or into engineering. The one non-AI EoC died for good, someone revived the AI after someone had killed it although they didn't complete their objectives, so forth.

Afterwards, there was a debate in #ss13-main for a while about how traitor AIs should be treated. There was two admins having stances that contradicted one another as well, if I remember correctly. Some say people should not react to the AI in the way that the crew reacted that round, others delivered the opposite.

Here's my personal take on it:
**Traitor/Malf AIs in their current state are as threatening as bloodsuckers or xenos if ignored, and need to be terminated upon discovery.**
Much like bloodsuckers, the longer they stay alive, the more power they can accumulate. APCs hacked means more things they can do, such as reactivating cameras, blowing up machines, and ultimately disabling the crew's capability to stop their cyborg army through easier means - a cyborg army which they more than likely have because [malf AIs naturally have this ability to just magnetize ghosts to positronic brains simply by a ghost reading the AI's laws upon examining them](https://media.discordapp.net/attachments/647696379908456448/669327544016961536/unknown.png).

Consciously allowing a traitor AI who you know is a traitor AI to be alive is an extremely risky endeavor, because you do not know what the AI's objectives are and it's almost guaranteed they have to kill someone, as they can't receive stealing objectives. Killing the AI is currently the only way to stop them _securely_. Anyone _trusting_ such an AI is a _massive idiot_, **especially** since Rule 4 states that antagonists should be trying to do their objectives.

Even without the malf AI's abilities to destroy any means of breaking into its core like blowing up chemistry, they have the ability to turn the entire station into a major hazard simply by flooding plasma and shocking doors everywhere.

Additionally, since the AI counts as a "traitor" unlike the malf AI gamemode, this suggests that the AI can collaborate with other traitors in completing their objectives, which can only reinforce their capabilities. There was one round where someone was teleporting around with bluespace tomatoes while they were carrying a carded malf AI, who was **doomsdaying**. This combination made it near impossible to stop the doomsdaying AI.

So this leads to my PR here. Since there are some who feel that a **round-ending antagonist on the same level as xenos** should be given a chance, my suggestion is that we should tone down the malf AI to start. Starting off by stripping it of the ability to use the Doomsday device, which will end rounds if the crew is not prepared to deal with it in a timely fashion. This isn't the absolute solution to this problem and debate, but it's a start. It doesn't stop the AI from just flooding everything with plasma, it doesn't stop them from sending their cyborg army to murder everything, it doesn't stop them with their all-mighty access to the station of doing terrible things. It just takes away something that was meant for the Malf AI gamemode, which just carried over to traitor AI, and is the first step to address this dispute that players appear to have.

Perhaps there could be means later on about "deconverting" the AI of its antagonist status (which I believe someone else had the idea of) so that there are alternate methods besides killing such a powerful antagonist, and to allow the AI alternatives of "bad ends" similarly to their carbon counterparts, who have punishments ranging from permabrig, to pacification as well.

## Changelog
:cl:
del: Traitorous AIs can no longer doomsday.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
