### PR TITLE
changes a migration error to use log_game instead of message_admins

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -271,7 +271,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			loadout_data["SAVE_[i]"] = list()
 		for(var/some_gear_item in saved_loadout_paths)
 			if(!ispath(text2path(some_gear_item)))
-				message_admins("Failed to copy item [some_gear_item] to new loadout system when migrating from version [current_version] to 40, issue: item is not a path")
+				log_game("Failed to copy item [some_gear_item] to new loadout system when migrating from version [current_version] to 40, issue: item is not a path")
 				continue
 			var/datum/gear/gear_item = text2path(some_gear_item)
 			if(!(initial(gear_item.loadout_flags) & LOADOUT_CAN_COLOR_POLYCHROMIC))


### PR DESCRIPTION
## About The Pull Request
the migration was never a problem and has had literally 0 errors so having it flood the chat for admins whenever an old user joins because their data is in such an old format it cant pass the newest migration is weird and unneeded

## Why It's Good For The Game
stops admin chat being flooded with a warning message about save migration whenever (very) old players join for the first time

## Changelog
:cl:
admin: migration error to version 39+ of savefiles is now logged instead of messaging all online admins in the chat
/:cl:
