### PR TITLE
Fixes the Ventcrawling element not detaching properly

### DIFF
--- a/code/datums/elements/ventcrawling.dm
+++ b/code/datums/elements/ventcrawling.dm
@@ -6,6 +6,10 @@
 /datum/element/ventcrawling/Attach(datum/target, duration = 0, given_tier = VENTCRAWLER_NUDE)
 	. = ..()
 
+	var/mob/living/person = target
+	if(!istype(person))
+		return FALSE
+
 	src.tier = given_tier
 
 	RegisterSignal(target, COMSIG_HANDLE_VENTCRAWL, .proc/handle_ventcrawl)
@@ -16,9 +20,10 @@
 		addtimer(CALLBACK(src, .proc/Detach, target), duration)
 
 /datum/element/ventcrawling/Detach(datum/target)
-	. = ..()
-
 	UnregisterSignal(target, list(COMSIG_HANDLE_VENTCRAWL, COMSIG_CHECK_VENTCRAWL))
+	to_chat(target, "<span class='notice'>You can no longer ventcrawl.</span>")
+
+	return ..()
 
 /datum/element/ventcrawling/proc/handle_ventcrawl(datum/target,atom/A)
 	var/mob/living/person = target

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -805,7 +805,7 @@
 
 /datum/species/golem/plastic/on_species_loss(mob/living/carbon/C)
 	. = ..()
-	C.RemoveElement(/datum/element/ventcrawling)
+	C.RemoveElement(/datum/element/ventcrawling, given_tier = VENTCRAWLER_ALWAYS)
 
 /datum/species/golem/bronze
 	name = "Bronze Golem"

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -169,7 +169,7 @@
 	if(istype(H, /mob/living/simple_animal))
 		var/mob/living/simple_animal/SA = H
 		if((human_caster.blood_volume <= (BLOOD_VOLUME_BAD*human_caster.blood_ratio)) || (ventcrawl_nude_only && length(human_caster.get_equipped_items(include_pockets = TRUE))))
-			SA.RemoveElement(/datum/element/ventcrawling)
+			SA.RemoveElement(/datum/element/ventcrawling, given_tier = VENTCRAWLER_ALWAYS)
 	if(transfer_name)
 		H.name = human_caster.name
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -110,7 +110,7 @@
 		to_chat(src, "<i>Your onboard antivirus has initiated lockdown. Motor servos are impaired, ventilation access is denied, and your display reports that you are hacked to all nearby.</i>")
 		hacked = TRUE
 		mind.special_role = "hacked drone"
-		RemoveElement(/datum/element/ventcrawling) // balance
+		RemoveElement(/datum/element/ventcrawling, given_tier = VENTCRAWLER_ALWAYS) // balance
 		speed = 1 //gotta go slow
 		message_admins("[src] ([src.key]) became a hacked drone hellbent on [clockwork ? "serving Ratvar" : "destroying the station"]!")
 	else


### PR DESCRIPTION
## About The Pull Request

Fixes the Ventcrawling element not detaching.
I made malformed calls to detach the ventcrawling element from mobs and as such it never got detached.

edit;
Retroactively tested through the making of a (previously, no longer) up-coming PR. Functions fine.

## Why It's Good For The Game

Imagine swapping golem shells and figuring out you can ventcrawl as whichever one you want for whatever reason.
This fixes that. Also lets you know when your ventcrawling has been removed (this was mostly a testing tool, but is nice feedback).

## Changelog
:cl:
fix: bespoke ventcrawling element not detaching due to malformed call
/:cl: