### PR TITLE
Literally just adds targets to give because i forgot to do that

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1237,7 +1237,7 @@
 	if(user.incapacitated() || !user.Adjacent(src))
 		return FALSE
 	if(W && user.a_intent == INTENT_HELP && W.can_give())
-		user.give()
+		user.give(src)
 		return TRUE
 
 /mob/living/carbon/verb/give_verb()
@@ -1253,4 +1253,4 @@
 	var/obj/item/I = usr.get_active_held_item()
 	var/mob/living/carbon/C = usr
 	if(I.can_give())
-		C.give()
+		C.give(src)


### PR DESCRIPTION

## Changelog
:cl:
fix: Combat mode right click and right click verb give's are now actualyl targeted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
