### PR TITLE
removes pacifism from ghost cafe

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -676,7 +676,6 @@
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_EXEMPT_HEALTH_EVENTS, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn, TRAIT_NO_MIDROUND_ANTAG, GHOSTROLE_TRAIT) //The mob can't be made into a random antag, they are still eligible for ghost roles popups.
-		ADD_TRAIT(new_spawn, TRAIT_PACIFISM, GHOSTROLE_TRAIT)
 		to_chat(new_spawn,"<span class='boldwarning'>Ghosting is free!</span>")
 		var/datum/action/toggle_dead_chat_mob/D = new(new_spawn)
 		D.Grant(new_spawn)


### PR DESCRIPTION
## About The Pull Request
removes pacifism from ghost cafe spawner
## Why It's Good For The Game
extended
Antagonists:

meanwhile, in the ghost cafe,
https://www.youtube.com/watch?v=7Aze726qAwA
## Changelog
:cl:
del: removes pacifism from ghost cafe. have fun beating up your coworkers
/:cl: