### PR TITLE
Meta Surgery Fixies

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55716,7 +55716,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cgM" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -56437,6 +56437,7 @@
 /obj/structure/curtain{
 	icon_state = "closed"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cie" = (
@@ -57088,14 +57089,14 @@
 /area/maintenance/port/aft)
 "cjw" = (
 /obj/structure/table,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/item/storage/backpack/duffelbag/med/surgery{
 	pixel_y = 5
 	},
 /obj/machinery/light_switch{
 	pixel_x = -26
+	},
+/obj/machinery/vending/wallmed{
+	pixel_y = 29
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/medical/surgery)
@@ -57114,8 +57115,8 @@
 "cjB" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/vending/wallmed{
-	pixel_y = 29
+/obj/machinery/firealarm{
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
@@ -57134,14 +57135,14 @@
 /area/medical/surgery)
 "cjD" = (
 /obj/structure/table,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/item/storage/backpack/duffelbag/med/surgery{
 	pixel_y = 5
 	},
 /obj/machinery/light_switch{
 	pixel_x = 28
+	},
+/obj/machinery/vending/wallmed{
+	pixel_y = 29
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
@@ -57799,9 +57800,6 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
@@ -57822,9 +57820,6 @@
 	dir = 8;
 	pixel_x = -12;
 	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -58913,11 +58908,11 @@
 /area/medical/surgery)
 "cnp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/medical{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
 	name = "Operating Theatre";
 	req_access_txt = "45"
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cnq" = (
@@ -59596,10 +59591,6 @@
 "coy" = (
 /obj/structure/chair{
 	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -60457,9 +60448,6 @@
 /area/medical/surgery)
 "cqb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Surgery Observation"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -60472,6 +60460,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Surgery Observation"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -64937,6 +64928,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -26
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cyo" = (
@@ -65311,11 +65306,6 @@
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "cze" = (
-/obj/machinery/door/airlock/research{
-	id_tag = "AuxGenetics";
-	name = "Genetics Access";
-	req_access_txt = "9"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -65323,13 +65313,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/door/airlock/research{
+	id_tag = "AuxGenetics";
+	name = "Genetics Access";
+	req_access_txt = "9"
+	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "czf" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -81809,12 +81800,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "kgN" = (
-/obj/machinery/door/airlock/medical{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/medical/glass{
 	name = "Operating Theatre";
 	req_access_txt = "45"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "krD" = (
@@ -82865,6 +82856,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"sos" = (
+/obj/structure/mirror,
+/turf/closed/wall,
+/area/medical/surgery)
 "sqe" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
@@ -102981,7 +102976,7 @@ cdl
 dwb
 cia
 cnm
-cia
+sos
 cid
 cnq
 coC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a firelock to the curtain between surgery rooms, removes one of the fire alarm buttons in observation
Makes the double mirror in Surgery Bays one mirror because it looked bad despite being reasonable for real life
Moves an intercom from inside of a door because that used to be a wall oops

sorry I guess I wasn't done my bad
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

polish good, fixies good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Firelock to Surgery Bay drapes
change: Swapped Nanomed and Fire Alarm button locations in both Surgery Bays
change: Removes the double mirror in both Surgery Bays to be a singular mirror
change: Moved an intercom to not be doorstuck below Paramedical Office
remove: One Surgery Observation Fire Alarm button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
