### PR TITLE
Tweaks blood bag consumption

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -109,16 +109,16 @@
 
 	if(C.is_mouth_covered())
 		if(user != C)
-			to_chat(user, "<span class='notice'>You can't drink force [C] to drink from [src] while their mouth is covered.</span>")
+			to_chat(user, "<span class='notice'>You can't force [C] to drink from [src] while their mouth is covered.</span>")
 			return
-		to_chat(user, "<span class='notice'>You can't drink from the [src] while your mouth is covered.</span>")
+		to_chat(user, "<span class='notice'>You can't drink from [src] while your mouth is covered.</span>")
 		return
 
 	if(!user.CheckActionCooldown())
 		return
 	if(user != C)
-		user.visible_message("<span class='danger'>[user] forces [C] to drink from the [src].</span>", \
-		"<span class='notice'>You force [C] to drink from the [src]</span>")
+		user.visible_message("<span class='danger'>[user] forces [C] to drink from [src].</span>", \
+		"<span class='notice'>You force [C] to drink from [src]</span>")
 		user.DelayNextAction(50)
 		if(do_mob(user, C, 50))
 			do_drink(C, user)
@@ -126,8 +126,8 @@
 	else
 		user.DelayNextAction(10)
 		if(do_mob(user, C, 10))
-			user.visible_message("<span class='notice'>[user] puts the [src] up to their mouth.</span>", \
-			"<span class='notice'>You take a sip from the [src].</span>")
+			user.visible_message("<span class='notice'>[user] puts [src] up to their mouth.</span>", \
+			"<span class='notice'>You take a sip from [src].</span>")
 			do_drink(C, user)
 
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -104,15 +104,17 @@
 		return ..()
 
 /obj/item/reagent_containers/blood/attack(mob/living/carbon/C, mob/user, def_zone)
-	if(!iscarbon(C) || !user.a_intent == INTENT_HELP || reagents.total_volume < 0)
+	if(!iscarbon(C) || !user.a_intent != INTENT_HELP || reagents.total_volume < 0)
 		..()
 
 	if(C.is_mouth_covered())
+		if(user != C)
+			to_chat(user, "<span class='notice'>You can't drink force [C] to drink from [src] while their mouth is covered.</span>")
+			return
 		to_chat(user, "<span class='notice'>You can't drink from the [src] while your mouth is covered.</span>")
 		return
 
 	if(!user.CheckActionCooldown())
-		to_chat(user, "<span class='notice'>You can't drink from the [src] so fast!</span>")
 		return
 	if(user != C)
 		user.visible_message("<span class='danger'>[user] forces [C] to drink from the [src].</span>", \
@@ -136,8 +138,8 @@
 	var/gulp_size = 3
 	var/fraction = min(gulp_size / reagents.total_volume, 1)
 	reagents.reaction(C, INGEST, fraction) 	//checkLiked(fraction, M) // Blood isn't food, sorry.
+	reagents.remove_any(5) //Inneficency, so hey, IVs are usefull.
 	reagents.trans_to(C, gulp_size)
-	reagents.remove_reagent(src, 5) //Inneficency, so hey, IVs are usefull.
 	playsound(C.loc,'sound/items/drink.ogg', rand(10, 50), TRUE)
 
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -104,31 +104,42 @@
 		return ..()
 
 /obj/item/reagent_containers/blood/attack(mob/living/carbon/C, mob/user, def_zone)
-	if(user.a_intent == INTENT_HELP && reagents.total_volume > 0 && iscarbon(C) && user.a_intent == INTENT_HELP)
-		if(C.is_mouth_covered())
-			to_chat(user, "<span class='notice'>You cant drink from the [src] while your mouth is covered.</span>")
-			return
-		if(user != C)
-			user.visible_message("<span class='danger'>[user] forces [C] to drink from the [src].</span>", \
-			"<span class='notice'>You force [C] to drink from the [src]</span>")
-			if(!do_mob(user, C, 50))
-				return
-		else
-			if(!do_mob(user, C, 10))
-				return
+	if(!iscarbon(C) || !user.a_intent == INTENT_HELP || reagents.total_volume < 0)
+		..()
 
-			to_chat(user, "<span class='notice'>You take a sip from the [src].</span>")
-			user.visible_message("<span class='notice'>[user] puts the [src] up to their mouth.</span>")
-		if(reagents.total_volume <= 0) // Safety: In case you spam clicked the blood bag on yourself, and it is now empty (below will divide by zero)
-			return
-		var/gulp_size = 3
-		var/fraction = min(gulp_size / reagents.total_volume, 1)
-		reagents.reaction(C, INGEST, fraction) 	//checkLiked(fraction, M) // Blood isn't food, sorry.
-		reagents.trans_to(C, gulp_size)
-		reagents.remove_reagent(src, 2) //Inneficency, so hey, IVs are usefull.
-		playsound(C.loc,'sound/items/drink.ogg', rand(10, 50), TRUE)
+	if(C.is_mouth_covered())
+		to_chat(user, "<span class='notice'>You can't drink from the [src] while your mouth is covered.</span>")
 		return
-	..()
+
+	if(!user.CheckActionCooldown())
+		to_chat(user, "<span class='notice'>You can't drink from the [src] so fast!</span>")
+		return
+	if(user != C)
+		user.visible_message("<span class='danger'>[user] forces [C] to drink from the [src].</span>", \
+		"<span class='notice'>You force [C] to drink from the [src]</span>")
+		user.DelayNextAction(50)
+		if(do_mob(user, C, 50))
+			do_drink(C, user)
+
+	else
+		user.DelayNextAction(10)
+		if(do_mob(user, C, 10))
+			user.visible_message("<span class='notice'>[user] puts the [src] up to their mouth.</span>", \
+			"<span class='notice'>You take a sip from the [src].</span>")
+			do_drink(C, user)
+
+
+/obj/item/reagent_containers/blood/proc/do_drink(mob/living/carbon/C, mob/user)
+	if(reagents.total_volume <= 0) // Safety: In case you spam clicked the blood bag on yourself, and it is now empty (below will divide by zero)
+		to_chat(user, "<span class='notice'>...and notice [src] is empty.</span>")
+		return
+	var/gulp_size = 3
+	var/fraction = min(gulp_size / reagents.total_volume, 1)
+	reagents.reaction(C, INGEST, fraction) 	//checkLiked(fraction, M) // Blood isn't food, sorry.
+	reagents.trans_to(C, gulp_size)
+	reagents.remove_reagent(src, 2) //Inneficency, so hey, IVs are usefull.
+	playsound(C.loc,'sound/items/drink.ogg', rand(10, 50), TRUE)
+
 
 /obj/item/reagent_containers/blood/bluespace
 	name = "bluespace blood pack"

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -137,7 +137,7 @@
 	var/fraction = min(gulp_size / reagents.total_volume, 1)
 	reagents.reaction(C, INGEST, fraction) 	//checkLiked(fraction, M) // Blood isn't food, sorry.
 	reagents.trans_to(C, gulp_size)
-	reagents.remove_reagent(src, 2) //Inneficency, so hey, IVs are usefull.
+	reagents.remove_reagent(src, 5) //Inneficency, so hey, IVs are usefull.
 	playsound(C.loc,'sound/items/drink.ogg', rand(10, 50), TRUE)
 
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -104,7 +104,7 @@
 		return ..()
 
 /obj/item/reagent_containers/blood/attack(mob/living/carbon/C, mob/user, def_zone)
-	if(!iscarbon(C) || !user.a_intent != INTENT_HELP || reagents.total_volume < 0)
+	if(!iscarbon(C) || user.a_intent != INTENT_HELP || reagents.total_volume <= 0)
 		..()
 
 	if(C.is_mouth_covered())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The way blood bags are drunk from directly now suffers from the clickdelay kev did and the inefficacy is now properly done, instead of the wrong way around.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bloodsuckers sucking blood bags at mach speed is not good, this also encourages them to use IV's instead of just cheesing blood
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You cannot spam drink from blood bags anymore
fix: Blood bag drinking inefficiency is now the right way, so you loose some of the blood drinking it straight

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
