### PR TITLE
Makes zeolites far, far easier to make

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -593,7 +593,6 @@
 	id = /datum/reagent/fermi/zeolites
 	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot! - But it's now somewhat dangerous, and needs a bit of gold to catalyze the reaction
 	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
-	required_catalysts = list(/datum/reagent/gold = 5)
 	//FermiChem vars:
 	OptimalTempMin 	= 500
 	OptimalTempMax 	= 750
@@ -604,7 +603,7 @@
 	//CatalystFact 	= 0
 	CurveSharpT 	= 1.5
 	CurveSharppH 	= 3
-	ThermicConstant = 5
+	ThermicConstant = 1
 	HIonRelease 	= -0.15
 	RateUpLim 		= 4
 	PurityMin 		= 0.5 //Good luck!


### PR DESCRIPTION
## About The Pull Request

They honestly do not need to be a fuck-you explody chem if you try making them at any reasonable pace. They don't need to be one of the hardest fermi chems *period*, even harder than powergame-ass SDGF or eigenstasium. And they don't particularly need to have a reliance on miners, either. Them being a fermi chem at all is a reasonable barrier.

## Why It's Good For The Game

Because radiation is godawful to deal with anyway, come on, it's not even a particularly well-designed mechanic.

## Changelog
:cl:
balance: Zeolites now only generate 1/5 the heat when reacting and don't require a catalyst.
/:cl: