### PR TITLE
Lowers max power req for Power Sink to explode in about 8.5 minutes and lowers the explosion size

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_EMPTY(power_sinks)
 	custom_materials = list(/datum/material/iron=750)
 	var/drain_rate = 1600000	// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 1e10		// maximum power that can be drained before exploding
+	var/max_power = 1.25e008		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = FALSE // stop spam, only warn the admins once that we are about to boom
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_EMPTY(power_sinks)
 	custom_materials = list(/datum/material/iron=750)
 	var/drain_rate = 1600000	// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 1.25e008		// maximum power that can be drained before exploding
+	var/max_power = 3.5e008		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = FALSE // stop spam, only warn the admins once that we are about to boom
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -155,5 +155,5 @@ GLOBAL_LIST_EMPTY(power_sinks)
 
 	if(power_drained >= max_power)
 		STOP_PROCESSING(SSobj, src)
-		explosion(src.loc, 4,8,16,32)
+		explosion(src.loc, 3,7,14,28)
 		qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This lowers the power requirement for a sink to explode from 1+e010 to 3.5+e008.  This should explode roughly 8 and 1/2 minutes.  It was tested in an environment where the network had a consistent 1.21MW.  It gives people enough time to find it while still allowing it to blow.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The sink was never exploding for the whole round even with a whopping 7MW in the grid.  This should:

1) Allow the sink to actually do its job of blowing up

2) Not be terrible for the rest of the station if it's never found (IE draining power forever).

## Changelog
:cl:
balance: Max power from 1+e010 to 3.5+e008
balance: lowers explosion size to 3,7,14,28
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
