### PR TITLE
Fixes twin sword sheaths icon/item state from being blank sprites

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -869,37 +869,37 @@
 	var/obj/item/storage/belt/sabre/twin/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
-	..()
+	. = ..()
 
 /obj/item/melee/smith/twohand/katana/on_enter_storage(datum/component/storage/S)
 	var/obj/item/storage/belt/sabre/twin/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/sheath.ogg', 25, 1)
-	..()
+	. = ..()
 
 /obj/item/melee/smith/wakizashi/on_exit_storage(datum/component/storage/S)
 	var/obj/item/storage/belt/sabre/twin/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
-	..()
+	. = ..()
 
 /obj/item/melee/smith/wakizashi/on_enter_storage(datum/component/storage/S)
 	var/obj/item/storage/belt/sabre/twin/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/sheath.ogg', 25, 1)
-	..()
+	. = ..()
 
 /obj/item/melee/bokken/on_exit_storage(datum/component/storage/S)
 	var/obj/item/storage/belt/sabre/twin/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
-	..()
+	. = ..()
 
 /obj/item/melee/bokken/on_enter_storage(datum/component/storage/S)
 	var/obj/item/storage/belt/sabre/twin/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/sheath.ogg', 25, 1)
-	..()
+	. = ..()
 
 /obj/item/storage/belt/plant
 	name = "botanical belt"

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -865,6 +865,42 @@
 	STR.max_items = 2
 	STR.max_w_class = WEIGHT_CLASS_BULKY + WEIGHT_CLASS_NORMAL //katana and waki.
 
+/obj/item/melee/smith/twohand/katana/on_exit_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/twin/B = S.parent
+	if(istype(B))
+		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
+	..()
+
+/obj/item/melee/smith/twohand/katana/on_enter_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/twin/B = S.parent
+	if(istype(B))
+		playsound(B, 'sound/items/sheath.ogg', 25, 1)
+	..()
+
+/obj/item/melee/smith/wakizashi/on_exit_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/twin/B = S.parent
+	if(istype(B))
+		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
+	..()
+
+/obj/item/melee/smith/wakizashi/on_enter_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/twin/B = S.parent
+	if(istype(B))
+		playsound(B, 'sound/items/sheath.ogg', 25, 1)
+	..()
+
+/obj/item/melee/bokken/on_exit_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/twin/B = S.parent
+	if(istype(B))
+		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
+	..()
+
+/obj/item/melee/bokken/on_enter_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/twin/B = S.parent
+	if(istype(B))
+		playsound(B, 'sound/items/sheath.ogg', 25, 1)
+	..()
+
 /obj/item/storage/belt/plant
 	name = "botanical belt"
 	desc = "A belt used to hold most hydroponics supplies. Suprisingly, not green."

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -853,8 +853,8 @@
 /obj/item/storage/belt/sabre/twin
 	name = "twin sheath"
 	desc = "Two sheaths. One is capable of holding a katana (or bokken) and the other a wakizashi. You could put two wakizashis in if you really wanted to. Now you can really roleplay as a samurai."
-	icon_state = "twinsheath"
-	item_state = "quiver" //this'll do.
+	icon_state = "2sheath"
+	item_state = "katana" //this'll do.
 	w_class = WEIGHT_CLASS_BULKY
 	fitting_swords = list(/obj/item/melee/smith/wakizashi, /obj/item/melee/smith/twohand/katana, /obj/item/melee/bokken)
 	starting_sword = null


### PR DESCRIPTION
Gives item state and icon state so they can actually be clicked on in inventory and seen on mobs

Uses the base katana sheath sprite when worn since well, that's literally what goes in it so of course you'd see one when worn.

Also adds missing sheathing/unsheathing sound that all of the other rapier and sabre sheaths have since it didn't make sense that they would but this would not

:cl:
fix: Twin Sword Sheaths have an equipment icon and icon when worn now and make a sound when sheathed/unsheathed
/:cl:

