### PR TITLE
Changes to ash drake transformation

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -398,6 +398,14 @@ Difficulty: Medium
 	crusher_loot = list()
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/sinew = 5, /obj/item/stack/sheet/bone = 30)
 
+/mob/living/simple_animal/hostile/megafauna/dragon/lesser/transformed //ash drake balanced around player control
+	name = "transformed ash drake"
+	desc = "A sentient being transformed into an ash drake"
+	mob_size = MOB_SIZE_HUMAN //prevents crusher vulnerability
+	move_force = MOVE_FORCE_NORMAL //stops them from destroying and unanchoring shit by walking into it
+	environment_smash = ENVIRONMENT_SMASH_STRUCTURES //no we dont want sentient megafauna be able to delete the entire station in a minute flat
+	damage_coeff = list(BRUTE = 0.7, BURN = 0.5, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1) //200 health but not locked to standard movespeed, needs armor befitting of a dragon
+
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/grant_achievement(medaltype,scoretype)
 	return
 
@@ -413,7 +421,8 @@ Difficulty: Medium
 			if(L in hit_list || L == source)
 				continue
 			hit_list += L
-			L.adjustFireLoss(20)
+			L.adjustFireLoss(5)
+			L.adjust_fire_stacks(6)
 			to_chat(L, "<span class='userdanger'>You're hit by [source]'s fire breath!</span>")
 
 		// deals damage to mechs

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -77,8 +77,8 @@
 	name = "Dragon Form"
 	desc = "Take on the shape a lesser ash drake."
 	invocation = "RAAAAAAAAWR!"
-	cooldown_min = 450
-	charge_max = 1800
+	cooldown_min = 150
+	charge_max = 600
 
 	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser/transformed
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -77,8 +77,6 @@
 	name = "Dragon Form"
 	desc = "Take on the shape a lesser ash drake."
 	invocation = "RAAAAAAAAWR!"
-	cooldown_min = 150
-	charge_max = 600
 
 	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser/transformed
 

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -77,8 +77,10 @@
 	name = "Dragon Form"
 	desc = "Take on the shape a lesser ash drake."
 	invocation = "RAAAAAAAAWR!"
+	cooldown_min = 450
+	charge_max = 1800
 
-	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser
+	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser/transformed
 
 
 /obj/shapeshift_holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a new subtype for lesser ash drakes that is balanced around player control as well as rebalancing the shapeshift spell
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why yes I'd to be able to transform into megafauna with MOVE_FORCE_OVERPOWERING, ENVIRONMENT_SMASH_RWALLS 20 burn adjustfireloss breath, swoop attack that goes through walls, atmos immunity, full no grav movement and gibbing every 20 seconds willy nilly without any downsides except i get 2 hit by kinetic crushers on backstab, which is never an issue anyways because I can just transform right back.

No let's please not do that, cooldown is now 3 minutes for transforming and you dont turn into literal megafauna instead a new subtype that is balanced around playe control, you are now not vulnerable to crusher detonation, you have burn and brute armor and you still get to keep the 80 obj damage for smashing machinery and airlocks if you so desire. And lastly you get to alt click swoop dunk and breathe fire that now adds fire stacks instead of armor piercing burn of 20
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new subtype to lesser ash drake balanced around player control
balance: rebalanced dragon transformation to a 1 minute cooldown as well as using the new subtype of megafauna
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
