### PR TITLE
Readds exhibitionist as a trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -192,6 +192,7 @@
 #define TRAIT_PERMABONER		"permanent_arousal"
 #define TRAIT_NEVERBONER		"never_aroused"
 #define TRAIT_NYMPHO			"nymphomaniac"
+#define TRAIT_EXHIB				"exhibitionist"
 #define TRAIT_MASO              "masochism"
 #define	TRAIT_HIGH_BLOOD        "high_blood"
 #define TRAIT_PARA              "paraplegic"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -121,6 +121,14 @@
 	var/mob/living/carbon/human/H = quirk_holder
 	H.arousal_rate = initial(H.arousal_rate)
 
+/datum/quirk/exhibitionism
+	name = "Exhibitionist"
+	desc = "You are aroused by certain kinds of attention."
+	value = 0
+	mob_trait = TRAIT_EXHIB
+	gain_text = "<span class='notice'>Prying eyes excite you.</span>"
+	lose_text = "<span class='notice'>You're not as excited by being watched anymore.</span>"
+
 /datum/quirk/alcohol_intolerance
 	name = "Alcohol Intolerance"
 	desc = "You take toxin damage from alcohol rather than getting drunk."

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -125,7 +125,7 @@
 							exhib_happened = TRUE
 						for(var/g in genits) // don't think this is O(n^2) and n is never more than... 4? anyway
 							var/obj/item/organ/genital/G = g
-							to_chat(M, "<span class='userlove'>[G.arousal_verb]!</span>")
+							to_chat(src, "<span class='userlove'>[G.arousal_verb]!</span>")
 				. += "[dicc.desc]"
 	if(CHECK_BITFIELD(user.client?.prefs.cit_toggles, VORE_EXAMINE))
 		var/cursed_stuff = attempt_vr(src,"examine_bellies",args) //vore Code

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -114,8 +114,18 @@
 
 	//CIT CHANGES START HERE - adds genital details to examine text
 	if(LAZYLEN(internal_organs) && CHECK_BITFIELD(user.client?.prefs.cit_toggles, GENITAL_EXAMINE))
+		var/exhib_happened = FALSE
 		for(var/obj/item/organ/genital/dicc in internal_organs)
 			if(istype(dicc) && dicc.is_exposed())
+				if(HAS_TRAIT(src, TRAIT_EXHIB))
+					var/list/genits = src.adjust_arousal(5, "exhibitionism")
+					if(length(genits))
+						if(!exhib_happened)
+							to_chat(src,"<span class='love'>You're getting some attention...</span>")
+							exhib_happened = TRUE
+						for(var/g in genits) // don't think this is O(n^2) and n is never more than... 4? anyway
+							var/obj/item/organ/genital/G = g
+							to_chat(M, "<span class='userlove'>[G.arousal_verb]!</span>")
 				. += "[dicc.desc]"
 	if(CHECK_BITFIELD(user.client?.prefs.cit_toggles, VORE_EXAMINE))
 		var/cursed_stuff = attempt_vr(src,"examine_bellies",args) //vore Code


### PR DESCRIPTION
## About The Pull Request

Adds an entirely new implementation of exhibitionist. Previously this was a preference toggle (??) which made it so that every mob near you (?!) increased your arousal if you had exposed bits. Instead, it now has a *probability* to increase your arousal if you have exposed bits *and someone who has the ability to see them examines you*.

## Why It's Good For The Game

Personally I think it's kind of an iffy implementation that might cause weirds, but it's all logged so at worst it's not completely horrible. Besides that, I always felt kinda bad for removing it.

## Changelog
:cl:
add: Exbihitionism, as a trait
/:cl: