### PR TITLE
Makes clockies yell less

### DIFF
--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
@@ -8,7 +8,7 @@
 	descname = "Powers Nearby Structures"
 	name = "Sigil of Transmission"
 	desc = "Places a sigil that can drain and will store energy to power clockwork structures."
-	invocations = list("Divinity...", "...power our creations!")
+	invocations = list("Divinity...", "...power our creations.")
 	channel_time = 70
 	power_cost = 200
 	whispered = TRUE
@@ -28,7 +28,7 @@
 	descname = "Powered Structure, Delay Emergency Shuttles"
 	name = "Prolonging Prism"
 	desc = "Creates a mechanized prism which will delay the arrival of an emergency shuttle by 2 minutes at a massive power cost."
-	invocations = list("May this prism...", "...grant us time to enact his will!")
+	invocations = list("May this prism...", "...grant us time to enact his will.")
 	channel_time = 80
 	power_cost = 300
 	object_path = /obj/structure/destructible/clockwork/powered/prolonging_prism
@@ -60,7 +60,7 @@
 	descname = "Powered Structure, Area Denial"
 	name = "Mania Motor"
 	desc = "Creates a mania motor which causes minor damage and a variety of negative mental effects in nearby non-Servant humans, potentially up to and including conversion."
-	invocations = list("May this transmitter...", "...break the will of all who oppose us!")
+	invocations = list("May this transmitter...", "...break the will of all who oppose us.")
 	channel_time = 80
 	power_cost = 750
 	object_path = /obj/structure/destructible/clockwork/powered/mania_motor
@@ -83,7 +83,7 @@
 	descname = "Powered Structure, Teleportation Hub"
 	name = "Clockwork Obelisk"
 	desc = "Creates a clockwork obelisk that can broadcast messages over the Hierophant Network or open a Spatial Gateway to any living Servant or clockwork obelisk."
-	invocations = list("May this obelisk...", "...take us to all places!")
+	invocations = list("May this obelisk...", "...take us to all places.")
 	channel_time = 80
 	power_cost = 300
 	object_path = /obj/structure/destructible/clockwork/powered/clockwork_obelisk
@@ -163,7 +163,7 @@
 	descname = "Well-Rounded Combat Construct"
 	name = "Clockwork Marauder"
 	desc = "Creates a shell for a clockwork marauder, a balanced frontline construct that can deflect projectiles with its shield."
-	invocations = list("Arise, avatar of Arbiter!", "Defend the Ark with vengeful zeal.")
+	invocations = list("Arise, avatar of Arbiter!", "Defend the Ark with vengeful zeal!")
 	channel_time = 80
 	power_cost = 8000
 	creator_message = "<span class='brass'>Your slab disgorges several chunks of replicant alloy that form into a suit of thrumming armor.</span>"

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -7,7 +7,7 @@
 	descname = "Generates Power From Starlight"
 	name = "Stargazer"
 	desc = "Forms a weak structure that generates power every second while within three tiles of starlight."
-	invocations = list("Capture their inferior light for us!")
+	invocations = list("Capture their inferior light for us.")
 	channel_time = 50
 	power_cost = 200
 	object_path = /obj/structure/destructible/clockwork/stargazer
@@ -16,6 +16,7 @@
 	usage_tip = "For obvious reasons, make sure to place this near a window or somewhere else that can see space!"
 	tier = SCRIPTURE_DRIVER
 	one_per_tile = TRUE
+	whispered = TRUE
 	primary_component = HIEROPHANT_ANSIBLE
 	sort_priority = 1
 	quickbind = TRUE
@@ -34,7 +35,7 @@
 	descname = "Power Generation"
 	name = "Integration Cog"
 	desc = "Fabricates an integration cog, which can be used on an open APC to replace its innards and passively siphon its power."
-	invocations = list("Take that which sustains them!")
+	invocations = list("Take that which sustains them.")
 	channel_time = 10
 	power_cost = 10
 	whispered = TRUE
@@ -55,7 +56,7 @@
 	descname = "Trap, Stunning"
 	name = "Sigil of Transgression"
 	desc = "Wards a tile with a sigil, which will briefly stun the next non-Servant to cross it and apply Belligerent to them."
-	invocations = list("Divinity, smite...", "...those who trespass here!")
+	invocations = list("Divinity, smite...", "...those who trespass here.")
 	channel_time = 50
 	power_cost = 50
 	whispered = TRUE
@@ -75,7 +76,7 @@
 	descname = "Trap, Conversion"
 	name = "Sigil of Submission"
 	desc = "Places a luminous sigil that will convert any non-Servants that remain on it for 8 seconds."
-	invocations = list("Divinity, enlighten...", "...those who trespass here!")
+	invocations = list("Divinity, enlighten...", "...those who trespass here.")
 	channel_time = 60
 	power_cost = 125
 	whispered = TRUE
@@ -95,7 +96,7 @@
 	descname = "Short-Range Single-Target Stun"
 	name = "Kindle"
 	desc = "Charges your slab with divine energy, allowing you to overwhelm a target with Ratvar's light."
-	invocations = list("Divinity, show them your light!")
+	invocations = list("Divinity, show them your light.")
 	whispered = TRUE
 	channel_time = 25 //2.5 seconds should be a okay compromise between being able to use it when needed, and not being able to just pause in combat for a second and hardstunning your enemy
 	power_cost = 125
@@ -118,7 +119,7 @@
 	descname = "Handcuffs"
 	name = "Hateful Manacles"
 	desc = "Forms replicant manacles around a target's wrists that function like handcuffs."
-	invocations = list("Shackle the heretic!", "Break them in body and spirit!")
+	invocations = list("Shackle the heretic!", "Break them in body and spirit.")
 	channel_time = 15
 	power_cost = 25
 	whispered = TRUE
@@ -269,7 +270,7 @@
 	descname = "New Clockwork Slab"
 	name = "Replicant"
 	desc = "Creates a new clockwork slab."
-	invocations = list("Metal, become greater!")
+	invocations = list("Metal, become greater.")
 	channel_time = 10
 	power_cost = 25
 	whispered = TRUE
@@ -290,7 +291,7 @@
 	descname = "Limited Xray Vision Glasses"
 	name = "Wraith Spectacles"
 	desc = "Fabricates a pair of glasses which grant true sight but cause gradual vision loss."
-	invocations = list("Show the truth of this world to me!")
+	invocations = list("Show the truth of this world to me.")
 	channel_time = 10
 	power_cost = 50
 	whispered = TRUE
@@ -310,7 +311,7 @@
 	name = "Spatial Gateway"
 	desc = "Tears open a miniaturized gateway in spacetime to any conscious servant that can transport objects or creatures to its destination. \
 	Each servant assisting in the invocation adds one additional use and four additional seconds to the gateway's uses and duration."
-	invocations = list("Spatial Gateway...", "...activate!")
+	invocations = list("Spatial Gateway...", "...activate.")
 	channel_time = 30
 	power_cost = 400
 	whispered = TRUE

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -29,7 +29,7 @@
 	descname = "Structure, Turret"
 	name = "Ocular Warden"
 	desc = "Forms an automatic short-range turret which will automatically attack nearby unrestrained non-Servants that can see it."
-	invocations = list("Guardians of Engine...", "...judge those who would harm us!")
+	invocations = list("Guardians of Engine...", "...judge those who would harm us.")
 	channel_time = 100
 	power_cost = 250
 	object_path = /obj/structure/destructible/clockwork/ocular_warden
@@ -105,7 +105,7 @@
 	descname = "Delayed Area Knockdown Glasses"
 	name = "Judicial Visor"
 	desc = "Creates a visor that can smite an area, applying Belligerent and briefly stunning. The smote area will explode after 3 seconds."
-	invocations = list("Grant me the flames of Engine!")
+	invocations = list("Grant me the flames of Engine.")
 	channel_time = 10
 	power_cost = 400
 	whispered = TRUE
@@ -124,7 +124,7 @@
 	descname = "Shield with empowerable bashes"
 	name = "Nezbere's shield"
 	desc = "Creates a shield which generates charge from blocking damage, using it to empower its bashes tremendously. It is repaired with brass, and while very durable, extremely weak to lasers and, even more so, to energy weaponry."
-	invocations = list("Shield me...", "... from the coming dark!")
+	invocations = list("Shield me...", "... from the coming dark.")
 	channel_time = 20
 	power_cost = 600 //Shouldn't be too spammable but not too hard to get either
 	whispered = TRUE
@@ -143,7 +143,7 @@
 	descname = "Summonable Armor and Weapons"
 	name = "Clockwork Armaments"
 	desc = "Allows the invoker to summon clockwork armor and a Ratvarian spear at will. The spear's attacks will generate Vitality, used for healing."
-	invocations = list("Grant me armaments...", "...from the forge of Armorer!")
+	invocations = list("Grant me armaments...", "...from the forge of Armorer.")
 	channel_time = 20
 	power_cost = 250
 	whispered = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ironically, alot of clockcult spells were highly obvious due to them yelling (! at the end of the invocation), which, can be heard over very big distances, and obviouly clockietalk is very very obvious.
This PR does a pass over their scriptures, removing the ! from alot of them that shouldn't be megaobvious if casted.
(Basically, all non-loud (reads: stuff thats not direct-combat or very-powerful) scripture got its ! cut)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hearing clockies do a stealthy thing from miles  away because of yellcode is pretty bad for them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Clock cultists now yell alot less when invoking scripture.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
