### PR TITLE
limb growers for pubby and delta

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -30845,6 +30845,7 @@
 /area/science)
 "bvF" = (
 /obj/machinery/requests_console{
+	announcementConsole = 1;
 	department = "Cargo Bay";
 	departmentType = 2;
 	pixel_x = -30

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -106349,10 +106349,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyK" = (
-/obj/structure/closet/crate/freezer/blood,
 /obj/machinery/vending/wallmed{
 	name = "Emergency NanoMed";
 	pixel_x = 26;
@@ -106368,6 +106368,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyL" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -37478,11 +37478,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHb" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
 	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/freezer,
 /area/medical/surgery)
 "bHc" = (
@@ -38110,6 +38109,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIq" = (


### PR DESCRIPTION
## About The Pull Request
puts limb growers on pubby and delta
pubby: limbgrower placed where limb crate was, limb crate moved to surgery
delta: limbgrower placed where blood crate was, blood crate moved a tile to compensate
makes box qm request console announcement capable
## Why It's Good For The Game
box/meta standard compliance
## Changelog
:cl:
add: Pubby and Delta now have roundstart limb-growers relatively close to, if not in, the operating theaters.
tweak: Box QM's console now can announce things.
/:cl: