### PR TITLE
Paramedic EVA suit now purchasable from Cargo

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -93,7 +93,7 @@
 /datum/supply_pack/medical/paramedicevasuit
 	name = "Paramedic EVA Suit"
 	desc = "Has some greytide been floating amongst carp for a dozen minutes now? Chemistry vented in a meth experiment gone wrong? Be the blue saviour this station desperately needs and get your Paramedical EVA suit today! Requires medical access to open."
-	cost = 2250
+	cost = 1975
 	access = ACCESS_MEDICAL
 	contains = list(/obj/item/tank/internals/emergency_oxygen,
 					/obj/item/clothing/head/helmet/space/eva/paramedic,

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -92,7 +92,7 @@
 
 /datum/supply_pack/medical/paramedicevasuit
 	name = "Paramedic EVA Suit"
-	desc = "Has some greytide been floating amongst carp for a dozen minutes now? Chemistry vented in a meth experiment gone wrong? Be the blue saviour this station desperately needs and get your Paramedical EVA suit today! Requires medical access to open."
+	desc = "Greytide pushing up daisies with the carp outside the station? Chemistry vented in a meth experiment gone wrong? Be the blue saviour this station desperately needs and get your Paramedical EVA suit today! Requires medical access to open."
 	cost = 1975
 	access = ACCESS_MEDICAL
 	contains = list(/obj/item/tank/internals/emergency_oxygen,

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -90,6 +90,18 @@
 	crate_name = "medical hardsuit"
 	crate_type = /obj/structure/closet/crate/secure/medical
 
+/datum/supply_pack/medical/paramedicevasuit
+	name = "Paramedic EVA Suit"
+	desc = "Has some greytide been floating amongst carp for a dozen minutes now? Chemistry vented in a meth experiment gone wrong? Be the blue saviour this station desperately needs and get your Paramedical EVA suit today! Requires medical access to open."
+	cost = 2250
+	access = ACCESS_MEDICAL
+	contains = list(/obj/item/tank/internals/emergency_oxygen,
+					/obj/item/clothing/head/helmet/space/eva/paramedic,
+					/obj/item/clothing/suit/space/eva/paramedic,
+					/obj/item/clothing/mask/breath)
+	crate_name = "paramedic EVA suit"
+	crate_type = /obj/structure/closet/crate/secure/medical
+
 /datum/supply_pack/medical/supplies
 	name = "Medical Supplies Crate"
 	desc = "Contains seven beakers, syringes, and bodybags. Three morphine bottles, four insulin pills. Two charcoal bottles, epinephrine bottles, antitoxin bottles, and large beakers. Finally, a single roll of medical gauze, as well as a bottle of stimulant pills for long, hard work days. German doctor not included."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added the paramedics EVA suit as a purchase from the cargo console.
Their crate come with the helmet, suit, a mask and an emergency oxygen tank.
It's cost is currently 1975, while almost entirely functionally identical to the eva suits which cost 3000 for two,
given it's easier access (medical) I decided to give it a premium, though still cheaper than the medical hardsuit at 2750.

desc = "Greytide pushing up daisies with the carp outside the station? Chemistry vented in a meth experiment gone wrong? Be the blue saviour this station desperately needs and get your Paramedical EVA suit today! Requires medical access to open."

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Cargo always likes more stuff to buy and the paramedics eva suit has been a long time coming.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the paramedics EVA suit as a purchase from the cargo console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
