### PR TITLE
fixes apids(bees) not rendering

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -699,6 +699,8 @@
 		else
 			if(species_id in GLOB.greyscale_limb_types) //should they have greyscales?
 				base_bp_icon = DEFAULT_BODYPART_ICON_ORGANIC
+			else
+				base_bp_icon = DEFAULT_BODYPART_ICON
 
 		if(base_bp_icon != DEFAULT_BODYPART_ICON)
 			color_src = mut_colors ? MUTCOLORS : ((H.dna.skin_tone_override && S.use_skintones == USE_SKINTONES_GRAYSCALE_CUSTOM) ? CUSTOM_SKINTONE : SKINTONE)


### PR DESCRIPTION
## About The Pull Request
title

if your species id isn't greyscale it now sets your icon to being the non-greyscale file
this entire process is ignored if you have a bodypart icon override value

what could go wrong? right? haha?

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: apids render now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
