### PR TITLE
Fixing maint areas in boxstation

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11030,18 +11030,12 @@
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"axo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "axp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "axq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -14253,10 +14247,6 @@
 "aGg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"aGh" = (
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aGi" = (
@@ -53350,7 +53340,7 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "ddM" = (
 /obj/structure/sign/poster/official/the_owl{
 	pixel_x = 32
@@ -53734,7 +53724,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/wood_diagonal,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "edA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54930,7 +54920,7 @@
 "gKG" = (
 /obj/structure/bedsheetbin/towel,
 /turf/open/floor/wood/wood_diagonal,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "gLz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56208,7 +56198,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "jJF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -56998,7 +56988,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "lzt" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/stripes/line,
@@ -57590,7 +57580,7 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "nbT" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -59057,7 +59047,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_diagonal,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "qIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59648,12 +59638,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/paramedic)
-"rWw" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_diagonal,
-/area/maintenance/fore)
 "rXl" = (
 /obj/structure/chair/office/light,
 /obj/machinery/firealarm{
@@ -59773,7 +59757,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_diagonal,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "sqg" = (
 /obj/structure/table/wood,
 /obj/item/clothing/under/misc/pj/red,
@@ -60210,7 +60194,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/wood_diagonal,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "trb" = (
 /obj/machinery/light{
 	dir = 4
@@ -60628,7 +60612,7 @@
 /obj/structure/girder,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/port/fore)
 "ugu" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -82684,11 +82668,11 @@ amC
 htu
 alU
 edj
-rWw
+ygb
 gKG
-arP
-aqR
-awb
+alU
+amC
+ntt
 ugq
 arP
 rPU
@@ -82943,10 +82927,10 @@ alU
 tqG
 spR
 qGw
-arP
-aGh
-awb
-axo
+alU
+aFJ
+ntt
+aAY
 arP
 aCh
 pIf
@@ -83197,12 +83181,12 @@ ali
 ali
 ali
 alU
-arP
+alU
 lzk
-arP
-arP
-arP
-avZ
+alU
+alU
+alU
+atO
 axp
 ayC
 azH

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11434,10 +11434,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ayC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/fore)
 "ayD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -82417,7 +82413,7 @@ lZN
 amC
 jIW
 ddI
-arP
+alU
 fgG
 rqW
 aGD
@@ -82674,7 +82670,7 @@ alU
 amC
 ntt
 ugq
-arP
+alU
 rPU
 fne
 aGr
@@ -82931,7 +82927,7 @@ alU
 aFJ
 ntt
 aAY
-arP
+alU
 aCh
 pIf
 kCo
@@ -83188,7 +83184,7 @@ alU
 alU
 atO
 axp
-ayC
+aue
 azH
 eEe
 aGv


### PR DESCRIPTION
## About The Pull Request

What it was before:
![image](https://user-images.githubusercontent.com/48370570/103596574-3b4b0800-4ecc-11eb-99af-9a4196bfefff.png)

What it should be:
![image](https://user-images.githubusercontent.com/48370570/103596585-3f772580-4ecc-11eb-9f6c-aeaf7b128d44.png)


## Why It's Good For The Game

This doesn't really matter, but I care about it and it bugs me when I open the map on boxstation.

## Changelog
:cl:
tweak: Fixes maint area in boxstation
/:cl: