### PR TITLE
Adds a new event: supermatter surge

### DIFF
--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -1,0 +1,22 @@
+/datum/round_event_control/supermatter_surge
+	name = "Supermatter Surge"
+	typepath = /datum/round_event/supermatter_surge
+	weight = 20
+	max_occurrences = 4
+	earliest_start = 10 MINUTES
+
+/datum/round_event_control/supermatter_surge/canSpawnEvent()
+	if(GLOB.main_supermatter_engine?.has_been_powered)
+		return ..()
+
+/datum/round_event/supermatter_surge
+	var/power = 2000
+
+/datum/round_event/supermatter_surge/setup()
+	power = rand(200,4000)
+
+/datum/round_event/supermatter_surge/announce()
+	priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert")
+
+/datum/round_event/supermatter_surge/start()
+	GLOB.main_supermatter_engine.matter_power += power

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -16,7 +16,8 @@
 	power = rand(200,4000)
 
 /datum/round_event/supermatter_surge/announce()
-	priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert")
+	if(power > 800 || prob(round(power/8)))
+		priority_announce("Class [round(power/500) + 1] supermatter surge detected. Intervention may be required.", "Anomaly Alert")
 
 /datum/round_event/supermatter_surge/start()
 	GLOB.main_supermatter_engine.matter_power += power

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2060,6 +2060,7 @@
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"
 #include "code\modules\events\stray_cargo.dm"
+#include "code\modules\events\supermatter_surge.dm"
 #include "code\modules\events\travelling_trader.dm"
 #include "code\modules\events\vent_clog.dm"
 #include "code\modules\events\wisdomcow.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an event that makes the supermatter power up a good deal for a short time. That's it. Only happens if there is a supermatter and it has been turned on, otherwise it won't try.

## Why It's Good For The Game

Mostly just trying to curb the anomaly spam. Plus, I think a tiny wrench thrown into SM operations is fun.

## Changelog
:cl:
add: "Supermatter surge" event, which might cause problems if the supermatter is not sufficiently cooled (i.e. the setup is messed up in some way)
/:cl: