### PR TITLE
moves the express supply console and upgrade disk to appropriate tabs

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -9,7 +9,7 @@
 	build_type = IMPRINTER
 	materials = list(/datum/material/glass = 1000)
 	build_path = /obj/item/circuitboard/computer/cargo/express
-	category = list("Mining Designs")
+	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/bluespace_pod
@@ -19,7 +19,7 @@
 	build_type = PROTOLATHE
 	materials = list(/datum/material/glass = 1000)
 	build_path = /obj/item/disk/cargo/bluespace_pod
-	category = list("Mining Designs")
+	category = list("Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/drill


### PR DESCRIPTION
## About The Pull Request
express supply console board moved to Computer Boards
bluespace supply pod upgrade disk moved to Electronics
## Why It's Good For The Game
proper categorizing is based actually
## Changelog
:cl:
tweak: Express supply console board moved to Computer Designs (in the imprinter), upgrade disk moved to Electronics (still in the lathe).
/:cl: