### PR TITLE
Restores speedup to meth and nuka cola

### DIFF
--- a/code/modules/movespeed/modifiers/reagents.dm
+++ b/code/modules/movespeed/modifiers/reagents.dm
@@ -15,4 +15,4 @@
 
 /datum/movespeed_modifier/reagent/meth
 	multiplicative_slowdown = -0.5
-	absolute_max_tiles_per_second = 10
+	absolute_max_tiles_per_second = 11

--- a/code/modules/movespeed/modifiers/reagents.dm
+++ b/code/modules/movespeed/modifiers/reagents.dm
@@ -12,3 +12,7 @@
 
 /datum/movespeed_modifier/reagent/nitryl
 	multiplicative_slowdown = -1
+
+/datum/movespeed_modifier/reagent/meth
+	multiplicative_slowdown = -0.5
+	absolute_max_tiles_per_second = 10

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -504,6 +504,14 @@
 	glass_desc = "Don't cry, Don't raise your eye, It's only nuclear wasteland."
 	value = REAGENT_VALUE_COMMON
 
+/datum/reagent/consumable/nuka_cola/on_mob_metabolize(mob/living/carbon/M)
+	M.add_movespeed_modifier(/datum/movespeed_modifier/reagent/meth)
+	return ..()
+
+/datum/reagent/consumable/nuka_cola/on_mob_end_metabolize(mob/living/carbon/M)
+	M.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/meth)
+	return ..()
+
 /datum/reagent/consumable/nuka_cola/on_mob_life(mob/living/carbon/M)
 	M.Jitter(20)
 	M.set_drugginess(30)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -173,10 +173,12 @@
 	..()
 	L.ignore_slowdown(type)
 	ADD_TRAIT(L, TRAIT_TASED_RESISTANCE, type)
+	L.add_movespeed_modifier(/datum/movespeed_modifier/reagent/meth)
 
 /datum/reagent/drug/methamphetamine/on_mob_end_metabolize(mob/living/L)
 	L.unignore_slowdown(type)
 	REMOVE_TRAIT(L, TRAIT_TASED_RESISTANCE, type)
+	L.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/meth)
 	..()
 
 /datum/reagent/drug/methamphetamine/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Not to be merged without #13893 

-1 multiplicative
Max buff is **up to 11 tiles** (old sprint + 1) enforced by automatic recalculation,.
**priority is the same as other modifiers so in theory it'll buff you. Sprint cannot push you past 10 tiles, as sprint has absolute lowest priority right now in terms of recalculation.**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I said I'd rebuff them once the systems were in place and this is a good time to shuffle around the meta anyways, especially with the nerf.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Meth and Nuka Cola once again, speed you up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
