### PR TITLE
Bigger Bellies

### DIFF
--- a/code/modules/vore/eating/vorepanel.dm
+++ b/code/modules/vore/eating/vorepanel.dm
@@ -4,8 +4,8 @@
 
 #define BELLIES_MAX 20
 #define BELLIES_NAME_MIN 2
-#define BELLIES_NAME_MAX 12
-#define BELLIES_DESC_MAX 1024
+#define BELLIES_NAME_MAX 24
+#define BELLIES_DESC_MAX 2048
 
 /mob/living/proc/insidePanel()
 	set name = "Vore Panel"

--- a/code/modules/vore/eating/vorepanel.dm
+++ b/code/modules/vore/eating/vorepanel.dm
@@ -5,7 +5,7 @@
 #define BELLIES_MAX 20
 #define BELLIES_NAME_MIN 2
 #define BELLIES_NAME_MAX 24
-#define BELLIES_DESC_MAX 2048
+#define BELLIES_DESC_MAX 4096
 
 /mob/living/proc/insidePanel()
 	set name = "Vore Panel"


### PR DESCRIPTION
Doubles the number of characters available to be used for bellies_desc_max.  Additionally, doubles the number of characters available for the bellies_name_max.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Quadruples the number of characters you can use for Belly-names and Belly descriptions
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Doubled from 12 to 24 for belly names 
Quadrupled from 1024 to 4096 for belly descriptions

## Why It's Good For The Game
We can already circumvent belly description limitations via varediting.  This simply cuts out the middle-man.  

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More characters good, doesn't really hurt anyone by adding more available characters, and again, the limitations can already be circumvented by simple variable editing.  This would allow normal players to use larger texts without making them have to get admins to varedit.  
## Changelog
:cl:
tweak: doubled max belly name length and quadrupled belly description length
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
