### PR TITLE
Did you know? Magrifle ammo being free lights is LIKELY A BUG.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -100,6 +100,10 @@
 	var/impact_light_intensity = 3
 	var/impact_light_range = 2
 	var/impact_light_color_override
+	// Normal lighting effects
+	var/fired_light_intensity = 1
+	var/fired_light_range = 0
+	var/fired_light_color = rgb(255, 255, 255)
 
 	//Homing
 	var/homing = FALSE
@@ -506,6 +510,7 @@
 		transform = M
 	trajectory_ignore_forcemove = TRUE
 	forceMove(starting)
+	set_light(fired_light_range, fired_light_intensity, fired_light_color)
 	trajectory_ignore_forcemove = FALSE
 	if(isnull(pixel_increment_amount))
 		pixel_increment_amount = SSprojectiles.global_pixel_increment_amount

--- a/code/modules/projectiles/projectile/bullets/ferromagnetic.dm
+++ b/code/modules/projectiles/projectile/bullets/ferromagnetic.dm
@@ -2,22 +2,22 @@
 	icon_state = "magjectile"
 	damage = 20
 	armour_penetration = 20
-	light_range = 3
+	fired_light_range = 3
 	pixels_per_second = TILES_TO_PIXELS(16.667)
 	range = 35
-	light_color = LIGHT_COLOR_RED
+	fired_light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/bullet/magnetic/disabler
 	icon_state = "magjectile-nl" //nl stands for non-lethal
 	damage = 2
 	armour_penetration = 10
 	stamina = 20
-	light_color = LIGHT_COLOR_BLUE
+	fired_light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/bullet/magnetic/weak
 	damage = 15
 	armour_penetration = 10
-	light_range = 2
+	fired_light_range = 2
 	range = 25
 
 /obj/item/projectile/bullet/magnetic/weak/disabler
@@ -30,8 +30,8 @@
 	stamina = 10
 	movement_type = FLYING | UNSTOPPABLE
 	range = 6
-	light_range = 1
-	light_color = LIGHT_COLOR_RED
+	fired_light_range = 1
+	fired_light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/bullet/incendiary/mag_inferno
 	icon_state = "magjectile-large"
@@ -40,8 +40,8 @@
 	movement_type = FLYING | UNSTOPPABLE
 	range = 20
 	pixels_per_second = TILES_TO_PIXELS(12.5)
-	light_range = 4
-	light_color = LIGHT_COLOR_RED
+	fired_light_range = 4
+	fired_light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/bullet/incendiary/mag_inferno/on_hit(atom/target, blocked = FALSE)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The projectile is meant the glow, not the ammo, hence light range/color not being on the actual ammo casing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Magrifle ammo no longer glows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
