### PR TITLE
Removes the illegal tech node from a few common items that are found through space/gateway/lavaland exploration.

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_clothing.dm
+++ b/code/modules/uplink/uplink_items/uplink_clothing.dm
@@ -98,6 +98,7 @@
 	item = /obj/item/clothing/gloves/tackler/combat/insulated
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	cost = 2
+	illegal_tech = FALSE
 
 /datum/uplink_item/device_tools/syndicate_eyepatch
 	name = "Mechanical Eyepatch"

--- a/code/modules/uplink/uplink_items/uplink_devices.dm
+++ b/code/modules/uplink/uplink_items/uplink_devices.dm
@@ -130,6 +130,7 @@
 			multitool and combat gloves that are resistant to shocks and heat."
 	item = /obj/item/storage/toolbox/syndicate
 	cost = 1
+	illegal_tech = FALSE
 
 /datum/uplink_item/device_tools/syndie_glue
 	name = "Glue"

--- a/code/modules/uplink/uplink_items/uplink_stealthdevices.dm
+++ b/code/modules/uplink/uplink_items/uplink_stealthdevices.dm
@@ -16,6 +16,7 @@
 			with these cards."
 	item = /obj/item/card/id/syndicate
 	cost = 2
+	illegal_tech = FALSE
 
 /datum/uplink_item/stealthy_tools/ai_detector
 	name = "Artificial Intelligence Detector"


### PR DESCRIPTION
…ce/gateway exploration

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes guerilla gloves, red toolbox and agent ID cards from unlocking the illegal tech node.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These items are common and can be found very easily when effort is put in towards it. Rather than letting the crew unlock illegal tech from exploration, it should be unlocked after sacrificing an antag's equipment. Illegal tech as it is unlocks quite a few powerful tools for the crew and raising the floor slightly on unlocking it leads to a healthier environment.

Brought to you by OOC balance discussions.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: removed red toolbox, agent id, and guerilla gloves from unlocking illegal tech.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
