### PR TITLE
gaming vendor - puts a golem vendor board in every liberators legacy

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1147,6 +1147,7 @@ obj/item/storage/box/stingbangs
 	new /obj/item/circuitboard/machine/destructive_analyzer(src)
 	new /obj/item/circuitboard/machine/circuit_imprinter/offstation(src)
 	new /obj/item/circuitboard/computer/rdconsole(src)
+	new /obj/item/circuitboard/machine/mining_equipment_vendor/golem(src)
 
 /obj/item/storage/box/silver_sulf
 	name = "box of silver sulfadiazine patches"


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
gamer vendor based
## Changelog
:cl:
add: Apparently someone started shoving golem vendor boards into every liberator's legacy. How odd!
/:cl: