### PR TITLE
Set buzz fuzz's addiction threshold to fit the comment

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -616,7 +616,7 @@
 	name = "Buzz Fuzz"
 	description = "~A Hive of Flavour!~ NOTICE: Addicting."
 	nutriment_factor = 0
-	addiction_threshold = 26 //A can and a sip
+	addiction_threshold = 31 //A can and a sip
 	color = "#8CFF00" // rgb: 135, 255, 0
 	taste_description = "carbonated honey and pollen"
 	glass_icon_state = "buzz_fuzz"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

addiction threshold is 26 for "a can and a sip" but cans have 30 units, not 25. before anyone says something smartass, this should really have been caught by *maintainers*.

## Why It's Good For The Game

wee i drank a can from the vendor and now i have a spammy addiction

## Changelog
:cl:
fix: Buzz Fuzz's addiction threshold is now a can and a sip as intended.
/:cl: