### PR TITLE
cell/proc/give() no longer lets you give negative charge

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -86,6 +86,8 @@
 
 // recharge the cell
 /obj/item/stock_parts/cell/proc/give(amount)
+	if(amount < 0)
+		return
 	if(rigged && amount > 0)
 		explode()
 		return 0


### PR DESCRIPTION
i'm not sure if this is why emps are making apcs below 0 but i'm upset