### PR TITLE
":n hey miners don't forget the dock silver" the PR - also includes a box whiteship tinyfan fix

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -37315,8 +37315,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bKk" = (
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/silver,
+/obj/item/stack/ore/silver{
+	amount = 2
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32964,6 +32964,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
+/obj/item/stack/ore/silver{
+	amount = 2
+	},
+/obj/item/stack/ore/iron,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "biu" = (

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -19827,6 +19827,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/stack/ore/silver{
+	amount = 2
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aJC" = (
@@ -20222,6 +20225,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/stack/ore/iron,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aKq" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -61209,6 +61209,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vzp" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/silver{
+	amount = 2
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "vzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -103631,7 +103639,7 @@ bbI
 bcG
 bdM
 beP
-bfH
+vzp
 bfH
 bhv
 bbI

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -1560,6 +1560,7 @@
 /area/shuttle/abandoned/bridge)
 "cc" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request
puts 2 pieces of silver and 1 piece of iron at every mining dock. this standard has been set by box and meta, which are the standard maps, and if you disagree with box/meta i'll fight you
also puts in a missing tinyfan on the box whiteship back room
## Why It's Good For The Game
can anyone specify a round that has been improved by not having roundstart brpeds
## Changelog
:cl:
add: The dock-silver standard set by Box and Meta has been enforced across maps in rotation (Delta, Pubby, Lambda).
fix: The Box whiteship now has its missing tiny fan back.
/:cl: