### PR TITLE
Makes tablets not permacontam.

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -9,6 +9,7 @@
 	var/light_on = FALSE
 	integrity_failure = 0.5
 	max_integrity = 100
+	rad_flags = RAD_PROTECT_CONTENTS
 	armor = list("melee" = 0, "bullet" = 20, "laser" = 20, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 
 	var/enabled = 0											// Whether the computer is turned on.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Tablet contents get contaminated and can't be decontaminated without reconstructing, and then the contamination never really goes away.

## Why It's Good For The Game

This behavior's kinda buggy in the first place? It doesn't add anything, either, just makes using tablets *as atmos techs, who get tablets roundstart*, a chore.

## Changelog
:cl:
tweak: Tablets now protect their contents from rads.
/:cl:
