### PR TITLE
sprinting now defaults to toggle rather than hold (because 90% of our players probably never check the keybinding preferences and from personal experience, holding down shift to move is awful)

### DIFF
--- a/code/modules/keybindings/keybind/movement.dm
+++ b/code/modules/keybindings/keybind/movement.dm
@@ -124,7 +124,8 @@
 	return TRUE
 
 /datum/keybinding/living/hold_sprint
-	hotkey_keys = list("Shift")
+	hotkey_keys = list()
+	classic_keys = list()
 	name = "hold_sprint"
 	full_name = "Sprint (hold down)"
 	description = "Hold down to sprint"
@@ -144,7 +145,8 @@
 	return TRUE
 
 /datum/keybinding/living/toggle_sprint
-	hotkey_keys = list()
+	hotkey_keys = list("Shift")
+	classic_keys = list("Shift")
 	name = "toggle_sprint"
 	full_name = "Sprint (toggle)"
 	description = "Press to toggle sprint"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

title
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: anyone new to the server is lucky enough to have their sprint default to toggle instead of hold
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
