### PR TITLE
adds a neutral quirk 'food critic' which lets you see food quality on examine

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -218,6 +218,8 @@
 #define TRAIT_LIVING_NO_DENSITY			"living_no_density"
 /// forces us to not render our overlays
 #define TRAIT_HUMAN_NO_RENDER			"human_no_render"
+/// allows you to see food quality by examining
+#define TRAIT_FOOD_CRITIC		"food_critic"
 
 // mobility flag traits
 // IN THE FUTURE, IT WOULD BE NICE TO DO SOMETHING SIMILAR TO https://github.com/tgstation/tgstation/pull/48923/files (ofcourse not nearly the same because I have my.. thoughts on it)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -138,3 +138,10 @@
 /datum/quirk/longtimer/on_spawn()
 	var/mob/living/carbon/C = quirk_holder
 	C.generate_fake_scars(rand(min_scars, max_scars))
+
+/datum/quirk/food_critic
+	name = "Food Critic"
+	desc = "You have spent such a long time around food that you are able to judge it with just a single glance."
+	value = 0
+	mob_trait = TRAIT_FOOD_CRITIC
+	medical_record_text = "Patient has refined senses, allowing them to know the quality of food with just a glance.."

--- a/code/modules/food_and_drinks/food.dm
+++ b/code/modules/food_and_drinks/food.dm
@@ -50,3 +50,8 @@
 			if((foodtype & BREAKFAST) && world.time - SSticker.round_start_time < STOP_SERVING_BREAKFAST)
 				SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "breakfast", /datum/mood_event/breakfast)
 			last_check_time = world.time
+
+/obj/item/reagent_containers/food/examine(mob/user)
+	. = ..()
+	if(HAS_TRAIT(user, TRAIT_FOOD_CRITIC))
+		. += list("The quality of the food is [food_quality].")


### PR DESCRIPTION
## About The Pull Request
for anyone who isn't aware food has quality which scales off things like machine upgrades, family knife, cutting your meat in the kitchen (or using an upgraded gibber), high potency ingredients, etc

it's just some nice flavour stuff to be able to see the exact quality i guess.

(and yes, this is tested.)

## Why It's Good For The Game

## Changelog
:cl:
add: adds a neutral quirk 'food critic' which lets you see food quality on examine
/:cl:
