### PR TITLE
Makes polychromic windbreaker's message not be nonsense

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -1040,6 +1040,12 @@
 	icon_state = "wbreakpoly"
 	item_state = "wbreakpoly"
 
+/obj/item/clothing/suit/toggle/wbreakpoly/on_toggle(mob/user)
+	if(suittoggled)
+		to_chat(usr, "<span class='notice'>You zip up [src].</span>")
+	else
+		to_chat(usr, "<span class='notice'>You unzip [src].</span>")
+
 /obj/item/clothing/suit/toggle/wbreakpoly/polychromic/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/polychromic, list("#464F65", "#916035", "#474747"), 3)

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -110,6 +110,9 @@
 	suit_toggle(user)
 	return TRUE
 
+/obj/item/clothing/suit/toggle/proc/on_toggle(mob/user) // override this, not suit_toggle, which does checks
+	to_chat(usr, "<span class='notice'>You toggle [src]'s [togglename].</span>")
+
 /obj/item/clothing/suit/toggle/ui_action_click()
 	suit_toggle()
 
@@ -119,7 +122,7 @@
 	if(!can_use(usr))
 		return 0
 
-	to_chat(usr, "<span class='notice'>You toggle [src]'s [togglename].</span>")
+	on_toggle(usr)
 	if(src.suittoggled)
 		src.icon_state = "[initial(icon_state)]"
 		src.suittoggled = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now, when you alt-click your windbreaker, it says, quote, "You toggle the polychromic windbreaker's ." This makes it so that it gives a more appropriate message.

## Why It's Good For The Game

My immersion. Also allows for toggleable suits to have more easily overridden behavior, which is fun.

## Changelog
:cl:
fix: Polychromic windbreaker's alt-click message is now coherent
code: Toggleable suits now have an on_toggle proc to be overridden.
/:cl: