### PR TITLE
heavily nerfs regen jelly, slime jelly, pyroxadone, due to them being makeable roundstart

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -201,13 +201,13 @@
 		var/power = 0
 		switch(M.bodytemperature)
 			if(BODYTEMP_HEAT_DAMAGE_LIMIT to 400)
-				power = 2
+				power = 1.5
 			if(400 to 460)
-				power = 3
+				power = 2.5
 			else
-				power = 5
+				power = 3.5
 		if(M.on_fire)
-			power *= 2
+			power *= 1.5
 
 		M.adjustOxyLoss(-2 * power, 0)
 		M.adjustBruteLoss(-power, 0)
@@ -1236,6 +1236,7 @@
 	color = "#91D865"
 	taste_description = "jelly"
 	value = REAGENT_VALUE_COMMON
+	overdose_threshold = 20
 
 /datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-1.5*REM, FALSE)
@@ -1244,6 +1245,11 @@
 	M.adjustToxLoss(-1.5*REM, 0, TRUE) //heals TOXINLOVERs
 	. = 1
 	..()
+
+/datum/reagent/medicine/regen_jelly/overdose_process(mob/living/carbon/M)
+	if(prob(5))
+		to_chat(M, "<span class='warning'>[pick("You feel sick.", "You don't feel too good..", "Your skin feels slimy.", "Your blood burns!")]</span>")
+	M.adjustToxLoss(3*REM, 0, TRUE)
 
 /datum/reagent/medicine/syndicate_nanites //Used exclusively by Syndicate medical cyborgs
 	name = "Restorative Nanites"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -134,12 +134,12 @@
 	value = REAGENT_VALUE_UNCOMMON
 
 /datum/reagent/toxin/slimejelly/on_mob_life(mob/living/carbon/M)
-	if(prob(10))
+	if(prob(10) && !isjellyperson(M))
 		to_chat(M, "<span class='danger'>Your insides are burning!</span>")
-		M.adjustToxLoss(rand(20,60)*REM, 0)
+		M.adjustToxLoss(rand(5,10)*REM, 0)
 		. = 1
 	else if(prob(40))
-		M.heal_bodypart_damage(5*REM)
+		M.heal_bodypart_damage(2*REM)
 		. = 1
 	..()
 


### PR DESCRIPTION
## About The Pull Request
they're not xenobio locked and people don't want them to go back to being xenobio locked from the looks of the other pr
that's fine but they need to be made to the same tier as other easy to get chems

## Why It's Good For The Game
if you're going to make overpowered stuff available roundstart, nerf it first

## Changelog
:cl:
balance: pyroxadones damage has been greatly decreased
balance: slime jelly heals less and cannot attempt to do toxin damage if you are a slime, its damage is also greatly reduced
balance: regen jelly now has an overdose at 20u at which it deals toxin damage, including to slime people
/:cl:
