### PR TITLE
funny trauma announce

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -27,6 +27,7 @@
 		if(!is_station_level(H.z))
 			continue
 		traumatize(H)
+		announce_to_ghosts(H)
 		break
 
 /datum/round_event/brain_trauma/proc/traumatize(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the spontaneous brain trauma event now announces to ghosts who got spontaneous brain damage
## Why It's Good For The Game
checking who got what funny trauma is god's gift to observer gang
## Changelog
:cl:
add: The spontaneous brain trauma event now announces to ghosts whoever got funnied upon.
/:cl: