### PR TITLE
Makes ash storm volume quieter

### DIFF
--- a/code/datums/looping_sounds/weather.dm
+++ b/code/datums/looping_sounds/weather.dm
@@ -8,7 +8,7 @@
 	start_sound = 'sound/weather/ashstorm/outside/active_start.ogg'
 	start_length = 130
 	end_sound = 'sound/weather/ashstorm/outside/active_end.ogg'
-	volume = 80
+	volume = 60
 
 /datum/looping_sound/active_inside_ashstorm
 	mid_sounds = list(
@@ -20,7 +20,7 @@
 	start_sound = 'sound/weather/ashstorm/inside/active_start.ogg'
 	start_length = 130
 	end_sound = 'sound/weather/ashstorm/inside/active_end.ogg'
-	volume = 60
+	volume = 20
 
 /datum/looping_sound/weak_outside_ashstorm
 	mid_sounds = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ash storms are noisy as heck. This reduces their volume, indoors far more than outdoors, since they're not really a threat indoors. Outdoors is now as loud as indoors was and indoors is now much, much quieter.

## Why It's Good For The Game

Doesn't really need to be that loud, it covers up, like, most of the game audio. 

## Changelog
:cl:
tweak:  Lowered ash storm volume
/:cl: