### PR TITLE
Windoors stay open longer

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -67,9 +67,9 @@
 /obj/machinery/door/window/proc/open_and_close()
 	open()
 	if(src.check_access(null))
-		sleep(50)
+		sleep(60)
 	else //secure doors close faster
-		sleep(20)
+		sleep(40)
 	close()
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)


### PR DESCRIPTION
## About The Pull Request

Windoors now stay open longer. Approximately 1 second longer for windoors without access requirements, and 2 seconds longer for windoors with. They close too fast.

## Why It's Good For The Game

Opening and closing the same windoor 4 times trying to get your access change from the HOP is not fun!

## Changelog
:cl:
tweak: windoor open length
/:cl: