### PR TITLE
Boxstation disposals update

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -13605,13 +13605,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 18
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aEB" = (
@@ -56987,6 +56984,17 @@
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/bar)
+"lqO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	sortType = 18
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "lre" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table/wood/poker,
@@ -57108,6 +57116,12 @@
 	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"lLf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/fore)
 "lMg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -58822,6 +58836,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"pMQ" = (
+/obj/structure/window/reinforced,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "pPi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60860,11 +60882,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/junction,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 26
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "uys" = (
@@ -84618,7 +84642,7 @@ ayD
 nez
 ngV
 xPY
-aOH
+pMQ
 hcb
 hcb
 syJ
@@ -84875,7 +84899,7 @@ ayE
 ayE
 ayE
 ayE
-ayE
+lLf
 ayE
 ayE
 ayE
@@ -85132,7 +85156,7 @@ ayH
 ayH
 ayH
 ayH
-ayH
+lqO
 ayH
 aFV
 ayH


### PR DESCRIPTION
## About The Pull Request

Adds in a (working!) disposal outlet for the theater, and, makes the dorms disposal actually work too.

## Why It's Good For The Game

Why was there the disposal sorting pipe for the theater when the theater moved, like a year ago. Aaaaaaah.

This is untested.

## Changelog
:cl:
add: Re-adds theater disposal outlet, and makes dorms disposal able to have things sent to it on boxstation.
/:cl: