### PR TITLE
Nyctophobia quirk now triggers in 0.2 seconds instead of instantly

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -137,8 +137,12 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	var/lums = T.get_lumcount()
 	if(lums <= 0.2)
 		if(quirk_holder.m_intent == MOVE_INTENT_RUN)
-			to_chat(quirk_holder, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
-			quirk_holder.toggle_move_intent()
+			sleep(2) //0.2 seconds of being in the dark
+			T = get_turf(quirk_holder)
+			lums = T.get_lumcount()
+			if(lums <= 0.2) //check again
+				to_chat(quirk_holder, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
+				quirk_holder.toggle_move_intent()
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "nyctophobia", /datum/mood_event/nyctophobia)
 	else
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -137,15 +137,17 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	var/lums = T.get_lumcount()
 	if(lums <= 0.2)
 		if(quirk_holder.m_intent == MOVE_INTENT_RUN)
-			sleep(2) //0.2 seconds of being in the dark
-			T = get_turf(quirk_holder)
-			lums = T.get_lumcount()
-			if(lums <= 0.2) //check again
-				to_chat(quirk_holder, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
-				quirk_holder.toggle_move_intent()
+			addtimer(CALLBACK(src, .proc/recheck),2) //0.2 seconds of being in the dark
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "nyctophobia", /datum/mood_event/nyctophobia)
 	else
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
+
+/datum/quirk/nyctophobia/proc/recheck()
+	var/turf/T = get_turf(quirk_holder)
+	var/lums = T.get_lumcount()
+	if(lums <= 0.2) //check again, did they remain in the dark for 0.2 seconds?
+		to_chat(quirk_holder, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
+		quirk_holder.toggle_move_intent()
 
 /datum/quirk/lightless
 	name = "Light Sensitivity"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so nyctophobia's forced-walking effects trigger after being 0.2 seconds in the dark, rather than instantly.

## Why It's Good For The Game

Ever heard of "light lag"? It's where lights attached to a character sometimes can't keep up with the moving character, or a shuttle has moved to a different location. It's not common unless the server is lagging, but it's **always** present when you take off in a shuttle of some kind, be it the miner shuttle or escape shuttle. It's guaranteed to force your nyctophobic character into walking mode whenever a shuttle transitions to the flying zone, and back to the regular Z levels. This is a pretty big nuisance if you're someone who frequently has to take the shuttle and have this quirk, like a miner.

_(yes, it is definitely feasible to be a miner with nyctophobia, it just basically means you have to have a flashlight in your pocket at all times, or have your PDA lit always.)_

0.2 seconds is long enough to make sure that the shuttle doesn't do this to your character under normal server latency conditions, while still being short enough to be a viable negative quirk still. It might be able to compensate somewhat for actual light lag if it does happen though.

## Changelog
:cl:
tweak: Nyctophobia quirk now has some light lag compensation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
