### PR TITLE
Fixes KAs being broken by circuits

### DIFF
--- a/code/modules/integrated_electronics/subtypes/weaponized.dm
+++ b/code/modules/integrated_electronics/subtypes/weaponized.dm
@@ -137,6 +137,10 @@
 	//Shooting Code:
 	A.preparePixelProjectile(target, src)
 	A.fire()
+	if(ismob(loc.loc))
+		installed_gun.shoot_live_shot(loc.loc)
+	else
+		installed_gun.shoot_live_shot() //Shitcode, but we don't have much of a choice
 	log_attack("[assembly] [REF(assembly)] has fired [installed_gun].")
 	return A
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes ICs breaking KAs when firing them(they can't be recharged after that)

## Why It's Good For The Game

Well, getting your KA broken forever isn't cool

## Changelog
:cl:
fix: KAs are no longer getting broken when fired by a circuit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
