### PR TITLE
About unarmed parrying..

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -220,8 +220,8 @@
 	parry_max_attacks = INFINITY
 	parry_failed_cooldown_duration = 2.25 SECONDS
 	parry_failed_stagger_duration = 2.25 SECONDS
-	parry_cooldown = 0
-	parry_failed_clickcd_duration = 0
+	parry_cooldown = 3 SECONDS
+	parry_failed_clickcd_duration = 0.5 SECONDS
 
 /obj/item/clothing/gloves/botanic_leather
 	name = "botanist's leather gloves"

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -95,9 +95,10 @@
 	parry_efficiency_considered_successful = 0.01
 	parry_efficiency_to_counterattack = 0.01
 	parry_max_attacks = 3
-	parry_cooldown = 30
-	parry_failed_stagger_duration = 0
-	parry_failed_clickcd_duration = 0.4
+	parry_cooldown = 3 SECONDS
+	parry_failed_cooldown_duration = 1.5 SECONDS
+	parry_failed_stagger_duration = 1 SECONDS
+	parry_failed_clickcd_duration = 0.4 SECONDS
 
 	parry_data = list(			// yeah it's snowflake
 		"UNARMED_PARRY_STAGGER" = 3 SECONDS,
@@ -135,16 +136,16 @@
 	parry_imperfect_falloff_percent = 20
 	parry_efficiency_perfect = 100
 	parry_efficiency_perfect_override = list(
-		ATTACK_TYPE_PROJECTILE_TEXT = 60,
+		TEXT_ATTACK_TYPE_PROJECTILE = 60,
 	)
 
 	parry_efficiency_considered_successful = 0.01
 	parry_efficiency_to_counterattack = 0.01
 	parry_max_attacks = INFINITY
-	parry_failed_cooldown_duration =  1.5 SECONDS
-	parry_failed_stagger_duration = 0
-	parry_cooldown = 0
-	parry_failed_clickcd_duration = 0.8
+	parry_failed_cooldown_duration =  3 SECONDS
+	parry_failed_stagger_duration = 2 SECONDS
+	parry_cooldown = 3 SECONDS
+	parry_failed_clickcd_duration = 0.8 SECONDS
 
 	parry_data = list(			// yeah it's snowflake
 		"UNARMED_PARRY_STAGGER" = 3 SECONDS,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Yeah this is getting out of hand.
If a lot of people keep making parry armwraps roundstart, and those actually gave them an absurdly good fighting chance in combat, even against antagonists with gear as I have witnessed, it's time to look at those values.
Silicons may be working on a PR to rebalance parrying & combat, but until then, it shouldn't stay in its current state either.

Pugilist and normal unarmed parries now have a cooldown even on success, and stagger slightly when failed. Plus some more changes, as you can see in the files themselves.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unarmed parries, especially pugilist ones, are WAY too strong right now. This kneecaps them somewhat, hopefully making them not as powerful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Kneecapped pugilist parries somewhat.
balance: Slightly nerfed default unarmed parries.
balance: Slightly nerfed traitor armwrap parries.
fix: Pugilist parries now cannot perfectly defend against projectiles, as they were supposed to.
fix: Some parrying numbers that one would think were in seconds didn't have the SECONDS. I added those.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
