### PR TITLE
The augment manipulator can make printed prosthetics look like the roundstart choosable limbs

### DIFF
--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -8,7 +8,19 @@
 	max_integrity = 200
 	var/obj/item/bodypart/storedpart
 	var/initial_icon_state
-	var/static/list/style_list_icons = list("standard" = 'icons/mob/augmentation/augments.dmi', "engineer" = 'icons/mob/augmentation/augments_engineer.dmi', "security" = 'icons/mob/augmentation/augments_security.dmi', "mining" = 'icons/mob/augmentation/augments_mining.dmi')
+	var/static/list/style_list_icons = list("standard" = 'icons/mob/augmentation/augments.dmi', 
+											"engineer" = 'icons/mob/augmentation/augments_engineer.dmi', 
+											"security" = 'icons/mob/augmentation/augments_security.dmi', 
+											"mining" = 'icons/mob/augmentation/augments_mining.dmi', 
+											"Talon" = 'icons/mob/augmentation/cosmetic_prosthetic/talon.dmi', 
+											"Nanotrasen" = 'icons/mob/augmentation/cosmetic_prosthetic/nanotrasen.dmi', 
+											"Hephaesthus" = 'icons/mob/augmentation/cosmetic_prosthetic/hephaestus.dmi', 
+											"Bishop" = 'icons/mob/augmentation/cosmetic_prosthetic/bishop.dmi', 
+											"Xion" = 'icons/mob/augmentation/cosmetic_prosthetic/xion.dmi',
+											"Grayson" = 'icons/mob/augmentation/cosmetic_prosthetic/grayson.dmi',
+											"Cybersolutions" = 'icons/mob/augmentation/cosmetic_prosthetic/cybersolutions.dmi',
+											"Ward" = 'icons/mob/augmentation/cosmetic_prosthetic/ward.dmi'
+											)
 
 /obj/machinery/aug_manipulator/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows the augment manipulator to paint printed prosthetic limbs to look like the limbs you can choose from the roundstart prosthetics list.

## Why It's Good For The Game

Why exactly do we have these full body sprites but nothing to use them with?

## Changelog
:cl:
tweak: Allows the augment manipulator to paint printed prosthetic limbs to look like the limbs you can choose from the roundstart prosthetics list.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
