### PR TITLE
Purges the cock and titty straining when both genitals are growing

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -81,16 +81,7 @@
 		H.reagents.remove_reagent(type, 5)
 		B.Insert(H)
 
-	//If they have them, increase size. If size is comically big, limit movement and rip clothes.
 	B.modify_size(0.05)
-
-	if (ISINRANGE_EX(B.cached_size, 8.5, 9) && (H.w_uniform || H.wear_suit))
-		var/target = H.get_bodypart(BODY_ZONE_CHEST)
-		if(!message_spam)
-			to_chat(H, "<span class='danger'>Your breasts begin to strain against your clothes tightly!</b></span>")
-			message_spam = TRUE
-		H.adjustOxyLoss(5, 0)
-		H.apply_damage(1, BRUTE, target)
 	return ..()
 
 /datum/reagent/fermi/breast_enlarger/overdose_process(mob/living/carbon/M) //Turns you into a female if male and ODing, doesn't touch nonbinary and object genders.
@@ -232,14 +223,6 @@
 		P.Insert(H)
 
 	P.modify_size(0.1)
-	var/max_D = CONFIG_GET(number/penis_max_inches_prefs)
-	if (ISINRANGE_EX(P.length, max_D + 0.5, max_D + 1) && (H.w_uniform || H.wear_suit))
-		var/target = H.get_bodypart(BODY_ZONE_CHEST)
-		if(!message_spam)
-			to_chat(H, "<span class='danger'>Your cock begin to strain against your clothes tightly!</b></span>")
-			message_spam = TRUE
-		H.apply_damage(2.5, BRUTE, target)
-
 	return ..()
 
 /datum/reagent/fermi/penis_enlarger/overdose_process(mob/living/carbon/human/M) //Turns you into a male if female and ODing, doesn't touch nonbinary and object genders.

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -30,7 +30,6 @@
 	inverse_chem		= /datum/reagent/fermi/BEsmaller //At really impure vols, it just becomes 100% inverse
 	can_synth = FALSE
 	value = REAGENT_VALUE_VERY_RARE
-	var/message_spam = FALSE
 
 /datum/reagent/fermi/breast_enlarger/on_mob_metabolize(mob/living/M)
 	. = ..()
@@ -180,7 +179,6 @@
 	inverse_chem		= /datum/reagent/fermi/PEsmaller //At really impure vols, it just becomes 100% inverse and shrinks instead.
 	can_synth = FALSE
 	value = REAGENT_VALUE_VERY_RARE
-	var/message_spam = FALSE
 
 /datum/reagent/fermi/penis_enlarger/on_mob_metabolize(mob/living/M)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Finalization of adding unrealism to cock and breast growth.

## Why It's Good For The Game

It makes no sense for this to be here when we're pretty much removing the downsides of oversized cocks and breasts to begin with.

This also makes it so you don't have to remove your jumpsuit potentially in the middle of the hallways much to the disdain of some poor prude when your cock is just dealing brute damage to you between these two ranges listed in the chemical. So to put it simply, it's for the better.

## Changelog
:cl:
tweak: No more straining when your cock or breasts are growing via incubus draft or succubus milk.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
