### PR TITLE
removes slime layering and stops puddle tackling

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -89,6 +89,11 @@
 		to_chat(user, "<span class='warning'>You can't tackle while tased!</span>")
 		return
 
+	left_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_L_ARM)
+	right_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_R_ARM)
+	if(left && right_paralysis)
+		to_chat(user, "<span class='warning'>You can't tackle without the use of your arms!</span>")
+
 	user.face_atom(A)
 
 	var/list/modifiers = params2list(params)
@@ -280,6 +285,10 @@
 		attack_mod -= 2
 	if(HAS_TRAIT(sacker, TRAIT_GIANT))
 		attack_mod += 2
+	left_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_L_ARM)
+	right_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_R_ARM)
+	if(left_paralysis || right_paralysis)
+		attack_mod -= 2
 
 	if(ishuman(target))
 		var/mob/living/carbon/human/S = sacker

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -89,8 +89,8 @@
 		to_chat(user, "<span class='warning'>You can't tackle while tased!</span>")
 		return
 
-	left_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_L_ARM)
-	right_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_R_ARM)
+	var/left_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_L_ARM)
+	var/right_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_R_ARM)
 	if(left && right_paralysis)
 		to_chat(user, "<span class='warning'>You can't tackle without the use of your arms!</span>")
 
@@ -285,8 +285,8 @@
 		attack_mod -= 2
 	if(HAS_TRAIT(sacker, TRAIT_GIANT))
 		attack_mod += 2
-	left_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_L_ARM)
-	right_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_R_ARM)
+	var/left_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_L_ARM)
+	var/right_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_R_ARM)
 	if(left_paralysis || right_paralysis)
 		attack_mod -= 2
 

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -89,9 +89,9 @@
 		to_chat(user, "<span class='warning'>You can't tackle while tased!</span>")
 		return
 
-	var/left_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_L_ARM)
-	var/right_paralysis = HAS_TRAIT(sacker, TRAIT_PARALYSIS_R_ARM)
-	if(left && right_paralysis)
+	var/left_paralysis = HAS_TRAIT(user, TRAIT_PARALYSIS_L_ARM)
+	var/right_paralysis = HAS_TRAIT(user, TRAIT_PARALYSIS_R_ARM)
+	if(left_paralysis && right_paralysis)
 		to_chat(user, "<span class='warning'>You can't tackle without the use of your arms!</span>")
 
 	user.face_atom(A)

--- a/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
+++ b/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
@@ -62,7 +62,6 @@
 
 				H.add_movespeed_modifier(/datum/movespeed_modifier/slime_puddle)
 
-				H.layer -= 1 //go one layer down so people go over you
 				ENABLE_BITFIELD(H.pass_flags, PASSMOB) //this actually lets people pass over you
 				squeak = H.AddComponent(/datum/component/squeak, custom_sounds = list('sound/effects/blobattack.ogg')) //blorble noise when people step on you
 
@@ -103,7 +102,6 @@
 	REMOVE_TRAIT(H, TRAIT_HUMAN_NO_RENDER, SLIMEPUDDLE_TRAIT)
 	H.update_disabled_bodyparts(silent = TRUE)
 	H.remove_movespeed_modifier(/datum/movespeed_modifier/slime_puddle)
-	H.layer += 1 //go one layer back above!
 	DISABLE_BITFIELD(H.pass_flags, PASSMOB)
 	is_puddle = FALSE
 	if(squeak)


### PR DESCRIPTION
## About The Pull Request
slime layering is cool, please don't abuse it
see title

## Why It's Good For The Game
unintended feature fix

## Changelog
:cl:
tweak: slime puddles are no longer layered down one layer
tweak: you cannot tackle with two paralysed arms
tweak: tackling with a single paralysed arm lowers your tackle roll by 2
/:cl:
