### PR TITLE
Fixes combat mode being permanently disabled under specific circumstances

### DIFF
--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -74,13 +74,19 @@
 
 /datum/status_effect/proc/on_remove() //Called whenever the buff expires or is removed; do note that at the point this is called, it is out of the owner's status_effects but owner is not yet null
 	SHOULD_CALL_PARENT(TRUE)
-	REMOVE_TRAIT(owner, TRAIT_COMBAT_MODE_LOCKED, src)
-	REMOVE_TRAIT(owner, TRAIT_SPRINT_LOCKED, src)
+	if(blocks_combatmode)
+		REMOVE_TRAIT(owner, TRAIT_COMBAT_MODE_LOCKED, src)
+	if(blocks_sprint)
+		REMOVE_TRAIT(owner, TRAIT_SPRINT_LOCKED, src)
 	return TRUE
 
 /datum/status_effect/proc/be_replaced() //Called instead of on_remove when a status effect is replaced by itself or when a status effect with on_remove_on_mob_delete = FALSE has its mob deleted
 	owner.clear_alert(id)
 	LAZYREMOVE(owner.status_effects, src)
+	if(blocks_combatmode)
+		REMOVE_TRAIT(owner, TRAIT_COMBAT_MODE_LOCKED, src)
+	if(blocks_sprint)
+		REMOVE_TRAIT(owner, TRAIT_SPRINT_LOCKED, src)
 	owner = null
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. The on_replace proc for status effects didn't correctly handle it when multiple combat locking effects were being active at one time. This fixes that.
Tested on local, this change resolved the issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Combat mode now will not stay permanently disabled due to status effects not working as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
