### PR TITLE
stops people using Message All on PDAs when their cartridge doesn't allow it

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -665,7 +665,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 				create_message(U, locate(href_list["target"]))
 
 			if("MessageAll")
-				send_to_all(U)
+				if(cartridge && cartridge.spam_enabled)
+					send_to_all(U)
 
 			if("toggle_block")
 				toggle_blocking(usr, href_list["target"])

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -665,7 +665,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				create_message(U, locate(href_list["target"]))
 
 			if("MessageAll")
-				if(cartridge && cartridge.spam_enabled)
+				if(cartridge?.spam_enabled)
 					send_to_all(U)
 
 			if("toggle_block")


### PR DESCRIPTION
## About The Pull Request
stops people using Message All on PDAs when their cartridge doesn't allow it

## Why It's Good For The Game
stops people using Message All on PDAs when their cartridge doesn't allow it

## Changelog
:cl:
fix: stops people using Message All on PDAs when their cartridge doesn't allow it
/:cl: