### PR TITLE
Maybe less christmas

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -554,7 +554,7 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 
 /datum/holiday/xmas
 	name = CHRISTMAS
-	begin_day = 10
+	begin_day = 18
 	begin_month = DECEMBER
 	end_day = 27
 	drone_hat = /obj/item/clothing/head/santa


### PR DESCRIPTION
## About The Pull Request

Ups the start date of christmas to the 18th.
For anyone curious, the start dates went 20th -> 10th and now to the 18th.

## Why It's Good For The Game

Debug items are fun, the 5th time you get them it's less fun.
The less rolling the dice, the better off people are.

## Changelog
:cl:
tweak: Christmas starts on the 18th now
/:cl: