### PR TITLE
why did i touch saycode - allows people to use asterisks, like god intended

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -956,7 +956,7 @@
 	if(hearing_args[HEARING_SPEAKER] == owner)
 		return
 	var/mob/living/carbon/C = owner
-	var/hypnomsg = uncostumize_say(hearing_args[HEARING_RAW_MESSAGE], hearing_args[HEARING_MESSAGE_MODE])
+	var/hypnomsg = uncustomize_say(hearing_args[HEARING_RAW_MESSAGE], hearing_args[HEARING_MESSAGE_MODE])
 	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
 	addtimer(CALLBACK(C, /mob/living/carbon.proc/gain_trauma, /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, hypnomsg), 10)
 	addtimer(CALLBACK(C, /mob/living.proc/Stun, 60, TRUE, TRUE), 15) //Take some time to think about it

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -60,13 +60,9 @@
 	if((input[1] == "!") && (length_char(input) > 1))
 		message_mode = MODE_CUSTOM_SAY
 		return copytext_char(input, 2)
-	var/customsayverb = findtext(input, "*")
-	if(customsayverb)
-		message_mode = MODE_CUSTOM_SAY
-		return lowertext(copytext_char(input, 1, customsayverb))
 	return ..()
 
-/proc/uncostumize_say(input, message_mode)
+/proc/uncustomize_say(input, message_mode)
 	. = input
 	if(message_mode == MODE_CUSTOM_SAY)
 		var/customsayverb = findtext(input, "*")


### PR DESCRIPTION
## About The Pull Request
removes the thing that uses asterisks for custom sayverbs
## Why It's Good For The Game
i hate hate hate not being able to use *
## Changelog
:cl:
tweak: Asterisk custom-say verbs are no more.
/:cl: