### PR TITLE
Makes hyper-nob, nitryl easier to make

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -358,7 +358,7 @@
 		/datum/gas/oxygen = 20,
 		/datum/gas/nitrogen = 20,
 		/datum/gas/nitrous_oxide = 5,
-		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST*400
+		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST*25
 	)
 
 /datum/gas_reaction/nitrylformation/react(datum/gas_mixture/air)
@@ -499,7 +499,7 @@
 	min_requirements = list(
 		/datum/gas/nitrogen = 10,
 		/datum/gas/tritium = 5,
-		"TEMP" = 5000000)
+		"ENER" = NOBLIUM_FORMATION_ENERGY)
 
 /datum/gas_reaction/nobliumformation/react(datum/gas_mixture/air)
 	var/old_heat_capacity = air.heat_capacity()

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -369,8 +369,8 @@
 	var/energy_used = heat_efficency*NITRYL_FORMATION_ENERGY
 	if ((air.get_moles(/datum/gas/oxygen) - heat_efficency < 0 )|| (air.get_moles(/datum/gas/nitrogen) - heat_efficency < 0)) //Shouldn't produce gas from nothing.
 		return NO_REACTION
-	air.adjust_moles(/datum/gas/oxygen, heat_efficency)
-	air.adjust_moles(/datum/gas/nitrogen, heat_efficency)
+	air.adjust_moles(/datum/gas/oxygen, -heat_efficency)
+	air.adjust_moles(/datum/gas/nitrogen, -heat_efficency)
 	air.adjust_moles(/datum/gas/nitryl, heat_efficency*2)
 
 	if(energy_used > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nitryl and hyper-nob require baffling amounts of temperature, essentially having fusion as a prerequisite. I'd rather this... not be the case. This does not change the reactions any, they still have the same effects, they're just easier to meet the conditions for.

Note that this means the supermatter can now spontaneously make nitryl if it gets spicy enough and it's N2/N2O cooled. Very fun.

EDIT: ALSO FIXES A BUG THAT'S BEEN IN NITRYL SINCE WE **ADDED EXTOOLS** BUT I NEVER NOTICED BECAUSE **NOBODY MAKES NITRYL LOL**

## Why It's Good For The Game

Nitryl is not... made. Ever. Specifically because it requires, I shit you not, 149,260 kelvins for a reaction which has a baseline temperature of... 37315. Hyper-nob is similarly ridiculous, using 2 gigajoules of heat but for some reason requiring *5,000,000* kelvins to start.

## Changelog
:cl:
fix: nitryl now consumes oxygen/nitrogen instead of generating them
balance: Hyper-nob and nitryl are easier to make.
/:cl: