### PR TITLE
Changes to dragon's blood and hierophant staff

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -991,14 +991,9 @@
 			H.right_eye_color = "fee5a3"
 			H.set_species(/datum/species/lizard)
 		if(2)
-			to_chat(user, "<span class='danger'>Your flesh begins to melt! Miraculously, you seem fine otherwise.</span>")
-			H.set_species(/datum/species/skeleton)
+			to_chat(user, "<span class='danger'>You feel strange! Your form starts distorting into that of a drake!</span>")
+			H.ForceContractDisease(new /datum/disease/transformation/dragon(), FALSE, TRUE)
 		if(3)
-			to_chat(user, "<span class='danger'>Power courses through you! You can now shift your form at will.</span>")
-			if(user.mind)
-				var/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/D = new
-				user.mind.AddSpell(D)
-		if(4)
 			to_chat(user, "<span class='danger'>You feel like you could walk straight through lava now.</span>")
 			H.weather_immunities |= "lava"
 
@@ -1007,19 +1002,22 @@
 
 /datum/disease/transformation/dragon
 	name = "dragon transformation"
-	cure_text = "nothing"
-	cures = list("adminordrazine")
+	disease_flags = CURABLE
+	bypasses_immunity = TRUE
+	cure_text = "Cryoxadone might regenerate and cool your cellular structure."
+	cures = list(/datum/reagent/medicine/cryoxadone)
+	cure_chance = 100
 	agent = "dragon's blood"
-	desc = "What do dragons have to do with Space Station 13?"
-	stage_prob = 20
+	desc = "Becoming a dragon is cool right?"
+	stage_prob = 5
 	severity = DISEASE_SEVERITY_BIOHAZARD
 	visibility_flags = 0
 	stage1	= list("Your bones ache.")
 	stage2	= list("Your skin feels scaly.")
 	stage3	= list("<span class='danger'>You have an overwhelming urge to terrorize some peasants.</span>", "<span class='danger'>Your teeth feel sharper.</span>")
 	stage4	= list("<span class='danger'>Your blood burns.</span>")
-	stage5	= list("<span class='danger'>You're a fucking dragon. However, any previous allegiances you held still apply. It'd be incredibly rude to eat your still human friends for no reason.</span>")
-	new_form = /mob/living/simple_animal/hostile/megafauna/dragon/lesser
+	stage5	= list("<span class='danger'>You're a dragon. However, any previous allegiances you held still apply. It'd be incredibly rude to eat your friends for no reason.</span>")
+	new_form = /mob/living/simple_animal/hostile/megafauna/dragon/lesser/transformed
 
 
 //Lava Staff
@@ -1282,8 +1280,8 @@
 			if(isliving(target) && chaser_timer <= world.time) //living and chasers off cooldown? fire one!
 				chaser_timer = world.time + chaser_cooldown
 				var/obj/effect/temp_visual/hierophant/chaser/C = new(get_turf(user), user, target, chaser_speed, friendly_fire_check)
-				C.damage = 30
-				C.monster_damage_boost = FALSE
+				C.damage = 15
+				C.monster_damage_boost = TRUE
 				log_combat(user, target, "fired a chaser at", src)
 			else
 				INVOKE_ASYNC(src, .proc/cardinal_blasts, T, user) //otherwise, just do cardinal blast
@@ -1399,10 +1397,10 @@
 		new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, user)
 		for(var/t in RANGE_TURFS(1, T))
 			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //blasts produced will not hurt allies
-			B.damage = 30
+			B.damage = 15
 		for(var/t in RANGE_TURFS(1, source))
 			var/obj/effect/temp_visual/hierophant/blast/B = new /obj/effect/temp_visual/hierophant/blast(t, user, TRUE) //but absolutely will hurt enemies
-			B.damage = 30
+			B.damage = 15
 		for(var/mob/living/L in range(1, source))
 			INVOKE_ASYNC(src, .proc/teleport_mob, source, L, T, user) //regardless, take all mobs near us along
 		sleep(6) //at this point the blasts detonate
@@ -1463,8 +1461,8 @@
 		if(!J)
 			return
 		var/obj/effect/temp_visual/hierophant/blast/B = new(J, user, friendly_fire_check)
-		B.damage = 30
-		B.monster_damage_boost = FALSE
+		B.damage = 15
+		B.monster_damage_boost = TRUE
 		previousturf = J
 		J = get_step(previousturf, dir)
 
@@ -1476,7 +1474,7 @@
 	sleep(2)
 	for(var/t in RANGE_TURFS(1, T))
 		var/obj/effect/temp_visual/hierophant/blast/B = new(t, user, friendly_fire_check)
-		B.damage = 15 //keeps monster damage boost due to lower damage
+		B.damage = 15 //keeps monster damage boost due to lower damage (now applied to all damage since it got lowered to 15 because 30 damage 50AP isnt cool)
 
 
 //Just some minor stuff

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -398,6 +398,14 @@ Difficulty: Medium
 	crusher_loot = list()
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
 
+/mob/living/simple_animal/hostile/megafauna/dragon/lesser/transformed //please use this for anything that turns players into controllable ash drake
+	name = "transformed ash drake"
+	desc = "a sentient being transformed into an ash drake."
+	damage_coeff = list(BRUTE = 0.70, BURN = 0.5, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1) //200 health but not very fast, need armor to compensate also its a fucking dragon come on
+	mob_size = MOB_SIZE_HUMAN //stops kinetic crushers from working on them
+	move_force = MOVE_FORCE_NORMAL //see comment below
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES //no we dont want sentient megafauna be able to delete the entire station in a minute flat
+
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)
 	return
 
@@ -413,7 +421,8 @@ Difficulty: Medium
 			if(L in hit_list || L == source)
 				continue
 			hit_list += L
-			L.adjustFireLoss(20)
+			L.adjustFireLoss(10)
+			L.adjust_fire_stacks(4)
 			to_chat(L, "<span class='userdanger'>You're hit by [source]'s fire breath!</span>")
 
 		// deals damage to mechs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the dragon transformation permanent into a new subtype, makes sure that hierophant actually does 15 damage not 30
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm not sure who thought being able to transform into megafauna at will which has the ability to delete r-walls, unanchor everything, spit fire that uses adjustfireloss, use the swoop attack that phases through anything and gib people for health was a good idea. This rebalances it so that it gives you a disease when you roll drake transformation on dragon's blood, which can be cured by cryoxadone instantly, that will permanently turn you into dragon/lesser/transformed. The new subtype is important because it removes the crusher vulnerability, the funny destruction of anything and gives you armor values befitting of a dragon. I wanted to make sure that turning into an ash drake was a viable choice and not just ERP bait.

We all know hierophant does 15 burn and 100AP right? wrong, it does 15 burn on melee but it's chasers and blast do 30 burn 50AP, this simply changes the value to 15 so miners stop getting a free e-sword. Don't worry in turn you get monster bonus damage enabled on all attacks.

Oh and removes skeleton transformation from dragon's blood, as much as I love trolling miners this is actually dumb and nobody wants this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new subtype to lesser ash drake that is balanced around player control please use this for the future
del: Removed skeleton transformation from dragon's blood
tweak: tweaked dragon's blood now gives you a disease instead of a spell
balance: rebalanced hierophant to now do 15 damage on chasers and blast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
