### PR TITLE
You will no longer unbuckle fireman-carried/piggybacked people when touching someone on help or grab intent

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -14,6 +14,9 @@
 	if(.)
 		return
 	if(can_buckle && has_buckled_mobs())
+		if(ishuman(src)) //prevent people from unbuckling fireman-carried/piggybacked people unless on disarm or harm intents
+			if(act_intent == INTENT_HELP || act_intent == INTENT_GRAB)
+				return
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in buckled_mobs
 			if(user_unbuckle_mob(unbuckled,user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Exactly what the title says. You will only unbuckle fireman-carried/piggybacked people on disarm or harm intent.

## Why It's Good For The Game

You that type of person that carries people around? How many times have you counted someone hugging you and dropping the person you're carrying in the process? This aims to stop that. It'd probably have some important application to those genuinely using fireman carry to get a dead body to medbay as well.

## Changelog
:cl:
tweak: You will now only unbuckle fireman-carried/piggybacked people on disarm or harm intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
