### PR TITLE
Gee kevin, why does atmos get /two/ air alarms?

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22024,13 +22024,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"bag" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "bah" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -53430,10 +53423,6 @@
 	dir = 4
 	},
 /obj/machinery/suit_storage_unit/atmos,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -99294,7 +99283,7 @@ aSZ
 aQc
 qaY
 acN
-bag
+aKR
 aJC
 aYV
 aYV
@@ -110841,7 +110830,7 @@ atS
 aaf
 aaf
 aaf
-atS
+asB
 aCR
 aEn
 aCR


### PR DESCRIPTION
## About The Pull Request

Removes two air alarms in the same room for the bar, and atmos.
Plus makes a wall in space apart of the station instead of nearspace. 

## Why It's Good For The Game

Consistency is good, plus, that was my bad and I should have fixed it already.

## Changelog
:cl:
del: Removes excess air alarms from boxstation
/:cl:
