### PR TITLE
Disabled abductors.

### DIFF
--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/abductor
 	name = "Abductors"
 	typepath = /datum/round_event/ghost_role/abductor
-	weight = 10
+	weight = 0
 	max_occurrences = 1
 	min_players = 20
 	gamemode_blacklist = list("nuclear","wizard","revolution","dynamic")


### PR DESCRIPTION
## About The Pull Request

Gives the abductors event a 0 weight, making it no longer happen outside of adminbus.

## Why It's Good For The Game

It has been ruled that gay baby jailing is "playing abductors well". Any antag that involves GBJ when played well is a bad antag and should be removed.

## Changelog
:cl:
del: Set the abductor event weight to 0.
/:cl: