### PR TITLE
Removes open-air fusion completely.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -256,6 +256,8 @@
 
 /datum/gas_reaction/fusion/react(datum/gas_mixture/air, datum/holder)
 	var/turf/open/location
+	if (isopenturf(holder))
+		return
 	if (istype(holder,/datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.
 		var/datum/pipeline/fusion_pipenet = holder
 		location = get_turf(pick(fusion_pipenet.members))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is literally no valid reason to do open-air fusion except to grief. It is objectively worse than canister fusion, and I have the math to back this up. Below ~1400 liters of volume, fusion is, on average, exothermic, due to the fact that, if it's stable enough, endothermicity will be reduced or even 0'd out. However, if instability is high, endothermicity will *increase*. ~1400 liters is the cutoff point where, on average, endothermicity is higher than 1, due to the fact that instability (which you can model as, essentially, a uniform distribution) is going to have a larger range (it's 0-2pi at 1000, 0-~3pi at 2500), so fusion will no longer be stable and will eventually stop at 2.7 kelvins. Open air is at *2500* liters. 

Due to this, open air fusion is completely worthless except as a way to kill anyone who gets near it and kill the server with projectile and reaction spam. 

## Why It's Good For The Game

Fusion is the slowest reaction in the game, by far, taking 10x as long to calculate as others, and, not only that, spawning projectiles and causing radiation, which further lag the hell out of the game. It's the closest thing a regular player can do to a denial-of-service attack. Open-air fusion exacerbates this by linearly increasing the amount of reacting gas mixtures, causing way more lag than canister fusion, *on top of* being objectively worse by any reasonable metric. The only reason anyone does it is because they don't know that it's worthless and griefy, so, I'm at the point where removing it is honestly probably the best option. 

## Changelog
:cl:
del: Fusion can no longer be done in open air.
/:cl: