### PR TITLE
Ports bluespace navigation gigabeacon from TG

### DIFF
--- a/code/modules/research/designs/machine_desings/machine_designs_engi.dm
+++ b/code/modules/research/designs/machine_desings/machine_designs_engi.dm
@@ -104,3 +104,11 @@
 	build_path = /obj/item/circuitboard/machine/thermomachine
 	category = list ("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/board/spaceship_navigation_beacon
+	name = "Machine Design (Bluespace Navigation Gigabeacon)"
+	desc = "The circuit board for a Bluespace Navigation Gigabeacon."
+	id = "spaceship_navigation_beacon"
+	build_path = /obj/item/circuitboard/machine/spaceship_navigation_beacon
+	category = list ("Teleportation Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -70,7 +70,7 @@
 	display_name = "Basic Shuttle Research"
 	description = "Research the technology required to create and use basic shuttles."
 	prereq_ids = list("practical_bluespace", "adv_engi")
-	design_ids = list("shuttle_creator", "engine_plasma", "engine_heater", "shuttle_control", "shuttle_docker")
+	design_ids = list("shuttle_creator", "engine_plasma", "engine_heater", "shuttle_control", "shuttle_docker","spaceship_navigation_beacon")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/shuttle_route_upgrade

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -11,6 +11,7 @@
 	var/list/jumpto_ports = list() //hashset of ports to jump to and ignore for collision purposes
 	var/obj/docking_port/stationary/my_port //the custom docking port placed by this console
 	var/obj/docking_port/mobile/shuttle_port //the mobile docking port of the connected shuttle
+	var/list/locked_traits = list(ZTRAIT_RESERVED, ZTRAIT_CENTCOM, ZTRAIT_AWAY, ZTRAIT_REEBE) //traits forbided for custom docking
 	var/view_range = 0
 	var/x_offset = 0
 	var/y_offset = 0
@@ -186,7 +187,7 @@
 	var/turf/eyeturf = get_turf(the_eye)
 	if(!eyeturf)
 		return SHUTTLE_DOCKER_BLOCKED
-	if(z_lock.len && !(eyeturf.z in z_lock))
+	if(!eyeturf.z || SSmapping.level_has_any_trait(eyeturf.z, locked_traits))
 		return SHUTTLE_DOCKER_BLOCKED
 
 	. = SHUTTLE_DOCKER_LANDING_CLEAR
@@ -224,9 +225,9 @@
 		if(hidden_turf_info)
 			. = SHUTTLE_DOCKER_BLOCKED_BY_HIDDEN_PORT
 
-	if(space_turfs_only)
+	if(length(whitelist_turfs))
 		var/turf_type = hidden_turf_info ? hidden_turf_info[2] : T.type
-		if(!ispath(turf_type, /turf/open/space))
+		if(!is_type_in_typecache(turf_type, whitelist_turfs))
 			return SHUTTLE_DOCKER_BLOCKED
 
 	if(length(whitelist_turfs))
@@ -324,12 +325,25 @@
 	var/list/L = list()
 	for(var/V in SSshuttle.stationary)
 		if(!V)
+			stack_trace("SSshuttle.stationary have null entry!")
 			continue
 		var/obj/docking_port/stationary/S = V
 		if(console.z_lock.len && !(S.z in console.z_lock))
 			continue
 		if(console.jumpto_ports[S.id])
-			L[S.name] = S
+			L["([L.len])[S.name]"] = S
+
+	for(var/V in SSshuttle.beacons)
+		if(!V)
+			stack_trace("SSshuttle.beacons have null entry!")
+			continue
+		var/obj/machinery/spaceship_navigation_beacon/nav_beacon = V
+		if(!nav_beacon.z || SSmapping.level_has_any_trait(nav_beacon.z, console.locked_traits))
+			break
+		if(!nav_beacon.locked)
+			L["([L.len]) [nav_beacon.name] located: [nav_beacon.x] [nav_beacon.y] [nav_beacon.z]"] = nav_beacon
+		else
+			L["([L.len]) [nav_beacon.name] locked"] = null
 
 	playsound(console, 'sound/machines/terminal_prompt.ogg', 25, 0)
 	var/selected = input("Choose location to jump to", "Locations", null) as null|anything in L

--- a/code/modules/shuttle/spaceship_navigation_beacon.dm
+++ b/code/modules/shuttle/spaceship_navigation_beacon.dm
@@ -1,0 +1,63 @@
+/obj/item/circuitboard/machine/spaceship_navigation_beacon
+	name = "Bluespace Navigation Gigabeacon (Machine Board)"
+	build_path = /obj/machinery/spaceship_navigation_beacon
+	req_components = list()
+
+
+/obj/machinery/spaceship_navigation_beacon
+	name = "Bluespace Navigation Gigabeacon"
+	desc = "A device that creates a bluespace anchor that allow ships jump near to it."
+	icon = 'icons/obj/abductor.dmi'
+	icon_state = "core"
+	use_power = IDLE_POWER_USE
+	idle_power_usage = 0
+	density = TRUE
+	circuit = /obj/item/circuitboard/machine/spaceship_navigation_beacon
+
+	var/locked = FALSE //Locked beacons don't allow to jump to it.
+
+
+/obj/machinery/spaceship_navigation_beacon/Initialize()
+	. = ..()
+	SSshuttle.beacons |= src
+
+obj/machinery/spaceship_navigation_beacon/emp_act()
+	locked = TRUE
+
+/obj/machinery/spaceship_navigation_beacon/Destroy()
+	SSshuttle.beacons -= src
+	return ..()
+
+// update the icon_state
+/obj/machinery/spaceship_navigation_beacon/update_icon()
+	if(powered())
+		icon_state = "core"
+	else
+		icon_state = "core-open"
+
+/obj/machinery/spaceship_navigation_beacon/power_change()
+	. = ..()
+	update_icon()
+
+/obj/machinery/spaceship_navigation_beacon/multitool_act(mob/living/user, obj/item/multitool/I)
+	if(panel_open)
+		var/new_name = "Beacon_[input("Enter the custom name for this beacon", "It be Beacon ..your input..") as text]"
+		if(new_name && Adjacent(user))
+			name = new_name
+			to_chat(user, "<span class='notice'>You change beacon name to [name].</span>")
+	else
+		locked =!locked
+		to_chat(user, "<span class='notice'>You [locked ? "" : "un"]lock [src].</span>")
+	return TRUE
+
+/obj/machinery/spaceship_navigation_beacon/examine()
+	.=..()
+	. += "<span class='[locked ? "warning" : "nicegreen"]'>Status: [locked ? "LOCKED" : "Stable"] </span>"
+
+/obj/machinery/spaceship_navigation_beacon/attackby(obj/item/W, mob/user, params)
+	if(default_deconstruction_screwdriver(user, "core-open", "core", W))
+		return
+	if(default_deconstruction_crowbar(W))
+		return
+
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3342,6 +3342,7 @@
 #include "code\modules\shuttle\shuttle.dm"
 #include "code\modules\shuttle\shuttle_rotate.dm"
 #include "code\modules\shuttle\snaxi.dm"
+#include "code\modules\shuttle\spaceship_navigation_beacon.dm"
 #include "code\modules\shuttle\special.dm"
 #include "code\modules\shuttle\supply.dm"
 #include "code\modules\shuttle\syndicate.dm"


### PR DESCRIPTION
port of https://github.com/tgstation/tgstation/pull/44807

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pr is a port of https://github.com/tgstation/tgstation/pull/44807. This adds the bluespace navigation beacon which expands the number of Z levels ships can go to if someone has built a beacon on said level. This is an amazing tool for offstation activities such as building ministations, running rescue missions, or just exploring. It is compatible with custom ships, whiteships, and other shuttles that have a way to select a custom docking port.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This provides far greater ship functionality while still requiring some work to be done to use it. It also makes other vessels like the custom ships far more useful and just generally provides more fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The bluespace navigation gigabeacon design has been added to shuttle research for those wanting to take their ships around space more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
