### PR TITLE
Prevents traitor AI from doomsdaying while carded

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	if (owner_AI.shunted)
 		return //prevent AI from activating doomsday while shunted.
 	if (istype(owner.loc, /obj/item/aicard))
-		return // prevent AI from activating doomsday while carded. If the AI gets carded after doomsdaying, there's already code to stop it then.
+		return //prevent AI from activating doomsday while carded. If the AI gets carded after doomsdaying, there's already code to stop it then.
 	active = TRUE
 	set_us_up_the_bomb(owner)
 
@@ -328,6 +328,10 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	owner.playsound_local(owner, 'sound/misc/server-ready.ogg', 50, 0)
 	sleep(30)
 	if(QDELETED(owner) || owner.stat == DEAD)
+		return
+	if(istype(owner.loc, /obj/item/aicard))
+		to_chat(owner, "<span class='boldnotice'>Error: Signal transmission failed. Reason: Lost connection to network.</span>")
+		to_chat(owner, "<span class='warning'>You can't activate the doomsday device while inside an intelliCard!</span>")
 		return
 	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", "Anomaly Alert", "aimalf")
 	set_security_level("delta")

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	if (owner_AI.shunted)
 		return //prevent AI from activating doomsday while shunted.
 	if (istype(owner.loc, /obj/item/aicard))
-		return //prevent AI from activating doomsday while carded. If the AI gets carded after doomsdaying, there's already code to stop it then.
+		return // prevent AI from activating doomsday while carded. If the AI gets carded after doomsdaying, there's already code to stop it then.
 	active = TRUE
 	set_us_up_the_bomb(owner)
 

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -261,6 +261,8 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 		return //prevent the AI from activating an already active doomsday
 	if (owner_AI.shunted)
 		return //prevent AI from activating doomsday while shunted.
+	if (istype(owner.loc, /obj/item/aicard))
+		return //prevent AI from activating doomsday while carded. If the AI gets carded after doomsdaying, there's already code to stop it then.
 	active = TRUE
 	set_us_up_the_bomb(owner)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This prevents the malf AI from activating the doomsday device while they're inside a card.

There's code that actually deactivates doomsday if the traitor AI gets carded while doomsday is happening anyways, which implies that this was supposed to be intentional to begin with.

## Why It's Good For The Game

Please see #13800.

I created this PR in case the verdict is that the change that traitor AIs need to have doomsday removed is declined, as mentioned in #13800. If doomsday doesn't get removed, at least make it so the malf AI can't collaborate with funny teleporting bluespace tomato traitors to make it near impossible for everyone to kill them in the limited time they have.

## Changelog
:cl:
balance: The traitor AI can no longer activate the doomsday device while carded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
