### PR TITLE
Fixes & Improves some antagpanel stuff

### DIFF
--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -15,13 +15,16 @@
 	var/ignore_holy_water = FALSE
 
 /datum/antagonist/clockcult/silent
+	name = "Silent Clock Cultist"
 	silent = TRUE
 	show_in_antagpanel = FALSE //internal
 
 /datum/antagonist/clockcult/neutered
+	name = "Neutered Clock Cultist"
 	neutered = TRUE
 
 /datum/antagonist/clockcult/neutered/traitor
+	name = "Traitor Clock Cultist"
 	ignore_eligibility_check = TRUE
 	ignore_holy_water = TRUE
 	show_in_roundend = FALSE

--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -188,7 +188,7 @@
 
 
 /datum/antagonist/clockcult/admin_add(datum/mind/new_owner,mob/admin)
-	add_servant_of_ratvar(new_owner.current, TRUE)
+	add_servant_of_ratvar(new_owner.current, TRUE, override_type = type)
 	message_admins("[key_name_admin(admin)] has made [new_owner.current] into a servant of Ratvar.")
 	log_admin("[key_name(admin)] has made [new_owner.current] into a servant of Ratvar.")
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -19,9 +19,11 @@
 	var/ignore_holy_water = FALSE
 
 /datum/antagonist/cult/neutered
+	name = "Neutered Cultist"
 	neutered = TRUE
 
 /datum/antagonist/cult/neutered/traitor
+	name = "Traitor Cultist"
 	ignore_eligibility_checks = TRUE
 	ignore_holy_water = TRUE
 	show_in_roundend = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cultist and Clock cultist subtypes were close to indistinguishable in the antag panel, besides that the clockcult version was not working at all (it made them a ../silent one always, regardless of selection)
This resolves bothof those problems.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it better to work with.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: The antag panel now correctly shows the names of cultist / clockcult datum subtypes.
fix: Adding clock cultists via the admin panel now works correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
