### PR TITLE
adminhelps and pms only sanitize text once, stopping ' becoming &39;! or whatever

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -174,7 +174,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 //is_bwoink is TRUE if this ticket was started by an admin PM
 /datum/admin_help/New(msg, client/C, is_bwoink)
 	//clean the input msg
-	msg = sanitize(copytext_char(msg,1,MAX_MESSAGE_LEN))
+	msg = copytext_char(msg,1,MAX_MESSAGE_LEN)
 	if(!msg || !C || !C.mob)
 		qdel(src)
 		return
@@ -263,7 +263,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 //message from the initiator without a target, all admins will see this
 //won't bug irc
 /datum/admin_help/proc/MessageNoRecipient(msg)
-	msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
+	msg = copytext_char(msg, 1, MAX_MESSAGE_LEN)
 	var/ref_src = "[REF(src)]"
 	//Message to be sent to all admins
 	var/admin_msg = "<span class='adminnotice'><span class='adminhelp'>Ticket [TicketHref("#[id]", ref_src)]</span><b>: [LinkedReplyName(ref_src)] [FullMonty(ref_src)]:</b> <span class='linkify'>[keywords_lookup(msg)]</span></span>"
@@ -523,7 +523,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
 
-	msg = trim(msg)
+	msg = sanitize(trim(msg))
 
 	if(!msg)
 		return

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -80,12 +80,6 @@
 		to_chat(src, "<span class='notice'>Message: [msg]</span>", confidential = TRUE)
 		return
 
-	//clean the message if it's not sent by a high-rank admin
-	if(!check_rights(R_SERVER|R_DEBUG,0)||external)//no sending html to the poor bots
-		msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
-		if(!msg)
-			return
-
 	var/client/recipient
 	var/recipient_ckey // Stored in case client is deleted between this and after the message is input
 	var/datum/admin_help/recipient_ticket // Stored in case client is deleted between this and after the message is input
@@ -119,6 +113,11 @@
 			to_chat(src, "<span class='danger'>Error: Use the admin IRC/Discord channel, nerd.</span>", confidential = TRUE)
 			return
 
+	//clean the message if it's not sent by a high-rank admin
+	if(!check_rights(R_SERVER|R_DEBUG,0)||external)//no sending html to the poor bots
+		msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
+		if(!msg)
+			return
 
 	else
 		//get message text, limit it's length.and clean/escape html

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -80,6 +80,12 @@
 		to_chat(src, "<span class='notice'>Message: [msg]</span>", confidential = TRUE)
 		return
 
+	//clean the message if it's not sent by a high-rank admin
+	if(!check_rights(R_SERVER|R_DEBUG,0)||external)//no sending html to the poor bots
+		msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
+		if(!msg)
+			return
+
 	var/client/recipient
 	var/recipient_ckey // Stored in case client is deleted between this and after the message is input
 	var/datum/admin_help/recipient_ticket // Stored in case client is deleted between this and after the message is input
@@ -141,14 +147,8 @@
 		to_chat(src, "<span class='danger'>Error: Admin-PM: You are unable to use admin PM-s (muted).</span>", confidential = TRUE)
 		return
 
-	if (src.handle_spam_prevention(msg,MUTE_ADMINHELP))
+	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
-
-	//clean the message if it's not sent by a high-rank admin
-	if(!check_rights(R_SERVER|R_DEBUG,0)||external)//no sending html to the poor bots
-		msg = sanitize(copytext_char(msg, 1, MAX_MESSAGE_LEN))
-		if(!msg)
-			return
 
 	var/rawmsg = msg
 


### PR DESCRIPTION
## About The Pull Request
fixing first death message for this in a different pr

test case to show html injection wont work for admin-helps:
![image](https://user-images.githubusercontent.com/59849408/105419965-7755cb00-5c37-11eb-819f-59b9386918ca.png)


## Why It's Good For The Game
makes adminhelps and admin pms more readable when certain symbols are used such as '

## Changelog
:cl:
admin: adminhelps and pms only sanitize once instead of twice
/:cl:
