### PR TITLE
[hello if someone could fight the maintainers to take a look that'd be great] fixes durathread armor kits

### DIFF
--- a/code/game/objects/items/armor_kits.dm
+++ b/code/game/objects/items/armor_kits.dm
@@ -10,35 +10,38 @@
 /obj/item/armorkit/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	// yeah have fun making subtypes and modifying the afterattack if you want to make variants
 	// idiot
-	// - hatter
 	var/used = FALSE
 
 	if(isobj(target) && istype(target, /obj/item/clothing/under))
 		var/obj/item/clothing/under/C = target
-		if(C.armor.melee < 10)
-			C.armor.melee = 10
+		if(C.damaged_clothes)
+			to_chat(user,"<span class='warning'>You should repair the damage done to [C] first.</span>")
+			return
+		if(C.armor.getRating("melee") < 10)
+			C.armor = C.armor.setRating("melee" = 10)
 			used = TRUE
-		if(C.armor.laser < 10)
-			C.armor.laser = 10
+		if(C.armor.getRating("laser") < 10)
+			C.armor = C.armor.setRating("laser" = 10)
 			used = TRUE
-		if(C.armor.fire < 40)
-			C.armor.fire = 40
+		if(C.armor.getRating("fire") < 40)
+			C.armor = C.armor.setRating("fire" = 40)
 			used = TRUE
-		if(C.armor.acid < 10)
-			C.armor.acid = 10
+		if(C.armor.getRating("acid") < 10)
+			C.armor = C.armor.setRating("acid" = 10)
 			used = TRUE
-		if(C.armor.bomb < 5)
-			C.armor.bomb = 5
+		if(C.armor.getRating("bomb") < 5)
+			C.armor = C.armor.setRating("bomb" = 5)
 			used = TRUE
 
 		if(used)
-			user.visible_message("<span class = 'notice'>[user] uses [src] on [C], reinforcing it and tossing the empty case away afterwards.</span>", \
-			"<span class = 'notice'>You reinforce [C] with [src], making it a little more protective! You toss the empty casing away afterwards.</span>")
-			C.name = "durathread [C.name]" // this disappears if it gets repaired, which is annoying
+			user.visible_message("<span class = 'notice'>[user] reinforces [C] with [src].</span>", \
+			"<span class = 'notice'>You reinforce [C] with [src], making it as protective as a durathread jumpsuit.</span>")
+			C.name = "durathread [C.name]"
+			C.upgrade_prefix = "durathread" // god i hope this works
 			qdel(src)
 			return
 		else
-			to_chat(user, "<span class = 'notice'>You stare at [src] and [C], coming to the conclusion that you probably don't need to reinforce it any further.")
+			to_chat(user, "<span class = 'notice'>You don't need to reinforce [C] any further.")
 			return
 	else
 		return

--- a/code/game/objects/items/armor_kits.dm
+++ b/code/game/objects/items/armor_kits.dm
@@ -17,6 +17,9 @@
 		if(C.damaged_clothes)
 			to_chat(user,"<span class='warning'>You should repair the damage done to [C] first.</span>")
 			return
+		if(C.attached_accessory)
+			to_chat(user,"<span class='warning'>Kind of hard to sew around [C.attached_accessory].</span>")
+			return
 		if(C.armor.getRating("melee") < 10)
 			C.armor = C.armor.setRating("melee" = 10)
 			used = TRUE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -31,6 +31,9 @@
 	// What items can be consumed to repair this clothing (must by an /obj/item/stack)
 	var/repairable_by = /obj/item/stack/sheet/cloth
 
+	// has this item been upgraded by an upgrade kit (see: durathread armor kits)
+	var/upgrade_prefix
+
 	//Var modification - PLEASE be careful with this I know who you are and where you live
 	var/list/user_vars_to_edit //VARNAME = VARVALUE eg: "name" = "butts"
 	var/list/user_vars_remembered //Auto built by the above + dropped() + equipped()
@@ -120,6 +123,8 @@
 	update_clothes_damaged_state(CLOTHING_PRISTINE)
 	obj_integrity = max_integrity
 	name = initial(name) // remove "tattered" or "shredded" if there's a prefix
+	if(upgrade_prefix)
+		name = upgrade_prefix + " " + initial(name)
 	body_parts_covered = initial(body_parts_covered)
 	slot_flags = initial(slot_flags)
 	damage_by_parts = null

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -32,6 +32,9 @@
 
 /obj/item/clothing/under/attackby(obj/item/I, mob/user, params)
 	if((has_sensor == BROKEN_SENSORS) && istype(I, /obj/item/stack/cable_coil))
+		if(damaged_clothes)
+			to_chat(user,"<span class='warning'>You should repair the damage done to [src] first.</span>")
+			return 0
 		var/obj/item/stack/cable_coil/C = I
 		I.use_tool(src, user, 0, 1)
 		has_sensor = HAS_SENSORS


### PR DESCRIPTION
## About The Pull Request
turns spaghetti into Worse, But Less Buggy Spaghetti
### ay but really though:
durathread armor kits:
- requires your jumpsuit to be repaired
- doesn't fucking upgrade every jumpsuit, ever, though, which is a plus
- also now the durathread prefix on your jumpsuit stays when you repair your uniform

repairing sensors on jumpsuits:
- requires a repaired jumpsuit
## Why It's Good For The Game
i hate durathread
## Changelog
:cl:
tweak: Repairing sensors on jumpsuits now requires a fully-intact jumpsuit. Find some cloth.
tweak: Durathread armor kits now require you to have a fully-repaired jumpsuit, first, with no attachments.
fix: Durathread armor kits now no longer weave the entirety of the jumpsuit armor universe into having armor.
/:cl: