### PR TITLE
Makes tresspas unusable while unconcious.

### DIFF
--- a/code/modules/antagonists/bloodsucker/bloodsucker_powers.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_powers.dm
@@ -30,6 +30,7 @@
 	var/can_be_staked = FALSE			// Only Feed can happen with a stake in you.
 	var/cooldown_static = FALSE			// Feed, Masquerade, and One-Shot powers don't improve their cooldown.
 	//var/not_bloodsucker = FALSE		// This goes to Vassals or Hunters, but NOT bloodsuckers.
+	var/must_be_concious = TRUE			//Can't use this ability while unconcious.
 
 /datum/action/bloodsucker/New()
 	if(bloodcost > 0)
@@ -101,6 +102,11 @@
 		if(display_error)
 			to_chat(owner, "<span class='warning'>Garlic in your blood is interfering with your powers!</span>")
 		return FALSE
+	if(must_be_concious)
+		if(owner.stat != CONSCIOUS)
+			if(display_error)
+				to_chat(owner, "<span class='warning'>You can't do this while you are unconcious!</span>")
+			return FALSE
 	// Incap?
 	if(must_be_capacitated)
 		var/mob/living/L = owner

--- a/code/modules/antagonists/bloodsucker/powers/go_home.dm
+++ b/code/modules/antagonists/bloodsucker/powers/go_home.dm
@@ -16,6 +16,7 @@
 	can_use_in_torpor = TRUE
 	must_be_capacitated = TRUE
 	can_be_immobilized = TRUE
+	must_be_concious = FALSE
 
 /datum/action/bloodsucker/gohome/CheckCanUse(display_error)
 	. = ..()

--- a/code/modules/antagonists/bloodsucker/powers/masquerade.dm
+++ b/code/modules/antagonists/bloodsucker/powers/masquerade.dm
@@ -27,6 +27,7 @@
 	warn_constant_cost = TRUE
 	can_use_in_torpor = TRUE // Masquerade is maybe the only one that can do this. It stops your healing.
 	cooldown_static = TRUE
+	must_be_concious = FALSE
 
 // NOTE: Firing off vulgar powers disables your Masquerade!
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes bloodsucker tresspass not work while unconcious.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Not intended to even be possible, illogically lets bloodsuckers try to run around while regenerating
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Bloodsuckers tresspass ability can no longer work while they are not awake.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
