### PR TITLE
Makes has_tail have a simpler check, probably fixing tail intertwining

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -264,10 +264,10 @@
 	return FALSE
 
 /mob/living/carbon/human/has_tail()
-	if(!dna || !dna.species)
+	if(!dna?.species?.tail_type)
 		return ..()
-	var/list/L = dna.species.mutant_bodyparts		// caches list because i refuse to type it out and because performance
-	return (L["mam_tail"] && (L["mam_tail"] != "None")) || (L["tail_human"] && (L["tail_human"] != "None")) || (L["tail_lizard"] && (L["tail_lizard"] != "None"))
+	else
+		return dna?.species?.mutant_bodyparts[dna?.species?.tail_type]
 
 /mob/living/start_pulling(atom/movable/AM, state, force = pull_force, supress_message = FALSE)
 	if(!AM || !src)


### PR DESCRIPTION
## About The Pull Request

See title. Tail intertwining isn't working cause only mammalians (?) actually pass the check. This replaces it with a watered-down version of the can_wag_tail check, which I know works.

## Why It's Good For The Game

fetish content

## Changelog
:cl:
fix: Made tail intertwining work.
/:cl:
