### PR TITLE
Revert "Fixess Energy Bola to be catchable"

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -377,3 +377,10 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 	breakouttime = 60
+
+/obj/item/restraints/legcuffs/bola/energy/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	if(iscarbon(hit_atom))
+		var/obj/item/restraints/legcuffs/beartrap/B = new /obj/item/restraints/legcuffs/beartrap/energy/cyborg(get_turf(hit_atom))
+		B.Crossed(hit_atom)
+		qdel(src)
+	..()


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#13897

https://tgstation13.org/wiki/Security_items#Energy_Bola
This was totally intended feature of Energy Bola
> A Bola that **can't be caught when thrown**. Once it attaches to someone, they are slowed until they take it off, **where it should disappear**. Use with disablers or stun batons to take down a fast foe. Useful for anti-hulk combat, as it is one of the few things that can slow them down.

Also it's kinda make sense as it's more technologically advance then its primitive counterpart.
