### PR TITLE
alternatively, replaces the cube sentinel spawn with an actual simplemob sentinel that drops a carbon sentinel body on death so you still get to run this to the ground without being able to be a literal alien queen 

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -435,7 +435,7 @@
 	name = "alien drone cube"
 	desc = "Just add water and run!"
 	tastes = list("the jungle" = 1, "acid" = 1)
-	dried_being = /mob/living/carbon/alien/humanoid/drone
+	dried_being = /mob/living/simple_animal/hostile/alien/sentinel/cube
 
 /obj/item/reagent_containers/food/snacks/cube/goat
 	name = "goat cube"

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -81,7 +81,7 @@
 /mob/living/simple_animal/hostile/alien/sentinel/cube
 	gold_core_spawnable = NO_SPAWN
 	health = 220
-	maxhealth = 220
+	maxHealth = 220
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -78,6 +78,15 @@
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 
+/mob/living/simple_animal/hostile/alien/sentinel/cube
+	gold_core_spawnable = NO_SPAWN
+	health = 220
+	maxhealth = 220
+	melee_damage_lower = 20
+	melee_damage_upper = 20
+	del_on_death = TRUE
+	loot = list(/obj/effect/mob_spawn/alien/corpse/humanoid/sentinel)
+	
 
 /mob/living/simple_animal/hostile/alien/queen
 	name = "alien queen"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

preserves some of the old functionality while making the cube not entirely harmless
xenobio is the only place that can get this with RNG and they have a billion ways to end a round. 
far as i'm concerned this is the right amount of anti-fun (see: no more free drones to brain transplant with the capacity of being a queen) without completely gutting the item.

closes #14266 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: xeno cube makes hostile xenos now, and drops a sentinel instead of a drone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
