### PR TITLE
fixes puddles breaking

### DIFF
--- a/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
+++ b/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
@@ -37,11 +37,11 @@
 			to_chat(owner, "There's something stuck to your hand, stopping you from transforming!")
 			return
 	if(IsAvailable())
-		transforming = TRUE
 		UpdateButtonIcon()
 		var/mutcolor = owner.get_ability_property(INNATE_ABILITY_SLIME_BLOBFORM, PROPERTY_BLOBFORM_COLOR) || ("#" + H.dna.features["mcolor"])
 		if(!is_puddle)
 			if(CHECK_MOBILITY(H, MOBILITY_USE)) //if we can use items, we can turn into a puddle
+				transforming = TRUE
 				is_puddle = TRUE //so we know which transformation to use when its used
 				ADD_TRAIT(H, TRAIT_HUMAN_NO_RENDER, SLIMEPUDDLE_TRAIT)
 				owner.cut_overlays() //we dont show our normal sprite, we show a puddle sprite


### PR DESCRIPTION
## About The Pull Request
using the button while stunned breaks it
this fixes that

i'll look at making some more changes soon including:
hitbox of the puddle being slightly larger than the puddle itself to stop the whole "its smaller!!!"
no moving under people it's stupid and not intended i'm not too sure how it even happened it was supposed to be people go over you, not you go under them, could make it like resting where it's a long delay of like 5 seconds to move under someone

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: using the puddle ability when stunned wont break it
/:cl:
