### PR TITLE
Adds a antag species blacklist and applies it to species it makes sense to have (#3620)

### DIFF
--- a/code/game/gamemodes/bloodsucker/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsucker/bloodsucker.dm
@@ -32,8 +32,7 @@
 	reroll_friendly = FALSE
 	enemy_minimum_age = 7
 	round_ends_with_antag_death = FALSE
-
-
+	restricted_species = list("plasmaman", "shadow", "skeleton", "synthliz", "synth", "vampire", "ipc", "dullahan", "android")
 	announce_span = "danger"
 	announce_text = "Filthy, bloodsucking vampires are crawling around disguised as crewmembers!\n\
 	<span class='danger'>Bloodsuckers</span>: The crew are cattle, while you are both shepherd and slaughterhouse.\n\

--- a/code/game/gamemodes/bloodsucker/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsucker/bloodsucker.dm
@@ -26,13 +26,13 @@
 	false_report_weight = 1
 	restricted_jobs = list("AI","Cyborg")
 	protected_jobs = list("Chaplain", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
+	restricted_species = list(SPECIES_SYNTH_LIZARD, SPECIES_SYNTH, SPECIES_ANDROID, SPECIES_DULLAHAN, SPECIES_PLASMAMAN, SPECIES_SKELETON, SPECIES_VAMPIRE, SPECIES_VAMPIRE_WEAK)
 	required_players = 20
 	required_enemies = 2
 	recommended_enemies = 4
 	reroll_friendly = FALSE
 	enemy_minimum_age = 7
 	round_ends_with_antag_death = FALSE
-	restricted_species = list("plasmaman", "shadow", "skeleton", "synthliz", "synth", "vampire", "ipc", "dullahan", "android")
 	announce_span = "danger"
 	announce_text = "Filthy, bloodsucking vampires are crawling around disguised as crewmembers!\n\
 	<span class='danger'>Bloodsuckers</span>: The crew are cattle, while you are both shepherd and slaughterhouse.\n\

--- a/code/game/gamemodes/bloodsucker/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsucker/bloodsucker.dm
@@ -26,7 +26,7 @@
 	false_report_weight = 1
 	restricted_jobs = list("AI","Cyborg")
 	protected_jobs = list("Chaplain", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")
-	restricted_species = list(SPECIES_SYNTH_LIZARD, SPECIES_SYNTH, SPECIES_ANDROID, SPECIES_DULLAHAN, SPECIES_PLASMAMAN, SPECIES_SKELETON, SPECIES_VAMPIRE, SPECIES_VAMPIRE_WEAK)
+	restricted_species = list(SPECIES_DULLAHAN, SPECIES_PLASMAMAN, SPECIES_SKELETON, SPECIES_VAMPIRE, SPECIES_VAMPIRE_WEAK)
 	required_players = 20
 	required_enemies = 2
 	recommended_enemies = 4

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -16,6 +16,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
+	restricted_species = list("synthliz", "synth", "ipc", "android")
 
 	announce_span = "green"
 	announce_text = "Alien changelings have infiltrated the crew!\n\

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -12,11 +12,11 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")	//citadel change - adds HoP, CE, CMO, and RD to ling role blacklist
+	restricted_species = list(SPECIES_SYNTH_LIZARD, SPECIES_SYNTH, SPECIES_ANDROID, SPECIES_DULLAHAN)
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
-	restricted_species = list("synthliz", "synth", "ipc", "android")
 
 	announce_span = "green"
 	announce_text = "Alien changelings have infiltrated the crew!\n\

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -12,7 +12,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")	//citadel change - adds HoP, CE, CMO, and RD to ling role blacklist
-	restricted_species = list(SPECIES_SYNTH_LIZARD, SPECIES_SYNTH, SPECIES_ANDROID, SPECIES_DULLAHAN)
+	restricted_species = list(SPECIES_DULLAHAN)
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -423,6 +423,7 @@
 			for(var/species_id in restricted_species)
 				var/mob/living/carbon/player_mob = player.current
 				if(player_mob.dna.species == restricted_species)
+					message_admins("[player.ckey] as [player] failed to qualify for antag due to being a restricted species")
 					candidates -= player
 
 	if(candidates.len < recommended_enemies && CONFIG_GET(keyed_list/force_antag_count)[config_tag])

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -25,6 +25,7 @@
 	var/list/restricted_jobs = list()	// Jobs it doesn't make sense to be.  I.E chaplain or AI cultist
 	var/list/protected_jobs = list()	// Jobs that can't be traitors because
 	var/list/required_jobs = list()		// alternative required job groups eg list(list(cap=1),list(hos=1,sec=2)) translates to one captain OR one hos and two secmans
+	var/list/restricted_species = list() //The ID of the species you dont want to be considered for this gamemode's antags, like bloodless species being a bloodsucker.
 	var/required_players = 0
 	var/maximum_players = -1 // -1 is no maximum, positive numbers limit the selection of a mode on overstaffed stations
 	var/required_enemies = 0
@@ -415,6 +416,13 @@
 		for(var/datum/mind/player in candidates)
 			for(var/job in restricted_jobs)					// Remove people who want to be antagonist but have a job already that precludes it
 				if(player.assigned_role == job)
+					candidates -= player
+
+	if(restricted_species)
+		for(var/datum/mind/player in candidates)
+			for(var/species_id in restricted_species)
+				var/mob/living/carbon/player_mob = player.current
+				if(player_mob.dna.species == restricted_species)
 					candidates -= player
 
 	if(candidates.len < recommended_enemies && CONFIG_GET(keyed_list/force_antag_count)[config_tag])

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -28,6 +28,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/show_to_ghosts = FALSE // Should this antagonist be shown as antag to ghosts? Shouldn't be used for stealthy antagonists like traitors
 
 	var/list/skill_modifiers
+	var/list/incompatible_species = list()
 
 /datum/antagonist/New()
 	GLOB.antagonists += src

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -797,11 +797,17 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						var/mode_path = GLOB.special_roles[i]
 						var/datum/game_mode/temp_mode = new mode_path
 						days_remaining = temp_mode.get_remaining_days(user.client)
-
+					if(pref_species && pref_species.incompatible_antag)
+						pref_species.incompatible_antag
+						var/antagonist_path = GLOB.special_roles[i]
+						var/datum/antagonist = new antagonist_path
+						if(pref_species.incompatible_antag in antagonist)
 					if(days_remaining)
 						dat += "<b>Be [capitalize(i)]:</b> <font color=red> \[IN [days_remaining] DAYS]</font><br>"
-					else
+					else if(I.species_allowed)
 						dat += "<b>Be [capitalize(i)]:</b> <a href='?_src_=prefs;preference=be_special;be_special_type=[i]'>[(i in be_special) ? "Enabled" : "Disabled"]</a><br>"
+					else
+						dat += "Your species is invalid for this antagonist"
 			dat += "<b>Midround Antagonist:</b> <a href='?_src_=prefs;preference=allow_midround_antag'>[(toggles & MIDROUND_ANTAG) ? "Enabled" : "Disabled"]</a><br>"
 
 			dat += "<br>"

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -741,6 +741,7 @@
 	var/has_antags = FALSE
 	if(client.prefs.be_special.len > 0)
 		has_antags = TRUE
+		if(client.prefs.be_special)
 	if(client.prefs.job_preferences.len == 0)
 		if(!ineligible_for_roles)
 			to_chat(src, "<span class='danger'>You have no jobs enabled, along with return to lobby if job is unavailable. This makes you ineligible for any round start role, please update your job preferences.</span>")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -186,6 +186,12 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	//	return 0 //It returns false when it runs the proc so they don't get jobs from the global list.
 	return 1 //It returns 1 to say they are a-okay to continue.
 
+//The same as the first but for antagonists
+/datum/species/proc/qualifies_for_antagonist(/datum/antagonist/A)
+	if(id in A.incompatible_species)
+		return FALSE
+	return TRUE
+
 //Will regenerate missing organs
 /datum/species/proc/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE)
 	var/obj/item/organ/brain/brain = C.getorganslot(ORGAN_SLOT_BRAIN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blocks nonorganic and buggy races from being changelings and bloodsuckers, and vampires too, since double vampires do not make sense at all
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Nonorganic species cant be bloodsuckers/changeling, and a few more that dont make sense or work well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
