### PR TITLE
removes deathgasping on death if already faking death as it's real easy to spot changelings in stasis otherwise

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -5,7 +5,7 @@
 	silent = FALSE
 	losebreath = 0
 
-	if(!gibbed)
+	if(!gibbed && !HAS_TRAIT(src, TRAIT_DEATHCOMA))
 		emote("deathgasp")
 
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

makes no sense something playing dead seizes up and falls limp again on actually reaching the threshold
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: things in DEATHCOMA do not deathgasp on death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
