### PR TITLE
Fixes fermichem EMPs being massive.

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -94,7 +94,7 @@
 		e.start()
 
 	if(ImpureTot) //If impure, v.small emp (0.6 or less)
-		empulse(T, impureTot, 1)
+		empulse(T, ImpureTot, 1)
 
 	my_atom.reagents.clear_reagents() //just in case
 	return

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -93,9 +93,8 @@
 		e.set_up(round((volume/28)*(pH-9)), T, 0, 0)
 		e.start()
 
-	if(!ImpureTot == 0) //If impure, v.small emp (0.6 or less)
-		ImpureTot *= volume
-		empulse(T, volume, 1)
+	if(ImpureTot) //If impure, v.small emp (0.6 or less)
+		empulse(T, impureTot, 1)
 
 	my_atom.reagents.clear_reagents() //just in case
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Multiplying by volume means that the EMP, instead of being "very small" as the comment claims, becomes a station-wide nightmare.

## Why It's Good For The Game

zeolites or funny sex chems breaking the entire station every 5 or 6 rounds isn't good

## Changelog
:cl:
balance: fermichem explosion EMPs don't cover the entire station
/:cl: