### PR TITLE
Fuck it, I'll just fix a whole bunch of stuff on cogstation

### DIFF
--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -48763,7 +48763,7 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "cbh" = (
-/obj/machinery/rnd/experimentor,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
 "cbi" = (
@@ -49607,13 +49607,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "ccL" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/rdconsole/experiment{
+	dir = 1
 	},
-/obj/machinery/rnd/bepis,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/science/explab)
 "ccM" = (
 /obj/structure/disposalpipe/segment{
@@ -56687,9 +56685,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqS" = (
-/obj/machinery/computer/rdconsole/experiment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/requests_console{
 	department = "Science";
@@ -56698,6 +56693,8 @@
 	pixel_x = -30;
 	receive_ore_updates = 1
 	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/plasteel,
 /area/science/explab)
 "cqT" = (
@@ -70823,6 +70820,10 @@
 	dir = 1
 	},
 /area/engine/atmos)
+"eJy" = (
+/obj/machinery/rnd/experimentor,
+/turf/open/floor/engine,
+/area/science/explab)
 "eKM" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/visible,
 /turf/open/floor/plasteel,
@@ -71222,6 +71223,10 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"sSg" = (
+/obj/machinery/rnd/bepis,
+/turf/open/floor/engine,
+/area/science/explab)
 "sVC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -92116,7 +92121,7 @@ cHj
 cqS
 cav
 cav
-ccL
+ctb
 caX
 caX
 caX
@@ -92370,13 +92375,13 @@ aVF
 caw
 caA
 cHk
-caP
+ccL
 caT
 caX
-caX
+eJy
 caX
 cbh
-caX
+sSg
 caX
 cbx
 cav

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -27653,6 +27653,9 @@
 /area/quartermaster/office)
 "biK" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "biL" = (
@@ -30650,8 +30653,11 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "boL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/science/mixing)
 "boM" = (
 /obj/machinery/mineral/ore_redemption{
@@ -35664,7 +35670,9 @@
 	name = "Toxins Launch Room";
 	req_access_txt = "7;8"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bzY" = (
@@ -35798,7 +35806,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bAm" = (
@@ -36039,7 +36046,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bAH" = (
@@ -36129,6 +36135,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bAQ" = (
@@ -36156,10 +36165,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bAV" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bAW" = (
@@ -37368,10 +37383,11 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "bDL" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/science/mixing)
 "bDM" = (
 /obj/structure/table/reinforced,
@@ -38183,12 +38199,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bFp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bFq" = (
@@ -40137,9 +40148,6 @@
 /area/space/nearstation)
 "bJw" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bJx" = (
@@ -40341,9 +40349,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "bJT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bJU" = (
@@ -42659,9 +42665,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bOF" = (
@@ -43768,9 +43771,7 @@
 /turf/open/floor/plating,
 /area/router)
 "bQX" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bQY" = (
@@ -49115,6 +49116,9 @@
 "cbP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -55003,6 +55007,9 @@
 /obj/item/target/alien,
 /obj/item/target,
 /obj/item/target/clown,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cnM" = (
@@ -55070,7 +55077,8 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cnT" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cnU" = (
@@ -70796,6 +70804,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
+"ebG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plating,
+/area/science/mixing)
 "eCy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -70984,6 +70997,13 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"iCa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "iQY" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -90814,10 +90834,10 @@ bOv
 bfo
 blI
 bfo
-bWS
-bcw
-bcw
-bcw
+bXg
+ebG
+ebG
+iCa
 bcy
 cbu
 csR
@@ -91326,9 +91346,9 @@ boJ
 fuR
 bzX
 bAl
-boL
+bdf
 bAG
-cnT
+bdf
 boQ
 cKJ
 bAP
@@ -91581,11 +91601,11 @@ bcy
 bcy
 bcy
 bcy
-bcy
+bWS
 bgC
 bdf
 boR
-bDL
+bdf
 boQ
 cKJ
 bAP
@@ -91838,11 +91858,11 @@ bQe
 aaU
 aaU
 aaU
-bcw
+boL
 bdf
 bdf
 bpM
-bFp
+bvj
 bvj
 cKK
 bAU
@@ -92095,7 +92115,7 @@ aye
 aaU
 aaU
 aaU
-bcw
+bDL
 cnL
 bdf
 bpR
@@ -92354,8 +92374,8 @@ abp
 abp
 bcy
 biK
-bdf
-bpR
+bFp
+cnT
 bJT
 bLl
 cKM

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -25068,14 +25068,14 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "bcZ" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -26858,9 +26858,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "bgY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
 /area/hallway/primary/central)
@@ -27034,11 +27031,12 @@
 /turf/open/floor/plasteel,
 /area/engine/secure_construction)
 "bht" = (
-/obj/structure/grille,
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/terminal,
+/obj/structure/grille,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
@@ -29611,13 +29609,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmM" = (
-/obj/structure/grille,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/terminal,
+/obj/structure/grille,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
@@ -43319,9 +43318,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Foyer";
 	network = list("minisat");
@@ -43339,7 +43335,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel,
-/area/ai_monitored/turret_protected/ai)
+/area/ai_monitored/turret_protected/ai_upload_foyer)
 "bQc" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -43401,9 +43397,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden,
 /turf/open/floor/plasteel,
@@ -44273,9 +44266,6 @@
 /area/science/robotics/lab)
 "bRW" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
@@ -44403,9 +44393,6 @@
 /area/science/xenobiology)
 "bSk" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -44492,9 +44479,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bSr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -44502,18 +44486,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "bSs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "bSt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -44715,9 +44693,6 @@
 /area/science/lab)
 "bSO" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -45238,9 +45213,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
@@ -45337,9 +45309,6 @@
 "bUi" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -46114,9 +46083,6 @@
 /area/engine/atmos)
 "bVF" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
@@ -46465,9 +46431,6 @@
 /area/science/mixing)
 "bWm" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/engineering{
 	name = "AI SMES Access";
 	req_one_access_txt = "10;24"
@@ -46569,9 +46532,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bWv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 8
 	},
@@ -51567,7 +51527,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -51960,9 +51919,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chy" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 10
 	},
@@ -52085,9 +52041,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/teg/hotloop)
@@ -55095,9 +55048,6 @@
 /turf/open/space/basic,
 /area/quartermaster/warehouse)
 "cnR" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -71347,6 +71297,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"uYy" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "vcb" = (
 /obj/machinery/atmospherics/pipe/simple/brown/visible,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -105741,7 +105699,7 @@ cgD
 cdV
 chy
 chN
-bWQ
+uYy
 bWQ
 cdo
 aPg

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -52028,18 +52028,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "chN" = (
@@ -67073,8 +67068,8 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "cJH" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -67679,11 +67674,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"cLc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "cLd" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -68104,13 +68094,13 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "cMa" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
+	},
+/obj/machinery/airlock_sensor/incinerator_atmos{
+	pixel_x = -8;
+	pixel_y = 24
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -68251,16 +68241,21 @@
 	pixel_x = -40;
 	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
+	},
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_x = -24;
+	pixel_y = -9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cMw" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -68379,10 +68374,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cMI" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supplymain/visible{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "cMJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -68420,10 +68418,8 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cMO" = (
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cMP" = (
@@ -70774,6 +70770,13 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dnN" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dpO" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	dir = 4
@@ -70793,6 +70796,14 @@
 	},
 /turf/open/floor/plating,
 /area/router)
+"dSZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "dVR" = (
 /obj/machinery/atmospherics/pipe/simple/violet/visible,
 /turf/open/floor/plasteel,
@@ -70810,11 +70821,12 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "eCy" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_atmos{
+	pixel_x = -25;
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -71029,6 +71041,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"jAv" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "kzb" = (
 /obj/machinery/atmospherics/pipe/manifold/orange/hidden{
 	dir = 4
@@ -71065,6 +71084,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mqE" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "mxW" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible{
@@ -71072,6 +71095,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"mDW" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "mEa" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -71214,8 +71244,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rUl" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -71295,8 +71325,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tZC" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -118825,7 +118855,7 @@ bNE
 cww
 cpO
 bYP
-cRg
+cMI
 cMH
 cww
 cMb
@@ -119602,7 +119632,7 @@ chn
 eCy
 chL
 cMv
-cMI
+cMJ
 anr
 aaa
 aaa
@@ -119859,7 +119889,7 @@ chp
 chx
 chM
 gDY
-jiZ
+mqE
 anr
 aaa
 aaa
@@ -120113,7 +120143,7 @@ uVD
 mqB
 dpO
 tZC
-qWY
+cwB
 rUl
 cMw
 cfs
@@ -120627,8 +120657,8 @@ sRD
 nAF
 cgz
 cJH
-cwB
-cMl
+qWY
+cJH
 cMx
 cMJ
 cxc
@@ -121391,7 +121421,7 @@ bSb
 cKS
 cKY
 bQO
-cLc
+cMO
 eIh
 bYd
 tXV
@@ -121401,7 +121431,7 @@ cwB
 cMc
 cMm
 cMy
-cML
+dSZ
 cLa
 cKY
 cLu
@@ -122419,7 +122449,7 @@ bTH
 cKU
 cKY
 cLa
-cLc
+cMO
 fgS
 car
 cwB
@@ -122429,7 +122459,7 @@ cwB
 cMg
 cMq
 cMB
-cML
+dSZ
 cMQ
 cKY
 cLw
@@ -123200,8 +123230,8 @@ cLs
 cLs
 cMs
 cME
-cMN
-aaU
+mDW
+dnN
 bZR
 caJ
 bpq
@@ -123447,7 +123477,7 @@ bTK
 cKW
 cKY
 bQV
-cLc
+cMO
 cLk
 ctk
 prx
@@ -123458,7 +123488,7 @@ prx
 iQY
 cMF
 cMO
-cMS
+jAv
 cMT
 cLy
 blM


### PR DESCRIPTION
## About The Pull Request

Snips the AI from the main power loop on cogstation.

Swaps the experimenter and bepis module around so it's closer to the console. That way the console autodetects the experimenter. 

Fixes toxins so there's not a pipe going straight through it:
![image](https://user-images.githubusercontent.com/48370570/103714187-0e5e2a00-4f8c-11eb-8511-cd5b7f76d036.png)

Also fixes up atmos on cogstation.

## Why It's Good For The Game

So the AI doesn't die from a power sink, and also silicon asked for it.
Also I **hate** how there are wires going through the walls, but, that's something for later.

## Changelog
:cl:
tweak: Removed the wires connecting the AI from the rest of the station on cogstation.
tweak: Fixes experimenter on cogstation.
tweak: Less pipes in the overall area in toxins on cogstation
/:cl: