### PR TITLE
Nightmares' light eater can now destroy messes that emit light

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -181,6 +181,10 @@
 		if(T.light_range && !isspaceturf(T)) //no fairy grass or light tile can escape the fury of the darkness.
 			to_chat(user, "<span class='notice'>You scrape away [T] with your [name] and snuff out its lights.</span>")
 			T.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
+	else if(is_cleanable(AM))
+		var/obj/effect/E = AM
+		if(E.light_range && E.light_power)
+			disintegrate(E)
 	else if(isliving(AM))
 		var/mob/living/L = AM
 		if(isethereal(AM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The nightmare's light eater can now destroy messes that emit light. Like glowing goo, or ectoplasmic puddles.

## Why It's Good For The Game

It's something the nightmare should have been able to destroy to begin with. That ghost burger can go away with that shenanigans.

## Changelog
:cl:
fix: The nightmare's light eater can now destroy messes that emit light, like glowing goo or ectoplasmic puddles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
