### PR TITLE
parrying nerf/pugilism buff

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -220,8 +220,8 @@
 	parry_max_attacks = INFINITY
 	parry_failed_cooldown_duration = 2.25 SECONDS
 	parry_failed_stagger_duration = 2.25 SECONDS
-	parry_cooldown = 3 SECONDS
-	parry_failed_clickcd_duration = 0.5 SECONDS
+	parry_cooldown = 0
+	parry_failed_clickcd_duration = 0
 
 /obj/item/clothing/gloves/botanic_leather
 	name = "botanist's leather gloves"

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -143,7 +143,7 @@
 	parry_efficiency_to_counterattack = 0.01
 	parry_max_attacks = INFINITY
 	parry_failed_cooldown_duration =  1.5 SECONDS
-	parry_failed_stagger_duration = 2
+	parry_failed_stagger_duration = 1 SECONDS
 	parry_cooldown = 0
 	parry_failed_clickcd_duration = 0.8
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -142,10 +142,10 @@
 	parry_efficiency_considered_successful = 0.01
 	parry_efficiency_to_counterattack = 0.01
 	parry_max_attacks = INFINITY
-	parry_failed_cooldown_duration =  3 SECONDS
-	parry_failed_stagger_duration = 2 SECONDS
-	parry_cooldown = 3 SECONDS
-	parry_failed_clickcd_duration = 0.8 SECONDS
+	parry_failed_cooldown_duration =  1.5 SECONDS
+	parry_failed_stagger_duration = 2
+	parry_cooldown = 0
+	parry_failed_clickcd_duration = 0.8
 
 	parry_data = list(			// yeah it's snowflake
 		"UNARMED_PARRY_STAGGER" = 3 SECONDS,

--- a/code/modules/mob/living/living_active_parry.dm
+++ b/code/modules/mob/living/living_active_parry.dm
@@ -23,6 +23,9 @@
 	if(!(combat_flags & COMBAT_FLAG_PARRY_CAPABLE))
 		to_chat(src, "<span class='warning'>You are not something that can parry attacks.</span>")
 		return
+	if(!(mobility_flags & MOBILITY_STAND))
+		to_chat(src, "<span class='warning'>You aren't able to parry without solid footing!</span>")
+		return
 	// Prioritize item, then martial art, then unarmed.
 	// yanderedev else if time
 	var/obj/item/using_item = get_active_held_item()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gives old pugilist values back, making parrying significantly less clunky than before.
also makes it so you can't parry while resting, because that's kinda dumb.

## Why It's Good For The Game

removing the ability to parry while floored means that you can now not just go horizontal and still parry, there's now a downside to it, and also nerfing things to where they're worse than base unarmed is kinda bad for those items, might as well just remove them at that point. 

## Changelog
:cl:
balance: reverted the pr that absolutely gutted pugilism and made it worse than base unarmed, also gives it a second long stagger 
balance: removed the ability to parry while horizontal, because that's dumb and makes it easy to just time the parries right.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
