### PR TITLE
Adds state check callbacks to machine frame tool use

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -117,12 +117,6 @@
 	if(user.a_intent == INTENT_HARM)
 		return ..()
 
-//callback proc used on stacks use_tool to stop unnecessary amounts being wasted from spam clicking.
-/obj/structure/frame/computer/proc/check_state(target_state)
-	if(state == target_state)
-		return TRUE
-	return FALSE
-
 /obj/structure/frame/computer/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(state == 4)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -21,6 +21,11 @@
 			circuit = null
 	qdel(src)
 
+//callback proc used on stacks use_tool to stop unnecessary amounts being wasted from spam clicking.
+/obj/structure/frame/proc/check_state(target_state)
+	if(state == target_state)
+		return TRUE
+	return FALSE
 
 /obj/structure/frame/machine
 	name = "machine frame"
@@ -84,7 +89,7 @@
 				if(!P.tool_start_check(user, amount=5))
 					return
 				to_chat(user, "<span class='notice'>You start to add cables to the frame...</span>")
-				if(P.use_tool(src, user, 20, volume=50, amount=5))
+				if(P.use_tool(src, user, 20, volume=50, amount=5, extra_checks = CALLBACK(src, .proc/check_state, 1)))
 					to_chat(user, "<span class='notice'>You add cables to the frame.</span>")
 					state = 2
 					icon_state = "box_1"
@@ -93,25 +98,23 @@
 			if(P.tool_behaviour == TOOL_SCREWDRIVER && !anchored)
 				user.visible_message("<span class='warning'>[user] disassembles the frame.</span>", \
 									"<span class='notice'>You start to disassemble the frame...</span>", "You hear banging and clanking.")
-				if(P.use_tool(src, user, 40, volume=50))
-					if(state == 1)
-						to_chat(user, "<span class='notice'>You disassemble the frame.</span>")
-						var/obj/item/stack/sheet/metal/M = new (loc, 5)
-						M.add_fingerprint(user)
-						qdel(src)
+				if(P.use_tool(src, user, 40, volume=50, extra_checks = CALLBACK(src, .proc/check_state, 1)))
+					to_chat(user, "<span class='notice'>You disassemble the frame.</span>")
+					var/obj/item/stack/sheet/metal/M = new (loc, 5)
+					M.add_fingerprint(user)
+					qdel(src)
 				return
 			if(P.tool_behaviour == TOOL_WRENCH)
 				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
-				if(P.use_tool(src, user, 40, volume=75))
-					if(state == 1)
-						to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
-						setAnchored(!anchored)
+				if(P.use_tool(src, user, 40, volume=75, extra_checks = CALLBACK(src, .proc/check_state, 1)))
+					to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
+					setAnchored(!anchored)
 				return
 
 		if(2)
 			if(P.tool_behaviour == TOOL_WRENCH)
 				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
-				if(P.use_tool(src, user, 40, volume=75))
+				if(P.use_tool(src, user, 40, volume=75, extra_checks = CALLBACK(src, .proc/check_state, 2)))
 					to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
 					setAnchored(!anchored)
 				return
@@ -169,7 +172,7 @@
 
 			if(P.tool_behaviour == TOOL_WRENCH && !circuit.needs_anchored)
 				to_chat(user, "<span class='notice'>You start [anchored ? "un" : ""]securing [name]...</span>")
-				if(P.use_tool(src, user, 40, volume=75))
+				if(P.use_tool(src, user, 40, volume=75, extra_checks = CALLBACK(src, .proc/check_state, 3)))
 					to_chat(user, "<span class='notice'>You [anchored ? "un" : ""]secure [name].</span>")
 					setAnchored(!anchored)
 				return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. More safety to prevent certain issues for occuring.
Also moves the check_state proc upwards in inheritance, to frames in general instead of just computers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
:)
Yes I am looking at you, people who stack wiring skillgain.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: All machine-frame based tool-use actions now have state-checking callbacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
