### PR TITLE
stops KAs going into circuits because why on earth would you ever allow this

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -19,6 +19,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
+	can_circuit = FALSE // why would you allow this
 
 	var/max_mod_capacity = 100
 	var/list/modkits = list()


### PR DESCRIPTION
## About The Pull Request
i want to delete circuits but i have nothing to replace it with and a big empty room would make me sad

it's a printable roundstart available high damage gun with no firing pin that can be upgraded to do 70-80 damage in high pressure environments and people want to be able to tape four together onto a circuit

yeah no that's not okay

also kevin's pr doesn't seem to stop you firing all four at once because of how circuit cooldowns work and i hate circuit shitcode

## Why It's Good For The Game
inspired by #14170 because if done you'll once again be able to tape together four KAs which is utterly stupid
not intended to close the other PR, it's a bugfix and i have nothing against fixing bugs (also making a pr for the sake of closing another pr is weird)

## Changelog
:cl:
balance: you cannot fit a KA into a gun circuit
/:cl: