### PR TITLE
Turns hive blessing into a traitor item and reworks it to turn people into a xenomorph larvae.

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -200,7 +200,7 @@
 	stage3	= list("<span class='danger'>Your throat feels very scratchy.</span>", "Your skin feels tight.", "<span class='danger'>You can feel something move...inside.</span>")
 	stage4	= list("<span class='danger'>Your skin feels very tight.</span>", "<span class='danger'>Your blood boils!</span>", "<span class='danger'>You can feel... something...inside you.</span>")
 	stage5	= list("<span class='danger'>Your skin feels as if it's about to burst off!</span>")
-	new_form = /mob/living/carbon/alien/humanoid/hunter
+	new_form = /mob/living/carbon/alien/larva
 	bantype = ROLE_ALIEN
 
 /datum/disease/transformation/xeno/stage_act()

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -96,7 +96,7 @@
 	name = "Hive's Blessing"
 	desc = "A syringe full of goo that when injected will slowly turn them into a xenomorph larvae."
 	item = /obj/item/reagent_containers/syringe/alien
-	cost = 20
+	cost = 24
 	player_minimum = 30
 	restricted_roles = list("Research Director", "Scientist", "Roboticist")
 

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -91,6 +91,15 @@
 	restricted_roles = list("Chaplain")
 	surplus = 5 //Very low chance to get it in a surplus crate even without being the chaplain
 
+
+/datum/uplink_item/role_restricted/hiveblessing
+	name = "Hive's Blessing"
+	desc = "A syringe full of goo that when injected will slowly turn them into a xenomorph larvae."
+	item = /obj/item/reagent_containers/syringe/alien
+	cost = 20
+	player_minimum = 30
+	restricted_roles = list("Research Director", "Scientist", "Roboticist")
+
 /datum/uplink_item/role_restricted/clockwork_slab
 	name = "Clockwork Slab"
 	desc = "A reverse engineered clockwork slab. Is this really a good idea?."
@@ -257,4 +266,4 @@
 	item = /obj/item/storage/toolbox/emergency/turret
 	cost = 11
 	restricted_roles = list("Station Engineer")
-	
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
First things first, this should not be merged without https://github.com/Citadel-Station-13/Citadel-Station-13/pull/14075 or https://github.com/Citadel-Station-13/Citadel-Station-13/pull/14083. The reason for this is hive's blessing needs to be removed from the lavaland ruin first. Otherwise this PR does exactly what is says on the tin, it adds the Hive blessing syringe as a 24 tc role and pop locked traitor item. The TC value isn't set in stone although it will not be under 20. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instead of removing what is a fun item, why don't we turn it into a traitor item for people to use.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Hive blessing has been added as a 24 tc item for members of the science department. It requires 30 players minimum to use.
balance: Xenomorph transformation disease no longer turns people into a hunter and now turns them into a larvae so they can evolve into the other xenomorph species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
