### PR TITLE
The garbage collector doesn't waste time anymore

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -115,18 +115,22 @@ SUBSYSTEM_DEF(garbage)
 
 	lastlevel = level
 
-	for (var/refID in queue)
-		if (!refID)
+	//We do this rather then for(var/refID in queue) because that sort of for loop copies the whole list.
+	//Normally this isn't expensive, but the gc queue can grow to 40k items, and that gets costly/causes overrun.
+	for (var/i in 1 to length(queue))
+		var/list/L = queue[i]
+		if (length(L) < 2)
 			count++
 			if (MC_TICK_CHECK)
 				return
 			continue
 
-		var/GCd_at_time = queue[refID]
+		var/GCd_at_time = L[1]
 		if(GCd_at_time > cut_off_time)
 			break // Everything else is newer, skip them
 		count++
 
+		var/refID = L[2]
 		var/datum/D
 		D = locate(refID)
 
@@ -202,10 +206,7 @@ SUBSYSTEM_DEF(garbage)
 
 	D.gc_destroyed = gctime
 	var/list/queue = queues[level]
-	if (queue[refid])
-		queue -= refid // Removing any previous references that were GC'd so that the current object will be at the end of the list.
-
-	queue[refid] = gctime
+	queue[++queue.len] = list(gctime, refid) // not += for byond reasons
 
 #ifdef LEGACY_REFERENCE_TRACKING
 /datum/controller/subsystem/garbage/proc/add_type_to_findref(type)


### PR DESCRIPTION
## About The Pull Request

Port of: https://github.com/tgstation/tgstation/pull/55595
Quote:
> Changes the garbage collectors for loop from a for(var/thing in list) to for(var/i in 1 to length(list))
> Converts the garbage queues from an assoc list of id to time, to a list of lists containing the same info.

## Why It's Good For The Game

Quote:
> Did you know that for(var/thing in list) scales in cost with the size of the list?
> Did you know that assoc accesses are slower then indexed accesses scaling with the size of the list?
> Did you know that the garbage collector queue balloons to massive size quite easily?
> 
> Note, this means harddels will happen more often, but that's only because the gc list will actually fully process more often.

## Changelog
:cl:
tweak: Porting garbage collection tweak from /tg/
/:cl: