### PR TITLE
noguns now takes precedence over trigger guard

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -116,7 +116,7 @@
 	if(!.)
 		return
 	if(HAS_TRAIT(src, TRAIT_NOGUNS))
-		to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
+		to_chat(src, "<span class='warning'>You can't bring yourself to use a ranged weapon!</span>")
 		return FALSE
 	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
 		if(HAS_TRAIT(src, TRAIT_CHUNKYFINGERS))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -115,12 +115,12 @@
 	. = ..()
 	if(!.)
 		return
+	if(HAS_TRAIT(src, TRAIT_NOGUNS))
+		to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
+		return FALSE
 	if(G.trigger_guard == TRIGGER_GUARD_NORMAL)
 		if(HAS_TRAIT(src, TRAIT_CHUNKYFINGERS))
 			to_chat(src, "<span class='warning'>Your meaty finger is much too large for the trigger guard!</span>")
-			return FALSE
-		if(HAS_TRAIT(src, TRAIT_NOGUNS))
-			to_chat(src, "<span class='warning'>Your fingers don't fit in the trigger guard!</span>")
 			return FALSE
 
 /mob/living/carbon/human/proc/get_bank_account()


### PR DESCRIPTION
## About The Pull Request
see title

## Why It's Good For The Game
"scarp/rbass using guns is intended design" what the fuck do you mean

## Changelog
:cl:
fix: The NOGUNS trait now takes precedence over the triggerguard checks.
/:cl:
