### PR TITLE
Adds Color Mates to every station (except Snaxi)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -29620,10 +29620,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bsU" = (
-/mob/living/simple_animal/hostile/retaliate/ghost,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/retaliate/ghost,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "bsV" = (
@@ -53488,6 +53488,10 @@
 	},
 /turf/closed/wall,
 /area/science/circuit)
+"dxF" = (
+/obj/machinery/gear_painter,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "dyE" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -56505,6 +56509,10 @@
 	},
 /turf/open/floor/wood/wood_diagonal,
 /area/maintenance/port/fore)
+"kqy" = (
+/obj/machinery/gear_painter,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "kqI" = (
 /obj/structure/window,
 /turf/open/floor/wood,
@@ -58551,6 +58559,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "pqR" = (
@@ -86334,7 +86343,7 @@ oKh
 oKh
 iiW
 iiW
-iiW
+dxF
 izv
 nfm
 bCq
@@ -98349,7 +98358,7 @@ awB
 att
 azh
 fHG
-fHG
+kqy
 kxf
 ufD
 alP

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -33604,6 +33604,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
+/obj/item/kirbyplants{
+	icon_state = "plant-20";
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bvu" = (
@@ -38936,10 +38940,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-20";
-	pixel_y = 3
-	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bGN" = (
@@ -52867,7 +52868,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/item/kirbyplants/random,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cjB" = (
@@ -71256,6 +71257,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/router/aux)
+"stP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "sAm" = (
 /obj/structure/plasticflaps,
 /obj/machinery/door/poddoor{
@@ -114255,7 +114263,7 @@ ckq
 bgf
 beB
 cxC
-bgq
+stP
 cjA
 biy
 bjN

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3535,9 +3535,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ajL" = (
@@ -3822,6 +3820,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
@@ -79384,6 +79385,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -38,7 +38,9 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "aae" = (
@@ -208,7 +210,9 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -701,7 +705,9 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/stamp/captain{
 	pixel_x = 8;
 	pixel_y = 6
@@ -1280,7 +1286,9 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1572,7 +1580,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/toy/figure/md{
 	pixel_x = 8;
 	pixel_y = 6
@@ -2440,7 +2450,9 @@
 /area/space/nearstation)
 "aet" = (
 /obj/item/storage/box/bodybags,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -2567,7 +2579,9 @@
 "aeH" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -3532,7 +3546,9 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -4088,7 +4104,9 @@
 "agY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5147,7 +5165,9 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiH" = (
@@ -5280,7 +5300,9 @@
 "aiQ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -5381,7 +5403,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -5602,7 +5626,9 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -7454,7 +7480,9 @@
 "amH" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -26
 	},
@@ -8497,7 +8525,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -8578,7 +8608,9 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/stamp/law{
 	pixel_x = 8;
 	pixel_y = 6
@@ -11443,7 +11475,9 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -12025,7 +12059,9 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
 "atY" = (
@@ -12096,7 +12132,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -12729,7 +12767,9 @@
 "avn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
@@ -12926,7 +12966,9 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/requests_console{
 	department = "Chapel";
 	departmentType = 2;
@@ -15044,7 +15086,9 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
 /obj/item/folder/white,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
 	name = "Chemistry Lobby Shutters"
@@ -15600,7 +15644,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/toy/figure/geneticist{
 	pixel_x = 8;
 	pixel_y = 6
@@ -15781,7 +15827,9 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
 /obj/item/folder/yellow,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters_2";
 	name = "Chemistry Hall Shutters"
@@ -16868,7 +16916,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/toy/figure/atmos{
 	pixel_x = 8;
 	pixel_y = 6
@@ -17081,7 +17131,9 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -30
@@ -18350,6 +18402,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/item/kirbyplants{
+	icon_state = "applebush"
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
@@ -19695,7 +19750,9 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aGK" = (
@@ -20844,7 +20901,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -21545,7 +21604,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aJR" = (
@@ -22111,7 +22172,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aKJ" = (
@@ -23376,7 +23439,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aMJ" = (
@@ -24999,7 +25064,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/toy/figure/engineer{
 	pixel_x = 8;
 	pixel_y = 6
@@ -25373,7 +25440,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/stamp/cmo{
 	pixel_x = 8;
 	pixel_y = 6
@@ -26247,7 +26316,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/camera{
 	c_tag = "Starboard Hallway Research Desk";
 	name = "starboard camera"
@@ -26763,7 +26834,9 @@
 	},
 /obj/item/book/manual/wiki/medicine,
 /obj/item/clothing/neck/stethoscope,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -27293,7 +27366,9 @@
 /obj/item/storage/box/bodybags{
 	pixel_y = 5
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -27594,7 +27669,9 @@
 "aTm" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -28444,7 +28521,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -29093,7 +29172,9 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -29406,7 +29487,9 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "aVF" = (
@@ -29564,7 +29647,9 @@
 /obj/item/storage/box/bodybags{
 	pixel_y = 2
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
@@ -29987,7 +30072,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -30094,7 +30181,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/door/window/brigdoor/westright{
 	name = "Armoury Desk";
 	req_access_txt = "3"
@@ -31276,7 +31365,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -31668,7 +31759,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics_shutters";
 	name = "Robotics Privacy Shutters"
@@ -31831,7 +31924,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters";
 	name = "Research Privacy Shutter"
@@ -34150,7 +34245,9 @@
 /obj/item/lipstick/random{
 	pixel_x = 6
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = 30
 	},
@@ -34289,7 +34386,9 @@
 /obj/item/stamp/rd{
 	pixel_x = 8
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bdw" = (
@@ -34600,7 +34699,9 @@
 	pixel_x = -6
 	},
 /obj/item/book/manual/wiki/experimentor,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -37082,7 +37183,9 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -38836,7 +38939,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft{
 	dir = 4;
@@ -38963,7 +39068,9 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40079,7 +40186,9 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -41515,7 +41624,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -41552,7 +41663,9 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/folder,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "boO" = (
@@ -42586,7 +42699,9 @@
 "bqA" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -43434,7 +43549,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/bar/atrium)
 "brQ" = (
@@ -43625,7 +43742,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -44834,7 +44953,9 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -44949,7 +45070,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "buq" = (
@@ -45970,9 +46093,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/kirbyplants{
-	icon_state = "applebush"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -46316,7 +46436,9 @@
 	},
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/item/reagent_containers/dropper,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Hydroponics Pen";
@@ -46839,7 +46961,9 @@
 	},
 /obj/item/clipboard,
 /obj/item/paper/fluff/holodeck/disclaimer,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "bxD" = (
@@ -48007,8 +48131,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/mixed,
 /obj/machinery/light/small,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "bzo" = (
@@ -48101,7 +48226,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = -32
 	},
@@ -48767,7 +48891,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "bAA" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -48777,15 +48900,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/storage/backpack{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/backpack,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26
 	},
+/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "bAB" = (
@@ -53389,7 +53508,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "bHU" = (
@@ -54190,7 +54311,9 @@
 /obj/item/lipstick/random{
 	pixel_x = 6
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -54797,11 +54920,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bKn" = (
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/pen,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -54810,6 +54928,11 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
+/obj/item/storage/backpack{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/backpack,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "bKo" = (
@@ -55424,6 +55547,14 @@
 /obj/item/radio/intercom{
 	pixel_x = 28;
 	pixel_y = 22
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	step_x = 0
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -57231,7 +57362,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/toy/figure/assistant{
 	pixel_x = 8;
 	pixel_y = 6
@@ -59429,7 +59562,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -59498,7 +59633,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "bRq" = (
@@ -59808,7 +59945,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bRQ" = (
@@ -59963,7 +60102,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/door/window/westright{
 	dir = 2;
 	name = "Control Desk";
@@ -60844,6 +60985,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bTD" = (
@@ -61021,6 +61163,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
 	},
+/obj/structure/table,
+/obj/item/pen{
+	step_x = 0
+	},
+/obj/item/paper_bin{
+	step_x = 0;
+	pixel_x = -4;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bTO" = (
@@ -61083,7 +61234,9 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -61259,19 +61412,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/pen,
-/obj/item/toy/figure/assistant{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bUi" = (
@@ -62727,7 +62869,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/blue,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westright{
 	name = "Control Desk";
@@ -63125,7 +63269,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -63507,7 +63653,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -63607,7 +63755,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -63654,6 +63804,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/item/toy/figure/assistant{
+	step_x = -1;
+	step_y = 28;
+	pixel_x = 8;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -64003,7 +64159,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/toy/figure/ce{
 	pixel_x = 8;
 	pixel_y = 6
@@ -67861,7 +68019,9 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/item/radio/intercom{
 	pixel_y = 22
 	},
@@ -69656,7 +69816,9 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
 "chR" = (
@@ -71333,7 +71495,7 @@
 	min_oxy = 5;
 	name = "Lia";
 	real_name = "Lia";
-	response_help = "pets";
+	!INVALID_VAR! = "pets";
 	turns_per_move = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -75449,7 +75611,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/machinery/door/window/brigdoor/northleft{
 	name = "Brig Control Desk";
 	req_access_txt = "3"
@@ -79221,7 +79385,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "czv" = (
@@ -79927,7 +80093,9 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -84387,7 +84555,9 @@
 "cRB" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/pen{
+	step_x = 0
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -71327,15 +71327,16 @@
 	icon_gib = "magicarp_gib";
 	icon_living = "magicarp";
 	icon_state = "magicarp";
-	maxHealth = 200;
 	max_co2 = 5;
 	max_tox = 2;
+	maxHealth = 200;
 	melee_damage_lower = 15;
 	melee_damage_upper = 20;
 	min_oxy = 5;
 	name = "Lia";
 	real_name = "Lia";
-	!INVALID_VAR! = "pets";
+	response_help_continuous = "pets";
+	response_help_simple = "pet";
 	turns_per_move = 10
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -38,9 +38,7 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "aae" = (
@@ -210,9 +208,7 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -705,9 +701,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/stamp/captain{
 	pixel_x = 8;
 	pixel_y = 6
@@ -1286,9 +1280,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1580,9 +1572,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/toy/figure/md{
 	pixel_x = 8;
 	pixel_y = 6
@@ -2450,9 +2440,7 @@
 /area/space/nearstation)
 "aet" = (
 /obj/item/storage/box/bodybags,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -2579,9 +2567,7 @@
 "aeH" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -3546,9 +3532,7 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -4104,9 +4088,7 @@
 "agY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5165,9 +5147,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiH" = (
@@ -5300,9 +5280,7 @@
 "aiQ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -5403,9 +5381,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -5626,9 +5602,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -7480,9 +7454,7 @@
 "amH" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -26
 	},
@@ -8525,9 +8497,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -8608,9 +8578,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/stamp/law{
 	pixel_x = 8;
 	pixel_y = 6
@@ -11475,9 +11443,7 @@
 	},
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -12059,9 +12025,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
 "atY" = (
@@ -12132,9 +12096,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
@@ -12767,9 +12729,7 @@
 "avn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
@@ -12966,9 +12926,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/requests_console{
 	department = "Chapel";
 	departmentType = 2;
@@ -15086,9 +15044,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
 /obj/item/folder/white,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
 	name = "Chemistry Lobby Shutters"
@@ -15644,9 +15600,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/toy/figure/geneticist{
 	pixel_x = 8;
 	pixel_y = 6
@@ -15827,9 +15781,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
 /obj/item/folder/yellow,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters_2";
 	name = "Chemistry Hall Shutters"
@@ -16916,9 +16868,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/toy/figure/atmos{
 	pixel_x = 8;
 	pixel_y = 6
@@ -17131,9 +17081,7 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -30
@@ -18402,9 +18350,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/item/kirbyplants{
-	icon_state = "applebush"
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
@@ -19750,9 +19695,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aGK" = (
@@ -20901,9 +20844,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -21604,9 +21545,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aJR" = (
@@ -22172,9 +22111,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aKJ" = (
@@ -23439,9 +23376,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aMJ" = (
@@ -25064,9 +24999,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/toy/figure/engineer{
 	pixel_x = 8;
 	pixel_y = 6
@@ -25440,9 +25373,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/stamp/cmo{
 	pixel_x = 8;
 	pixel_y = 6
@@ -26316,9 +26247,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/camera{
 	c_tag = "Starboard Hallway Research Desk";
 	name = "starboard camera"
@@ -26834,9 +26763,7 @@
 	},
 /obj/item/book/manual/wiki/medicine,
 /obj/item/clothing/neck/stethoscope,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -27366,9 +27293,7 @@
 /obj/item/storage/box/bodybags{
 	pixel_y = 5
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -27669,9 +27594,7 @@
 "aTm" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -28521,9 +28444,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -29172,9 +29093,7 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -29487,9 +29406,7 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "aVF" = (
@@ -29647,9 +29564,7 @@
 /obj/item/storage/box/bodybags{
 	pixel_y = 2
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
@@ -30072,9 +29987,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -30181,9 +30094,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/door/window/brigdoor/westright{
 	name = "Armoury Desk";
 	req_access_txt = "3"
@@ -31365,9 +31276,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -31759,9 +31668,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics_shutters";
 	name = "Robotics Privacy Shutters"
@@ -31924,9 +31831,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters";
 	name = "Research Privacy Shutter"
@@ -34245,9 +34150,7 @@
 /obj/item/lipstick/random{
 	pixel_x = 6
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = 30
 	},
@@ -34386,9 +34289,7 @@
 /obj/item/stamp/rd{
 	pixel_x = 8
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bdw" = (
@@ -34699,9 +34600,7 @@
 	pixel_x = -6
 	},
 /obj/item/book/manual/wiki/experimentor,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -37183,9 +37082,7 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -38939,9 +38836,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westleft{
 	dir = 4;
@@ -39068,9 +38963,7 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40186,9 +40079,7 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -41624,9 +41515,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -41663,9 +41552,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/folder,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port)
 "boO" = (
@@ -42699,9 +42586,7 @@
 "bqA" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -43549,9 +43434,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/bar/atrium)
 "brQ" = (
@@ -43742,9 +43625,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/light/small,
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -44953,9 +44834,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -45070,9 +44949,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "buq" = (
@@ -46093,6 +45970,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/item/kirbyplants{
+	icon_state = "applebush"
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -46436,9 +46316,7 @@
 	},
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/item/reagent_containers/dropper,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Hydroponics Pen";
@@ -46961,9 +46839,7 @@
 	},
 /obj/item/clipboard,
 /obj/item/paper/fluff/holodeck/disclaimer,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "bxD" = (
@@ -48226,6 +48102,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = -32
 	},
@@ -48904,7 +48781,6 @@
 	dir = 8;
 	pixel_x = 26
 	},
-/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "bAB" = (
@@ -49517,6 +49393,7 @@
 	dir = 1;
 	name = "recreation camera"
 	},
+/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bBy" = (
@@ -53508,9 +53385,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "bHU" = (
@@ -54311,9 +54186,7 @@
 /obj/item/lipstick/random{
 	pixel_x = 6
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -55553,9 +55426,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bLd" = (
@@ -57362,9 +57233,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/toy/figure/assistant{
 	pixel_x = 8;
 	pixel_y = 6
@@ -59562,9 +59431,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -59633,9 +59500,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "bRq" = (
@@ -59945,9 +59810,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bRQ" = (
@@ -60102,9 +59965,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/door/window/westright{
 	dir = 2;
 	name = "Control Desk";
@@ -60986,6 +60847,10 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/item/toy/figure/assistant{
+	pixel_x = 8;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bTD" = (
@@ -61164,14 +61029,11 @@
 	dir = 10
 	},
 /obj/structure/table,
-/obj/item/pen{
-	step_x = 0
-	},
 /obj/item/paper_bin{
-	step_x = 0;
 	pixel_x = -4;
 	pixel_y = 4
 	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bTO" = (
@@ -61234,9 +61096,7 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -62869,9 +62729,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/blue,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/westright{
 	name = "Control Desk";
@@ -63269,9 +63127,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -63653,9 +63509,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -63755,9 +63609,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -63804,12 +63656,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/item/toy/figure/assistant{
-	step_x = -1;
-	step_y = 28;
-	pixel_x = 8;
-	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -64159,9 +64005,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/toy/figure/ce{
 	pixel_x = 8;
 	pixel_y = 6
@@ -68019,9 +67863,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/item/radio/intercom{
 	pixel_y = 22
 	},
@@ -69816,9 +69658,7 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/engineering)
 "chR" = (
@@ -75611,9 +75451,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/item/folder/red,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/machinery/door/window/brigdoor/northleft{
 	name = "Brig Control Desk";
 	req_access_txt = "3"
@@ -79385,9 +79223,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "czv" = (
@@ -80093,9 +79929,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -84555,9 +84389,7 @@
 "cRB" = (
 /obj/structure/table,
 /obj/item/paper_bin,
-/obj/item/pen{
-	step_x = 0
-	},
+/obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},

--- a/_maps/map_files/LambdaStation/dorms.dmm
+++ b/_maps/map_files/LambdaStation/dorms.dmm
@@ -13764,6 +13764,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "Jp" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4826,6 +4826,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "aiU" = (
@@ -23177,6 +23178,9 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/newscaster{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aTy" = (
@@ -23186,17 +23190,6 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"aTz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
@@ -81348,6 +81341,21 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"foN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/machinery/gear_painter,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/locker)
 "fpa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -81974,6 +81982,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"lFR" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/entry)
 "lGS" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -97543,7 +97561,7 @@ blU
 aiT
 bEs
 bHJ
-aiT
+lFR
 iSt
 mcS
 alK
@@ -118601,8 +118619,8 @@ aOD
 aPK
 aQV
 aOu
-aTz
-aUM
+aTt
+foN
 aUM
 aYe
 dnh

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -15268,6 +15268,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "axG" = (
@@ -19618,9 +19621,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aEL" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
@@ -19635,6 +19635,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aEM" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -511,10 +511,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "abi" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
+/obj/machinery/gear_painter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "abj" = (
@@ -59138,6 +59138,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qAx" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "qAM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/cigbutt,
@@ -60933,6 +60940,10 @@
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uNA" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -104126,8 +104137,8 @@ aaY
 awB
 abe
 abi
-axw
-axw
+uNA
+qAx
 axw
 axw
 aBX

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10524,6 +10524,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"yl" = (
+/obj/machinery/gear_painter,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "yn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
@@ -43992,7 +43996,7 @@ NS
 Nd
 ZL
 NS
-NS
+yl
 Nd
 CU
 NS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds Color Mates to every station _that matters,_ of a certain amount.

I'm not going to go into detail of where every single Colormate has been placed on each station, but the basic jist is, wherever a Clothesmate is in the room, a Colormate also now exists in the same room. Unless that Clothesmate is inside Genetics, which two stations happen to have. Which means you're likely going to be seeing these colormates in dorms or in locker rooms.

No objects have been deleted to make way for these Colormates - not even the potted plants. Some objects have been relocated however. Like said potted plants.

also apparently a minor fix to the HoS's pet carp on Kilo.

_(edit: Yes I may be bashing Snaxi out of silliness but the real reason I ignored Snaxi is because I believed another mapper was working on Snaxi right now and I felt it wasn't worth making changes when they're making changes to it right now.)_

edit 2: I figured one in the ghost cafe would also be handy, since I know people like to experiment with outfitting in there. So it's been added in there too.

## Why It's Good For The Game

Might as well make good use of this new feature that we've been given and save science the time of having to print a colormate circuit every round.

## Changelog
:cl:
add: Color Mates have been added to all stations (except Snaxi). Enjoy coloring your attire without having to bug science!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
