### PR TITLE
disabling adminhelp noises no longer disables looc

### DIFF
--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -17,7 +17,7 @@ GLOBAL_VAR_INIT(normal_looc_colour, "#6699CC")
 	if(!msg)
 		return
 
-	if(!(prefs.toggles & CHAT_OOC))
+	if(!(prefs.chat_toggles & CHAT_OOC))
 		to_chat(src, "<span class='danger'> You have OOC muted.</span>")
 		return
 	if(jobban_isbanned(mob, "OOC"))
@@ -63,14 +63,14 @@ GLOBAL_VAR_INIT(normal_looc_colour, "#6699CC")
 		if (isobserver(M))
 			continue //Also handled later.
 
-		if(C.prefs.toggles & CHAT_OOC)
+		if(C.prefs.chat_toggles & CHAT_OOC)
 			if(GLOB.LOOC_COLOR)
 				to_chat(C, "<font color='[GLOB.LOOC_COLOR]'><b><span class='prefix'>LOOC:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></b></font>")
 			else
 				to_chat(C, "<span class='looc'><span class='prefix'>LOOC:</span> <EM>[src.mob.name]:</EM> <span class='message'>[msg]</span></span>")
 
 	for(var/client/C in GLOB.admins)
-		if(C.prefs.toggles & CHAT_OOC)
+		if(C.prefs.chat_toggles & CHAT_OOC)
 			var/prefix = "(R)LOOC"
 			if (C.mob in heard)
 				prefix = "LOOC"


### PR DESCRIPTION
## About The Pull Request
if you touch preferences code you are inherently a bad person

issue was that it was checking toggles and not chat_toggles

not a high priority considering it's an admin setting but a bug nonetheless

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: disabling adminhelp noises no longer disables looc
/:cl:
