### PR TITLE
Replaces carbon xeno drone with a simplemob sentinal in the beno cube

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -432,7 +432,7 @@
 	dried_being = /mob/living/carbon/monkey
 
 /obj/item/reagent_containers/food/snacks/cube/beno
-	name = "alien drone cube"
+	name = "alien sentinel cube"
 	desc = "Just add water and run!"
 	tastes = list("the jungle" = 1, "acid" = 1)
 	dried_being = /mob/living/simple_animal/hostile/alien/sentinel

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -63,7 +63,7 @@
 	filling_color = "#ee7676"
 	tastes = list("fish" = 1, "pan seared vegtables" = 1)
 	foodtype = MEAT | VEGETABLES | FRIED
-	
+
 /obj/item/reagent_containers/food/snacks/sushi_basic
 	name = "funa hosomaki"
 	desc = "A small cylindrical kudzu skin, filled with rice and fish."
@@ -435,7 +435,7 @@
 	name = "alien drone cube"
 	desc = "Just add water and run!"
 	tastes = list("the jungle" = 1, "acid" = 1)
-	dried_being = /mob/living/carbon/alien/humanoid/drone
+	dried_being = /mob/living/simple_animal/hostile/alien/sentinel
 
 /obj/item/reagent_containers/food/snacks/cube/goat
 	name = "goat cube"


### PR DESCRIPTION
## About The Pull Request

Replaces carbon xeno drone with a simplemob sentinal in the beno cube

## Why It's Good For The Game

It's clearly not the intended design of the cube, spawning in a brainless carbon mob, based on the "run!" part of the description. Plus, a drone can easily turn into a queen, which isn't ideal for something that's only accessible through silver slimes.

## Changelog
:cl:
tweak: Xeno cube now makes an aggressive sentinal instead of a brainless drone
/:cl:
