### PR TITLE
Max groin cannon size increased before being punished for erecting a massive mayo-blaster to -max roundstart config- inches instead of 20

### DIFF
--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -45,9 +45,9 @@
 			new_size = 1
 		if(7 to 11) //If large
 			new_size = 2
-		if(12 to 20) //If massive
+		if(12 to 24) //If massive
 			new_size = 3
-		if(21 to 34) //If massive and due for large effects
+		if(25 to 34) //If massive and due for large effects
 			new_size = 3
 			enlargement = TRUE
 		if(35 to INFINITY) //If comical

--- a/code/modules/arousal/organs/penis.dm
+++ b/code/modules/arousal/organs/penis.dm
@@ -40,17 +40,18 @@
 	var/rounded_length = round(length)
 	var/new_size
 	var/enlargement = FALSE
+	var/max_D = CONFIG_GET(number/penis_max_inches_prefs)
 	switch(rounded_length)
 		if(0 to 6) //If modest size
 			new_size = 1
 		if(7 to 11) //If large
 			new_size = 2
-		if(12 to 24) //If massive
+		if(12 to max_D) //If massive
 			new_size = 3
-		if(25 to 34) //If massive and due for large effects
+		if(max_D + 1 to max_D+13) //If massive and due for large effects, modified in case some server owner running recent citcode decides to be insane with dick sizes in the config
 			new_size = 3
 			enlargement = TRUE
-		if(35 to INFINITY) //If comical
+		if(max_D+14 to INFINITY) //If comical
 			new_size = 4 //no new sprites for anything larger yet
 			enlargement = TRUE
 	if(owner)

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -232,7 +232,8 @@
 		P.Insert(H)
 
 	P.modify_size(0.1)
-	if (ISINRANGE_EX(P.length, 24.5, 25) && (H.w_uniform || H.wear_suit))
+	var/max_D = CONFIG_GET(number/penis_max_inches_prefs)
+	if (ISINRANGE_EX(P.length, max_D + 0.5, max_D + 1) && (H.w_uniform || H.wear_suit))
 		var/target = H.get_bodypart(BODY_ZONE_CHEST)
 		if(!message_spam)
 			to_chat(H, "<span class='danger'>Your cock begin to strain against your clothes tightly!</b></span>")

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -232,7 +232,7 @@
 		P.Insert(H)
 
 	P.modify_size(0.1)
-	if (ISINRANGE_EX(P.length, 20.5, 21) && (H.w_uniform || H.wear_suit))
+	if (ISINRANGE_EX(P.length, 24.5, 25) && (H.w_uniform || H.wear_suit))
 		var/target = H.get_bodypart(BODY_ZONE_CHEST)
 		if(!message_spam)
 			to_chat(H, "<span class='danger'>Your cock begin to strain against your clothes tightly!</b></span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What the title says. The meat sticks can be a whole two feet long as per current server config instead of slightly below a two-footer before you suffer the consequences of slowdown and blood loss.

## Why It's Good For The Game

The server config was changed recently so that you can have roundstart 24 inch thunderswords instead of 20 inch yogurt flingers. If there are characters that are created with this maximum roundstart packaging in mind, they will likely throb out of the round before too long unless this is also changed. Meaning chemistry won't be pestered over flesh flute shrinking requests being erected up when players make this mistake, because the tan bananas will be more tolerable at that size.

It also likely will be appreciated by a certain giant red panda who people keep making vore jokes over.

## Changelog
:cl:
tweak: You can now have a max-roundstart-dicksize-config inch long johnson before you start suffering blood loss and slowdowns instead of a 20 inch one.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
