### PR TITLE
MetaStation Paramedical + Surgery Revamp

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53185,9 +53185,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/vehicle/ridden/wheelchair{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cbP" = (
@@ -55177,9 +55174,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/vehicle/ridden/wheelchair{
-	dir = 4
-	},
+/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "cfL" = (
@@ -57970,6 +57965,9 @@
 /area/medical/medbay/central)
 "cln" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/vehicle/ridden/wheelchair{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "clo" = (
@@ -80245,7 +80243,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/surgery";
-	dir = 4;
 	name = "Surgery APC";
 	pixel_y = -26
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56434,8 +56434,10 @@
 	},
 /area/medical/surgery)
 "cid" = (
-/obj/structure/sign/poster/official/cleanliness,
-/turf/closed/wall,
+/obj/structure/curtain{
+	icon_state = "closed"
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cie" = (
 /obj/machinery/firealarm{
@@ -57112,6 +57114,9 @@
 "cjB" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/vending/wallmed{
+	pixel_y = 29
+	},
 /turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
 "cjC" = (
@@ -58903,11 +58908,8 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cnm" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/structure/sign/poster/official/cleanliness,
+/turf/closed/wall,
 /area/medical/surgery)
 "cnp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60433,8 +60435,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/machinery/light_switch{
-	pixel_y = -27
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
@@ -101953,7 +101955,7 @@ cia
 cjw
 ckU
 cmk
-cnm
+cnt
 coy
 cUH
 crj
@@ -102978,7 +102980,7 @@ dux
 cdl
 dwb
 cia
-cia
+cnm
 cia
 cid
 cnq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -52010,19 +52010,23 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bZV" = (
-/obj/item/storage/toolbox/emergency,
-/obj/item/hand_labeler,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bZW" = (
-/obj/item/cigbutt,
+/obj/item/cigbutt{
+	pixel_x = 6;
+	pixel_y = -6
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/hand_labeler,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bZX" = (
@@ -53085,7 +53089,6 @@
 	},
 /area/maintenance/port/aft)
 "cbG" = (
-/obj/item/storage/box/lights/mixed,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -53178,11 +53181,12 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/vehicle/ridden/wheelchair{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -55173,7 +55177,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/bloodbankgen,
+/obj/vehicle/ridden/wheelchair{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "cfL" = (
@@ -56421,34 +56427,25 @@
 /turf/closed/wall,
 /area/medical/surgery)
 "cib" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall,
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/white/corner,
 /area/medical/surgery)
 "cic" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 10
 	},
-/turf/closed/wall,
-/area/medical/surgery)
-"cid" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/medical/surgery)
+"cid" = (
+/obj/structure/sign/poster/official/cleanliness,
+/turf/closed/wall,
+/area/medical/surgery)
 "cie" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -57093,56 +57090,62 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cjw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"cjx" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"cjy" = (
-/obj/item/cigbutt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/light_switch{
+	pixel_x = -26
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white/corner,
 /area/medical/surgery)
 "cjz" = (
-/obj/structure/chair,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"cjA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
+"cjA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
 /area/medical/surgery)
 "cjB" = (
-/obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
 "cjC" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 22
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/suit/apron/surgical,
+/turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
 "cjD" = (
-/obj/structure/chair,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/dark,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 5
+	},
+/obj/machinery/light_switch{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 8
+	},
 /area/medical/surgery)
 "cjE" = (
 /obj/structure/bed/roller,
@@ -57152,9 +57155,6 @@
 	listening = 0;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Sleepers";
@@ -57171,12 +57171,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cjF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cjG" = (
@@ -57188,7 +57183,6 @@
 /area/medical/sleeper)
 "cjH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cjI" = (
@@ -57790,71 +57784,72 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "ckU" = (
-/obj/structure/chair,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
+/obj/machinery/computer/operating{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"ckV" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"ckW" = (
-/obj/machinery/holopad,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/medical/surgery)
 "ckX" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"ckY" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"ckZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Observation"
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"cla" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"clb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"clc" = (
-/obj/item/cigbutt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/sign/warning/nosmoking{
+/obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/medical/surgery)
+"ckY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/medical/surgery)
+"ckZ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/medical/surgery)
+"cla" = (
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"clb" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"clc" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/medical/surgery)
 "cld" = (
 /obj/machinery/sleeper{
@@ -57894,6 +57889,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "clg" = (
@@ -58441,26 +58437,32 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cmk" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
 /area/medical/surgery)
 "cml" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/medical/surgery)
 "cmm" = (
-/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
 /area/medical/surgery)
 "cmn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Observation"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
 /area/medical/surgery)
 "cmo" = (
 /obj/effect/spawner/structure/window,
@@ -58903,78 +58905,33 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cnm" = (
-/obj/structure/table,
-/obj/item/hemostat,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel,
-/area/medical/surgery)
-"cnn" = (
-/obj/structure/table,
-/obj/item/surgicaldrill,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white/side,
-/area/medical/surgery)
-"cno" = (
-/obj/structure/table,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
-/obj/item/circular_saw,
-/turf/open/floor/plasteel/white/side,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/medical/surgery)
 "cnp" = (
-/obj/structure/table,
-/obj/item/cautery{
-	pixel_x = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/razor{
-	pixel_y = 5
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
 	},
-/turf/open/floor/plasteel/white/side,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cnq" = (
-/obj/structure/table,
-/obj/item/retractor,
-/turf/open/floor/plasteel,
+/obj/machinery/smartfridge/organ/preloaded,
+/turf/closed/wall,
 /area/medical/surgery)
 "cnr" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/plasteel/white/side,
-/area/medical/surgery)
-"cns" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white/side,
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/medical/surgery)
 "cnt" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_x = 30
-	},
-/obj/structure/bedsheetbin{
-	pixel_x = 2
-	},
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/glasses/eyepatch,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/gun/syringe/dart,
-/turf/open/floor/plasteel/white/side,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/medical/surgery)
 "cnu" = (
 /obj/machinery/power/apc{
@@ -59637,82 +59594,92 @@
 	},
 /area/maintenance/port/aft)
 "coy" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/apron/surgical,
-/obj/machinery/airalarm{
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/vomit/old{
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coA" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coC" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery";
-	dir = 4;
-	name = "Surgery APC";
-	pixel_x = 26
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coD" = (
-/obj/structure/bed/roller,
-/obj/machinery/light/small{
-	dir = 8
+/obj/item/cigbutt{
+	pixel_x = -8;
+	pixel_y = 12
 	},
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coF" = (
-/obj/structure/bed,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/item/trash/popcorn{
+	pixel_x = -5;
+	pixel_y = -4
 	},
-/obj/item/bedsheet/medical,
-/turf/open/floor/plasteel/white,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coG" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
 	},
-/turf/open/floor/plating,
 /area/medical/surgery)
 "coH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -59720,6 +59687,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "coI" = (
@@ -60439,95 +60407,89 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cpT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cpU" = (
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"cpW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"cpX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"cpY" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"cpZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/holopad,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cpT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"cpW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/medical/surgery)
+"cpX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/medical/surgery)
+"cpZ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/medical/surgery)
 "cqa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cqb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Surgery Observation"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cqc" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
@@ -61165,66 +61127,36 @@
 	},
 /area/maintenance/port/aft)
 "crj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/light_switch{
-	pixel_x = -28
+	pixel_x = -26
 	},
-/turf/open/floor/plasteel/white/side{
+/turf/open/floor/plasteel/white/corner,
+/area/medical/surgery)
+"crl" = (
+/turf/open/floor/plasteel/white/side,
+/area/medical/surgery)
+"crm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side,
+/area/medical/surgery)
+"crn" = (
+/obj/machinery/light{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
-"crk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"cro" = (
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"crl" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"crm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"crn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/medical/surgery)
-"cro" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "crq" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
 "crr" = (
 /obj/machinery/airalarm{
@@ -61669,23 +61601,46 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "csj" = (
-/obj/structure/closet/secure_closet/medical2,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/limbgrower,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/medical/surgery)
 "csk" = (
+/obj/machinery/light,
+/obj/machinery/bloodbankgen,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"csl" = (
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/door/window/northleft{
+	name = "Surgery Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"csl" = (
-/obj/machinery/light,
+"csm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/machinery/door/window/northright{
+	name = "Surgery Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery";
 	dir = 1;
@@ -61693,72 +61648,38 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"csm" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/medical/surgery)
 "csn" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1485;
-	listening = 0;
-	name = "Station Intercom (Medbay)";
-	pixel_y = -30
-	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel,
-/area/medical/surgery)
-"cso" = (
-/obj/structure/bed/roller,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/chair/office/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"csp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"cso" = (
+/obj/item/bedsheet/medical{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/bed{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/medical/surgery)
+"csp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "csq" = (
 /obj/structure/bed,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/item/bedsheet/medical,
-/obj/machinery/newscaster{
-	pixel_y = -32
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
 	},
-/obj/machinery/camera{
-	c_tag = "Medbay Recovery Room";
-	dir = 1;
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "csr" = (
 /obj/machinery/door/airlock/maintenance{
@@ -62325,8 +62246,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ctr" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/medical{
+	dir = 1
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -62376,6 +62301,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
 "ctv" = (
@@ -62458,7 +62393,7 @@
 "ctD" = (
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
-/area/medical/genetics)
+/area/medical/paramedic)
 "ctE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
@@ -62728,29 +62663,38 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cui" = (
-/obj/structure/closet/crate,
-/obj/item/coin/silver,
-/obj/item/reagent_containers/spray/weedspray,
-/obj/item/paper,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/table/reinforced,
+/obj/structure/bedsheetbin{
+	pixel_x = 2
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/eyepatch,
+/obj/item/gun/syringe/dart,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/medical/surgery)
 "cuj" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/structure/sign/poster/official/medical_green_cross{
+	pixel_y = -32
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
-	dir = 1;
-	name = "Port Quarter Maintenance APC";
-	pixel_y = 24
+/obj/structure/bed{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/item/bedsheet/medical{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/medical/surgery)
 "cuk" = (
 /obj/structure/table,
 /obj/item/folder/white{
@@ -62936,14 +62880,16 @@
 	},
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 4
 	},
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 4
 	},
 /obj/item/storage/pill_bottle/mutadone,
-/obj/item/storage/pill_bottle/mannitol,
+/obj/item/storage/pill_bottle/mannitol{
+	pixel_x = 5
+	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62981,10 +62927,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -5
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "cuw" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -62994,51 +62942,41 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"cux" = (
-/obj/structure/noticeboard{
-	desc = "A board for pinning important notices upon. Probably helpful for keeping track of requests.";
-	name = "requests board";
-	pixel_x = -32;
-	pixel_y = 32
+/obj/machinery/computer/crew,
+/obj/machinery/vending/wallmed{
+	pixel_x = -25
 	},
+/turf/open/floor/plasteel,
+/area/medical/paramedic)
+"cux" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/genetics)
+/area/medical/paramedic)
 "cuy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "genetics_shutters";
-	name = "genetics shutters"
+/obj/structure/table/glass,
+/obj/item/flashlight/lamp{
+	pixel_x = -1;
+	pixel_y = 11
 	},
-/turf/open/floor/plating,
-/area/medical/genetics)
-"cuz" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 6
+/obj/effect/spawner/lootdrop/cig_packs{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/medical/genetics)
+/area/medical/paramedic)
 "cuA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -63046,6 +62984,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -63346,8 +63287,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cvn" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -63528,72 +63469,61 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cvC" = (
-/obj/machinery/firealarm{
-	dir = 4;
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/medical/paramedic";
+	dir = 8;
+	name = "Paramedic Station APC";
 	pixel_x = -24
 	},
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
-/area/medical/genetics)
+/area/medical/paramedic)
 "cvD" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
+/obj/item/cigbutt{
+	pixel_x = -15;
+	pixel_y = 14
+	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel,
-/area/medical/genetics)
+/area/medical/paramedic)
 "cvE" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/glass,
 /obj/item/folder/white{
 	pixel_x = 4;
-	pixel_y = -3
+	pixel_y = 4
 	},
-/obj/item/pen,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Genetics Desk";
-	req_access_txt = "5;9"
+/obj/item/pen/blue{
+	pixel_x = 5;
+	pixel_y = 3
 	},
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Outer Window"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "genetics_shutters";
-	name = "genetics shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/genetics)
-"cvF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/medical/genetics)
+/area/medical/paramedic)
+"cvF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/paramedic)
 "cvG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet{
@@ -63853,7 +63783,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cwj" = (
-/obj/item/cigbutt,
+/obj/structure/closet/crate,
+/obj/item/coin/silver,
+/obj/item/reagent_containers/spray/weedspray,
+/obj/item/paper,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cwm" = (
@@ -63865,12 +63802,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cwn" = (
-/obj/structure/rack,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/flashlight/pen,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/medical/surgery)
 "cwo" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -64061,20 +63996,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cwD" = (
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
 /obj/machinery/camera{
-	c_tag = "Genetics Desk";
+	c_tag = "Paramedics Office";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -64082,26 +64012,15 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/medical/genetics)
+/area/medical/paramedic)
 "cwE" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/button/door{
-	id = "genetics_shutters";
-	name = "genetics shutters control";
-	pixel_x = 28;
-	req_access_txt = "9"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/medical/genetics)
+/area/medical/paramedic)
 "cwF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -64109,6 +64028,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cwG" = (
@@ -64333,11 +64253,28 @@
 	},
 /area/maintenance/port/aft)
 "cxc" = (
-/obj/item/trash/chips,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Recovery Room";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/structure/sign/poster/official/love_ian{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/medical/surgery)
 "cxd" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/rack,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/flashlight/pen,
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -64383,6 +64320,16 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "cxi" = (
@@ -64491,11 +64438,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -64513,63 +64460,74 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cxv" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/genetics)
-"cxw" = (
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/item/stack/packageWrap,
-/obj/item/pen,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"cxx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/effect/landmark/start/paramedic,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
-/area/medical/genetics)
-"cxy" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_x = 28
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/area/medical/paramedic)
+"cxw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/paramedic,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/medical/paramedic)
+"cxx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light,
+/obj/structure/closet/secure_closet/paramedic,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/paramedic)
+"cxy" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"cxz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/medical/paramedic)
+"cxz" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=10.1-Central-from-Aft";
 	location = "10-Aft-To-Central"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -64579,6 +64537,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -64710,17 +64671,36 @@
 	},
 /area/maintenance/port/aft)
 "cxR" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/trash/chips,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cxS" = (
-/obj/item/latexballon,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cxT" = (
-/obj/item/clothing/suit/ianshirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cxU" = (
@@ -64885,6 +64865,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cyh" = (
@@ -64892,65 +64873,68 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cyi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research{
-	id_tag = "AuxGenetics";
-	name = "Genetics Lab";
-	req_access_txt = "9"
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/medical/paramedic)
+"cyk" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/medical/paramedic)
+"cyl" = (
+/turf/closed/wall,
+/area/medical/paramedic)
+"cym" = (
+/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"cyj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"cyk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"cyl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/medical/genetics)
-"cym" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	id_tag = "AuxGenetics";
 	name = "Genetics Access";
 	req_access_txt = "9"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "cyn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65278,42 +65262,42 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "cza" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "czb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Genetics Lab";
+	dir = 6;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "czc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
@@ -65321,35 +65305,36 @@
 /obj/machinery/light_switch{
 	pixel_x = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "cze" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/door/airlock/research{
+	id_tag = "AuxGenetics";
+	name = "Genetics Access";
+	req_access_txt = "9"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "czf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -26
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -65363,9 +65348,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "czh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
@@ -65374,6 +65356,7 @@
 	req_one_access_txt = "29"
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "czi" = (
@@ -65927,6 +65910,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
@@ -67855,9 +67841,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEd" = (
@@ -67876,28 +67860,21 @@
 	pixel_y = -3
 	},
 /obj/item/clothing/gloves/color/latex,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/medical/morgue)
-"cEf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
+/area/medical/surgery)
+"cEf" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
 "cEg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -67908,13 +67885,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cEh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cEi" = (
@@ -68343,11 +68318,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -68357,9 +68338,15 @@
 	name = "Morgue";
 	req_access_txt = "6"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "cEZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cFa" = (
@@ -68840,6 +68827,9 @@
 /area/medical/morgue)
 "cFY" = (
 /obj/structure/closet,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cFZ" = (
@@ -68847,6 +68837,9 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -72322,17 +72315,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cMo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/aft";
+	dir = 1;
+	name = "Port Quarter Maintenance APC";
+	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -72899,10 +72889,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cNg" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light/small,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cNh" = (
@@ -75895,8 +75891,12 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "cUH" = (
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
 /area/medical/surgery)
 "cUL" = (
 /obj/docking_port/stationary/random{
@@ -79639,9 +79639,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -80245,6 +80242,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/medical/surgery";
+	dir = 4;
+	name = "Surgery APC";
+	pixel_y = -26
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -81359,6 +81365,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"fpa" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fpY" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
@@ -81457,6 +81469,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gtn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
+"gwW" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gEk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -81519,6 +81557,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"hny" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/curtain,
+/turf/open/floor/plasteel/white/side,
+/area/medical/surgery)
 "hyP" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -81766,6 +81809,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"kgN" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -81982,8 +82034,22 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "lWL" = (
-/obj/machinery/smartfridge/organ/preloaded,
-/turf/closed/wall,
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
 /area/medical/surgery)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
@@ -82057,6 +82123,10 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"mqC" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "mvj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -82109,6 +82179,10 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
+/area/maintenance/port/aft)
+"nho" = (
+/obj/item/latexballon,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nhy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -82265,6 +82339,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oeQ" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ohj" = (
 /obj/item/integrated_electronics/analyzer,
 /obj/item/integrated_electronics/debugger,
@@ -82519,6 +82599,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"qee" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qhe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -82627,6 +82717,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"reM" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "roa" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/small{
@@ -82650,6 +82750,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"rvd" = (
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rzX" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -82780,6 +82887,17 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"sBC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/paramedic)
+"sCN" = (
+/obj/item/clothing/suit/ianshirt,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sFv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82954,6 +83072,13 @@
 /obj/item/flashlight,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"umv" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "upN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -83074,6 +83199,14 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"vwZ" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general{
+	color = "#0000ff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/medical/surgery)
 "vxG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -100807,7 +100940,7 @@ cwi
 dux
 dux
 dux
-aaa
+dux
 aaa
 cBR
 cCK
@@ -101062,9 +101195,9 @@ cuf
 cvk
 cwh
 bXE
+bXE
 dvq
 dux
-aaa
 aaa
 cBR
 cBR
@@ -101318,10 +101451,10 @@ chZ
 chZ
 cvl
 cbx
+cfD
 ceu
 dux
-dux
-aaf
+mqC
 aaa
 aaa
 cBR
@@ -101568,7 +101701,7 @@ cia
 cia
 cia
 cia
-cpT
+cDP
 cia
 cia
 cia
@@ -101576,9 +101709,9 @@ ceu
 dyg
 dvt
 bXE
+bXE
 dvE
 dux
-aaf
 aaf
 aaf
 dBN
@@ -101825,17 +101958,17 @@ ckU
 cmk
 cnm
 coy
-cpU
+cUH
 crj
 csj
 cia
 cug
 dyg
+bXE
 dDw
 bXE
-cNg
+rvd
 dux
-aaa
 aaa
 aaa
 cBR
@@ -102076,23 +102209,23 @@ bXE
 cer
 dux
 dwb
-cib
-cjx
-ckV
+cia
+cjC
+cla
 cml
-cnn
+cnt
 coz
-coz
-crk
+cUH
+crq
 csk
 cia
 cuh
 cvm
 cDK
-cxc
+ceu
 cxR
+oeQ
 dux
-aaa
 aaa
 aaa
 dBN
@@ -102333,11 +102466,11 @@ bXE
 bYJ
 dux
 dwe
+cia
+cjB
+cpT
 cic
-cjy
-ckW
-cmk
-cno
+cnr
 coA
 cUH
 crl
@@ -102346,10 +102479,10 @@ cia
 ceu
 ceu
 dyg
+ceu
 dux
 dux
 dux
-aaa
 aaa
 aaa
 cBR
@@ -102590,23 +102723,23 @@ dvt
 dux
 dux
 dwb
-cic
+cia
 cjz
 ckX
 cmm
 cnp
 coB
-coB
+vwZ
 crm
 csm
 cia
-cui
+dux
 cwj
-dyg
+cNg
+ceu
 dux
-cxS
+nho
 dux
-aaf
 aaf
 aaf
 cBR
@@ -102847,23 +102980,23 @@ cdi
 dux
 cdl
 dwb
-cic
-cjA
-ckY
-cmk
+cia
+cia
+cia
+cid
 cnq
 coC
 cpW
 crn
 csn
-cia
-cdl
-cMm
-cMo
+cui
 dux
-cxT
+cxS
+cNf
+fpa
 dux
-aaa
+sCN
+dux
 aaa
 aaa
 aaf
@@ -103104,23 +103237,23 @@ dux
 dux
 cfD
 dwb
-cic
 cia
+cib
 ckZ
-cia
-cia
-cia
+cjA
+kgN
+coB
 cpX
 cia
 lWL
 cia
-ceu
+cia
 dyg
+bXE
 dyw
 dux
-cxS
+nho
 dux
-aaa
 aaa
 aaa
 aaf
@@ -103361,20 +103494,20 @@ cdj
 cse
 cdj
 cgL
-cid
+cia
 cjB
-cla
-cmk
+cro
+ckY
 cnr
 coD
-cpY
-cro
+cqa
+cnt
 cso
+cuj
 cia
-cfD
 dyj
 ceu
-dux
+ceu
 dux
 dux
 dux
@@ -103618,18 +103751,18 @@ cdk
 ceu
 cfE
 dwi
-cic
+cia
 cjC
 clb
 cmn
-cns
+cnt
 coE
 cpZ
-coB
+hny
 csp
+cwn
 csr
-duH
-dyg
+cxT
 ceu
 cMm
 cwm
@@ -103875,17 +104008,17 @@ dux
 dux
 cfF
 dwj
-cic
+cia
 cjD
 clc
-cmk
+coG
 cnt
 coF
-cqa
-crq
+cEe
+cnt
 csq
+cxc
 cia
-dux
 diM
 cwm
 cNf
@@ -104132,20 +104265,20 @@ cdl
 cev
 cev
 cgO
-cic
 cia
 cia
 cia
 cia
-coG
+cia
+cia
 cqb
 cia
 cia
 cia
-cuj
-cbx
+cia
+cMo
 dDw
-bXE
+gwW
 cxU
 cxU
 czN
@@ -104401,7 +104534,7 @@ csr
 duH
 bXE
 cvn
-cwn
+dvE
 cxd
 cxU
 cyN
@@ -104655,9 +104788,9 @@ coI
 cqd
 crs
 css
-dux
-dux
-dux
+cvp
+cvp
+cvp
 cxU
 cxU
 cxU
@@ -108773,7 +108906,7 @@ cvA
 cwB
 cxt
 cyg
-cyZ
+reM
 cAd
 ctA
 dbr
@@ -109285,9 +109418,9 @@ ctA
 ctA
 ctA
 ctA
-cxv
-cyi
 ctA
+ctA
+cym
 ctA
 ctA
 cCi
@@ -109538,12 +109671,12 @@ coV
 cqt
 cga
 cKJ
-ctB
+cyl
 cuw
 cvC
 cwD
 cxw
-cyj
+cyl
 czb
 cAf
 cBc
@@ -110052,18 +110185,18 @@ coX
 cnL
 cga
 cbC
-ctB
+cyl
 cuy
 cvE
-ctB
+cxv
 cxy
 cyl
 czd
-cAg
+gtn
 ctB
 cCe
 cCe
-cEe
+cCe
 cEY
 cCe
 cCe
@@ -110310,11 +110443,11 @@ coY
 cga
 csI
 ctD
-cuz
 cvF
-ctB
-ctB
-cym
+sBC
+cyl
+cyi
+cyl
 cze
 ctB
 cBd
@@ -110825,18 +110958,18 @@ crG
 csK
 ctF
 car
-car
+czg
 car
 cxA
 car
-czg
+car
 cAi
 ctF
 car
 car
-czg
-cFb
 car
+cFb
+czg
 car
 cHO
 cIF
@@ -111082,7 +111215,7 @@ crH
 csL
 ctG
 cgc
-cvG
+qee
 chh
 cxB
 cyo
@@ -111093,7 +111226,7 @@ cCm
 cpa
 cEh
 cFc
-chh
+umv
 chh
 cvG
 cIG


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As a continuation of the modifications done to BoxStation, MetaStation will now have a new Paramedic Office and a revamped Surgery.

- The new Paramedic Office has been placed where Genetics had a reception office.
- Surgery has now been split into two Surgery Bays, and Surgery Observation has been minimized and moved below them.
- Maints have been moved down by one tile to compensate for taking a few tiles from it.
- A new Recovery Room has been put in place of the old Recovery Hall, and sectioned off to increase privacy.
- Moved the Blood Bank Generator next to the newly placed Limb Grower in Surgery Observation below the two new Surgery Bays, and puts the relevant crates nearby, but also locks them off from the public while still being easily accessible to medical staff.
- Adds two wheelchairs to Medbay for replacement purposes.

Credits: Layout feedback from both @Chiirno and @MrJWhit, and @MrJWhit's help with checking over piping errors.
Also thanks to YogsStation for huge inspiration on the Paramedic Office

Old Surgery: 
![image](https://user-images.githubusercontent.com/6299921/103447900-691f1b00-4c46-11eb-8af4-db4b8cc3856d.png)

New Surgery:
![image](https://user-images.githubusercontent.com/6299921/103469010-3cd1d000-4d14-11eb-99c8-b15e5606d6a3.png)

Old Genetics Reception:
![image](https://user-images.githubusercontent.com/6299921/103447921-b0a5a700-4c46-11eb-8c22-75cf6bd3f320.png)

New Paramedic Office:
![image](https://user-images.githubusercontent.com/6299921/103448020-44c43e00-4c48-11eb-9734-70d11779860e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Surgery was just a literal copy of the previous BoxStation layout. This changes that, but in a way that allows it to be differentiated from the new BoxStation Surgery Bay, and to possibly help add a new, better feel to the area.

There was nowhere for Paramedics to sit in, officially, and not take up hallway space in Medbay. Also, Genetics should not really be public-facing, in the sense that they shouldn't just be giving out gene mods to the public, and if a person needs to be in Genetics for health reasons, they likely are already coming through Medbay proper. However, the doors into Genetics from the hallway have been kept, for those with access to come and go.

There was also no good place to put the Limb Grower, and the round-start Prosthetic Limbs Crate was always taking up space and getting in the way in Medbay Storage.

In addition, MetaStation, like BoxStation, also did not have replacement wheelchairs, so they have been added.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New Paramedic Office next to Genetics where the old Genetics Reception used to be
change: Surgery, Surgery Observation, and Recovery Hall layout revamped drastically
change: Maints below Surgery lowered by one tile to recover lost tile space from Surgery expansion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
