### PR TITLE
Mass air alarm fixings for (basically) every station

### DIFF
--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -6004,11 +6004,11 @@
 	c_tag = "Security Checkpoint";
 	pixel_x = 22
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
@@ -32289,10 +32289,6 @@
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -71184,6 +71180,13 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pMW" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "pZq" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -121382,7 +121385,7 @@ amV
 aqI
 aqB
 aGO
-auy
+pMW
 aqB
 aqI
 amV

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -49530,7 +49530,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -113323,10 +113323,6 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/storage/box/evidence,
 /obj/item/taperecorder,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -30529,9 +30529,6 @@
 	dir = 8
 	},
 /obj/structure/closet/bombcloset,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "aXC" = (
@@ -43701,10 +43698,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /mob/living/simple_animal/chicken{
 	desc = "The arch-nemesis of Kentucky.";
 	name = "Popeye";
@@ -46363,9 +46356,6 @@
 "bwK" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
 /turf/open/floor/grass,
 /area/chapel/main)
 "bwL" = (
@@ -48132,16 +48122,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
-"bzx" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/crew_quarters/locker)
 "bzy" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -58156,10 +58136,6 @@
 	icon_state = "plant-02";
 	pixel_y = 3
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/machinery/camera{
 	c_tag = "Prison Wing Cells";
 	dir = 4;
@@ -61358,7 +61334,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/space)
+/area/security/warden)
 "bUs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -67210,10 +67186,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "cdU" = (
@@ -71327,9 +71299,9 @@
 	icon_gib = "magicarp_gib";
 	icon_living = "magicarp";
 	icon_state = "magicarp";
+	maxHealth = 200;
 	max_co2 = 5;
 	max_tox = 2;
-	maxHealth = 200;
 	melee_damage_lower = 15;
 	melee_damage_upper = 20;
 	min_oxy = 5;
@@ -83280,10 +83252,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Port Tanks";
@@ -108992,7 +108960,7 @@ bss
 btV
 aEu
 bxW
-bzx
+bIV
 bKq
 bKq
 bKq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1111,10 +1111,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acx" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/cryopod{
 	dir = 8
 	},
@@ -40497,10 +40493,9 @@
 /area/maintenance/port)
 "bBr" = (
 /obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
 /area/library)
 "bBs" = (
@@ -45866,10 +45861,6 @@
 /area/library)
 "bML" = (
 /obj/machinery/light/small,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /turf/open/floor/wood,
 /area/library)
 "bMM" = (
@@ -59581,6 +59572,10 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "coz" = (
@@ -61596,10 +61591,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "csl" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -102698,7 +102689,7 @@ bue
 bwa
 bxU
 bzD
-bBr
+dmD
 bSx
 bEw
 bzE
@@ -103733,7 +103724,7 @@ bGs
 bHS
 bzE
 bLk
-bzE
+bBr
 bue
 bPS
 bPR

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -4924,7 +4924,6 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/item/gun/energy/e_gun/hos,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -40543,6 +40542,9 @@
 	areastring = "/area/maintenance/starboard/aft";
 	name = "Starboard Quater Maintenance APC";
 	pixel_y = -26
+	},
+/obj/structure/cable/white{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -4928,6 +4928,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/gun/energy/e_gun/hos,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain/private)
 "ahI" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16530,6 +16530,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMr" = (
@@ -47631,6 +47634,9 @@
 	pixel_x = -25;
 	specialfunctions = 4
 	},
+/obj/machinery/airalarm{
+	pixel_y = 22
+	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main/monastery)
 "cgM" = (
@@ -47978,6 +47984,9 @@
 	normaldoorcontrol = 1;
 	pixel_x = -25;
 	specialfunctions = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main/monastery)
@@ -51465,6 +51474,10 @@
 	icon_state = "right";
 	name = "Coffin Storage";
 	req_one_access_txt = "22"
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -59433,6 +59446,10 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 23
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)


### PR DESCRIPTION
## About The Pull Request

Adds some air alarms where some rooms didn't have any (pubby), and removed rooms that had two air alarms that were too close (a few here and there on other maps).
Plus some random fixes, kilo had some floor decals on a wall (and a place in security that didn't have a defined area, oops), and a wire that's missing on omega.

## Why It's Good For The Game

Ladies, please, keep your panties and stop throwing them at me for this. I'm a taken man.
But really, it's just nice. Boxstation will be fixed up once the current boxstation PR is completed.

## Changelog
:cl:
tweak: Remaps some air alarms for sanity.
/:cl: