### PR TITLE
well that's what i get for trusting my own code - makes golem GPSes start off, but actually this time

### DIFF
--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -26,15 +26,16 @@ GLOBAL_LIST_EMPTY(GPS_list)
 	if(. == COMPONENT_INCOMPATIBLE || !isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 	var/atom/A = parent
-	A.add_overlay("working")
+	if(starton)
+		A.add_overlay("working")
+	else
+		tracking = FALSE
 	A.name = "[initial(A.name)] ([gpstag])"
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, .proc/interact)
 	if(!emp_proof)
 		RegisterSignal(parent, COMSIG_ATOM_EMP_ACT, .proc/on_emp_act)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/on_AltClick)
-	if(!starton)
-		tracking = FALSE
 
 ///Called on COMSIG_ITEM_ATTACK_SELF
 /datum/component/gps/item/proc/interact(datum/source, mob/user)

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -8,11 +8,12 @@
 	slot_flags = ITEM_SLOT_BELT
 	obj_flags = UNIQUE_RENAME
 	var/gpstag = "COM0"
+	var/emp_proof = FALSE
 	var/starton = TRUE
 
 /obj/item/gps/Initialize()
 	. = ..()
-	AddComponent(/datum/component/gps/item, gpstag, starton)
+	AddComponent(/datum/component/gps/item, gpstag, emp_proof, starton)
 
 /obj/item/gps/science
 	icon_state = "gps-s"


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
actually works, like it was supposed to. original pr was merged not too long back
## Changelog
:cl:
fix: Free Golem Ship GPSes now start as disabled. Like they were supposed to.
/:cl:
