### PR TITLE
rebalances changeling combat mutations

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -150,7 +150,7 @@
 	dna_cost = 2
 	loudness = 2
 	req_human = 1
-	recharge_slowdown = 0.5
+	recharge_slowdown = 0.6
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
@@ -493,7 +493,7 @@
 	helmet_type = /obj/item/clothing/head/helmet/space/changeling
 	suit_name_simple = "flesh shell"
 	helmet_name_simple = "space helmet"
-	recharge_slowdown = 0.5
+	recharge_slowdown = 0.6
 	blood_on_castoff = 1
 
 /obj/item/clothing/suit/space/changeling
@@ -542,7 +542,7 @@
 	dna_cost = 1
 	loudness = 2
 	req_human = 1
-	recharge_slowdown = 0.5
+	recharge_slowdown = 0.6
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_armor"
 	action_background_icon_state = "bg_ling"
@@ -672,7 +672,7 @@
 	dna_cost = 2
 	loudness = 2
 	req_human = 1
-	recharge_slowdown = 0.5
+	recharge_slowdown = 0.6
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_gauntlets"
 	action_background_icon_state = "bg_ling"

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -21,6 +21,7 @@
 	chemical_cost = 1000
 	dna_cost = -1
 
+	var/recharge_slowdown = 0
 	var/silent = FALSE
 	var/weapon_type
 	var/weapon_name_simple
@@ -37,6 +38,8 @@
 		if(!silent)
 			playsound(user, 'sound/effects/blobattack.ogg', 30, 1)
 			user.visible_message("<span class='warning'>With a sickening crunch, [user] reforms [user.p_their()] [weapon_name_simple] into an arm!</span>", "<span class='notice'>We assimilate the [weapon_name_simple] back into our body.</span>", "<span class='italics>You hear organic matter ripping and tearing!</span>")
+		var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+		changeling.chem_recharge_slowdown -= recharge_slowdown
 		user.update_inv_hands()
 		return 1
 
@@ -57,6 +60,8 @@
 	user.put_in_hands(W)
 	if(!silent)
 		playsound(user, 'sound/effects/blobattack.ogg', 30, 1)
+	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	changeling.chem_recharge_slowdown += recharge_slowdown
 	return W
 
 /obj/effect/proc_holder/changeling/weapon/on_refund(mob/user)
@@ -141,10 +146,11 @@
 	name = "Arm Blade"
 	desc = "We reform one of our arms into a deadly blade."
 	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form. This ability is loud, and might cause our blood to react violently to heat."
-	chemical_cost = 10
+	chemical_cost = 5
 	dna_cost = 2
 	loudness = 2
 	req_human = 1
+	recharge_slowdown = 0.5
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
@@ -532,7 +538,7 @@
 	name = "Chitinous Armor"
 	desc = "We turn our skin into tough chitin to protect us from damage."
 	helptext = "Upkeep of the armor requires a constant expenditure of chemicals, resulting in a reduced chemical generation. The armor is strong against brute force, but does not provide much protection from lasers. Cannot be used in lesser form. This ability is loud, and might cause our blood to react violently to heat."
-	chemical_cost = 20
+	chemical_cost = 10
 	dna_cost = 1
 	loudness = 2
 	req_human = 1
@@ -662,10 +668,11 @@
 	name = "Bone Gauntlets"
 	desc = "We turn our hands into solid bone and chitin, sacrificing dexterity for raw strength."
 	helptext = "These grotesque, bone-and-chitin gauntlets are remarkably good at beating victims senseless, and cannot be used in lesser form. This ability is loud, and might cause our blood to react violently to heat."
-	chemical_cost = 10 // same cost as armblade because its a sidegrade (sacrifice utility for punching people violently)
+	chemical_cost = 5 // same cost as armblade because its a sidegrade (sacrifice utility for punching people violently)
 	dna_cost = 2
 	loudness = 2
 	req_human = 1
+	recharge_slowdown = 0.5
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_gauntlets"
 	action_background_icon_state = "bg_ling"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

reduces immediate chemical usage for: armblade, chitin armor, gloves

boosts chemical regeneration slowdown to 0.6 for each. this means if you have two active, you are now draining -0.2/tick unless you absorbed another changeling for the recharge buff
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

someone pointed out this out and i realized it's a good point that they're just these things that are being kept always-on with barely any downsides minus the armor's 0.5 reduction that does barely anything given you can just hit and run

oh and we've been constantly buffing changeling combat with honestly the biggest buff being when i redid meth chemical (which i still need to redo but busy)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: changeling combat mutations rebalanced. most of them take chemicals to upkeep now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
