### PR TITLE
Minor minning station QoL

### DIFF
--- a/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
+++ b/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
@@ -3170,7 +3170,9 @@
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "VY" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request

The oxygen locker, in the outside-ish part, starts out wrenched to the ground.

## Why It's Good For The Game

Makes sense for something in a cycling air room to have the locker wrenched down.
Before anyone asks, I will not be mirroring this to the public mining side. They don't get any nice things.

## Changelog
:cl:
tweak: Mining station oxygen locker on the cycling airlock starts out wrenched.
/:cl:
