### PR TITLE
prioritises mobs with clients in the banning panel

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -257,9 +257,8 @@
 
 		for(var/mob/M in GLOB.player_list)
 			if(M.ckey == banckey)
-				playermob = M
-				break
-
+				if(!playermob || M.client) // prioritise mobs with a client to stop the 'oops the dead body with no client got forwarded'
+					playermob = M
 
 		banreason = "(MANUAL BAN) "+banreason
 


### PR DESCRIPTION
## About The Pull Request
don't just pick the first mob with the right ckey you see please
this leads to the banning panel sometimes forwarding a mob with no client, meaning it doesn't kick the player when it should

## Why It's Good For The Game
fix

## Changelog
:cl:
fix: banning panel prioritises mobs with clients now when trying to find them if they're in the game
/:cl:

