### PR TITLE
Port "Let Me Tell You A Story"

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -19,7 +19,6 @@
 	/// How much brute damage they do to simple animals
 	var/meleeSlashSAPower = 35
 
-	var/obj/item/card/id/wear_id = null // Fix for station bounced radios -- Skie
 	var/has_fine_manipulation = 0
 	var/move_delay_add = 0 // movement delay to add
 


### PR DESCRIPTION
## About The Pull Request

Port of: https://github.com/tgstation/tgstation/pull/51236

## Why It's Good For The Game

The post from Fox:
Come, let me tell you a story of the old days----of SHITCODE.

AGhhhhh.

Once upon a time, SS13 code was terrible (who are we joking, it still is, but that's a story for another day), and when any carbon subtype, minus humans, talked over radio, it would runtime.

Of course, coders set about fixing this problem---can't have nonsense like that, so...of course, the most logical thing was done.

Instead of solving the awfulness that was not only using the wrong istype check and a wonderful colon override as well:

tgstation/code/game/objects/radio/radio.dm

Line 148 in 9eb0e80

 if (istype(M, /mob/living/carbon)) 
A "Fix" was applied instead: 9eb0e80#diff-b5f801c8078b7d8dd9f0661b359dfa9e

Whereby var/obj/item/card/id/wear_id = null was added to monkeys and aliens to "fix" them having an ID holder and not throwing a runtime.........Thus ensuring:

Fox would find it one day and call this utterly moronic and while also ensuring that all future carbon mobs created without implementing this same "fix" would have the same exact problem.

Then radio code got rewritten to be non-stupid and this still hung around until today.

The End

## Changelog
:cl:
fix: Alien radio code
/:cl: