### PR TITLE
something something gauze things

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -391,7 +391,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("construction bag", /obj/item/storage/bag/construction, 4), \
 	null, \
 	new/datum/stack_recipe("string", /obj/item/weaponcrafting/string, 1, time = 10), \
-	new/datum/stack_recipe("improvised gauze", /obj/item/stack/medical/gauze/improvised, 1, 2, 6), \
+	new/datum/stack_recipe("improvised gauze", /obj/item/stack/medical/gauze/improvised, 1, 2, 10), \
 	new/datum/stack_recipe("rag", /obj/item/reagent_containers/rag, 1), \
 	new/datum/stack_recipe("towel", /obj/item/reagent_containers/rag/towel, 3), \
 	new/datum/stack_recipe("bedsheet", /obj/item/bedsheet, 3), \

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1125,7 +1125,7 @@
 /datum/reagent/space_cleaner/sterilizine/reaction_obj(obj/O, reac_volume)
 	if(istype(O, /obj/item/stack/medical/gauze))
 		var/obj/item/stack/medical/gauze/G = O
-		reac_volume = min((reac_volume / 10), G.amount)
+		reac_volume = min((reac_volume / 5), G.amount)
 		new /obj/item/stack/medical/gauze/adv(get_turf(G), reac_volume)
 		G.use(reac_volume)
 


### PR DESCRIPTION
## About The Pull Request
- improv gauze stacksizes in crafting bumped up to 10 to accommodate for their max stacksize
- pouring sterilizine on gauze now takes the standardized 5u instead of 10u per sterilized gauze
## Why It's Good For The Game
stacksize parity + sterilizine usage parity
## Changelog
:cl:
tweak: Improvised gauzes can now be crafted in stacks up to 10, like their maximum stacksize implies they should be capable of doing.
fix: Pouring sterilizine on gauze now takes the proper 5u per sterilized gauze instead of 10u.
/:cl:
