### PR TITLE
Makes regen coma properly work at 25% when sleeping; makes coma more precedent

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -265,12 +265,12 @@
 	var/mob/living/M = A.affected_mob
 	if(HAS_TRAIT(M, TRAIT_DEATHCOMA))
 		return power
-	else if(M.IsUnconscious() || M.stat == UNCONSCIOUS)
-		return power * 0.9
 	else if(M.stat == SOFT_CRIT)
 		return power * 0.5
 	else if(M.IsSleeping())
 		return power * 0.25
+	else if(M.IsUnconscious() || M.stat == UNCONSCIOUS)
+		return power * 0.9
 	else if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma)
 		to_chat(M, "<span class='warning'>You feel yourself slip into a regenerative coma...</span>")
 		active_coma = TRUE

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -263,6 +263,10 @@
 
 /datum/symptom/heal/coma/CanHeal(datum/disease/advance/A)
 	var/mob/living/M = A.affected_mob
+	if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma)
+		to_chat(M, "<span class='warning'>You feel yourself slip into a regenerative coma...</span>")
+		active_coma = TRUE
+		addtimer(CALLBACK(src, .proc/coma, M), 60)
 	if(HAS_TRAIT(M, TRAIT_DEATHCOMA))
 		return power
 	else if(M.stat == SOFT_CRIT)
@@ -271,10 +275,6 @@
 		return power * 0.25
 	else if(M.IsUnconscious() || M.stat == UNCONSCIOUS)
 		return power * 0.9
-	else if(M.getBruteLoss() + M.getFireLoss() >= 70 && !active_coma)
-		to_chat(M, "<span class='warning'>You feel yourself slip into a regenerative coma...</span>")
-		active_coma = TRUE
-		addtimer(CALLBACK(src, .proc/coma, M), 60)
 
 /datum/symptom/heal/coma/proc/coma(mob/living/M)
 	if(deathgasp)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Regen coma's "25% effectiveness in sleeping" wasn't working cause sleeping implies unconsciousness. This fixes that.

Also makes it so that regen coma will *always* put you into a coma if you take enough damage, instead of going through other checks first; it's underwhelming anyway.

## Why It's Good For The Game

Regen coma is kinda bad, so it should get a minor buff. Also, it being weak when sleeping is something that should work.

## Changelog
:cl:
balance: Regen coma now puts into a coma even from crit or while unconscious.
fix: Regen coma now properly weakens while asleep.
/:cl: