### PR TITLE
utility uniform typos and making the capdrobe not suck

### DIFF
--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -24,7 +24,7 @@
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
 
 /obj/item/clothing/under/rank/civilian/util
-	name = "generic utility uniform"
+	name = "utility uniform"
 	desc = "A utility uniform worn by various crew."
 	icon_state = "utilgen"
 	item_state = "utilgen"

--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -3,11 +3,12 @@
 	name = "captain's jumpsuit"
 	icon_state = "captain"
 	item_state = "b_suit"
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 15)
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 
 /obj/item/clothing/under/rank/captain/util
-	name = "Command Utiltiy Uniform"
+	name = "command utility uniform"
 	desc = "A utility uniform for command personnel."
 	icon_state = "utilcom"
 	item_state = "utilcom"
@@ -26,7 +27,6 @@
 /obj/item/clothing/under/rank/captain/suit
 	name = "captain's suit"
 	desc = "A green suit and yellow necktie. Exemplifies authority."
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 15)
 	icon_state = "green_suit"
 	item_state = "dg_suit"
 	can_adjust = FALSE

--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -131,7 +131,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 5)
 
 /obj/item/clothing/under/rank/medical/doctor/util
-	name = "Medical Utility Uniform"
+	name = "medical utility uniform"
 	desc = "Utility jumpsuit for medical personnel"
 	icon_state = "utilmed"
 	item_state = "utilmed"

--- a/code/modules/clothing/under/jobs/rnd.dm
+++ b/code/modules/clothing/under/jobs/rnd.dm
@@ -62,7 +62,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 5)
 
 /obj/item/clothing/under/rank/rnd/scientist/util
-	name = "Science Utility Uniform"
+	name = "science utility uniform"
 	desc = "A utility uniform for science personnel"
 	icon_state = "utilsci"
 	item_state = "utilsci"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -544,7 +544,7 @@
 					/obj/item/clothing/glasses/sunglasses/gar/supergar = 1,
 					/obj/item/clothing/gloves/color/captain = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/cap_wardrobe
-	payment_department = ACCOUNT_CIV
+	payment_department = ACCOUNT_SEC
 	default_price = PRICE_ALMOST_EXPENSIVE
 	extra_price = PRICE_ABOVE_EXPENSIVE
 


### PR DESCRIPTION
## Changelog
:cl:
spellcheck: Utility uniforms now comply with the "nonproper equipment names" thing.
fix: The CapDrobe now allows the captain to get his own clothes for free. Probably.
tweak: All captains' clothes now offer 15 woundarmor, up from the 5. Because apparently only the suit and tie and its suitskirt subtype have this wound armor, which is dumb.
/:cl:
