### PR TITLE
Port of "Puts encryption keys in hand when removed"

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -283,14 +283,12 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
 				secure_radio_connections[ch_name] = null
 
-			var/turf/T = user.drop_location()
-			if(T)
-				if(keyslot)
-					keyslot.forceMove(T)
-					keyslot = null
-				if(keyslot2)
-					keyslot2.forceMove(T)
-					keyslot2 = null
+			if(keyslot)
+				user.put_in_hands(keyslot)
+				keyslot = null
+			if(keyslot2)
+				user.put_in_hands(keyslot2)
+				keyslot2 = null
 
 			recalculateChannels()
 			to_chat(user, "<span class='notice'>You pop out the encryption keys in the headset.</span>")


### PR DESCRIPTION
## About The Pull Request

Port of: https://github.com/tgstation/tgstation/pull/48277

## Why It's Good For The Game

It's a good quality of life, also, better for tators trying to steal encryptions they shouldn't. 

## Changelog
:cl:
tweak: Makes encryption keys be put in the hands of the user when able instead of being dropped on the floor when removed from headsets
/:cl:
