### PR TITLE
adds aesthetic sterile masks (and the paper mask) to the loadout panel

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -33,6 +33,15 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	mutantrace_variation = STYLE_MUZZLE
 
+/obj/item/clothing/mask/surgical/aesthetic
+	name = "aesthetic sterile mask"
+	desc = "A sterile mask designed to help prevent the spread of diseases. This one doesn't seem like it does a whole lot, somehow."
+	flags_inv = HIDEFACE
+	flags_cover = null
+	visor_flags_inv = null
+	visor_flags_cover = null
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+
 /obj/item/clothing/mask/surgical/attack_self(mob/user)
 	adjustmask(user)
 

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -40,6 +40,7 @@
 	flags_cover = null
 	visor_flags_inv = null
 	visor_flags_cover = null
+	permeability_coefficient = 1
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 
 /obj/item/clothing/mask/surgical/attack_self(mob/user)

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -30,3 +30,4 @@
 	name = "Paper mask"
 	path = /obj/item/clothing/mask/paper
 	cost = 2
+	

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -20,3 +20,13 @@
 	path = /obj/item/clothing/mask/gas
 	cost = 2
 	restricted_roles = list("Chief Engineer", "Atmospheric Technician", "Station Engineer") //*shrug
+
+/datum/gear/mask/sterile
+	name = "Aesthetic sterile mask"
+	path = /obj/item/clothing/mask/surgical/aesthetic
+	cost = 2
+
+/datum/gear/mask/paper
+	name = "Paper mask"
+	path = /obj/item/clothing/mask/paper
+	cost = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

lets you halt the spread of The C Word Virus without having to rob medbay (the one in the loadout panel has none of the benefits or at least should not)
also the latter probably is gonna make aleks cream his pants

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it's fetish content : )

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: roundstart aesthetic sterile masks and roundstart paper masks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
