### PR TITLE
Adds suit sensor damage, clothing damage changes

### DIFF
--- a/code/__DEFINES/_flags/obj_flags.dm
+++ b/code/__DEFINES/_flags/obj_flags.dm
@@ -18,8 +18,8 @@
 
 /// Integrity defines for clothing (not flags but close enough)
 #define CLOTHING_PRISTINE	0 // We have no damage on the clothing
-#define CLOTHING_DAMAGED	1 // There's some damage on the clothing but it still has at least one functioning bodypart and can be equipped
-#define CLOTHING_SHREDDED	2 // The clothing is useless and cannot be equipped unless repaired first
+#define CLOTHING_DAMAGED	1 // There's some damage on the clothing but it still has at least one functioning bodypart
+#define CLOTHING_SHREDDED	2 // The clothing is near useless and has their sensors broken
 
 // If you add new ones, be sure to add them to /obj/Initialize as well for complete mapping support
 

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -173,8 +173,18 @@ GLOBAL_LIST_EMPTY(bloody_footprints_cache)
 
 #define BROKEN_SENSORS -1
 #define NO_SENSORS 0
-#define HAS_SENSORS 1
-#define LOCKED_SENSORS 2
+#define DAMAGED_SENSORS_LIVING 1
+#define DAMAGED_SENSORS_VITALS 2
+#define HAS_SENSORS 3
+
+//suit sensor flags: sensor_flag defines
+#define SENSOR_RANDOM (1<<0)
+#define SENSOR_LOCKED (1<<1)
+
+//suit sensor integrity percentage threshold defines
+#define SENSOR_INTEGRITY_COORDS 0.2
+#define SENSOR_INTEGRITY_VITALS 0.6
+#define SENSOR_INTEGRITY_BINARY 1
 
 //Wet floor type flags. Stronger ones should be higher in number.
 #define TURF_DRY		(0)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -277,7 +277,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/under/chameleon)
 	item_state = "bl_suit"
 	desc = "It's a plain jumpsuit. It has a small dial on the wrist."
 	sensor_mode = SENSOR_OFF //Hey who's this guy on the Syndicate Shuttle??
-	random_sensor = FALSE
+	sensor_flags = NONE
 	resistance_flags = NONE
 	can_adjust = FALSE
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -233,7 +233,7 @@
 /obj/item/clothing/examine(mob/user)
 	. = ..()
 	if(damaged_clothes == CLOTHING_SHREDDED)
-		. += "<span class='warning'><b>It is completely shredded and requires mending before it can be worn again!</b></span>"
+		. += "<span class='warning'><b>It is completely shredded and requires mending!</b></span>"
 		return
 	for(var/zone in damage_by_parts)
 		var/pct_damage_part = damage_by_parts[zone] / limb_integrity * 100
@@ -437,12 +437,10 @@ BLIND     // can't see anything
 		damaged_clothes = CLOTHING_SHREDDED
 		body_parts_covered = NONE
 		name = "shredded [initial(name)]"
-		slot_flags = NONE
-		update_clothes_damaged_state()
+		update_clothes_damaged_state(CLOTHING_SHREDDED)
 		if(ismob(loc))
 			var/mob/M = loc
-			M.visible_message("<span class='danger'>[M]'s [src.name] falls off, completely shredded!</span>", "<span class='warning'><b>Your [src.name] falls off, completely shredded!</b></span>", vision_distance = COMBAT_MESSAGE_RANGE)
-			M.dropItemToGround(src)
+			M.visible_message("<span class='danger'>[M]'s [src.name] is completely shredded!</span>", "<span class='userdanger'>Your [src.name] is completely shredded!</span>", vision_distance = COMBAT_MESSAGE_RANGE)
 	else
 		..()
 

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -7,11 +7,14 @@
 	slot_flags = ITEM_SLOT_ICLOTHING
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 5)
 	mutantrace_variation = STYLE_DIGITIGRADE|USE_TAUR_CLIP_MASK
-	limb_integrity = 30
+	limb_integrity = 120
 	var/fitted = FEMALE_UNIFORM_FULL // For use in alternate clothing styles for women
 	var/has_sensor = HAS_SENSORS // For the crew computer
-	var/random_sensor = TRUE
+	var/sensor_flags = SENSOR_RANDOM
 	var/sensor_mode = NO_SENSORS
+	var/sensor_mode_intended = NO_SENSORS //if sensors become damaged and are repaired later, it will revert to the user's intended preferences
+	var/sensormaxintegrity = 200 //if this is zero, then our sensors can only be destroyed by shredded clothing
+	var/sensordamage = 0 //how much damage did our sensors take?
 	var/can_adjust = TRUE
 	var/adjusted = NORMAL_STYLE
 	var/alt_covers_chest = FALSE // for adjusted/rolled-down jumpsuits, FALSE = exposes chest and arms, TRUE = exposes arms only
@@ -32,29 +35,75 @@
 
 /obj/item/clothing/under/attackby(obj/item/I, mob/user, params)
 	if((has_sensor == BROKEN_SENSORS) && istype(I, /obj/item/stack/cable_coil))
-		if(damaged_clothes)
-			to_chat(user,"<span class='warning'>You should repair the damage done to [src] first.</span>")
+		if(damaged_clothes == CLOTHING_SHREDDED)
+			to_chat(user,"<span class='warning'>[src] is too damaged to have its suit sensors repaired! Repair it first.</span>")
 			return 0
 		var/obj/item/stack/cable_coil/C = I
 		I.use_tool(src, user, 0, 1)
 		has_sensor = HAS_SENSORS
+		sensordamage = 0
+		sensor_mode = sensor_mode_intended
 		to_chat(user,"<span class='notice'>You repair the suit sensors on [src] with [C].</span>")
 		return 1
+
 	if(!attach_accessory(I, user))
 		return ..()
+
+/obj/item/clothing/under/take_damage_zone(def_zone, damage_amount, damage_type, armour_penetration)
+	..()
+	if(sensormaxintegrity == 0 || has_sensor == NO_SENSORS) return //sensors are invincible if max integrity is 0
+	var/damage_dealt = take_damage(damage_amount * 0.1, damage_type, armour_penetration, FALSE) * 10 // only deal 10% of the damage to the general integrity damage, then multiply it by 10 so we know how much to deal to limb
+	sensordamage += damage_dealt
+	var/integ = has_sensor
+	var/newinteg = sensorintegrity()
+	if(newinteg != integ)
+		if(newinteg < integ && iscarbon(src.loc)) //the first check is to see if for some inexplicable reason the attack healed our suit sensors
+			var/mob/living/carbon/C = src.loc
+			switch(newinteg)
+				if(DAMAGED_SENSORS_VITALS)
+					to_chat(C,"<span class='warning'>Your tracking beacon on your suit sensors have shorted out!</span>")
+				if(DAMAGED_SENSORS_LIVING)
+					to_chat(C,"<span class='warning'>Your vital tracker on your suit sensors have shorted out!</span>")
+				if(BROKEN_SENSORS)
+					to_chat(C,"<span class='userdanger'>Your suit sensors have shorted out completely!</span>")
+		updatesensorintegrity(newinteg)
+
+
+/obj/item/clothing/under/proc/sensorintegrity()
+	var/percentage = sensordamage/sensormaxintegrity //calculate the percentage of how much damage taken
+	if(percentage < SENSOR_INTEGRITY_COORDS) return HAS_SENSORS
+	else if(percentage < SENSOR_INTEGRITY_VITALS) return DAMAGED_SENSORS_VITALS
+	else if(percentage < SENSOR_INTEGRITY_BINARY) return DAMAGED_SENSORS_LIVING
+	else return BROKEN_SENSORS
+
+/obj/item/clothing/under/proc/updatesensorintegrity(integ = HAS_SENSORS)
+	if(sensormaxintegrity == 0 || has_sensor == NO_SENSORS) return //sanity check
+	has_sensor = integ
+	switch(has_sensor)
+		if(HAS_SENSORS)
+			sensor_mode = sensor_mode_intended
+		if(DAMAGED_SENSORS_VITALS)
+			if(sensor_mode > SENSOR_VITALS) sensor_mode = SENSOR_VITALS
+		if(DAMAGED_SENSORS_LIVING)
+			if(sensor_mode > SENSOR_LIVING) sensor_mode = SENSOR_LIVING
+		if(BROKEN_SENSORS)
+			sensor_mode = NO_SENSORS
+
 
 /obj/item/clothing/under/update_clothes_damaged_state()
 	..()
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_inv_w_uniform()
-	if(has_sensor > NO_SENSORS)
+	if(has_sensor > NO_SENSORS && damaged_clothes == CLOTHING_SHREDDED)
 		has_sensor = BROKEN_SENSORS
+		sensordamage = sensormaxintegrity
 
 /obj/item/clothing/under/New()
-	if(random_sensor)
+	if(sensor_flags & SENSOR_RANDOM)
 		//make the sensor mode favor higher levels, except coords.
 		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS, SENSOR_COORDS)
+	sensor_mode_intended = sensor_mode
 	..()
 
 /obj/item/clothing/under/equipped(mob/user, slot)
@@ -143,9 +192,14 @@
 			. += "Alt-click on [src] to wear it normally."
 		else
 			. += "Alt-click on [src] to wear it casually."
-	if (has_sensor == BROKEN_SENSORS)
-		. += "Its sensors appear to be shorted out."
-	else if(has_sensor > NO_SENSORS)
+	switch(has_sensor)
+		if(BROKEN_SENSORS)
+			. += "<span class='warning'>Its sensors appear to be shorted out completely. It can be repaired using cable.</span>"
+		if(DAMAGED_SENSORS_LIVING)
+			. += "<span class='warning'>Its sensors appear to have its tracking beacon and vital tracker broken. It can be repaired using cable.</span>"
+		if(DAMAGED_SENSORS_VITALS)
+			. += "<span class='warning'>Its sensors appear to have its tracking beacon broken. It can be repaired using cable.</span>"
+	if(has_sensor > NO_SENSORS)
 		switch(sensor_mode)
 			if(SENSOR_OFF)
 				. += "Its sensors appear to be disabled."
@@ -167,11 +221,11 @@
 		return
 	if (!can_use(M))
 		return
-	if(src.has_sensor == LOCKED_SENSORS)
-		to_chat(usr, "The controls are locked.")
-		return 0
 	if(src.has_sensor == BROKEN_SENSORS)
 		to_chat(usr, "The sensors have shorted out!")
+		return 0
+	if(src.sensor_flags & SENSOR_LOCKED)
+		to_chat(usr, "The controls are locked.")
 		return 0
 	if(src.has_sensor <= NO_SENSORS)
 		to_chat(usr, "This suit does not have any sensors.")
@@ -182,18 +236,34 @@
 	if(get_dist(usr, src) > 1)
 		to_chat(usr, "<span class='warning'>You have moved too far away!</span>")
 		return
-	sensor_mode = modes.Find(switchMode) - 1
+	sensor_mode_intended = modes.Find(switchMode) - 1
 
 	if (src.loc == usr)
-		switch(sensor_mode)
+		switch(sensor_mode_intended)
 			if(0)
 				to_chat(usr, "<span class='notice'>You disable your suit's remote sensing equipment.</span>")
+				sensor_mode = sensor_mode_intended
 			if(1)
 				to_chat(usr, "<span class='notice'>Your suit will now only report whether you are alive or dead.</span>")
+				sensor_mode = sensor_mode_intended
 			if(2)
-				to_chat(usr, "<span class='notice'>Your suit will now only report your exact vital lifesigns.</span>")
+				if(src.has_sensor == DAMAGED_SENSORS_LIVING)
+					to_chat(usr, "<span class='warning'>Your suit's vital tracker is broken, so it will only report whether you are alive or dead.</span>")
+					sensor_mode = SENSOR_LIVING
+				else
+					to_chat(usr, "<span class='notice'>Your suit will now only report your exact vital lifesigns.</span>")
+					sensor_mode = sensor_mode_intended
 			if(3)
-				to_chat(usr, "<span class='notice'>Your suit will now report your exact vital lifesigns as well as your coordinate position.</span>")
+				switch(src.has_sensor)
+					if(DAMAGED_SENSORS_LIVING)
+						to_chat(usr, "<span class='warning'>Your suit's tracking beacon and vital tracker is broken, so it will only report whether you are alive or dead.</span>")
+						sensor_mode = SENSOR_LIVING
+					if(DAMAGED_SENSORS_VITALS)
+						to_chat(usr, "<span class='warning'>Your suit's tracking beacon is broken, so it will only report your vital lifesigns.</span>")
+						sensor_mode = SENSOR_VITALS
+					if(HAS_SENSORS)
+						to_chat(usr, "<span class='notice'>Your suit will now report your exact vital lifesigns as well as your coordinate position.</span>")
+						sensor_mode = sensor_mode_intended
 
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
@@ -210,19 +280,28 @@
 	if(!isliving(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return
 
-	if(has_sensor == LOCKED_SENSORS)
-		to_chat(user, "The controls are locked.")
-		return
-	if(has_sensor == BROKEN_SENSORS)
-		to_chat(user, "The sensors have shorted out!")
-		return
+	if(src.has_sensor == BROKEN_SENSORS)
+		to_chat(usr, "The sensors have shorted out!")
+		return 0
+	if(src.sensor_flags & SENSOR_LOCKED)
+		to_chat(usr, "The controls are locked.")
+		return 0
 	if(has_sensor <= NO_SENSORS)
 		to_chat(user, "This suit does not have any sensors.")
 		return
 
-	sensor_mode = SENSOR_COORDS
+	sensor_mode_intended = SENSOR_COORDS
 
-	to_chat(user, "<span class='notice'>Your suit will now report your exact vital lifesigns as well as your coordinate position.</span>")
+	switch(src.has_sensor)
+		if(DAMAGED_SENSORS_LIVING)
+			to_chat(usr, "<span class='warning'>Your suit's tracking beacon and vital tracker is broken, so it will only report whether you are alive or dead.</span>")
+			sensor_mode = SENSOR_LIVING
+		if(DAMAGED_SENSORS_VITALS)
+			to_chat(usr, "<span class='warning'>Your suit's tracking beacon is broken, so it will only report your vital lifesigns.</span>")
+			sensor_mode = SENSOR_VITALS
+		if(HAS_SENSORS)
+			to_chat(usr, "<span class='notice'>Your suit will now report your exact vital lifesigns as well as your coordinate position.</span>")
+			sensor_mode = sensor_mode_intended
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -51,7 +51,7 @@
 
 /obj/item/clothing/under/take_damage_zone(def_zone, damage_amount, damage_type, armour_penetration)
 	..()
-	if(sensormaxintegrity == 0 || has_sensor == NO_SENSORS) return //sensors are invincible if max integrity is 0
+	if(sensormaxintegrity == 0 || has_sensor == NO_SENSORS || sensordamage >= sensormaxintegrity) return //sensors are invincible if max integrity is 0
 	var/damage_dealt = take_damage(damage_amount * 0.1, damage_type, armour_penetration, FALSE) * 10 // only deal 10% of the damage to the general integrity damage, then multiply it by 10 so we know how much to deal to limb
 	sensordamage += damage_dealt
 	var/integ = has_sensor

--- a/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
@@ -59,7 +59,7 @@
 	item_state = "captain_envirosuit"
 	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 95, "acid" = 95, "wound" = 15)
 	sensor_mode = SENSOR_COORDS
-	random_sensor = FALSE
+	sensor_flags = NONE
 
 /obj/item/clothing/under/plasmaman/mime
 	name = "mime envirosuit"

--- a/code/modules/clothing/under/jobs/Plasmaman/security.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/security.dm
@@ -5,7 +5,7 @@
 	item_state = "security_envirosuit"
 	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 95, "acid" = 95, "wound" = 10)
 	sensor_mode = SENSOR_COORDS
-	random_sensor = FALSE
+	sensor_flags = NONE
 
 /obj/item/clothing/under/plasmaman/security/warden
 	name = "warden plasma envirosuit"

--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -5,7 +5,7 @@
 	item_state = "b_suit"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0, "wound" = 15)
 	sensor_mode = SENSOR_COORDS
-	random_sensor = FALSE
+	sensor_flags = NONE
 
 /obj/item/clothing/under/rank/captain/util
 	name = "command utility uniform"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -12,7 +12,7 @@
 	strip_delay = 50
 	alt_covers_chest = TRUE
 	sensor_mode = SENSOR_COORDS
-	random_sensor = FALSE
+	sensor_flags = NONE
 
 /obj/item/clothing/under/rank/security/officer
 	name = "security jumpsuit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -23,16 +23,15 @@
 	name = "prison jumpsuit"
 	desc = "It's standardised Nanotrasen prisoner-wear. Its suit sensors are stuck in the \"Fully On\" position."
 	icon_state = "prisoner"
-	item_state = "o_suit"
-	has_sensor = LOCKED_SENSORS
+	item_state = "prisoner"
 	sensor_mode = SENSOR_COORDS
-	random_sensor = FALSE
+	sensor_flags = SENSOR_LOCKED
 
 /obj/item/clothing/under/rank/prisoner/skirt
 	name = "prison jumpskirt"
 	desc = "It's standardised Nanotrasen prisoner-wear. Its suit sensors are stuck in the \"Fully On\" position."
 	icon_state = "prisoner_skirt"
-	item_state = "o_suit"
+	item_state = "prisoner_skirt"
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
@@ -166,6 +165,7 @@
 /obj/item/clothing/under/misc/gear_harness
 	name = "gear harness"
 	desc = "A simple, inconspicuous harness replacement for a jumpsuit."
+	limb_integrity = 180
 	icon_state = "gear_harness"
 	item_state = "gear_harness"
 	can_adjust = TRUE

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -90,7 +90,7 @@ As the Chief Engineer, you can rename areas or create entirely new ones using yo
 As the Chief Engineer, your hardsuit is significantly better than everybody else's. It has the best features of both engineering and atmospherics hardsuits - boasting nigh-invulnerability to radiation and all atmospheric conditions.
 As the Chief Engineer, you can spy on and even forge PDA communications with the message monitor console! The key is in your office.
 As the Chief Engineer, your locker contains a jetpack upgrade that can be attached to hardsuits.
-As the Chief Engineer, the power flow control console in your office will show you APC infos and lets you control them remotely. 
+As the Chief Engineer, the power flow control console in your office will show you APC infos and lets you control them remotely.
 As an Engineer, the supermatter shard is an extremely dangerous piece of equipment: touching it will disintegrate you.
 As an Engineer, you can electrify grilles by placing wire "nodes" beneath them: the big seemingly unconnected bulges from a half completed wiring job.
 As an Engineer, return to Engineering once in a while to check on the engine and SMES cells. It's always a good idea to make sure containment isn't compromised.
@@ -112,7 +112,7 @@ As an Atmospheric Technician, your backpack firefighter tank can launch resin. T
 As an Atmospheric Technician, your ATMOS holofan projectors can blocks gases and heat while allowing objects to pass through. With it, you can quickly contain gas spills, fires and hull breaches. Or, use it to create a plasmaman friendly lounge.
 As an Atmospheric Technician, burning a plasma/oxygen mix inside the incinerator will not only produce power, but also gases such as tritium and water vapor.
 As an Atmospheric Technician, you can change the layer of a pipe by clicking with it on a wrenched pipe or other atmos component of the desired layer.
-As an Atmospheric Technician, you can take a few cans worth of N2/N2O and cool it down at local freezers. This is a good idea when dealing with (or preparing for) a supermatter meltdown. 
+As an Atmospheric Technician, you can take a few cans worth of N2/N2O and cool it down at local freezers. This is a good idea when dealing with (or preparing for) a supermatter meltdown.
 As the Head of Security, you are expected to coordinate your security force to handle any threat that comes to the station. Sometimes it means making use of the armory to handle a blob, sometimes it means being ruthless during a revolution or cult.
 As the Head of Security, you can call for executions or forced cyborgization, but may require the Captain's approval.
 As the Head of Security, don't let the power go to your head. You may have high access, great equipment, and a miniature army at your side, but being a terrible person without a good reason is grounds for banning.
@@ -121,14 +121,14 @@ As the Warden, keep a close eye on the armory at all times, as it is a favored s
 As the Warden, if a prisoner's crimes are heinous enough you can put them in permabrig or the gulag. Make sure to check on them once in a while!
 As the Warden, never underestimate the power of tech slugs! Scattershot fires a cone of weaker lasers with little damage fall off, Ion slugs fires EMPs that only effect the tiles they hit, and Pulse slugs fire a singular laser that can one-hit almost any wall!
 As the Warden, you can use a surgical saw on riot shotguns to shorten the barrel, making them able to fit in your backpack. Make sure to empty them prior lest you blast yourself in the face!
-As the Warden, you can implant criminals you suspect might re-offend with devices that will track their location and allow you to remotely inject them with disabling chemicals. 
+As the Warden, you can implant criminals you suspect might re-offend with devices that will track their location and allow you to remotely inject them with disabling chemicals.
 As the Warden, you can use handcuffs on orange prisoner shoes to turn them into cuffed shoes, forcing prisoners to walk and potentially thwarting an escape.
 As the Warden, tracker implants can be used on crewmembers. Doing this will let you track their person even without suit sensors and even instantly teleport to them at the local teleporter, although the implant will biodegrade after 5 minutes if its holder ever expires.
 As the Warden, cryostasis shotgun darts hold 10u of chemicals that will not react until it hits someone.
 As the Warden, chemical implants can be loaded with a cocktail of healing or combat chems, perfect for the HoS or other security officers to make use of in a pinch. Be sure to keep a eye on them though, as they cannot be injected without the prisoner management console! EMPs or starvation might lead to the chemical implant going off preemptively.
 As the Warden, tracker implants can be used on your security officers. Doing this will let you be able to message them when telecomms are out, or when you suspect comms are compromised. This is also good against rogue AIs as the prisoner tracker doesn't leave logs or alarms for the AI.
 As a Security Officer, remember that correlation does not equal causation. Someone may have just been at the wrong place at the wrong time!
-As a Security Officer, remember that your belt can hold more than one stun baton. 
+As a Security Officer, remember that your belt can hold more than one stun baton.
 As a Security Officer, remember harm beating someone in the head with a blunt object can deconvert them form a being a revolutionary! This sadly doesn't work against either cult, nor does this protect them from getting reconverted unlike a mindshield implant.
 As a Security Officer, remember that you can attach a seclite to your taser or your helmet!
 As a Security Officer, communicate and coordinate with your fellow officers using the security channel (:s) to avoid confusion.
@@ -283,7 +283,7 @@ As a Ghost, you can double click on just about anything to follow it. Or just wa
 As a Ghost, there's a button in the OOC tab labeled Observe, it lets you see through someone's eyes as if you were the one who's playing them.
 As a Devil, you gain power for every three souls you control, however you also become more obvious.
 As a Devil, as long as you control at least one other soul, you will automatically resurrect, as long as a banishment ritual is not performed.
-At which time a Devil's nameth is spake on the tongue of man, the Devil may appeareth. 
+At which time a Devil's nameth is spake on the tongue of man, the Devil may appeareth.
 You can swap floor tiles by holding a crowbar in one hand and a stack of tiles in the other.
 When hacking doors, cutting and mending a "test light wire" will restore power to the door.
 When crafting most items, you can either manually combine parts or use the crafting menu.
@@ -301,3 +301,5 @@ Being out of combat mode makes makes you deal less damage to people and objects 
 Resting makes you deal less damage to people and objects when attacking. This stacks with the penalty incurred by being out of combat mode.
 You do not regenerate as much stamina while in combat mode. Resting (being on the ground) makes you regenerate stamina faster.
 Keybinds can be reassigned in character setup on the keybindings tab. This is extremely useful, especially if you know how to use independent binds.
+If your suit sensors have been shorted out, you can use cable coil to fix them by using the coil on your suit. Your suit needs to be in proper condition, however.
+Most clothing when damaged can be repaired using cloth, but there may be some clothes out there that will require different stacks of materials.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some changes to clothing damage and about clothing damage, and now the brand new addition of suit sensor damage.

Change 1:
Shredded clothing no longer drops. It's just completely useless and doesn't provide any armor bonuses anymore of any kind.

Change 2:
Suit sensors will get shorted out completely when clothing gets shredded, rather than getting damaged. Suit sensors can't be repaired until the shredded clothing gets repaired first.

Change 3:
Uniform limb integrity has been upped from 30 to 120. This is reflective of the change to suit sensors listed below. Uniforms are much more durable but the suit sensors have undergone some changes.

Change 4:
Probably the most important part of this PR. **Suit sensors now have integrity.** The more damaged they become, the less features that will be active from these suit sensors, starting from their coordinate system to the vital system, to breaking completely after binary sensors are gone.

Currently, all uniforms have suit sensors with 200 integrity overall, but a uniform can be modified to have more or less integrity by a coder later if desired. When 20% of this integrity is gone, suit sensors lose their tracking beacon capabilities. When 60% is gone, it loses the vital sensors. When 100% is gone, it's just broken. Obviously.

This means it would take two e-sword hits to destroy the suit sensor's tracking beacon, (it takes 40 damage to remove 20% of the integrity with current code) but rather than the original behavior of destroying suit sensors completely, it reduces it to vital trackers, alerting anyone paying attention to sensors of your condition, but not where you're currently at.

Change 5:
It wasn't really made clear that you could repair suit sensors. Two new tips of the round have been added to reflect this. The examine text is also reflective of this. Hopefully, this means everyone will be aware of needing cable coil to fix their suit sensors from now on.

Change 6:
Apparently the prisoner uniform sprites were messed up. This fixes that.

## Why It's Good For The Game
**Why I changed clothes dropping:**
It's not fun to have to deal with your clothes just shredding up and all your contents just dropping to the ground. It's about as obnoxious as having to deal with the abductor shrink ray.

This shouldn't mess with stuff like acid removing clothes. If clothes sustain enough damage, they will still get reduced to ashes by burning, reduced to shreds by explosions, or puddles of goop by acid and all that.

**The changes to how suit sensors are damaged:**
Previous behavior of how suit sensors would usually end up getting destroyed was that **if a single limb of a clothing gets torn away, the suit sensors are destroyed outright.** This pretty much made suit sensors useless and you might as well have them turned off. With this new system of suit sensor integrity, it still takes the same amount of esword hits to remove a crew member's ability to track you down after you get damaged, but the crew, if they're vigilant in monitoring suit sensors will see that you're getting hurt somewhere rather than you just disappearing off of sensors.

Suddenly, suit sensors are actually useful again, and victims of heresy would actually do well to keep those sensors up. They might not know where you're at precisely, but they'll know you died somewhere in maintenance at least. Isn't that comforting?

## Changelog
:cl:
balance: Clothing no longer drops when shredded. It just becomes useless.
balance: Suit sensors are guaranteed to short out when the clothes become shredded, not damaged now.
balance: Uniform limb integrity increased from 30 to 120.
balance: Suit sensor damage has been added. The more damaged your suit sensors get, the less features that will be available from these suit sensors. It takes two e-sword hits to ruin your tracking beacon for instance.
tweak: Examine text on uniforms is now more clear about needing cable coil to repair your suit sensors.
fix: Fixed prisoner uniform sprite paths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
