### PR TITLE
Makes cursed heart more tolerable

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -2,6 +2,7 @@
 #define AB_CHECK_STUN 2
 #define AB_CHECK_LYING 4
 #define AB_CHECK_CONSCIOUS 8
+#define AB_CHECK_ALIVE 16
 
 /datum/action
 	var/name = "Generic Action"
@@ -114,6 +115,9 @@
 			return FALSE
 	if(check_flags & AB_CHECK_CONSCIOUS)
 		if(owner.stat)
+			return FALSE
+	if(check_flags & AB_CHECK_ALIVE)
+		if(owner.stat == DEAD)
 			return FALSE
 	return TRUE
 

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -114,7 +114,7 @@ obj/item/organ/heart/slime
 	var/last_pump = 0
 	var/add_colour = TRUE //So we're not constantly recreating colour datums
 	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)
-	var/blood_loss = 100 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
+	var/blood_loss = 50 //600 blood is human default, so 5 failures (below 122 blood is where humans die because reasons?)
 
 	//How much to heal per pump, negative numbers would HURT the player
 	var/heal_brute = 0
@@ -123,7 +123,11 @@ obj/item/organ/heart/slime
 
 
 /obj/item/organ/heart/cursed/attack(mob/living/carbon/human/H, mob/living/carbon/human/user, obj/target)
+
 	if(H == user && istype(H))
+		if(NOBLOOD in H.dna.species.species_traits)
+			to_chat(user, "<span class='danger'>[src] refuses to become one with [H]")
+			return
 		playsound(user,'sound/effects/singlebeat.ogg',40,1)
 		user.temporarilyRemoveItemFromInventory(src, TRUE)
 		Insert(user)
@@ -137,6 +141,8 @@ obj/item/organ/heart/slime
 	if(world.time > (last_pump + pump_delay))
 		if(ishuman(owner) && owner.client) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/H = owner
+			if(NOBLOOD in H.dna.species.species_traits) //Otherwise people without will be eternally stuck red
+				return
 			if(H.dna && !(NOBLOOD in H.dna.species.species_traits))
 				H.blood_volume = max(H.blood_volume - blood_loss, 0)
 				to_chat(H, "<span class = 'userdanger'>You have to keep pumping your blood!</span>")
@@ -156,6 +162,8 @@ obj/item/organ/heart/slime
 	return ..()
 
 /datum/action/item_action/organ_action/cursed_heart
+	check_flags = AB_CHECK_ALIVE //We wanna be able to do this always, else thisll just stupidly kill whoever has it
+	required_mobility_flags = NONE
 	name = "Pump your blood"
 
 //You are now brea- pumping blood manually
@@ -175,7 +183,8 @@ obj/item/organ/heart/slime
 		var/mob/living/carbon/human/H = owner
 		if(istype(H))
 			if(H.dna && !(NOBLOOD in H.dna.species.species_traits))
-				H.blood_volume = min(H.blood_volume + cursed_heart.blood_loss*0.5, BLOOD_VOLUME_MAXIMUM)
+				if(H.blood_volume < BLOOD_VOLUME_NORMAL) //We don't need to go too high, otherwise we get annoying messages.
+					H.blood_volume = min(H.blood_volume + cursed_heart.blood_loss * 0.5, BLOOD_VOLUME_MAXIMUM)
 				H.remove_client_colour(/datum/client_colour/cursed_heart_blood)
 				cursed_heart.add_colour = TRUE
 				H.adjustBruteLoss(-cursed_heart.heal_brute)
@@ -184,7 +193,7 @@ obj/item/organ/heart/slime
 
 
 /datum/client_colour/cursed_heart_blood
-	priority = 100 //it's an indicator you're dieing, so it's very high priority
+	priority = 100 //it's an indicator you're dying, so it's very high priority
 	colour = "red"
 
 /obj/item/organ/heart/cybernetic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the cursed heart more tolerable, by allowing it to be used while unconcious, or if you are without hand ability, plus adds some more sanity if you literally can't have blood, and halves the amount of blood it removes each loop by half, as it was stupidly high, and still is, and makes it not give you excessive amounts of blood, because that gives annoying fluff messages.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dying due to the cursed heart, which is inside your fucking body, because you are missing arms does not make sense, plus the cursed heart can really kill you stupidly fast, it can take you to zero blood extremely quickly which just fucking kills you.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The cursed heart now only takes away half as much blood every loop, and can be used as long as you are alive, instead if only you are awake/able to use your hands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
