### PR TITLE
Makes gas sensors fireproof

### DIFF
--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -6,6 +6,7 @@
 	name = "gas sensor"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor1"
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 0)
 
 	var/on = TRUE
 


### PR DESCRIPTION
## About The Pull Request

Gives gas sensors 100 fire armor and nothing else.

## Why It's Good For The Game

So that way you can actually see the fire going on before it breaks down forever.
This will breakdown as fusion temperatures, but, hey, that's just fusion for you.

## Changelog
:cl:
add: Makes gas sensors fireproof.
/:cl:
