### PR TITLE
species with NOTRANSSTING cannot have envy's knife used on them

### DIFF
--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -145,4 +145,4 @@
 				user.visible_message("<span class='warning'>[user]'s appearance shifts into [H]'s!</span>", \
 				"<span class='boldannounce'>[H.p_they(TRUE)] think[H.p_s()] [H.p_theyre()] <i>sooo</i> much better than you. Not anymore, [H.p_they()] won't.</span>")
 		else
-			to_chat(H, "<span class='warning'>You are unable to transform into [H]!</span>")
+			to_chat(user, "<span class='warning'>You are unable to transform into [H]!</span>")

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -136,10 +136,13 @@
 		return
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
-		if(user.real_name != H.dna.real_name)
-			user.real_name = H.dna.real_name
-			H.dna.transfer_identity(user, transfer_SE=1)
-			user.updateappearance(mutcolor_update=1)
-			user.domutcheck()
-			user.visible_message("<span class='warning'>[user]'s appearance shifts into [H]'s!</span>", \
-			"<span class='boldannounce'>[H.p_they(TRUE)] think[H.p_s()] [H.p_theyre()] <i>sooo</i> much better than you. Not anymore, [H.p_they()] won't.</span>")
+		if(!(NOTRANSSTING in H.dna.species.species_traits))
+			if(user.real_name != H.dna.real_name)
+				user.real_name = H.dna.real_name
+				H.dna.transfer_identity(user, transfer_SE=1)
+				user.updateappearance(mutcolor_update=1)
+				user.domutcheck()
+				user.visible_message("<span class='warning'>[user]'s appearance shifts into [H]'s!</span>", \
+				"<span class='boldannounce'>[H.p_they(TRUE)] think[H.p_s()] [H.p_theyre()] <i>sooo</i> much better than you. Not anymore, [H.p_they()] won't.</span>")
+		else
+			to_chat(H, "<span class='warning'>You are unable to transform into [H]!</span>")


### PR DESCRIPTION
## About The Pull Request
stop abusing this to turn invisible

## Why It's Good For The Game
bug/exploit

## Changelog
:cl:
fix: species with NOTRANSSTING cannot have envy's knife used on them
/:cl: