### PR TITLE
Stops gear harness from getting deleted by 2 laser shots

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -169,12 +169,12 @@
 	icon_state = "gear_harness"
 	item_state = "gear_harness"
 	can_adjust = TRUE
-	body_parts_covered = CHEST|GROIN
+	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 
 /obj/item/clothing/under/misc/gear_harness/toggle_jumpsuit_adjust()
 	if(!body_parts_covered)
 		to_chat(usr, "<span class='notice'>Your gear harness is now covering your chest and groin.</span>")
-		body_parts_covered = CHEST|GROIN
+		body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	else
 		to_chat(usr, "<span class='notice'>Your gear harness is no longer covering anything.</span>")
 		body_parts_covered = NONE


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops gear harness from getting deleted from 2 lasers because the clothing damage code is absolute shitcode and I don't even want to go into detail how bad it is and why adding leg and arm coverage works
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes clothing item and fix man good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: stops gear harness from deleting by 2 laser shots
fix: fixes gear harness from deleting by getting sneezed on
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
