### PR TITLE
Small blob tweaks + fix

### DIFF
--- a/code/modules/antagonists/blob/blob/blobs/resource.dm
+++ b/code/modules/antagonists/blob/blob/blobs/resource.dm
@@ -26,7 +26,7 @@
 		return
 	flick("blob_resource_glow", src)
 	if(overmind)
-		overmind.add_points(1)
+		overmind.add_points(2)
 		resource_delay = world.time + 40 + overmind.resource_blobs.len * 2.5 //4 seconds plus a quarter second for each resource blob the overmind has
 	else
 		resource_delay = world.time + 40

--- a/code/modules/antagonists/blob/blob/powers.dm
+++ b/code/modules/antagonists/blob/blob/powers.dm
@@ -147,7 +147,7 @@
 	set category = "Blob"
 	set name = "Create Factory Blob (60)"
 	set desc = "Create a spore tower that will spawn spores to harass your enemies."
-	createSpecial(60, /obj/structure/blob/factory, 7, 1)
+	createSpecial(60, /obj/structure/blob/factory, 5, 1)
 
 /mob/camera/blob/verb/create_blobbernaut()
 	set category = "Blob"
@@ -195,6 +195,7 @@
 		to_chat(blobber, "The <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font> reagent [blobstrain.shortdesc ? "[blobstrain.shortdesc]" : "[blobstrain.description]"]")
 	else
 		to_chat(src, "<span class='warning'>You could not conjure a sentience for your blobbernaut. Your points have been refunded. Try again later.</span>")
+		B.naut = FALSE
 		add_points(40)
 
 /mob/camera/blob/verb/relocate_core()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes the permanent consumption of a factory blob if ghosts opt not to become a naut.  Also changes resource blob pointgen from 1 to 2 and allows factory blobs to be placed 5 tiles apart instead of 7.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The fix - Fixes are good, wasting resources and towers are not.

Blob Factory Placement - 7 tiles felt very tight and still didn't even feel like 7 tiles because of the node requirement as well.  5 should still keep it per node without ability to spam it.

Blob Resource Tower Point Gen - Since blobs are GENERALLY late game and have to deal with a metric ton of things (Infinitely refillable Welders, various guns, TK, Xray lasers, other antags etc) this SHOULD help a small bit against that without being overly OP.

## Changelog
:cl:
balance: Blob Resource Tower to 2 points per instead of 1 point per.
balance: Blob Factory Towers can be placed 5 tiles apart instead of 7.
fix: Fixes Blobbernaut Factories consuming Factories if no naut is chosen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
