### PR TITLE
Made slaughter demon have higher weight if there's more blood

### DIFF
--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -9,6 +9,7 @@
 
 /datum/round_event_control/slaughter/canSpawnEvent()
 	var/t = /datum/round_event_control/slaughter
+	weight = initial(t.weight)
 	var/list/allowed_turf_typecache = typecacheof(/turf/open) - typecacheof(/turf/open/space)
 	var/list/allowed_z_cache = list()
 	for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))

--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -8,8 +8,7 @@
 	min_players = 20
 
 /datum/round_event_control/slaughter/canSpawnEvent()
-	var/t = /datum/round_event_control/slaughter
-	weight = initial(t.weight)
+	weight = initial(src.weight)
 	var/list/allowed_turf_typecache = typecacheof(/turf/open) - typecacheof(/turf/open/space)
 	var/list/allowed_z_cache = list()
 	for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))

--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -18,7 +18,7 @@
 			continue
 		if(!C.can_bloodcrawl_in())
 			continue
-		if(!IsValidDebrisLocation(C.loc, allowed_turf_typecache, allowed_z_cache, C.type, FALSE))
+		if(!SSpersistence.IsValidDebrisLocation(C.loc, allowed_turf_typecache, allowed_z_cache, C.type, FALSE))
 			continue
 		weight += 0.05
 	return ..()

--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -7,7 +7,21 @@
 	earliest_start = 1 HOURS
 	min_players = 20
 
-
+/datum/round_event_control/slaughter/canSpawnEvent()
+	var/t = /datum/round_event_control/slaughter
+	var/list/allowed_turf_typecache = typecacheof(/turf/open) - typecacheof(/turf/open/space)
+	var/list/allowed_z_cache = list()
+	for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
+		allowed_z_cache[num2text(z)] = TRUE
+	for(var/obj/effect/decal/cleanable/C in world)
+		if(!C.loc || QDELETED(C))
+			continue
+		if(!C.can_bloodcrawl_in())
+			continue
+		if(!IsValidDebrisLocation(C.loc, allowed_turf_typecache, allowed_z_cache, C.type, FALSE))
+			continue
+		weight += 0.05
+	return ..()
 
 /datum/round_event/ghost_role/slaughter
 	minimum_required = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. It just checks for how much blood there is on station and makes slaughter demon more likely the more there is.

## Why It's Good For The Game

Slaughter demon's super rare and it gives a bigger incentive for people to clean up blood.

## Changelog
:cl:
add: Slaughter demon event now increases weight based on how much blood there is.
/:cl: