### PR TITLE
organic repair surgery can be done on a cyborg torso

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -8,7 +8,7 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-	requires_bodypart_type = 0
+	requires_bodypart_type = NONE
 	replaced_by = /datum/surgery
 	ignore_clothes = TRUE
 	var/healing_step_type

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -21,6 +21,12 @@
 					healing_step_type, //hehe cheeky
 					/datum/surgery_step/close)
 
+/datum/surgery/healing/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
+	for(var/obj/item/bodypart/B in target.bodyparts)
+		if(B.is_organic_limb(TRUE))
+			return ..()
+
+
 /datum/surgery_step/heal
 	name = "repair body"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 65, /obj/item/pen = 55)

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -8,7 +8,7 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-	requires_bodypart_type = BODYPART_ORGANIC
+	requires_bodypart_type = 0
 	replaced_by = /datum/surgery
 	ignore_clothes = TRUE
 	var/healing_step_type


### PR DESCRIPTION

## About The Pull Request

Title says it all.

## Why It's Good For The Game

Sometimes people need their torsos replaced due to infection, resulting in someone who has a cyborg torso but is otherwise organic.

## Changelog
:cl:
tweak: you can repair organic limbs on a person with a cyborg torso
/:cl:
