### PR TITLE
Removes prevent from leaving alive, maroon objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -256,6 +256,7 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 	else
 		explanation_text = "Free Objective"
 
+/*
 /datum/objective/maroon
 	name = "maroon"
 	var/target_role_type=0
@@ -281,6 +282,7 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 
 /datum/objective/maroon/admin_edit(mob/admin)
 	admin_simple_target_pick(admin)
+*/
 
 /datum/objective/debrain
 	name = "debrain"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -256,7 +256,6 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 	else
 		explanation_text = "Free Objective"
 
-/*
 /datum/objective/maroon
 	name = "maroon"
 	var/target_role_type=0
@@ -282,7 +281,6 @@ If not set, defaults to check_completion instead. Set it. It's used by cryo.
 
 /datum/objective/maroon/admin_edit(mob/admin)
 	admin_simple_target_pick(admin)
-*/
 
 /datum/objective/debrain
 	name = "debrain"

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -149,8 +149,6 @@
 	if(prob(50))
 		if(LAZYLEN(active_ais()) && prob(100/GLOB.joined_player_list.len))
 			add_objective(new/datum/objective/destroy, TRUE)
-		else if(prob(30))
-			add_objective(new/datum/objective/maroon, TRUE)
 		else
 			add_objective(new/datum/objective/assassinate, TRUE)
 	else

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -442,19 +442,19 @@
 				kill_objective.find_target()
 			objectives += kill_objective
 			
-		else
+		/*else
 			var/datum/objective/maroon/maroon_objective = new
 			maroon_objective.owner = owner
 			if(team_mode)
 				maroon_objective.find_target_by_role(role = ROLE_CHANGELING, role_type = 1, invert = 1)
 			else
 				maroon_objective.find_target()
-			objectives += maroon_objective
+			objectives += maroon_objective*/
 
 			if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
 				var/datum/objective/escape/escape_with_identity/identity_theft = new
 				identity_theft.owner = owner
-				identity_theft.target = maroon_objective.target
+				identity_theft.target = kill_objective.target
 				identity_theft.update_explanation_text()
 				objectives += identity_theft
 				escape_objective_possible = FALSE

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -441,6 +441,15 @@
 			else
 				kill_objective.find_target()
 			objectives += kill_objective
+			
+		else
+			var/datum/objective/maroon/maroon_objective = new
+			maroon_objective.owner = owner
+			if(team_mode)
+				maroon_objective.find_target_by_role(role = ROLE_CHANGELING, role_type = 1, invert = 1)
+			else
+				maroon_objective.find_target()
+			objectives += maroon_objective
 
 			if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
 				var/datum/objective/escape/escape_with_identity/identity_theft = new

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -441,14 +441,6 @@
 			else
 				kill_objective.find_target()
 			objectives += kill_objective
-		else
-			var/datum/objective/maroon/maroon_objective = new
-			maroon_objective.owner = owner
-			if(team_mode)
-				maroon_objective.find_target_by_role(role = ROLE_CHANGELING, role_type = 1, invert = 1)
-			else
-				maroon_objective.find_target()
-			objectives += maroon_objective
 
 			if (!(locate(/datum/objective/escape) in objectives) && escape_objective_possible)
 				var/datum/objective/escape/escape_with_identity/identity_theft = new

--- a/code/modules/antagonists/traitor/classes/assassin.dm
+++ b/code/modules/antagonists/traitor/classes/assassin.dm
@@ -8,7 +8,6 @@
 /datum/traitor_class/human/assassin/forge_single_objective(datum/antagonist/traitor/T)
 	.=1
 	var/permakill_prob = 20
-	var/is_dynamic = FALSE
 	var/datum/game_mode/dynamic/mode
 	if(istype(SSticker.mode,/datum/game_mode/dynamic))
 		mode = SSticker.mode

--- a/code/modules/antagonists/traitor/classes/assassin.dm
+++ b/code/modules/antagonists/traitor/classes/assassin.dm
@@ -12,7 +12,6 @@
 	var/datum/game_mode/dynamic/mode
 	if(istype(SSticker.mode,/datum/game_mode/dynamic))
 		mode = SSticker.mode
-		is_dynamic = TRUE
 		permakill_prob = max(0,mode.threat_level-50)
 	var/list/active_ais = active_ais()
 	if(active_ais.len && prob(100/GLOB.joined_player_list.len))

--- a/code/modules/antagonists/traitor/classes/assassin.dm
+++ b/code/modules/antagonists/traitor/classes/assassin.dm
@@ -20,11 +20,6 @@
 		destroy_objective.owner = T.owner
 		destroy_objective.find_target()
 		T.add_objective(destroy_objective)
-	else if(prob(30) || (is_dynamic && (mode.storyteller.flags & NO_ASSASSIN)))
-		var/datum/objective/maroon/maroon_objective = new
-		maroon_objective.owner = T.owner
-		maroon_objective.find_target()
-		T.add_objective(maroon_objective)
 	else if(prob(permakill_prob))
 		var/datum/objective/assassinate/kill_objective = new
 		kill_objective.owner = T.owner

--- a/code/modules/antagonists/traitor/classes/human.dm
+++ b/code/modules/antagonists/traitor/classes/human.dm
@@ -41,11 +41,6 @@
 			destroy_objective.owner = T.owner
 			destroy_objective.find_target()
 			T.add_objective(destroy_objective)
-		else if(prob(30) || (is_dynamic && (mode.storyteller.flags & NO_ASSASSIN)))
-			var/datum/objective/maroon/maroon_objective = new
-			maroon_objective.owner = T.owner
-			maroon_objective.find_target()
-			T.add_objective(maroon_objective)
 		else if(prob(max(0,assassin_prob-20)))
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = T.owner

--- a/code/modules/antagonists/traitor/classes/subterfuge.dm
+++ b/code/modules/antagonists/traitor/classes/subterfuge.dm
@@ -17,11 +17,6 @@
 			kill_objective.owner = T.owner
 			kill_objective.find_target()
 			T.add_objective(kill_objective)
-		else
-			var/datum/objective/maroon/maroon_objective = new
-			maroon_objective.owner = T.owner
-			maroon_objective.find_target()
-			T.add_objective(maroon_objective)
 	else
 		var/list/weights = list()
 		weights["sabo"] = length(subtypesof(/datum/sabotage_objective))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What it says on the tin
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I literally only see either permakill/lockerstuffing or round end shuttle aggrograb yeet or objective begging "oh please don't go on the shuttle". Terrible, awful objective that only promotes lame and toxic gameplay and goes against our whole do not game end do not objective rush policy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed maroon objective due to toxic gameplay behaviour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
