### PR TITLE
Ling & Bloodsucker healing now affects IPCs / Synths

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -438,12 +438,19 @@
 		return
 	else
 		linked_alert.icon_state = "fleshmend"
-	owner.adjustBruteLoss(-10, FALSE)
-	owner.adjustFireLoss(-5, FALSE)
 	owner.adjustOxyLoss(-10)
 	if(!iscarbon(owner))
+		owner.adjustBruteLoss(-10, FALSE)
+		owner.adjustFireLoss(-5, FALSE)
 		return
 	var/mob/living/carbon/C = owner
+	var/list/damaged_parts = C.get_damaged_bodyparts(TRUE,TRUE, status = list(BODYPART_ORGANIC, BODYPART_HYBRID, BODYPART_NANITES))
+	if(damaged_parts.len)
+		for(var/obj/item/bodypart/part in damaged_parts)
+			part.heal_damage(10/damaged_parts.len, 5/damaged_parts.len, only_organic = FALSE, updating_health = FALSE)
+		C.updatehealth()
+		C.update_damage_overlays()
+
 	QDEL_LIST(C.all_scars)
 
 /obj/screen/alert/status_effect/fleshmend
@@ -599,7 +606,7 @@
 
 	//Heal brain damage and toxyloss, alongside trauma
 	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -8)
-	owner.adjustToxLoss(-6, forced = TRUE)
+	owner.adjustToxLoss(-6, forced = TRUE, toxins_type = TOX_OMNI)
 	M.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 	//Purges 50 rads per tick
 	if(owner.radiation > 0)

--- a/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
@@ -120,9 +120,14 @@
 		if(bruteheal + fireheal + toxinheal > 0) 	// Just a check? Don't heal/spend, and return.
 			if(mult == 0)
 				return TRUE
+
 			// We have damage. Let's heal (one time)
-			C.adjustBruteLoss(-bruteheal * mult, forced = TRUE)// Heal BRUTE / BURN in random portions throughout the body.
-			C.adjustFireLoss(-fireheal * mult, forced = TRUE)
+			var/list/damaged_parts = C.get_damaged_bodyparts(TRUE,TRUE, status = list(BODYPART_ORGANIC, BODYPART_HYBRID, BODYPART_NANITES))
+			if(damaged_parts.len)
+				for(var/obj/item/bodypart/part in damaged_parts)	// Heal BRUTE / BURN equally distibuted over all damaged bodyparts.
+					part.heal_damage((bruteheal * mult)/damaged_parts.len, (fireheal * mult)/damaged_parts.len, only_organic = FALSE, updating_health = FALSE)
+				C.updatehealth()
+				C.update_damage_overlays()
 			C.adjustToxLoss(-toxinheal * mult * 2, forced = TRUE) //Toxin healing because vamps arent immune
 			//C.heal_overall_damage(bruteheal * mult, fireheal * mult)				 // REMOVED: We need to FORCE this, because otherwise, vamps won't heal EVER. Swapped to above.
 			AddBloodVolume((bruteheal * -0.5 + fireheal * -1 + toxinheal * -0.2) / mult * costMult)	// Costs blood to heal
@@ -276,7 +281,7 @@
 /datum/antagonist/bloodsucker/proc/FinalDeath()
 		//Dont bother if we are already supposed to be dead
 	if(FinalDeath)
-		return 
+		return
 	FinalDeath = TRUE //We are now supposed to die. Lets not spam it.
 	if(!iscarbon(owner.current)) //Check for non carbons.
 		owner.current.gib()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alternative PR to #13817 
This PR makes fleshmend and bloodsucker healing affect hybrid limbs (not full on robotic ones), aswell as allowing anatomic panacea to heal corruption.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is needed for those antags to not be severely hampered due to their selected species.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Fleshmend, Anatomic Panacea and bloodsucker healing now work for Synths / IPCs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
