### PR TITLE
removes shrink ray again because "wait, whose idea was to readd this?" (turns out it was shoehorned back in by lettern during the tgui port)

### DIFF
--- a/code/modules/antagonists/abductor/equipment/orderable_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/orderable_gear.dm
@@ -69,6 +69,7 @@ GLOBAL_LIST_INIT(abductor_gear, subtypesof(/datum/abductor_gear))
 	build_path = /obj/item/abductor_machine_beacon/chem_dispenser
 	category = "Advanced Gear"
 
+/*
 /datum/abductor_gear/shrink_ray
 	name = "Shrink Ray Blaster"
 	description = "This is a piece of frightening alien tech that enhances the magnetic pull of atoms in a localized space to temporarily make an object shrink. \
@@ -77,3 +78,4 @@ GLOBAL_LIST_INIT(abductor_gear, subtypesof(/datum/abductor_gear))
 	cost = 2
 	build_path = /obj/item/gun/energy/shrink_ray
 	category = "Advanced Gear"
+*/


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
"ah, i deeply enjoy getting all my equipment dropped in a single click," said probably no one ever

it was shoehorned back in with tgui thanks lettern
## Changelog
:cl:
del: Apparently, shrink rays were buyable again, despite a PR having been made a while ago specifically for removing shrink rays. They're gone again.
/:cl: