### PR TITLE
Heretic sacrifice target logging + a fix

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -69,6 +69,9 @@
 #define LINGBLOOD_EXPLOSION_THRESHOLD (LINGBLOOD_DETECTION_THRESHOLD * LINGBLOOD_EXPLOSION_MULT) //Hey, important to note here: the explosion threshold is explicitly more than, rather than more than or equal to. This stops a single loud ability from triggering the explosion threshold.
 
 ///Heretics --
+GLOBAL_LIST_EMPTY(living_heart_cache)	//A list of all living hearts in existance, for us to iterate through.
+
+
 #define IS_HERETIC(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic))
 #define IS_HERETIC_MONSTER(mob) (mob.mind?.has_antag_datum(/datum/antagonist/heretic_monster))
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -455,7 +455,7 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 	var/target_real_name // Has to be stored because the target's real_name can change over the course of the round
 	var/target_missing_id
 
-/datum/objective/escape/escape_with_identity/find_target()
+/datum/objective/escape/escape_with_identity/find_target(dupe_search_range, blacklist)
 	target = ..()
 	update_explanation_text()
 
@@ -553,7 +553,7 @@ GLOBAL_LIST_EMPTY(possible_items)
 		for(var/I in subtypesof(/datum/objective_item/steal))
 			new I
 
-/datum/objective/steal/find_target()
+/datum/objective/steal/find_target(dupe_search_range, blacklist)
 	var/list/datum/mind/owners = get_owners()
 	var/approved_targets = list()
 	check_items:
@@ -631,7 +631,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		for(var/I in subtypesof(/datum/objective_item/special) + subtypesof(/datum/objective_item/stack))
 			new I
 
-/datum/objective/steal/special/find_target()
+/datum/objective/steal/special/find_target(dupe_search_range, blacklist)
 	return set_target(pick(GLOB.possible_items_special))
 
 /datum/objective/steal/exchange
@@ -844,7 +844,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	name = "destroy AI"
 	martyr_compatible = 1
 
-/datum/objective/destroy/find_target()
+/datum/objective/destroy/find_target(dupe_search_range, blacklist)
 	var/list/possible_targets = active_ais(1)
 	var/mob/living/silicon/ai/target_ai = pick(possible_targets)
 	target = target_ai.mind
@@ -1124,7 +1124,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/hoard/heirloom
 	name = "steal heirloom"
 
-/datum/objective/hoard/heirloom/find_target()
+/datum/objective/hoard/heirloom/find_target(dupe_search_range, blacklist)
 	set_target(pick(GLOB.family_heirlooms))
 
 GLOBAL_LIST_EMPTY(traitor_contraband)
@@ -1141,7 +1141,7 @@ GLOBAL_LIST_EMPTY(cult_contraband)
 	if(!GLOB.cult_contraband.len)
 		GLOB.cult_contraband = list(/obj/item/clockwork/slab,/obj/item/clockwork/component/belligerent_eye,/obj/item/clockwork/component/belligerent_eye/lens_gem,/obj/item/shuttle_curse,/obj/item/cult_shift)
 
-/datum/objective/hoard/collector/find_target()
+/datum/objective/hoard/collector/find_target(dupe_search_range, blacklist)
 	var/obj/item/I
 	var/I_type
 	if(prob(50))
@@ -1172,7 +1172,7 @@ GLOBAL_LIST_EMPTY(possible_sabotages)
 		for(var/I in subtypesof(/datum/sabotage_objective))
 			new I
 
-/datum/objective/sabotage/find_target()
+/datum/objective/sabotage/find_target(dupe_search_range, blacklist)
 	var/list/datum/mind/owners = get_owners()
 	var/approved_targets = list()
 	check_sabotages:

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -10,6 +10,8 @@
 	var/give_equipment = TRUE
 	var/list/researched_knowledge = list()
 	var/total_sacrifices = 0
+	var/list/sac_targetted = list()		//Which targets did living hearts give them, but they did not sac?
+	var/list/actually_sacced = list()	//Which targets did they actually sac?
 	var/ascended = FALSE
 
 /datum/antagonist/heretic/admin_add(datum/mind/new_owner,mob/admin)
@@ -175,6 +177,17 @@
 		knowledge_message += "[EK.name]"
 	parts += knowledge_message.Join(", ")
 
+	parts += "<b>Targets assigned by living hearts, but not sacrificed:</b>"
+	if(!sac_targetted.len)
+		parts += "None."
+	else
+		parts += sac_targetted.Join(",")
+	parts += "<b>Sacrifices performed:</b>"
+	if(!actually_sacced.len)
+		parts += "<span class='redtext'>None!</span>"
+	else
+		parts += actually_sacced.Join(",")
+
 	return parts.Join("<br>")
 ////////////////
 // Knowledge //
@@ -212,6 +225,22 @@
 		. += EK.cost
 	if(ascended)
 		. += 20
+
+/datum/antagonist/heretic/antag_panel()
+	var/list/parts = list()
+	parts += ..()
+	parts += "<b>Targets currently assigned by living hearts (Can give a false negative if they stole someone elses living heart, check the other heretics if this is suspected to be the case):</b>"
+	if(!sac_targetted.len)
+		parts += "None."
+	else
+		parts += sac_targetted.Join(",")
+	parts += "<b>Targets actually sacrificed:</b>"
+	if(!actually_sacced.len)
+		parts += "None."
+	else
+		parts += actually_sacced.Join(",")
+	return parts.Join("<br>")
+
 
 ////////////////
 // Objectives //

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -229,7 +229,7 @@
 /datum/antagonist/heretic/antag_panel()
 	var/list/parts = list()
 	parts += ..()
-	parts += "<b>Targets currently assigned by living hearts (Can give a false negative if they stole someone elses living heart, check the other heretics if this is suspected to be the case):</b>"
+	parts += "<b>Targets currently assigned by living hearts (Can give a false negative if they stole someone elses living heart):</b>"
 	if(!sac_targetted.len)
 		parts += "None."
 	else
@@ -239,7 +239,8 @@
 		parts += "None."
 	else
 		parts += actually_sacced.Join(",")
-	return parts.Join("<br>")
+
+	return (parts.Join("<br>") + "<br>")
 
 
 ////////////////

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -6,6 +6,17 @@
 	w_class = WEIGHT_CLASS_SMALL
 	///Target
 	var/mob/living/carbon/human/target
+	var/datum/antagonist/heretic/sac_targetter	//The heretic who used this to acquire the current target - gets cleared when target gets sacrificed.
+
+/obj/item/living_heart/Initialize()
+	. = ..()
+	GLOB.living_heart_cache.Add(src)	//Add is better than +=.
+
+/obj/item/living_heart/Destroy()
+	GLOB.living_heart_cache.Remove(src)
+	if(sac_targetter && target)
+		sac_targetter.sac_targetted.Remove(target.real_name)
+	return ..()
 
 /obj/item/living_heart/attack_self(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Testmerge this first. Did localtest it, but couldn't exactly perfectly test it with just me around. Shouldn't break things, but might work in unintended ways.

This adds some code in regards to which targets a heretic currently has assigned by their living hearts, aswell as to which targets they did sacrifice. This information is displayed both in the antag panel, aswell as at roundend.
Additionally, fixes a borderline exploity bug / oversight with living hearts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes and some more info about what heretics were up to is pretty neat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: The heretic antag panel now shows their sacrifices & current sacrifice targets.
tweak: The heretic roundend report now shows their sacrifices and nonsacrificed targets.
fix: Living hearts can no longer select the same target as another living heart, removing a certain problem.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
