### PR TITLE
Uncaps TEG output

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -66,7 +66,10 @@
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
 				var/heat = energy_transfer*(1-efficiency)
-				lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
+				if(delta_temperature < 16800) // second point where derivative of below function = 1
+					lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
+				else
+					lastgen += delta_temperature + 482102 // value of above function at 16800, or very nearly so
 
 				hot_air.set_temperature(hot_air.return_temperature() - energy_transfer/hot_air_heat_capacity)
 				cold_air.set_temperature(cold_air.return_temperature() + heat/cold_air_heat_capacity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It was starting to bother me a bit that the TEG is hard-capped due to the use of a logistic function, so this uncaps it without removing the reason the logistic function was used in the first place.

## Why It's Good For The Game

my TEG goes above 200,000 kelvins but never above 2 megawatts. unfair

## Changelog
:cl:
balance: uncapped TEG power, buffing high-temp TEGs
/:cl: