### PR TITLE
Hyperblade restored to uplink

### DIFF
--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -439,7 +439,9 @@
 	force_on = 15 //As strong a survival knife/bone dagger
 
 /obj/item/melee/transforming/energy/sword/cx/attackby(obj/item/W, mob/living/user, params)
-	if(istype(W, /obj/item/melee/transforming/energy/sword/cx))
+	if(istype(W, /obj/item/melee/transforming/energy/sword/cx/traitor))
+		return
+	else if(istype(W, /obj/item/melee/transforming/energy/sword/cx))
 		if(HAS_TRAIT(W, TRAIT_NODROP) || HAS_TRAIT(src, TRAIT_NODROP))
 			to_chat(user, "<span class='warning'>\the [HAS_TRAIT(src, TRAIT_NODROP) ? src : W] is stuck to your hand, you can't attach it to \the [HAS_TRAIT(src, TRAIT_NODROP) ? W : src]!</span>")
 			return

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -138,15 +138,6 @@
 	cost = 8
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
 
-/datum/uplink_item/dangerous/dtooth
-	name = "Dragon's Tooth Sword"
-	desc = "The Dragon's Tooth sword is a blackmarket modification of a Non-Eutactic Blade, \
-			which utilizes a hardlight blade that is dynamically 'forged' on demand to create a deadly sharp edge that is unbreakable. \
-			It appears to have a wooden grip and a shaved down guard."
-	item = /obj/item/melee/transforming/energy/sword/cx/traitor
-	cost = 8
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
-
 /datum/uplink_item/dangerous/shield
 	name = "Energy Shield"
 	desc = "An incredibly useful personal shield projector, capable of reflecting energy projectiles and defending \

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -118,11 +118,32 @@
 /datum/uplink_item/dangerous/doublesword/get_discount()
 	return pick(4;0.8,2;0.65,1;0.5)
 
+/datum/uplink_item/dangerous/hyperblade
+	name = "Hypereutactic Blade"
+	desc = "The result of two Dragon Tooth swords combining, you wouldn't want to see this coming at you down the hall! \
+			Requires two hands to wield and it slows you down.  You can also recolor it!"
+	item = /obj/item/dualsaber/hypereutactic
+	player_minimum = 25
+	cost = 16
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
+
+/datum/uplink_item/dangerous/hyperblade/get_discount()
+	return pick(4;0.8,2;0.65,1;0.5)
+
 /datum/uplink_item/dangerous/sword
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be \
 			pocketed when inactive. Activating it produces a loud, distinctive noise."
 	item = /obj/item/melee/transforming/energy/sword/saber
+	cost = 8
+	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
+
+/datum/uplink_item/dangerous/dtooth
+	name = "Dragon's Tooth Sword"
+	desc = "The Dragon's Tooth sword is a blackmarket modification of a Non-Eutactic Blade, \
+			which utilizes a hardlight blade that is dynamically 'forged' on demand to create a deadly sharp edge that is unbreakable. \
+			It appears to have a wooden grip and a shaved down guard."
+	item = /obj/item/melee/transforming/energy/sword/cx/traitor
 	cost = 8
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Re adding the Hyperblade to the uplink.  Hyperblade is also poplocked like dsword. It has a fundamentally different playstyle compared to the dsword, so it doesn't need a choice beacon.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Hyperblade is a nice extra addition to change up staleness.

Also a literal Dee moment.

## Changelog
:cl:
add: Hyperblade to uplink with poplock
balance: Removes combination of two Dragon Tooth Swords while keeping it for regular eutactics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
