### PR TITLE
stops shredder ammo from being instant delimb on one shot

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/ballistic/rifles.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/rifles.dm
@@ -168,8 +168,8 @@
 /obj/item/projectile/bullet/cflechetteshredder	//you only get this with a 30TC bundle,5 magazines, as such this should be the superior ammotype
 	name = "flechette (shredder)"
 	damage = 10
-	dismemberment = 50
-	wound_bonus = 50
+	dismemberment = 15
+	wound_bonus = 20
 	armour_penetration = 100
 	sharpness = SHARP_EDGED
 	wound_falloff_tile = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
shredder delimbed on one hit, no matter what armor lol, no more completely busted shit
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
oh god why didnt i test this on limbs FIRST
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balane: unfucks wound balancing on the shredder ammo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
