### PR TITLE
towering tendrils - a slight addition to the minimum spawn system

### DIFF
--- a/code/controllers/subsystem/minimum_spawns.dm
+++ b/code/controllers/subsystem/minimum_spawns.dm
@@ -11,9 +11,9 @@ SUBSYSTEM_DEF(min_spawns)
 	var/list/valid_mining_turfs_2 = list() // snaxi underground turfs
 
 GLOBAL_LIST_INIT(minimum_lavaland_spawns, list(
-	/obj/structure/spawner/lavaland,
-	/obj/structure/spawner/lavaland/goliath,
-	/obj/structure/spawner/lavaland/legion,
+	/obj/structure/spawner/lavaland/indestructible,
+	/obj/structure/spawner/lavaland/indestructible/goliath,
+	/obj/structure/spawner/lavaland/indestructible/legion,
 	/mob/living/simple_animal/hostile/megafauna/dragon,
 	/mob/living/simple_animal/hostile/megafauna/colossus,
 	/mob/living/simple_animal/hostile/megafauna/bubblegum

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -58,6 +58,9 @@
 	else
 		return ..()
 
+/obj/item/gps/internal/indestructible
+	gpstag = "Unnerving Signal"
+
 /obj/item/gps/internal/mining
 	icon_state = "gps-m"
 	gpstag = "MINER"

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -12,13 +12,13 @@
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril)
 	var/loot_type = /obj/structure/closet/crate/necropolis/tendril/all
 
-	move_resist=INFINITY // just killing it tears a massive hole in the ground, let's not move it
+	move_resist = INFINITY // just killing it tears a massive hole in the ground, let's not move it
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 
 	var/gps = null
+	var/gps_type = /obj/item/gps/internal
 	var/obj/effect/light_emitter/tendril/emitted_light
-
 
 /obj/structure/spawner/lavaland/goliath
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/goliath/beast/tendril)
@@ -29,6 +29,23 @@
 /obj/structure/spawner/lavaland/icewatcher
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing)
 
+/obj/structure/spawner/lavaland/indestructible
+	name = "towering necropolis tendril"
+	desc = "A towering, vile tendril of corruption unyielding, its depth almost unfathomable. Terrible monsters are pouring out of it, and it seems far too hardy to be natural."
+	gps_type = /obj/item/gps/internal/indestructible
+	resistance_flags = FIRE_PROOF | LAVA_PROOF | INDESTRUCTIBLE
+	max_integrity = INFINITY
+	spawn_time = 20 SECONDS
+
+/obj/structure/spawner/lavaland/indestructible/goliath
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/goliath/beast/tendril)
+
+/obj/structure/spawner/lavaland/indestructible/legion
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril)
+
+/obj/structure/spawner/lavaland/indestructible/icewatcher
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/icewing)
+
 GLOBAL_LIST_INIT(tendrils, list())
 /obj/structure/spawner/lavaland/Initialize()
 	. = ..()
@@ -37,7 +54,7 @@ GLOBAL_LIST_INIT(tendrils, list())
 		if(ismineralturf(F))
 			var/turf/closed/mineral/M = F
 			M.ScrapeAway(null, CHANGETURF_IGNORE_AIR)
-	gps = new /obj/item/gps/internal(src)
+	gps = new gps_type(src)
 	GLOB.tendrils += src
 
 /obj/structure/spawner/lavaland/deconstruct(disassembled)


### PR DESCRIPTION
## About The Pull Request
the minimum spawn subsystem now drops Towering Necropolis Tendrils, which are basically tendrils but:
- unique signal: "Unnerving Signal" instead of "Eerie Signal"
- intended to be indestructible (max_integrity 1e31, resistance_flags INDESTRUCTIBLE)
- spawn a new mob every 20 seconds instead of every 30

other than that basically nothing else
## Why It's Good For The Game
three less chances for lords of gunk to smash the funny heehoo tendrils and get quirky tendril loot
## Changelog
:cl:
add: The tendrils placed by the minimum spawn subsystem are now indestructible "towering necropolis tendrils".
/:cl:

