### PR TITLE
Jungle Gateway Quickfix

### DIFF
--- a/_maps/RandomZLevels/away_mission/jungleresort.dmm
+++ b/_maps/RandomZLevels/away_mission/jungleresort.dmm
@@ -413,10 +413,6 @@
 /obj/item/toy/figure/chef,
 /turf/open/floor/wood,
 /area/awaymission/jungleresort)
-"gC" = (
-/obj/item/clothing/head/rice_hat/cursed,
-/turf/open/floor/plating/dirt/jungle,
-/area/awaymission/jungleresort)
 "gK" = (
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted,
@@ -13828,7 +13824,7 @@ io
 du
 YF
 io
-gC
+io
 io
 io
 ia
@@ -26666,4 +26662,3 @@ bG
 bG
 bG
 "}
-


### PR DESCRIPTION
fucked up.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yo I accidently left a cursed rice hat right at the gate's entrance and forgot to remove it after my testing and fucking around, my bad.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
No more easy get for the funny hat.
## Changelog
:cl:
fix: cursed rice hat right in front of the jungle gateway's entrance is now removed from this dimensional plane 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
