### PR TITLE
exiting a bluespace jar through any means, hardstuns you for 5 seconds

### DIFF
--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -328,8 +328,9 @@
 		REMOVE_TRAIT(occupant, TRAIT_RESISTHIGHPRESSURE, "bluespace_container_resist_high_pressure")
 		REMOVE_TRAIT(occupant, TRAIT_RESISTLOWPRESSURE, "bluespace_container_resist_low_pressure")
 	name = initial(name)
-	to_chat(occupant, "You pop out of the [src], slightly dazed!")
-	occupant.Stun(5 SECONDS)
+	if(iscarbon(occupant))
+		to_chat(occupant, "You pop out of the [src], slightly dazed!")
+		occupant.Stun(5 SECONDS)
 
 /obj/item/pet_carrier/bluespace/return_air()
 	if(!occupant_gas_supply)

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -328,6 +328,8 @@
 		REMOVE_TRAIT(occupant, TRAIT_RESISTHIGHPRESSURE, "bluespace_container_resist_high_pressure")
 		REMOVE_TRAIT(occupant, TRAIT_RESISTLOWPRESSURE, "bluespace_container_resist_low_pressure")
 	name = initial(name)
+	to_chat(occupant, "You pop out of the [src], slightly dazed!")
+	occupant.Stun(5 SECONDS)
 
 /obj/item/pet_carrier/bluespace/return_air()
 	if(!occupant_gas_supply)


### PR DESCRIPTION
## About The Pull Request
be it thrown, resisted out, or let out, the occupant will be hardstunned for 5 seconds
this only applies to carbons

the hardstun-on-exit was suggested by reagen, it's a pretty good idea and i did say if people abuse it, i'll nerf it

## Why It's Good For The Game
people are abusing the jar that wasn't meant to be abused

## Changelog
:cl:
balance: exiting a bluespace jar through any means, hardstuns you for 5 seconds
/:cl:
