### PR TITLE
fixes the 'undeleted query' message at the start of every shift

### DIFF
--- a/modular_citadel/code/modules/mentor/mentor.dm
+++ b/modular_citadel/code/modules/mentor/mentor.dm
@@ -80,10 +80,12 @@ GLOBAL_PROTECT(mentor_href_token)
 			return
 		var/datum/DBQuery/query_load_mentors = SSdbcore.NewQuery("SELECT ckey FROM [format_table_name("mentor")]")
 		if(!query_load_mentors.Execute())
+			qdel(query_load_mentors)
 			return
 		while(query_load_mentors.NextRow())
 			var/ckey = ckey(query_load_mentors.item[1])
 			new /datum/mentors(ckey)
+		qdel(query_load_mentors)
 
 // new client var: mentor_datum. Acts the same way holder does towards admin: it holds the mentor datum. if set, the guy's a mentor.
 /client


### PR DESCRIPTION
## About The Pull Request
the query for checking mentors now gets properly deleted

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: the query for checking mentors now gets properly deleted
/:cl:
