### PR TITLE
More Synth tweaks

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -61,7 +61,7 @@
 #define BODYPART_NANITES   4
 
 #define HYBRID_BODYPART_DAMAGE_THRESHHOLD 25 //How much damage has to be suffered until the damage threshhold counts as passed
-#define HYBRID_BODYPART_THESHHOLD_MINDAMAGE 15 //Which damage value this limb cannot be healed out of via easy nonsurgical means if the threshhold has been passed, state resets if damage value goes below mindamage.
+#define HYBRID_BODYPART_THESHHOLD_MINDAMAGE 10 //Which damage value this limb cannot be healed out of via easy nonsurgical means if the threshhold has been passed, state resets if damage value goes below mindamage.
 
 #define BODYPART_NOT_DISABLED 0
 #define BODYPART_DISABLED_DAMAGE 1

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -411,15 +411,18 @@
 	if(isrobotic(src))
 		apply_status_effect(/datum/status_effect/no_combat_mode/robotic_emp, severity / 20)
 	severity *= 0.5
+	var/do_not_stun = FALSE
 	if(HAS_TRAIT(src, TRAIT_ROBOTIC_ORGANISM))
 		severity *= 0.5 //Robotpeople take less limb damage, but instead suffer system corruption (see carbon emp_act)
+		do_not_stun = TRUE
 	for(var/obj/item/bodypart/L in src.bodyparts)
 		if(L.is_robotic_limb())
 			if(!informed)
 				to_chat(src, "<span class='userdanger'>You feel a sharp pain as your robotic limbs overload.</span>")
 				informed = TRUE
 			L.receive_damage(0,severity/10)
-			Stun(severity*2)
+			if(!do_not_stun)	//Tiny bit better than checking for the trait another six times in succession
+				Stun(severity*2)
 
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit)
 	var/list/damaged = list()

--- a/code/modules/surgery/emergency_reboot.dm
+++ b/code/modules/surgery/emergency_reboot.dm
@@ -23,7 +23,7 @@
 
 /datum/surgery_step/force_reboot
 	name = "initiate system reboot"
-	implements = list(TOOL_MULTITOOL = 100)
+	implements = list(TOOL_MULTITOOL = 100, /obj/item/borg/upgrade/restart = 100)
 	time = 100
 
 /datum/surgery_step/force_reboot/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/emergency_reboot.dm
+++ b/code/modules/surgery/emergency_reboot.dm
@@ -40,7 +40,7 @@
 	target.updatehealth()
 	var/tplus = world.time - target.timeofdeath
 	if(target.revive())
-		target.visible_message("...[target]'s posibrain flickers to action once again!")
+		target.visible_message("...[target]'s posibrain flickers to life once again!")
 		target.emote("ping")
 		var/list/policies = CONFIG_GET(keyed_list/policyconfig)
 		var/timelimit = CONFIG_GET(number/defib_cmd_time_limit) * 10 //the config is in seconds, not deciseconds

--- a/code/modules/surgery/emergency_reboot.dm
+++ b/code/modules/surgery/emergency_reboot.dm
@@ -54,7 +54,7 @@
 		target.visible_message("...[target]'s posibrain flickers a few times, before the lights fade yet again...")
 		return FALSE
 
-/datum/surgery_step/revive/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/force_reboot/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(user, target, "<span class='notice'>You attempt to reboot [target]'s posibrain, but [target.p_they()] doesn't react.</span>",
 		"[user] attempts to reboot [target]'s posibrain, but [target.p_they()] doesn't react.",
 		"[user] attempts to reboot [target]'s posibrain, but [target.p_they()] doesn't react")

--- a/code/modules/surgery/emergency_reboot.dm
+++ b/code/modules/surgery/emergency_reboot.dm
@@ -1,0 +1,62 @@
+//Emergency Reboot: A surgery that allows for revival of Synthetics without the need for a defib. Doesn't all all the organs like the Revival surgery though.
+
+/datum/surgery/emergency_reboot
+	name = "Emergency Reboot"
+	desc = "A surgery forcing the posibrain of a robot to begin it's reboot procedure, if their body can sustain its operation."
+	possible_locs = list(BODY_ZONE_HEAD)
+	requires_bodypart_type = BODYPART_ROBOTIC	//If you are a Synth with a organic head (somehow), this won't work.
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/open_hatch, /datum/surgery_step/mechanic_unwrench, /datum/surgery_step/force_reboot, /datum/surgery_step/mechanic_wrench, /datum/surgery_step/mechanic_close)
+
+/datum/surgery/emergency_reboot/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
+	if(!..())
+		return FALSE
+	if(target.stat != DEAD)
+		return FALSE
+	if(target.suiciding || HAS_TRAIT(target, TRAIT_NOCLONE) || target.hellbound)
+		return FALSE
+	if(!HAS_TRAIT(target, TRAIT_ROBOTIC_ORGANISM))
+		return FALSE
+	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
+	if(!B || !istype(B, /obj/item/organ/brain/ipc))
+		return FALSE
+	return TRUE
+
+/datum/surgery_step/force_reboot
+	name = "initiate system reboot"
+	implements = list(TOOL_MULTITOOL = 100)
+	time = 100
+
+/datum/surgery_step/force_reboot/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You prepare to begin rebooting [target]'s posibrain.</span>",
+		"[user] prepares to reboot [target]'s posibrain with [tool].",
+		"[user] prepares to reboot [target]'s posibrain with [tool].")
+	target.notify_ghost_cloning("Someone is trying to reboot you! Re-enter your corpse if you want to be revived!", source = target)
+
+/datum/surgery_step/force_reboot/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You successfully initiate a reboot in [target]'s posibrain...</span>",
+		"[user] initiates a reboot in [target]'s posibrain...",
+		"[user] initiates a reboot in [target]'s posibrain...")
+	target.adjustOxyLoss(-50, 0)
+	target.updatehealth()
+	var/tplus = world.time - target.timeofdeath
+	if(target.revive())
+		target.visible_message("...[target]'s posibrain flickers to action once again!")
+		target.emote("ping")
+		var/list/policies = CONFIG_GET(keyed_list/policyconfig)
+		var/timelimit = CONFIG_GET(number/defib_cmd_time_limit) * 10 //the config is in seconds, not deciseconds
+		var/late = timelimit && (tplus > timelimit)
+		var/policy = late? policies[POLICYCONFIG_ON_DEFIB_LATE] : policies[POLICYCONFIG_ON_DEFIB_INTACT]
+		if(policy)
+			to_chat(target, policy)
+		target.log_message("revived using surgical revival, [tplus] deciseconds from time of death, considered [late? "late" : "memory-intact"] revival under configured policy limits.", LOG_GAME)
+		return TRUE
+	else
+		target.visible_message("...[target]'s posibrain flickers a few times, before the lights fade yet again...")
+		return FALSE
+
+/datum/surgery_step/revive/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='notice'>You attempt to reboot [target]'s posibrain, but [target.p_they()] doesn't react.</span>",
+		"[user] attempts to reboot [target]'s posibrain, but [target.p_they()] doesn't react.",
+		"[user] attempts to reboot [target]'s posibrain, but [target.p_they()] doesn't react")
+	target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 199)
+	return FALSE

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -2,11 +2,16 @@
 	name = "removal of embedded objects"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/remove_object)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
+
+/datum/surgery/embedded_removal/robot
+	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/open_hatch, /datum/surgery_step/remove_object)
+
 /datum/surgery_step/remove_object
 	name = "remove embedded objects"
 	time = 32
 	accept_hand = 1
 	var/obj/item/bodypart/L = null
+
 /datum/surgery_step/remove_object/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	L = surgery.operated_bodypart
 	if(L)

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -4,6 +4,7 @@
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 
 /datum/surgery/embedded_removal/robot
+	requires_bodypart_type = BODYPART_ROBOTIC
 	steps = list(/datum/surgery_step/mechanic_open, /datum/surgery_step/open_hatch, /datum/surgery_step/remove_object)
 
 /datum/surgery_step/remove_object

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3425,6 +3425,7 @@
 #include "code\modules\surgery\dental_implant.dm"
 #include "code\modules\surgery\embalming.dm"
 #include "code\modules\surgery\emergency_cardioversion_recovery.dm"
+#include "code\modules\surgery\emergency_reboot.dm"
 #include "code\modules\surgery\experimental_dissection.dm"
 #include "code\modules\surgery\eye_surgery.dm"
 #include "code\modules\surgery\graft_synthtissue.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does the following:
Synths can now be revived via surgery, (emergency reboot surgery), which requires no defib (they still need to be in a defibbable state though)
Synths do no get hardstunned from EMPs anymore.
Synths have access to the embed removal surgery again.
**Reduces the capped damage on synth limbs when past the damage threshold to 10 (from 15).**
<!-- Describe The Pull R)quest. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More synth balance stuff adressing their issues.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: A new surgery, allowing revival of synths without a defib at hand.
balance: Semi-permanent damage of Synth limbs caused by passing the damage threshold: 10 <- 15.
tweak: The embed removal surgery now has a version for Synths.
balance: EMPs no longer hardstun Synths.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
