### PR TITLE
Makes vampries dust when they can't pay the blood cost, not before

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -53,7 +53,7 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	if(C.blood_volume < 0.75)
+	if(C.blood_volume > 0.75)
 		C.blood_volume -= 0.75 //Will take roughly 19.5 minutes to die from standard blood volume, roughly 83 minutes to die from max blood volume.
 	else
 		C.dust(FALSE, TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -126,7 +126,7 @@
 	. = ..()
 	var/obj/item/organ/heart/vampire/darkheart = getorgan(/obj/item/organ/heart/vampire)
 	if(darkheart)
-		. += "<span class='notice'>Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM].</span>"
+		. += "Current blood level: [blood_volume]/[BLOOD_VOLUME_MAXIMUM]."
 
 
 /obj/item/organ/heart/vampire

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -53,10 +53,11 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	C.blood_volume -= 0.75 //Will take roughly 19.5 minutes to die from standard blood volume, roughly 83 minutes to die from max blood volume.
-	if(C.blood_volume <= (BLOOD_VOLUME_SURVIVE*C.blood_ratio))
-		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
-		C.dust()
+	if(C.blood_volume < 0.75)
+		C.blood_volume -= 0.75 //Will take roughly 19.5 minutes to die from standard blood volume, roughly 83 minutes to die from max blood volume.
+	else
+		C.dust(FALSE, TRUE)
+
 	var/area/A = get_area(C)
 	if(istype(A, /area/chapel))
 		to_chat(C, "<span class='danger'>You don't belong here!</span>")

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -3,7 +3,7 @@
 	id = SPECIES_VAMPIRE
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,DRINKSBLOOD,HAS_FLESH,HAS_BONE)
-	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_NOBREATH)
+	inherent_traits = list(TRAIT_NOHUNGER,TRAIT_NOBREATH,TRAIT_NOMARROW)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
 	mutant_bodyparts = list("mcolor" = "FFFFFF", "tail_human" = "None", "ears" = "None", "deco_wings" = "None")
 	exotic_bloodtype = "U"
@@ -53,8 +53,8 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	if(C.blood_volume > 0.75)
-		C.blood_volume -= 0.75 //Will take roughly 19.5 minutes to die from standard blood volume, roughly 83 minutes to die from max blood volume.
+	if(C.blood_volume > 0.5)
+		C.blood_volume -= 0.5 //Will take roughly 19.5 minutes to die from standard blood volume, roughly 83 minutes to die from max blood volume.
 	else
 		C.dust(FALSE, TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 Makes vampire the race only get dusted if they're cant pay the blood toll, plus makes dusting drop their items on the ground. Plus removes the span in their statpanel thing which are no longer needed
Makes vampires have the nomarrow trait, just like bloodsuckers do, so they don't suffer from low blood effects, but they'll still die once blood reaches zero
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The current amount can be a bit sudden, and unexpected, let people have the chance to save vampires, and it's rather fucky to completely have items destroyed due to a vampire dying.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Vampires no longer suffer from low blood effects, and sets their species blood loss to 0.5, due to them not benefitting from the blood regeneration that they used to from handle_blood
tweak:Vampires the race only get dusted if they cant pay their blood toll, which is 0.5, instead of 125 or so, and no longer delete their inventories upon dusting due to lack of blood
fix: Vampire statpanel no longer shows spans unnecesary
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
