### PR TITLE
Box Chapel Redecoration [updated]

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -60579,8 +60579,8 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "tSm" = (
-/obj/structure/musician/piano,
 /obj/effect/decal/cleanable/cobweb,
+/obj/structure/musician/piano,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "tSo" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12995,8 +12995,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Chapel North"
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/chapel/main)
+"aCP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/grown/poppy{
@@ -13005,31 +13009,21 @@
 /obj/item/reagent_containers/food/snacks/grown/harebell{
 	pixel_y = 5
 	},
-/turf/open/floor/wood/wood_large,
-/area/chapel/main)
-"aCP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aCQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/hydroponics/soil,
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
 	},
-/obj/structure/bookcase,
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/grass,
 /area/chapel/main)
 "aCR" = (
 /turf/closed/wall,
@@ -13582,28 +13576,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEm" = (
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Mass Driver";
-	req_access_txt = "22"
+/obj/structure/bookcase,
+/obj/machinery/camera{
+	c_tag = "Chapel North"
 	},
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "chapelgun";
-	name = "Holy Driver"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aEn" = (
-/obj/machinery/door/poddoor{
-	id = "chapelgun";
-	name = "Chapel Launcher Door"
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aEz" = (
 /obj/machinery/power/apc{
@@ -13997,14 +13980,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aFA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/computer/pod/old{
-	density = 0;
-	icon = 'icons/obj/airlock_machines.dmi';
-	icon_state = "airlock_control_standby";
-	id = "chapelgun";
-	name = "Mass Driver Controller";
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
@@ -14743,9 +14720,9 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aHi" = (
-/obj/structure/closet/crate/coffin,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/morgue{
+	name = "Confession Booth (Chaplain)";
+	req_access_txt = "22"
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
@@ -14762,46 +14739,47 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aHk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/table/wood,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aHl" = (
-/obj/structure/closet/crate/coffin,
-/obj/machinery/door/window/eastleft{
-	name = "Coffin Storage";
-	req_access_txt = "22"
+/obj/structure/chair/comfy/plywood,
+/obj/machinery/light/floor,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_x = 25
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aHm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/obj/structure/lattice,
+/turf/closed/wall,
 /area/chapel/main)
 "aHn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "chapelgun";
+	name = "Holy Driver"
 	},
-/obj/structure/chair/wood/normal{
-	dir = 4
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Mass Driver";
+	req_access_txt = "22"
 	},
-/turf/open/floor/carpet,
-/area/chapel/main)
-"aHo" = (
-/obj/structure/table/glass,
-/obj/item/storage/book/bible,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/wood/wood_large,
-/area/chapel/main)
-"aHq" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/chapel/main)
 "aHu" = (
@@ -15301,8 +15279,13 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aIz" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/table/wood,
+/obj/item/storage/crayons{
+	pixel_y = 8
+	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aIB" = (
@@ -15317,19 +15300,15 @@
 "aIC" = (
 /obj/effect/landmark/start/chaplain,
 /obj/structure/chair/comfy/plywood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/chapel/office)
 "aID" = (
-/obj/structure/closet/crate/coffin,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"aIE" = (
-/obj/structure/table/glass,
-/turf/open/floor/wood/wood_large,
-/area/chapel/main)
 "aIH" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -15806,12 +15785,12 @@
 /area/hydroponics)
 "aJM" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_y = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/item/flashlight/lamp{
+	pixel_y = 15
 	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/office)
@@ -15847,14 +15826,14 @@
 /area/library)
 "aJT" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_y = 20
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
 /obj/item/pen/fountain{
-	pixel_y = 20
+	pixel_y = 4
 	},
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -15874,15 +15853,12 @@
 /turf/open/floor/carpet,
 /area/chapel/office)
 "aJV" = (
-/obj/structure/closet/crate/coffin,
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "Coffin Storage";
-	req_access_txt = "22"
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/turf/open/floor/plating,
+/area/chapel/main)
 "aJW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -15946,12 +15922,10 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "aKe" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/matches{
-	pixel_x = 4;
-	pixel_y = -8
+/obj/structure/chair/wood/normal{
+	dir = 4
 	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/carpet,
 /area/chapel/main)
 "aKf" = (
 /obj/structure/cable{
@@ -16407,7 +16381,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/wood/wood_large,
+/turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aLt" = (
 /turf/open/floor/wood{
@@ -16848,7 +16822,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/wood/wood_large,
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aMM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -17210,22 +17187,21 @@
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aNX" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "Confessional Intercom";
-	pixel_x = 25
-	},
-/obj/structure/chair/comfy/plywood,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
-"aNY" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
+/obj/structure/closet/crate/coffin,
+/obj/machinery/door/window/eastright{
+	dir = 8;
+	name = "Coffin Storage";
 	req_access_txt = "22"
 	},
 /turf/open/floor/plasteel/dark,
+/area/chapel/main)
+"aNY" = (
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
 /area/chapel/main)
 "aNZ" = (
 /obj/structure/chair,
@@ -17706,7 +17682,12 @@
 	},
 /area/chapel/main)
 "aPo" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/closet/crate/coffin,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	name = "Coffin Storage";
+	req_access_txt = "22"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aPp" = (
@@ -18116,7 +18097,7 @@
 	pixel_x = -5;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet,
 /area/chapel/main)
 "aQx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18129,24 +18110,17 @@
 	},
 /area/chapel/main)
 "aQz" = (
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1480;
-	name = "Confessional Intercom";
-	pixel_x = 25
+/obj/structure/closet/crate/coffin,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQA" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aQB" = (
 /obj/effect/turf_decal/tile/red{
@@ -19178,7 +19152,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aTk" = (
@@ -23926,14 +23899,15 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "bfb" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/machinery/computer/pod/old{
+	density = 0;
+	icon = 'icons/obj/airlock_machines.dmi';
+	icon_state = "airlock_control_standby";
+	id = "chapelgun";
+	name = "Mass Driver Controller";
+	pixel_x = 24
 	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "bfc" = (
 /obj/machinery/power/apc{
@@ -49372,11 +49346,10 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "csT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/obj/structure/table/glass,
+/obj/item/storage/book/bible,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "csU" = (
 /obj/structure/transit_tube/station/reverse,
@@ -52008,10 +51981,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cBZ" = (
-/obj/structure/table/wood,
-/obj/item/storage/crayons{
-	pixel_y = 8
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet,
 /area/chapel/office)
 "cCb" = (
@@ -53481,12 +53454,9 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "dmX" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel Office";
-	req_access_txt = "22"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/chapel/main)
 "dnW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -56392,6 +56362,17 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kdF" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/crate/coffin,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "kdO" = (
 /obj/machinery/pool/controller,
 /turf/open/floor/plasteel/yellowsiding,
@@ -56791,10 +56772,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kOL" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/glass,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -57442,13 +57421,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "mzv" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
+/obj/machinery/door/morgue{
+	name = "Confession Booth"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "mzB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57661,9 +57637,9 @@
 /area/crew_quarters/locker)
 "mZx" = (
 /obj/structure/table/glass,
-/obj/item/storage/fancy/candle_box{
-	pixel_x = 5;
-	pixel_y = 4
+/obj/item/storage/box/matches{
+	pixel_x = 4;
+	pixel_y = -8
 	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
@@ -58942,7 +58918,7 @@
 	pixel_x = 5;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet,
 /area/chapel/main)
 "pYQ" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -59039,6 +59015,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qkn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -59133,6 +59110,11 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
+"qCR" = (
+/obj/structure/musician/piano,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "qEB" = (
 /obj/machinery/hydroponics/soil{
 	pixel_y = 8
@@ -59266,6 +59248,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"qUh" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Office";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "qVP" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -60576,8 +60565,9 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "tSm" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/musician/piano,
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "tSo" = (
@@ -61314,13 +61304,18 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "vqE" = (
-/obj/structure/closet/crate/coffin,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/chair/wood/normal{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
+/obj/machinery/light/floor,
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1480;
+	name = "Confessional Intercom";
+	pixel_x = -25
+	},
 /turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/area/chapel/main)
 "vqP" = (
 /obj/structure/bed/dogbed{
 	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.";
@@ -62355,11 +62350,12 @@
 /turf/open/floor/carpet,
 /area/library)
 "xES" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/chair/wood/normal{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 5;
+	pixel_y = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "xFM" = (
 /obj/item/clothing/gloves/color/rainbow,
@@ -62450,6 +62446,12 @@
 /obj/item/instrument/trombone,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"xRa" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-20"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "xSW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -108514,7 +108516,7 @@ aJT
 aLc
 aFw
 tSm
-kOL
+aFz
 aFz
 aRR
 aTe
@@ -108769,8 +108771,8 @@ aGY
 aII
 aJW
 aMX
-aFw
-mzv
+qUh
+aFz
 aPl
 aQv
 aPl
@@ -108779,7 +108781,7 @@ aUI
 aTg
 aRS
 aZf
-aFz
+xRa
 bbF
 aYV
 aXq
@@ -109023,10 +109025,10 @@ aCM
 aEg
 aFw
 aHi
-aHi
-aJV
-aMX
-dmX
+aFw
+aFw
+aFw
+aFw
 aFz
 aPk
 aQu
@@ -109282,10 +109284,10 @@ aFw
 aHl
 aID
 vqE
-aFw
 aCR
+qCR
 aFz
-aFz
+aRS
 aQw
 aRS
 aRS
@@ -109535,14 +109537,14 @@ aAz
 asB
 aCO
 aEh
-aNW
-aHk
-aNW
-aNW
-qkn
+aCR
+aCR
+aCR
+mzv
+aCR
 aML
 aFz
-aFz
+aRS
 pXG
 cdl
 aRS
@@ -109793,10 +109795,10 @@ asB
 aCQ
 aEk
 fsQ
-aHn
-csT
-csT
 fsQ
+fsQ
+fsQ
+qkn
 aLr
 aFB
 aPn
@@ -110050,11 +110052,11 @@ asB
 aCP
 aMM
 aFA
-aHm
-xES
-xES
 aMM
 aMM
+aMM
+aMM
+aEj
 aEj
 aPm
 aQx
@@ -110064,7 +110066,7 @@ aUJ
 aTh
 aXz
 aZg
-aFz
+xRa
 bbF
 aYV
 bdv
@@ -110304,18 +110306,18 @@ ayj
 azx
 aAB
 asB
-aCR
 aEm
-aCR
 aNW
-aNW
-aNW
-aNW
-aCR
-aNY
-aCR
 aQA
-aCR
+aNW
+aNW
+aNW
+aNW
+aFz
+aFz
+aFz
+aFz
+aFz
 aTj
 aFz
 aVV
@@ -110561,14 +110563,14 @@ asB
 asB
 asB
 asB
-aCR
+aHk
+aNW
 bfb
-aCR
-aHo
-aIE
 aKe
-mZx
-aCR
+aKe
+aKe
+aNW
+kdF
 aNX
 aPo
 aQz
@@ -110821,10 +110823,10 @@ atS
 aCR
 aEn
 aCR
-aHq
-aHq
-aHq
-aHq
+aKe
+aKe
+aKe
+aNW
 aCR
 aCR
 aCR
@@ -111074,14 +111076,14 @@ atS
 aoV
 aoV
 aaf
-atS
-aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
+gXs
+aHm
+aHn
+aCR
+aNW
+aNW
+aNW
+aNW
 aMZ
 aNZ
 aPp
@@ -111331,14 +111333,14 @@ aaH
 aoV
 aoV
 aaf
-atS
-aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
+gXs
+aHm
+aJV
+aCR
+csT
+kOL
+mZx
+xES
 aMZ
 aOb
 aPr
@@ -111588,14 +111590,14 @@ aaH
 aoV
 aoV
 aoV
-atS
-aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
+gXs
+aHm
+aNY
+aCR
+dmX
+dmX
+dmX
+dmX
 aMZ
 aOa
 aVX
@@ -111845,7 +111847,7 @@ atS
 aoV
 aoV
 aoV
-atS
+gXs
 aaf
 aaa
 aaf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12999,8 +12999,12 @@
 	c_tag = "Chapel North"
 	},
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/reagent_containers/food/snacks/grown/harebell,
+/obj/item/reagent_containers/food/snacks/grown/poppy{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/grown/harebell{
+	pixel_y = 5
+	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aCP" = (
@@ -13024,6 +13028,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/bookcase,
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aCR" = (
@@ -14792,6 +14797,7 @@
 "aHo" = (
 /obj/structure/table/glass,
 /obj/item/storage/book/bible,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aHq" = (
@@ -15842,13 +15848,13 @@
 "aJT" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
-	pixel_y = 5
+	pixel_y = 20
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/item/pen/fountain{
-	pixel_y = 7
+	pixel_y = 20
 	},
 /turf/open/floor/carpet,
 /area/chapel/office)
@@ -16398,7 +16404,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aLt" = (
@@ -16837,7 +16845,9 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aML" = (
-/obj/structure/bookcase,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aMM" = (
@@ -18129,6 +18139,7 @@
 	dir = 1
 	},
 /obj/machinery/light/floor,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQA" = (
@@ -19167,6 +19178,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aTk" = (
@@ -52001,9 +52013,8 @@
 "cBZ" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons{
-	pixel_y = -8
+	pixel_y = 8
 	},
-/obj/item/stamp/chap,
 /turf/open/floor/carpet,
 /area/chapel/office)
 "cCb" = (
@@ -53472,6 +53483,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"dmX" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Office";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "dnW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -54421,11 +54439,8 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "fsQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "fty" = (
 /obj/structure/lattice,
@@ -56778,6 +56793,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kOL" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-18"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -57118,6 +57139,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"lNB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/xmastree{
+	pixel_x = 14
+	},
+/turf/open/floor/carpet,
+/area/chapel/main)
 "lNH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -57376,6 +57406,10 @@
 /obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"mtU" = (
+/obj/structure/sign/departments/holy,
+/turf/closed/wall,
+/area/chapel/main)
 "mug" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -57410,6 +57444,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"mzv" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "mzB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/window,
@@ -57447,14 +57490,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"mFB" = (
-/obj/structure/table/glass,
-/obj/item/storage/fancy/candle_box{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/turf/open/floor/wood/wood_large,
-/area/chapel/main)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -57578,12 +57613,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"mQb" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_large,
-/area/chapel/main)
 "mQp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57633,6 +57662,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"mZx" = (
+/obj/structure/table/glass,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "naI" = (
 /turf/open/space,
 /area/space/station_ruins)
@@ -57670,10 +57707,6 @@
 "ndq" = (
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"new" = (
-/obj/structure/musician/piano,
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "nez" = (
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
@@ -58466,15 +58499,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"oZC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/xmastree{
-	pixel_x = 14
-	},
-/turf/open/floor/carpet,
-/area/chapel/main)
 "paJ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -58915,6 +58939,14 @@
 	icon_state = "wood-broken2"
 	},
 /area/maintenance/port/fore)
+"pXG" = (
+/obj/structure/table/wood,
+/obj/item/candle{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "pYQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
@@ -59009,6 +59041,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qkn" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "qkC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59825,10 +59863,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"som" = (
-/obj/structure/sign/departments/holy,
-/turf/closed/wall,
-/area/chapel/main)
 "spR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -60544,6 +60578,11 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"tSm" = (
+/obj/structure/musician/piano,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "tSo" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -61277,6 +61316,14 @@
 /obj/item/clothing/under/misc/pj/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"vqE" = (
+/obj/structure/closet/crate/coffin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "vqP" = (
 /obj/structure/bed/dogbed{
 	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off.";
@@ -61878,14 +61925,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"wIu" = (
-/obj/structure/table/wood,
-/obj/item/candle{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "wJA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61904,13 +61943,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"wPW" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel Office";
-	req_access_txt = "22"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "wQg" = (
 /obj/structure/pool/ladder{
 	dir = 2;
@@ -62056,15 +62088,6 @@
 /obj/item/coin/gold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xci" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "xcl" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -62335,13 +62358,12 @@
 /turf/open/floor/carpet,
 /area/library)
 "xES" = (
-/obj/structure/closet/crate/coffin,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/wood/normal{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/turf/open/floor/carpet,
+/area/chapel/main)
 "xFM" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -62423,15 +62445,6 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"xPS" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/wood/wood_large,
-/area/chapel/main)
 "xPY" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
@@ -108503,8 +108516,8 @@ cBZ
 aJT
 aLc
 aFw
-new
-aFz
+tSm
+kOL
 aFz
 aRR
 aTe
@@ -108513,7 +108526,7 @@ aFz
 aRS
 aXW
 baz
-som
+mtU
 bcx
 aXq
 aYV
@@ -108760,7 +108773,7 @@ aII
 aJW
 aMX
 aFw
-xci
+mzv
 aPl
 aQv
 aPl
@@ -109016,7 +109029,7 @@ aHi
 aHi
 aJV
 aMX
-wPW
+dmX
 aFz
 aPk
 aQu
@@ -109271,7 +109284,7 @@ aEi
 aFw
 aHl
 aID
-xES
+vqE
 aFw
 aCR
 aFz
@@ -109282,7 +109295,7 @@ aRS
 aRS
 aRS
 aRS
-oZC
+lNB
 aRS
 bbF
 aYV
@@ -109529,11 +109542,11 @@ aNW
 aHk
 aNW
 aNW
-xPS
+qkn
 aML
 aFz
 aFz
-wIu
+pXG
 cdl
 aRS
 aRS
@@ -109782,11 +109795,11 @@ aAA
 asB
 aCQ
 aEk
-aLr
+fsQ
 aHn
 csT
 csT
-mQb
+fsQ
 aLr
 aFB
 aPn
@@ -110041,8 +110054,8 @@ aCP
 aMM
 aFA
 aHm
-fsQ
-fsQ
+xES
+xES
 aMM
 aMM
 aEj
@@ -110557,7 +110570,7 @@ aCR
 aHo
 aIE
 aKe
-mFB
+mZx
 aCR
 aNX
 aPo

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -49347,8 +49347,10 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "csT" = (
 /obj/structure/table/glass,
-/obj/item/storage/book/bible,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/storage/book/bible{
+	pixel_y = -1
+	},
 /turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "csU" = (
@@ -53487,6 +53489,14 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/theatre)
+"dsJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/glass,
+/obj/item/toy/figure/chaplain{
+	pixel_y = -9
+	},
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "dtx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59537,6 +59547,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rxF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/glass,
+/obj/item/storage/book/bible{
+	pixel_y = 17
+	},
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "ryr" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -62353,6 +62371,10 @@
 /obj/structure/table/glass,
 /obj/item/storage/fancy/candle_box{
 	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 1;
 	pixel_y = 4
 	},
 /turf/open/floor/wood/wood_large,
@@ -109795,8 +109817,8 @@ asB
 aCQ
 aEk
 fsQ
-fsQ
-fsQ
+dsJ
+rxF
 fsQ
 qkn
 aLr
@@ -111079,7 +111101,7 @@ aaf
 gXs
 aHm
 aHn
-aCR
+dmX
 aNW
 aNW
 aNW
@@ -111336,7 +111358,7 @@ aaf
 gXs
 aHm
 aJV
-aCR
+dmX
 csT
 kOL
 mZx

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -34056,9 +34056,6 @@
 /area/medical/surgery)
 "bCJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bCK" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -12995,13 +12995,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/camera{
+	c_tag = "Chapel North"
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/obj/item/reagent_containers/food/snacks/grown/harebell,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aCP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/obj/item/clothing/under/misc/burial,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aCQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -13010,7 +13024,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aCR" = (
 /turf/closed/wall,
@@ -13536,7 +13550,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aEi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13556,7 +13570,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aEl" = (
 /obj/effect/landmark/event_spawn,
@@ -13987,7 +14001,7 @@
 	name = "Mass Driver Controller";
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aFB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -14617,7 +14631,7 @@
 	departmentType = 2;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aGV" = (
 /obj/structure/disposalpipe/segment{
@@ -14652,7 +14666,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aGZ" = (
 /obj/machinery/door/airlock/security{
@@ -14703,7 +14717,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/vending/wardrobe/chap_wardrobe,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aHg" = (
 /obj/machinery/light_switch{
@@ -14712,7 +14726,7 @@
 /obj/machinery/camera{
 	c_tag = "Chapel Office"
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aHh" = (
 /obj/structure/cable{
@@ -14746,7 +14760,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aHl" = (
 /obj/structure/closet/crate/coffin,
@@ -14760,22 +14774,25 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/chapel/main)
 "aHn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/chapel/main)
 "aHo" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/item/reagent_containers/food/snacks/grown/harebell,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
-	},
+/obj/item/storage/book/bible,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aHq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15280,7 +15297,7 @@
 "aIz" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aIB" = (
 /obj/structure/bodycontainer/crematorium{
@@ -15293,8 +15310,8 @@
 /area/chapel/office)
 "aIC" = (
 /obj/effect/landmark/start/chaplain,
-/obj/structure/chair,
-/turf/open/floor/plasteel/grimy,
+/obj/structure/chair/comfy/plywood,
+/turf/open/floor/carpet,
 /area/chapel/office)
 "aID" = (
 /obj/structure/closet/crate/coffin,
@@ -15305,7 +15322,7 @@
 /area/chapel/office)
 "aIE" = (
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aIH" = (
 /obj/structure/table,
@@ -15328,7 +15345,7 @@
 /area/construction/mining/aux_base)
 "aII" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aIJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15787,11 +15804,10 @@
 	pixel_y = 10
 	},
 /obj/structure/disposalpipe/segment,
-/obj/item/nullrod,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aJO" = (
 /obj/structure/table,
@@ -15826,23 +15842,30 @@
 "aJT" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
-	pixel_x = -2;
 	pixel_y = 5
 	},
-/obj/item/storage/crayons,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/item/pen/fountain{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet,
 /area/chapel/office)
 "aJU" = (
 /obj/structure/table/wood,
-/obj/item/pen,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/reagent_containers/food/drinks/bottle/holywater{
+	pixel_x = 9;
+	pixel_y = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/item/nullrod{
+	pixel_x = -15;
+	pixel_y = 3
+	},
+/turf/open/floor/carpet,
 /area/chapel/office)
 "aJV" = (
 /obj/structure/closet/crate/coffin,
@@ -15851,13 +15874,14 @@
 	name = "Coffin Storage";
 	req_access_txt = "22"
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aJW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aJX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -15917,9 +15941,11 @@
 /area/gateway)
 "aKe" = (
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/chapel{
-	dir = 4
+/obj/item/storage/box/matches{
+	pixel_x = 4;
+	pixel_y = -8
 	},
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aKf" = (
 /obj/structure/cable{
@@ -16248,7 +16274,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aLb" = (
 /obj/structure/disposalpipe/segment{
@@ -16267,7 +16293,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aLd" = (
 /obj/structure/table,
@@ -16286,13 +16312,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aLe" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aLf" = (
 /obj/machinery/airalarm{
@@ -16372,10 +16398,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aLr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aLt" = (
 /turf/open/floor/wood{
@@ -16813,16 +16837,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aML" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/bookcase,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aMM" = (
-/obj/machinery/camera{
-	c_tag = "Chapel North"
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood/wood_large,
 /area/chapel/main)
 "aMN" = (
 /obj/machinery/chem_master/condimaster,
@@ -16887,7 +16907,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aMX" = (
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/wood/wood_large,
 /area/chapel/office)
 "aMY" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -17177,12 +17197,8 @@
 /turf/open/floor/wood,
 /area/library)
 "aNW" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel Office";
-	req_access_txt = "22"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "aNX" = (
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -17190,7 +17206,8 @@
 	name = "Confessional Intercom";
 	pixel_x = 25
 	},
-/obj/structure/chair,
+/obj/structure/chair/comfy/plywood,
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aNY" = (
@@ -18085,6 +18102,10 @@
 /area/chapel/main)
 "aQw" = (
 /obj/structure/table/wood,
+/obj/item/trash/candle{
+	pixel_x = -5;
+	pixel_y = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQx" = (
@@ -18104,9 +18125,10 @@
 	name = "Confessional Intercom";
 	pixel_x = 25
 	},
-/obj/structure/chair{
+/obj/structure/chair/wood/normal{
 	dir = 1
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aQA" = (
@@ -19111,24 +19133,32 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aTf" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "aTg" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
 /area/chapel/main)
 "aTh" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "aTi" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/assistant,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
@@ -19659,28 +19689,36 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aUH" = (
-/obj/structure/chair/stool,
 /obj/effect/landmark/start/assistant,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
 /area/chapel/main)
 "aUI" = (
-/obj/structure/chair/stool,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
 /area/chapel/main)
 "aUJ" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
 /area/chapel/main)
 "aUK" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -20207,8 +20245,10 @@
 /turf/open/floor/wood,
 /area/library)
 "aVU" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
@@ -46267,7 +46307,7 @@
 "chY" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/engineering)
 "cia" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -46617,7 +46657,7 @@
 "ciW" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/engineering)
 "ciX" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -46632,14 +46672,14 @@
 /obj/item/lightreplacer,
 /obj/item/lightreplacer,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/engineering)
 "ciY" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
 	name = "secure storage"
 	},
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/engineering)
 "ciZ" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -46947,7 +46987,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/engineering)
 "cjN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -47234,11 +47274,11 @@
 "ckB" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/engineering)
 "ckC" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/engineering)
 "ckD" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -49324,8 +49364,10 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "csT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/xmastree,
-/turf/open/floor/plasteel/dark,
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/carpet,
 /area/chapel/main)
 "csU" = (
 /obj/structure/transit_tube/station/reverse,
@@ -51958,13 +52000,11 @@
 /area/maintenance/starboard/aft)
 "cBZ" = (
 /obj/structure/table/wood,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/obj/item/clothing/under/misc/burial,
-/turf/open/floor/plasteel/grimy,
+/obj/item/storage/crayons{
+	pixel_y = -8
+	},
+/obj/item/stamp/chap,
+/turf/open/floor/carpet,
 /area/chapel/office)
 "cCb" = (
 /obj/structure/table,
@@ -54381,8 +54421,12 @@
 /turf/open/floor/plasteel,
 /area/security/range)
 "fsQ" = (
-/turf/open/floor/plating,
-/area/engine/storage)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/chapel/main)
 "fty" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -57403,6 +57447,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mFB" = (
+/obj/structure/table/glass,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "mGw" = (
 /obj/machinery/door/airlock/security{
 	name = "Labor Shuttle";
@@ -57526,6 +57578,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"mQb" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "mQp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57612,6 +57670,10 @@
 "ndq" = (
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"new" = (
+/obj/structure/musician/piano,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "nez" = (
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
@@ -58404,6 +58466,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"oZC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/xmastree{
+	pixel_x = 14
+	},
+/turf/open/floor/carpet,
+/area/chapel/main)
 "paJ" = (
 /obj/machinery/light{
 	dir = 4;
@@ -59754,6 +59825,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"som" = (
+/obj/structure/sign/departments/holy,
+/turf/closed/wall,
+/area/chapel/main)
 "spR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -61803,6 +61878,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wIu" = (
+/obj/structure/table/wood,
+/obj/item/candle{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "wJA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61821,6 +61904,13 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"wPW" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Office";
+	req_access_txt = "22"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "wQg" = (
 /obj/structure/pool/ladder{
 	dir = 2;
@@ -61966,6 +62056,15 @@
 /obj/item/coin/gold,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"xci" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "xcl" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -62236,8 +62335,13 @@
 /turf/open/floor/carpet,
 /area/library)
 "xES" = (
-/turf/closed/wall/r_wall,
-/area/engine/storage)
+/obj/structure/closet/crate/coffin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "xFM" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -62319,6 +62423,15 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"xPS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_large,
+/area/chapel/main)
 "xPY" = (
 /obj/structure/table/wood,
 /obj/machinery/light{
@@ -87889,14 +88002,14 @@ cdc
 cdZ
 bVI
 cay
-xES
-xES
-xES
-xES
-xES
-xES
-xES
-xES
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
 cfL
 coH
 cBO
@@ -88146,14 +88259,14 @@ bWB
 cec
 bVI
 kNv
-xES
+ccw
 chY
 ciX
 cjM
 ckB
 ckB
 ckB
-xES
+ccw
 cnY
 coH
 cgR
@@ -88403,14 +88516,14 @@ cde
 ceb
 bVI
 cay
-xES
+ccw
 chY
-fsQ
+ciZ
 ciW
 ckB
 ckB
 ckC
-xES
+ccw
 cnX
 coH
 cps
@@ -88660,14 +88773,14 @@ cdf
 ced
 bVI
 cay
-xES
-fsQ
-fsQ
-fsQ
+ccw
+ciZ
+ciZ
+ciZ
 ckC
 ckC
 ckC
-xES
+ccw
 coa
 coJ
 clJ
@@ -88917,14 +89030,14 @@ bWB
 bWB
 bVI
 cay
-xES
-xES
+ccw
+ccw
 ciY
 ciY
-xES
-xES
-xES
-xES
+ccw
+ccw
+ccw
+ccw
 cnZ
 coH
 cgI
@@ -108390,7 +108503,7 @@ cBZ
 aJT
 aLc
 aFw
-aFz
+new
 aFz
 aFz
 aRR
@@ -108400,7 +108513,7 @@ aFz
 aRS
 aXW
 baz
-aCR
+som
 bcx
 aXq
 aYV
@@ -108646,8 +108759,8 @@ aGY
 aII
 aJW
 aMX
-aNW
-aFz
+aFw
+xci
 aPl
 aQv
 aPl
@@ -108902,8 +109015,8 @@ aFw
 aHi
 aHi
 aJV
-aFw
-aFw
+aMX
+wPW
 aFz
 aPk
 aQu
@@ -109158,9 +109271,9 @@ aEi
 aFw
 aHl
 aID
-aID
+xES
 aFw
-aMM
+aCR
 aFz
 aFz
 aQw
@@ -109169,7 +109282,7 @@ aRS
 aRS
 aRS
 aRS
-aZf
+oZC
 aRS
 bbF
 aYV
@@ -109412,15 +109525,15 @@ aAz
 asB
 aCO
 aEh
-aFz
+aNW
 aHk
-aFz
-aFz
-aTe
+aNW
+aNW
+xPS
 aML
 aFz
 aFz
-aQw
+wIu
 cdl
 aRS
 aRS
@@ -109669,11 +109782,11 @@ aAA
 asB
 aCQ
 aEk
-aFB
+aLr
 aHn
-aFB
 csT
-aFB
+csT
+mQb
 aLr
 aFB
 aPn
@@ -109925,13 +110038,13 @@ awO
 awO
 asB
 aCP
-aEj
+aMM
 aFA
 aHm
-aEj
-aEj
-aEj
-aEj
+fsQ
+fsQ
+aMM
+aMM
 aEj
 aPm
 aQx
@@ -110184,10 +110297,10 @@ asB
 aCR
 aEm
 aCR
-aPl
-aQv
-aPl
-aQv
+aNW
+aNW
+aNW
+aNW
 aCR
 aNY
 aCR
@@ -110444,7 +110557,7 @@ aCR
 aHo
 aIE
 aKe
-aIE
+mFB
 aCR
 aNX
 aPo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes an effort to give Box Station's Chapel a more welcoming feeling and character, without going too heavily on revamping the entire area in shape, and to bring it closer to how decorated other station Chapels are currently.

Preview: 
![image](https://cdn.discordapp.com/attachments/546822932278673420/803350073907478588/chapel2.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Box Station's Chapel is currently the worst of the four main maps (Box, Meta, Pubby, Delta) in terms of looks, and though this doesn't attempt to make them completely on par with the other three mentioned, it's an attempt at making it at least feel more like a Chapel should feel like.

Also the having stools instead of pews was dumb, we have pews. They should be used in the Chapel.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes engineering secure storage being the wrong area because I fucked that up previously my bad
fix: removes funny extra light switch under right surgery table in surgery oops
add: Added chairs to the corpse launch viewing area
add: Small garden plot for flowers for parity with other station Chapels
add: Plain Bible to glass tables in Chapel
add: Candles and Matchbox to glass tables in Chapel
add: More glass tables, with a chaplain figure and another spare bible.
add: Bookcase to Box Chapel for parity with other station Chapels
add: Minimoog to Box Chapel as substitute for a church organ
add: Holy department sign just below Chapel
change: Expanded the corpse launching area to feel less congested
change: Added windows to the corpse launch so you can look inside I guess?
change: Moved flowers and burial garments to the corner next to the corpse launcher
change: Box Chaplain's office door is moved over one
change: Confessional is now connected to Chaplain's office for parity with other station Chapels
change: Moved coffins over to old confessional location
change: Box Chapel now has pews instead of stools
change: Box Chapel Confessional is now lit instead of being nearly pitch black
remove: Two coffins from Chapel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
