### PR TITLE
itt: i dont test my code again - free golem ship GPSes start disabled

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -18,7 +18,7 @@
 /obj/item/mining_scanner,
 /obj/item/flashlight/lantern,
 /obj/item/card/id/mining,
-/obj/item/gps/mining,
+/obj/item/gps/mining/off,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "d" = (
@@ -32,7 +32,7 @@
 /obj/item/mining_scanner,
 /obj/item/flashlight/lantern,
 /obj/item/card/id/mining,
-/obj/item/gps/mining,
+/obj/item/gps/mining/off,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "e" = (
@@ -71,8 +71,8 @@
 /area/ruin/powered/golem_ship)
 "k" = (
 /obj/machinery/computer/arcade/battle{
-	icon_state = "arcade";
-	dir = 4
+	dir = 4;
+	icon_state = "arcade"
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
@@ -112,8 +112,8 @@
 /area/ruin/powered/golem_ship)
 "s" = (
 /obj/machinery/computer/arcade/orion_trail{
-	icon_state = "arcade";
-	dir = 4
+	dir = 4;
+	icon_state = "arcade"
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)

--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	var/updating = TRUE //Automatic updating of GPS list. Can be set to manual by user.
 	var/global_mode = TRUE //If disabled, only GPS signals of the same Z level are shown
 
-/datum/component/gps/item/Initialize(_gpstag = "COM0", emp_proof = FALSE)
+/datum/component/gps/item/Initialize(_gpstag = "COM0", emp_proof = FALSE, starton = TRUE)
 	. = ..()
 	if(. == COMPONENT_INCOMPATIBLE || !isitem(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -33,6 +33,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		RegisterSignal(parent, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/on_AltClick)
+	if(!starton)
+		tracking = FALSE
 
 ///Called on COMSIG_ITEM_ATTACK_SELF
 /datum/component/gps/item/proc/interact(datum/source, mob/user)

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -8,10 +8,11 @@
 	slot_flags = ITEM_SLOT_BELT
 	obj_flags = UNIQUE_RENAME
 	var/gpstag = "COM0"
+	var/starton = TRUE
 
 /obj/item/gps/Initialize()
 	. = ..()
-	AddComponent(/datum/component/gps/item, gpstag)
+	AddComponent(/datum/component/gps/item, gpstag, starton)
 
 /obj/item/gps/science
 	icon_state = "gps-s"
@@ -25,6 +26,9 @@
 	icon_state = "gps-m"
 	gpstag = "MINE0"
 	desc = "A positioning system helpful for rescuing trapped or injured miners, keeping one on you at all times while mining might just save your life."
+
+/obj/item/gps/mining/off
+	starton = FALSE
 
 /obj/item/gps/cyborg
 	icon_state = "gps-b"


### PR DESCRIPTION
## About The Pull Request
see title - starts all golem GPSes off except one in case someone wants to follow that one MINE0 signal in hopes that it's not a single goliath pod
## Why It's Good For The Game
coders weren't lyin, that golem ship can game pretty hard, bro...maybe a little too hard
## Changelog
:cl:
balance: The free golem ship's GPSes no longer start on. They were never meant to, but they did.
/:cl: