### PR TITLE
Allows repeated mode adjust to be >100 total

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -415,7 +415,7 @@ Example config:
 			while(recent_round)
 				adjustment += repeated_mode_adjust[recent_round]
 				recent_round = SSpersistence.saved_modes.Find(name,recent_round+1,0)
-			probability *= ((100-adjustment)/100)
+			probability *= max(0,((100-adjustment)/100))
 		runnable_storytellers[S] = probability
 	return runnable_storytellers
 
@@ -448,7 +448,7 @@ Example config:
 				while(recent_round)
 					adjustment += repeated_mode_adjust[recent_round]
 					recent_round = SSpersistence.saved_modes.Find(M.config_tag,recent_round+1,0)
-				final_weight *= ((100-adjustment)/100)
+				final_weight *= max(0,((100-adjustment)/100))
 			runnable_modes[M] = final_weight
 	return runnable_modes
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -106,6 +106,7 @@
 			for(var/i in 1 to 3)
 				if(config_tag in saved_dynamic_rules[i])
 					weight_mult -= (repeated_mode_adjust[i]/100)
+	weight_mult = max(0,weight_mult)
 	if(config_tag in costs)
 		cost = costs[config_tag]
 	if(config_tag in requirementses)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

because turns out we need harder prevention here and adding them up to more than 100 causes bugs

## Why It's Good For The Game

more config flexibility

## Changelog
:cl:
tweak: Allowed repeated mode adjust config to be more than 100% total (will just clamp to 0)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
