### PR TITLE
Fixes self-refueling welders

### DIFF
--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -23,7 +23,7 @@
 	resistance_flags = FIRE_PROOF
 
 	var/self_fueling = FALSE //Do we refill ourselves or not
-	var/nextrefueltick = 0 // How long it takes before we get a new fuel unit
+	var/nextrefueltick = 0 //When is the next tick we refuel?
 	var/refueling_interval = 10	//Every how many processing ticks does this refuel? (1 = every processing tick)
 
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=30)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -24,13 +24,14 @@
 
 	var/self_fueling = FALSE //Do we refill ourselves or not
 	var/nextrefueltick = 0 // How long it takes before we get a new fuel unit
+	var/refueling_interval = 10	//Every how many processing ticks does this refuel? (1 = every processing tick)
 
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=30)
 	var/welding = 0 	//Whether or not the welding tool is off(0), on(1) or currently welding(2)
 	var/status = TRUE 		//Whether the welder is secured or unsecured (able to attach rods to it to make a flamethrower)
 	var/max_fuel = 20 	//The max amount of fuel the welder can hold
 	var/change_icons = 1
-	var/can_off_process = 0
+	var/can_off_process = FALSE
 	var/light_intensity = 2 //how powerful the emitted light is when used.
 	var/progress_flash_divisor = 10
 	var/burned_fuel_for = 0	//when fuel was last removed
@@ -66,6 +67,14 @@
 		. += "[initial(icon_state)]-on"
 
 /obj/item/weldingtool/process()
+	//This handles refueling. Its looking at how much fuel the tool has and comparing that to how much it holds
+	//This then looks if the refuel tick has come based on world time.
+	//Then looks if we refuel ourselves or not.
+
+	if(self_fueling && get_fuel() < max_fuel && nextrefueltick <= world.time)
+		nextrefueltick = world.time + refueling_interval
+		reagents.add_reagent(/datum/reagent/fuel, 1)
+
 	switch(welding)
 		if(0)
 			force = 3
@@ -85,14 +94,6 @@
 
 	//This is to start fires. process() is only called if the welder is on.
 	open_flame()
-
-	//This handles refueling. Its looking at how much fuel the tool has and comparing that to how much it holds
-	//This then looks if the refuel tick has come based on world time.
-	//Then looks if we refuel ourselves or not.
-
-	if(get_fuel() < max_fuel && nextrefueltick < world.time && self_fueling)
-		nextrefueltick = world.time + 10
-		reagents.add_reagent(/datum/reagent/fuel, 1)
 
 /obj/item/weldingtool/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] welds [user.p_their()] every orifice closed! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -367,7 +368,7 @@
 	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
 	change_icons = 0
 	self_fueling = TRUE
-	can_off_process = 1
+	can_off_process = TRUE
 	light_intensity = 1
 	toolspeed = 0.5
 
@@ -384,16 +385,20 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "welder"
 	self_fueling = TRUE
+	can_off_process = TRUE
+	refueling_interval = 1
 	toolspeed = 0.1
 	light_intensity = 0
 	change_icons = 0
 
 /obj/item/weldingtool/advanced
 	name = "advanced welding tool"
-	desc = "A modern welding tool combined with an alien welding tool, it never runs out of fuel and works almost as fast."
+	desc = "A modern welding tool combined with an alien welding tool, it almost never runs out of fuel and works nearly as fast."
 	icon = 'icons/obj/advancedtools.dmi'
 	icon_state = "welder"
 	self_fueling = TRUE
+	can_off_process = TRUE
+	refueling_interval = 2
 	toolspeed = 0.2
 	light_intensity = 0
 	change_icons = 0

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -376,6 +376,7 @@
 	name = "brass welding tool"
 	desc = "A brass welder that seems to constantly refuel itself. It is faintly warm to the touch."
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+	refueling_interval = 5
 	icon_state = "clockwelder"
 	item_state = "brasswelder"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Triiiiilby!
This once again allows self-fueling welders to refuel while off, aswell as un-nerfing abductor welding tools, which had 1/10th of the fuel recharge rate in relation to before.
Additionally, fixes the fact brass welders were supposed to recharge faster than experimental ones.. except there was no code doing that at all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Self-fueling weldingtools recharge fuel properly again.
fix: Brass welders now actually recharge faster than experimental ones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
