### PR TITLE
Ports disposable sentry gun for station engineers as a traitor item from TG

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -774,6 +774,9 @@
 	stun_projectile_sound = 'sound/weapons/gunshot_smg.ogg'
 	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 80, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 
+/obj/machinery/porta_turret/syndicate/pod/toolbox
+	max_integrity = 100
+
 /obj/machinery/porta_turret/syndicate/shuttle/target(atom/movable/target)
 	if(target)
 		setDir(get_dir(base, target))//even if you can't shoot, follow the target

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -283,6 +283,7 @@ effective or pretty fucking useless.
         var/obj/machinery/porta_turret/syndicate/pod/toolbox/turret = new(get_turf(loc))
         turret.faction = list("[REF(user)]")
         qdel(src)
+		return
 
     ..()
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -264,6 +264,7 @@ effective or pretty fucking useless.
 		GLOB.active_jammers -= src
 	update_icon()
 
+/*portable turret*/
 /obj/item/storage/toolbox/emergency/turret
 	desc = "You feel a strange urge to hit this with a wrench."
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -283,7 +283,7 @@ effective or pretty fucking useless.
         var/obj/machinery/porta_turret/syndicate/pod/toolbox/turret = new(get_turf(loc))
         turret.faction = list("[REF(user)]")
         qdel(src)
-		return
+        return
 
     ..()
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -264,6 +264,28 @@ effective or pretty fucking useless.
 		GLOB.active_jammers -= src
 	update_icon()
 
+/obj/item/storage/toolbox/emergency/turret
+	desc = "You feel a strange urge to hit this with a wrench."
+
+/obj/item/storage/toolbox/emergency/turret/PopulateContents()
+	new /obj/item/screwdriver(src)
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool(src)
+	new /obj/item/crowbar(src)
+	new /obj/item/analyzer(src)
+	new /obj/item/wirecutters(src)
+
+/obj/item/storage/toolbox/emergency/turret/attackby(obj/item/I, mob/living/user, params)
+    if(I.tool_behaviour == TOOL_WRENCH && user.a_intent == INTENT_HARM)
+        user.visible_message("<span class='danger'>[user] bashes [src] with [I]!</span>", \
+            "<span class='danger'>You bash [src] with [I]!</span>", null, COMBAT_MESSAGE_RANGE)
+        playsound(src, "sound/items/drill_use.ogg", 80, TRUE, -1)
+        var/obj/machinery/porta_turret/syndicate/pod/toolbox/turret = new(get_turf(loc))
+        turret.faction = list("[REF(user)]")
+        qdel(src)
+
+    ..()
+
 /obj/item/headsetupgrader
 	name = "headset upgrader"
 	desc = "A tool that can be used to upgrade a normal headset to be able to protect from flashbangs."

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -251,3 +251,4 @@
 	item = /obj/item/storage/toolbox/emergency/turret
 	cost = 11
 	restricted_roles = list("Station Engineer")
+	

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -244,3 +244,10 @@
 	cost = 2
 	item = /obj/item/clothing/shoes/magboots/crushing
 	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+
+/datum/uplink_item/role_restricted/turretbox
+	name = "Disposable Sentry Gun"
+	desc = "A disposable sentry gun deployment system cleverly disguised as a toolbox, apply wrench for functionality."
+	item = /obj/item/storage/toolbox/emergency/turret
+	cost = 11
+	restricted_roles = list("Station Engineer")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/52931

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The only thing I have to say here is Buildin a sentry.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds the disposable sentry gun from tg for 11tc each.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
