### PR TITLE
Adjusts the abductors event to only trigger when there's 30 players.

### DIFF
--- a/code/modules/events/abductor.dm
+++ b/code/modules/events/abductor.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/abductor
 	weight = 10
 	max_occurrences = 1
-	min_players = 20
+	min_players = 30
 	gamemode_blacklist = list("nuclear","wizard","revolution","dynamic")
 
 /datum/round_event/ghost_role/abductor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
core problemo with abductors is they function as a side antag meant for server(s) with a lot bigger population so naturally they stay a side antag and usually get smoked pretty easily because of the 20 assistants all with backpack spears or w/e
but on cit, they might as well be a main antag, they have almost no tweaks/adjustments that I know of, usually almost always manage to get abductions because there's always one cumbrain or few, so then they easily can get extra abductor gear to gamer the station with
I'm not willing to to dip my foot too far into balancing abductors yet since I believe silicons has some combat mode adjustments coming up so this is a hotfix for now which should hopefully help reduce the impact of abductors on rounds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked abductors event to require 30 instead of 20 players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
