### PR TITLE
Removes Hive's Blessing and Xeno Queen Corpse from the Alien Ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
@@ -218,8 +218,8 @@
 "aY" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs,
-/mob/living/simple_animal/hostile/alien/drone,
 /obj/structure/alien/weeds/node,
+/mob/living/simple_animal/hostile/alien/drone,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "aZ" = (
@@ -530,10 +530,6 @@
 "lG" = (
 /obj/structure/alien/weeds,
 /obj/effect/mob_spawn/alien/corpse/humanoid/drone,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
-"pE" = (
-/obj/effect/mob_spawn/alien/corpse/humanoid/queen,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "wA" = (
@@ -1618,7 +1614,7 @@ ag
 wA
 ag
 ag
-pE
+ag
 ag
 at
 ag
@@ -1667,7 +1663,7 @@ ac
 ah
 af
 ac
-at
+ag
 ag
 ag
 ag
@@ -1719,7 +1715,7 @@ ar
 ah
 ak
 kp
-at
+ag
 ag
 ag
 aw
@@ -1769,7 +1765,7 @@ ac
 ak
 ac
 ac
-at
+ag
 ag
 av
 ag

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
@@ -522,11 +522,6 @@
 /obj/item/clothing/mask/facehugger/impregnated,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"kp" = (
-/obj/structure/alien/weeds,
-/obj/item/reagent_containers/syringe/alien,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/xenonest)
 "lG" = (
 /obj/structure/alien/weeds,
 /obj/effect/mob_spawn/alien/corpse/humanoid/drone,
@@ -1714,7 +1709,7 @@ ah
 ar
 ah
 ak
-kp
+ag
 ag
 ag
 ag


### PR DESCRIPTION

## About The Pull Request

Tin.

## Why It's Good For The Game

It's been a long time coming, and it seems to do a lot more harm than good, from causing balance issues with the strong knockdowns, to people soft griefing with it. It also seems like people are obnoxious about it. A lot of people dislike it, and as the person that originally added the ruin and Hive's blessing, I think it's time they go.

## Changelog
:cl:
del: Hive's blessing and the xeno queen corpse have been removed from the lavaland alien ruin.
/:cl:
