### PR TITLE
Locks Bluespace Jars to be admin-only

### DIFF
--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -332,6 +332,7 @@
 		to_chat(occupant, "You pop out of the [src], slightly dazed!")
 		occupant.Stun(5 SECONDS)
 
+
 /obj/item/pet_carrier/bluespace/return_air()
 	if(!occupant_gas_supply)
 		occupant_gas_supply = new
@@ -352,5 +353,15 @@
 /obj/item/pet_carrier/bluespace/load_occupant(mob/living/user, mob/living/target)
 	if(..())
 		name = "[initial(name)] ([target])"
+
+/obj/item/pet_carrier/bluespace/single_use
+	desc = "A jar, that seems to be bigger on the inside, somehow allowing lifeforms to fit through its narrow entrance. This one looks exceptionally fragile."
+
+/obj/item/pet_carrier/bluespace/single_use/remove_occupant(mob/living/occupant)
+	. = ..()
+
+	if(!QDELETING(src))
+		playsound(src, "shatter", 70, 1)
+		qdel(src)
 
 #undef pet_carrier_full

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -360,7 +360,7 @@
 /obj/item/pet_carrier/bluespace/single_use/remove_occupant(mob/living/occupant)
 	. = ..()
 
-	if(!QDELETING(src))
+	if(!QDELETED(src))
 		playsound(src, "shatter", 70, 1)
 		qdel(src)
 

--- a/code/modules/events/travelling_trader.dm
+++ b/code/modules/events/travelling_trader.dm
@@ -200,7 +200,7 @@
 	return FALSE
 
 /mob/living/carbon/human/dummy/travelling_trader/animal_hunter/give_reward(mob/giver) //the reward is actually given in a jar, because releasing it onto the station might be a bad idea
-	var/obj/item/pet_carrier/bluespace/jar = new(get_turf(src))
+	var/obj/item/pet_carrier/bluespace/single_use/jar = new(get_turf(src))
 	var/chosen_animal = pickweight(possible_rewards)
 	var/mob/living/new_animal = new chosen_animal(jar)
 	if(giver && giver.tag)

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -105,13 +105,3 @@
 	materials = list(/datum/material/iron = 2000, /datum/material/bluespace = 500)
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-
-/datum/design/bluespace_carrier
-	name = "Bluespace Jar"
-	desc = "A jar used to contain creatures, using the power of bluespace."
-	id = "bluespace_carrier"
-	build_type = PROTOLATHE
-	build_path = /obj/item/pet_carrier/bluespace
-	materials = list(/datum/material/glass = 1000, /datum/material/bluespace = 600)
-	category = list("Bluespace Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -13,7 +13,7 @@
 	display_name = "Applied Bluespace Research"
 	description = "Using bluespace to make things faster and better."
 	prereq_ids = list("bluespace_basic", "engineering")
-	design_ids = list("bs_rped","biobag_holding","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "bluespacesmartdart", "xenobio_slimebasic", "bluespace_tray", "bluespace_carrier")
+	design_ids = list("bs_rped","biobag_holding","minerbag_holding", "bluespacebeaker", "bluespacesyringe", "phasic_scanning", "bluespacesmartdart", "xenobio_slimebasic", "bluespace_tray")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/adv_bluespace


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Unfortunately, jars are repeatedly causing quite some issues, sometimes because of willing carrying, sometimes unwilling, with it simply not really being worth it to keep it, given that its initial intent was simply a way to carry someone without piggybacking them.

This PR removes jars from the techweb, but keeps them in the code for if admins want to do something with them (or god forbid christmas trees / simillar 'grab any object' things)
One single type of bluespace jar remains acquirable in-game, which is the jar the travelling animal trader gives you your reward in. Though, this type will shatter as soon as you release whatever was in it, since I didn't want to just remove this entire trader subtype and a single-use jar with the given simplemob should be okay.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Jars have been merged since over half a year and are still causing issues every now and then. After alot of discussion & cases of people using them in unintentional, yet codewise completely correct ways, it's time for them to go.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Bluespace jars can no longer be printed / acquired from lathes / techwebs.
tweak: The travelling animal trader now gives you your reward in a one-use bluespace jar.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
