### PR TITLE
Messages admins of certain holodeck actions

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -115,13 +115,20 @@
 				return FALSE
 			var/valid = FALSE
 			var/list/checked = program_cache.Copy()
-			if(obj_flags & EMAGGED)
-				checked |= emag_programs
 			for(var/prog in checked)
 				var/list/P = prog
 				if(P["type"] == program_to_load)
 					valid = TRUE
 					break
+			if(obj_flags & EMAGGED) //split up into separate for loops instead of together so we can adminlog it
+				checked = emag_programs.Copy()
+				for(var/prog in checked)
+					var/list/P = prog
+					if(P["type"] == program_to_load)
+						valid = TRUE
+						log_game("[key_name(usr)] has loaded the restricted holodeck program [program_to_load]")
+						message_admins("[ADMIN_LOOKUPFLW(usr)] has loaded the restricted holodeck program [program_to_load]")
+						break
 			if(!valid)
 				return FALSE
 
@@ -134,6 +141,14 @@
 			nerf(obj_flags & EMAGGED)
 			obj_flags ^= EMAGGED
 			say("Safeties restored. Restarting...")
+			if(obj_flags & EMAGGED)
+				to_chat(usr,"<span class='warning'>You vastly increase projector power and override the safety and security protocols.</span>")
+				log_game("[key_name(usr)] has disabled safeties on the holodeck computer")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] has disabled safeties on the holodeck computer")
+			else
+				to_chat(usr,"<span class='notice'>You restore the safeties to the holodeck.</span>")
+				log_game("[key_name(usr)] has reenabled safeties on the holodeck computer")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] has reenabled safeties on the holodeck computer")
 
 /obj/machinery/computer/holodeck/process()
 	if(damaged && prob(10))
@@ -179,6 +194,7 @@
 	to_chat(user, "<span class='warning'>You vastly increase projector power and override the safety and security protocols.</span>")
 	say("Warning. Automatic shutoff and derezzing protocols have been corrupted. Please call Nanotrasen maintenance and do not use the simulator.")
 	log_game("[key_name(user)] emagged the Holodeck Control Console")
+	message_admins("[ADMIN_LOOKUPFLW(user)] emagged the Holodeck Control Console.")
 	nerf(!(obj_flags & EMAGGED))
 
 /obj/machinery/computer/holodeck/emp_act(severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This sets it up so the admins are notified when someone is disabling safeties and/or loading restricted holodeck programs.

## Why It's Good For The Game

ADMIN: Admin Adminson/(Adam Administ) (FLW): why is the AI loading the plasma fire program as a non-antag?

## Changelog
:cl:
admin: Admins now receive messages regarding certain holodeck actions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
