### PR TITLE
Gives all of kevins characters codersocks

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -36,6 +36,9 @@
 	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT, /atom.proc/clean_blood)
 	GLOB.human_list += src
 
+	if(H.key == silicons)
+		H.socks = stockings
+
 
 /mob/living/carbon/human/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Don't worry, kevin will always have codersocks now.

## Why It's Good For The Game

Surely it must be hard for kevin to make a character and then give them codersocks. If only there were an easy solution to try and automate that process, and here I am, to help that process along. Don't worry kevin, you don't need to ask anyone else to do this, you can thank me later.

## Changelog
:cl:
tweak: Gives all of kevins characters codersocks
/:cl:
