### PR TITLE
Set Pose from RP server is now a thing (in reality this just modifies existing temporary flavor text to be better but no one here understands enough code so I'll spare the explanation)

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -32,7 +32,6 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	always_show = _always_show
 	can_edit = _edit
 	save_key = _save_key
-	max_length = _max_length
 	examine_no_preview = _examine_no_preview
 
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/show_flavor)
@@ -40,7 +39,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	if(can_edit && ismob(target)) //but only mobs receive the proc/verb for the time being
 		var/mob/M = target
 		LAZYOR(GLOB.mobs_with_editable_flavor_text[M], src)
-		M.verbs |= /mob/proc/manage_flavor_tests
+		add_verb(M, /mob/proc/manage_flavor_tests)
 
 	if(save_key && ishuman(target))
 		RegisterSignal(target, COMSIG_HUMAN_PREFS_COPIED_TO, .proc/update_prefs_flavor_text)
@@ -189,3 +188,10 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 /datum/element/flavor_text/carbon/temporary
 	examine_full_view = TRUE
 	max_len = 1024
+
+/datum/element/flavor_text/carbon/temporary/Attach(datum/target, text, _name, _addendum, _max_len, _always_show, _edit, _save_key, _examine_no_preview)
+	. = ..()
+	if(. & ELEMENT_INCOMPATIBLE)
+		return
+	if(ismob(target))
+		add_verb(target, /mob/proc/set_pose)

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -124,7 +124,10 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	set category = "IC"
 
 	var/list/L = GLOB.mobs_with_editable_flavor_text[src]
-	var/datum/element/flavor_text/carbon/temporary/T = locate() in L
+	var/datum/element/flavor_text/carbon/temporary/T
+	for(var/i in L)
+		if(istype(i, /datum/element/flavor_text/carbon/temporary))
+			T = i
 	if(T)
 		to_chat(src, "<span class='warning'>Your mob type does not support temporary flavor text.</span>")
 		return
@@ -195,3 +198,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		return
 	if(ismob(target))
 		add_verb(target, /mob/proc/set_pose)
+
+/datum/element/flavor_Text/carbon/temporary/Detach(datum/source, force)
+	. = ..()
+	if(ismob(source))
+		remove_verb(target, /mob/proc/set_pose)

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -13,6 +13,8 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	var/save_key
 	/// Do not attempt to render a preview on examine. If this is on, it will display as \[flavor_name\]
 	var/examine_no_preview = FALSE
+	/// Examine FULLY views. Overrides examine_no_preview
+	var/examine_full_view = FALSE
 
 /datum/element/flavor_text/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key, _examine_no_preview = FALSE)
 	. = ..()
@@ -30,6 +32,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	always_show = _always_show
 	can_edit = _edit
 	save_key = _save_key
+	max_length = _max_length
 	examine_no_preview = _examine_no_preview
 
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/show_flavor)
@@ -71,6 +74,9 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		examine_list += "<span class='notice'><a href='?src=[REF(src)];show_flavor=[REF(target)]'>\[[flavor_name]\]</a></span>"
 		return
 	var/msg = replacetext(text, "\n", " ")
+	if(examine_full_view)
+		examine_list += "[msg]"
+		return
 	if(length_char(msg) <= 40)
 		examine_list += "<span class='notice'>[msg]</span>"
 	else
@@ -112,6 +118,18 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		return
 	var/datum/element/flavor_text/F = choices[chosen]
 	F.set_flavor(src)
+
+/mob/proc/set_pose()
+	set name = "Set Pose"
+	set desc = "Sets your temporary flavor text"
+	set category = "IC"
+
+	var/list/L = GLOB.mobs_with_editable_flavor_text[src]
+	var/datum/element/flavor_text/carbon/temporary/T = locate() in L
+	if(T)
+		to_chat(src, "<span class='warning'>Your mob type does not support temporary flavor text.</span>")
+		return
+	T.set_flavor(src)
 
 /datum/element/flavor_text/proc/set_flavor(mob/user)
 	if(!(user in texts_by_atom))
@@ -167,3 +185,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		texts_by_atom[user] = ""
 		if(user.dna)
 			user.dna.features[save_key] = ""
+
+/datum/element/flavor_text/carbon/temporary
+	examine_full_view = TRUE
+	max_len = 1024

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	for(var/i in L)
 		if(istype(i, /datum/element/flavor_text/carbon/temporary))
 			T = i
-	if(T)
+	if(!T)
 		to_chat(src, "<span class='warning'>Your mob type does not support temporary flavor text.</span>")
 		return
 	T.set_flavor(src)

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -202,4 +202,4 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 /datum/element/flavor_Text/carbon/temporary/Detach(datum/source, force)
 	. = ..()
 	if(ismob(source))
-		remove_verb(target, /mob/proc/set_pose)
+		remove_verb(source, /mob/proc/set_pose)

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -155,7 +155,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	var/static/list/i_dont_even_know_who_you_are = typecacheof(list(/datum/antagonist/abductor, /datum/antagonist/ert,
 													/datum/antagonist/nukeop, /datum/antagonist/wizard))
 
-/datum/element/flavor_text/carbon/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key = "flavor_text", _examine_no_preview = FALSE)
+/datum/element/flavor_text/carbon/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key, _examine_no_preview = FALSE)
 	if(!iscarbon(target))
 		return ELEMENT_INCOMPATIBLE
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -43,7 +43,7 @@
 		AddComponent(/datum/component/mood)
 	AddComponent(/datum/component/combat_mode)
 	AddElement(/datum/element/flavor_text/carbon, _name = "Flavor Text", _save_key = "flavor_text")
-	AddElement(/datum/element/flavor_text, "", "Temporary Flavor Text", "This should be used only for things pertaining to the current round!")
+	AddElement(/datum/element/flavor_text/carbon/temporary, "", "Set Pose (Temporary Flavor Text)", "This should be used only for things pertaining to the current round!")
 	AddElement(/datum/element/flavor_text, _name = "OOC Notes", _addendum = "Put information on ERP/vore/lewd-related preferences here. THIS SHOULD NOT CONTAIN REGULAR FLAVORTEXT!!", _always_show = TRUE, _save_key = "ooc_notes", _examine_no_preview = TRUE)
 
 /mob/living/carbon/human/Destroy()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -43,7 +43,7 @@
 		AddComponent(/datum/component/mood)
 	AddComponent(/datum/component/combat_mode)
 	AddElement(/datum/element/flavor_text/carbon, _name = "Flavor Text", _save_key = "flavor_text")
-	AddElement(/datum/element/flavor_text/carbon/temporary, "", "Set Pose (Temporary Flavor Text)", "This should be used only for things pertaining to the current round!")
+	AddElement(/datum/element/flavor_text/carbon/temporary, "", "Set Pose (Temporary Flavor Text)", "This should be used only for things pertaining to the current round!", _save_key = null)
 	AddElement(/datum/element/flavor_text, _name = "OOC Notes", _addendum = "Put information on ERP/vore/lewd-related preferences here. THIS SHOULD NOT CONTAIN REGULAR FLAVORTEXT!!", _always_show = TRUE, _save_key = "ooc_notes", _examine_no_preview = TRUE)
 
 /mob/living/carbon/human/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Temporary flavor text, as set pose, will now be fully visible in examine and have its own verb
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows you to set a short (1024 char max, no line break) description of character poses/whatnot for ARPEE purposes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: set-pose has been added
tweak: temporary flavor text renamed to set pose, fully visible in examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
