### PR TITLE
Fixes loadout specific polychromic hoodies not having their hoods polychromable

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -698,6 +698,8 @@ SUBSYSTEM_DEF(job)
 					if(polychromic && istype(polychromic))
 						var/list/polychromic_entry = polychromic.colors_by_atom[I]
 						if(polychromic_entry)
+							if(polychromic.suits_with_helmet_typecache[I.type]) //is this one of those toggleable hood/helmet things?
+								polychromic.connect_helmet(I,i[LOADOUT_COLOR])
 							polychromic.colors_by_atom[I] = i[LOADOUT_COLOR]
 							I.update_icon()
 				else

--- a/code/datums/elements/polychromic.dm
+++ b/code/datums/elements/polychromic.dm
@@ -165,6 +165,15 @@
 /datum/element/polychromic/proc/on_examine(atom/source, mob/user, list/examine_list)
 	examine_list += "<span class='notice'>Alt-click to recolor it.</span>"
 
+/datum/element/polychromic/proc/connect_helmet(atom/I, var/applycolor)
+	if(isitem(I))
+		if(istype(I,/obj/item/clothing/suit/hooded))
+			var/obj/item/clothing/suit/hooded/Isuit = I
+			colors_by_atom[Isuit.hood] = applycolor
+		else if(istype(I,/obj/item/clothing/suit/space/hardsuit))
+			var/obj/item/clothing/suit/space/hardsuit/Isuit = I
+			colors_by_atom[Isuit.helmet] = applycolor
+
 /datum/element/polychromic/proc/register_helmet(atom/source, obj/item/clothing/head/H)
 	if(!isitem(H)) //backup in case if it messes up somehow
 		if(istype(source,/obj/item/clothing/suit/hooded)) //so how come it be like this, where toggleable headslots are named separately (helmet/hood) anyways?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes loadout specific polychromic hoodies not having their hoods polychromable. Polychromic hoodies that were obtained on-station rather than on-spawn didn't have this problem.

This was basically something that was overlooked by @timothyteakettle when he was adding in colorable loadout stuff. Didn't want to pester him about fixing it when he could work on other things so I fixed it myself.

this fix is probably a little band-aidy but I tried other methods and they don't seem to work. This felt like the best way to go about it.

## Why It's Good For The Game

I just want my hoodies to work, damn it. I plan on adding outfits which will follow the same polychromic functions as the hoodie.

## Changelog
:cl:
fix: Polychromic hoodies that were obtained from the loadout have functional colorable hoods now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
