### PR TITLE
sentient viruses can now infect synths and ipcs (fastest salt in the west)

### DIFF
--- a/code/modules/antagonists/disease/disease_disease.dm
+++ b/code/modules/antagonists/disease/disease_disease.dm
@@ -5,6 +5,7 @@
 	viable_mobtypes = list(/mob/living/carbon/human)
 	mutable = FALSE
 	var/mob/camera/disease/overmind
+	infectable_biotypes = MOB_ORGANIC|MOB_ROBOTIC
 
 /datum/disease/advance/sentient_disease/New()
 	..()


### PR DESCRIPTION
## About The Pull Request
total immunity to every disease in the game is enough but complete immunity to an antag is stupid

## Why It's Good For The Game
balance, stops sentient disease being useless when half the crew are synths

## Changelog
:cl:
balance: sentient viruses can now infect synths and ipcs
/:cl:
