### PR TITLE
Nightmare Lights Damage Buff

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -203,6 +203,15 @@
 		var/obj/item/I = AM
 		if(I.light_range && I.light_power)
 			disintegrate(I)
+	else if (isstructure(AM))
+		var/obj/structure/S = AM
+		if(istype(S, /obj/structure/glowshroom) || istype(S, /obj/structure/marker_beacon))
+			qdel(S)
+			visible_message("<span class='danger'>[S] is disintegrated by [src]!</span>")
+	else if(AM.light_range && AM.light_power  && !(istype(AM, /obj/machinery/power/apc) || istype(AM, /obj/machinery/airalarm)))
+		var/obj/target_object = AM
+		target_object.take_damage(force * 5, BRUTE, "melee", 0)
+
 
 /obj/item/light_eater/proc/disintegrate(obj/item/O)
 	if(istype(O, /obj/item/pda))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nightmares now deals 5x to most light producing object, with the exception of APCs and Air Alarms. 
(In particular they break console screens in one shot)
They also now one shot glowshrooms and miners beacons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The Nightmare requiring 14 hits to remove a glowshroom is pretty silly.
The time it normally takes to destroy consoles and other lightsources should also be quicker than an assistant with a toolbox.
Thought the exact extent of this bonus damage can be discussed, I've set it at x5 for the moment.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Nightmare now deals additional damage to most light sources.
fix: Nightmare now one-shots miners beacons and glowshrooms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
