### PR TITLE
Adds some more instant summons safety

### DIFF
--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -81,6 +81,9 @@
 							var/obj/machinery/portable_atmospherics/P = item_to_retrieve.loc
 							P.disconnect()
 							P.update_icon()
+						if(istype(item_to_retrieve.loc, /obj/machinery/disposal) || istype(item_to_retrieve.loc, /obj/structure/disposalpipe))	//If it's in disposals, only recall the item.
+							break
+
 
 						item_to_retrieve = item_to_retrieve.loc
 

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -81,8 +81,11 @@
 							var/obj/machinery/portable_atmospherics/P = item_to_retrieve.loc
 							P.disconnect()
 							P.update_icon()
-						if(istype(item_to_retrieve.loc, /obj/machinery/disposal) || istype(item_to_retrieve.loc, /obj/structure/disposalpipe))	//If it's in disposals, only recall the item.
+						else if(istype(item_to_retrieve.loc, /obj/machinery/disposal) || istype(item_to_retrieve.loc, /obj/structure/disposalpipe))	//If it's in disposals, only recall the item.
 							break
+						else if(istype(item_to_retrieve.loc, /obj/machinery/nuclearbomb))	//I feel like yandev
+							break	//Just to be sure.
+
 
 
 						item_to_retrieve = item_to_retrieve.loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Prevents instant summons from recalling disposal-related things aswell as nuclear bombs (including the station self destruct).
This will close #7673
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Safety good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Instant summons can no longer do wacky stuff with disposals (and nukes).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
