### PR TITLE
About ratvarian borgs and spells sometimes not working (+ a few other small things)

### DIFF
--- a/code/modules/antagonists/clockcult/clock_helpers/clock_rites.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/clock_rites.dm
@@ -165,14 +165,16 @@
 /datum/clockwork_rite/treat_wounds/cast(var/mob/living/invoker, var/turf/T, var/mob/living/carbon/human/target)
 	if(!target)
 		return FALSE
-	if(!target.all_wounds.len)
+	if(!target.all_wounds || !target.all_wounds.len)
 		to_chat(invoker, "<span class='inathneq_small'>This one does not require mending.</span>")
 		return FALSE
 	.= ..()
 	if(!.)
 		return FALSE
 	target.adjustToxLoss(10 * target.all_wounds.len)
-	QDEL_LIST(target.all_wounds)
+	for(var/i in target.all_wounds)
+		var/datum/wound/mended = i
+		mended.remove_wound()
 	to_chat(target, "<span class='warning'>You feel your wounds heal, but are overcome with deep nausea.</span>")
 	new /obj/effect/temp_visual/ratvar/sigil/vitality(T)
 

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -203,10 +203,10 @@
 		to_chat(user, "<span class='warning'>You need to hold the slab in your active hand to recite scripture!</span>")
 		return FALSE
 	var/initial_tier = initial(scripture.tier)
-	if(initial_tier == SCRIPTURE_PERIPHERAL)
+	if(initial_tier == SCRIPTURE_PERIPHERAL && !issilicon(user))	//Silicons use peripheral scripture & cannot open the slab.
 		to_chat(user, "<span class='warning'>Nice try using href exploits</span>")
 		return
-	if(!GLOB.ratvar_awakens && !no_cost && !SSticker.scripture_states[initial_tier])
+	if(!GLOB.ratvar_awakens && !no_cost && !SSticker.scripture_states[initial_tier] &&!issilicon(user))	//silicons can't choose their spells, so lets allow them to always cast their assigned ones.
 		to_chat(user, "<span class='warning'>That scripture is not unlocked, and cannot be recited!</span>")
 		return FALSE
 	var/datum/clockwork_scripture/scripture_to_recite = new scripture


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does a few things:
First and foremost, it fixes an issue with clockwork silicons being unable to cast some of their spells due to their spell type not being available to most other people.
Secondly, this allows silicons to always (when there's enough power, that means) cast their assigned spells, as they cannot choose their spells  and therefore should generally have access to the ones specifically assigned to them.
Thirdly, it fixes a few small issues with the woundmending rite.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes good.
Borgs always having their assigned spells available should be useful if the cult manages to convert a silicon early-on, but should't have any impact on the later phases of the round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The woundmending rite no longer causes runtimes.
fix: Ratvarian borgs can now use their tier-0 spells.
balance: Ratvarian borgs can always use their assigned spells, if there is enough power.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
