### PR TITLE
what atvs? - replaces the snowcabin ATVs with snowmobiles

### DIFF
--- a/_maps/RandomZLevels/away_mission/SnowCabin.dmm
+++ b/_maps/RandomZLevels/away_mission/SnowCabin.dmm
@@ -881,7 +881,7 @@
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "cT" = (
-/obj/vehicle/ridden/atv,
+/obj/vehicle/ridden/atv/snowmobile,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -893,7 +893,7 @@
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "cV" = (
-/obj/vehicle/ridden/atv,
+/obj/vehicle/ridden/atv/snowmobile,
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "cW" = (


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
we hate infinite sprint
## Changelog
:cl:
balance: The ATVs on SnowCabin.dmm have been replaced with snowmobiles.
/:cl:
