### PR TITLE
rebalances most available cybernetic limbs, axes damage reduction, makes upgraded limbs quite beefy/expensive (waiting on combat rework)

### DIFF
--- a/code/modules/cargo/exports/organs_robotics.dm
+++ b/code/modules/cargo/exports/organs_robotics.dm
@@ -136,10 +136,10 @@
 	unit_name = "robotic limb replacement"
 	export_types = list(/obj/item/bodypart/l_arm/robot/surplus, /obj/item/bodypart/r_arm/robot/surplus, /obj/item/bodypart/l_leg/robot/surplus, /obj/item/bodypart/r_leg/robot/surplus)
 
-/datum/export/robotics/surplus_upgraded
+/datum/export/robotics/upgraded
 	cost = 80
 	unit_name = "upgraded robotic limb replacement"
-	export_types = list(/obj/item/bodypart/l_arm/robot/surplus_upgraded, /obj/item/bodypart/r_arm/robot/surplus_upgraded, /obj/item/bodypart/l_leg/robot/surplus_upgraded, /obj/item/bodypart/r_leg/robot/surplus_upgraded)
+	export_types = list(/obj/item/bodypart/l_arm/robot/upgraded, /obj/item/bodypart/r_arm/robot/upgraded, /obj/item/bodypart/l_leg/robot/upgraded, /obj/item/bodypart/r_leg/robot/upgraded, /obj/item/bodypart/chest/robot/upgraded, /obj/item/bodypart/head/robot/upgraded)
 
 /datum/export/robotics/surgery_gear_basic
 	cost = 50

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -985,50 +985,71 @@
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/adv_r_leg
-	name = "Advanced prosthetic right leg"
-	desc = "A renforced prosthetic right leg."
-	id = "adv_r_leg"
+/datum/design/upgraded_r_leg
+	name = "Upgraded prosthetic right leg"
+	desc = "A reinforced prosthetic right leg."
+	id = "upgraded_r_leg"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(/datum/material/iron = 6000, /datum/material/glass = 3500, /datum/material/gold = 500, /datum/material/titanium = 800)
-	construction_time = 40
-	build_path = /obj/item/bodypart/r_leg/robot/surplus_upgraded
+	materials = list(/datum/material/iron = 10000, /datum/material/plasma = 1000, /datum/material/titanium = 5000)
+	construction_time = 160
+	build_path = /obj/item/bodypart/r_leg/robot/upgraded
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/adv_l_leg
-	name = "Advanced prosthetic left leg"
-	desc = "A renforced prosthetic left leg."
-	id = "adv_l_leg"
+/datum/design/upgraded_l_leg
+	name = "Upgraded prosthetic left leg"
+	desc = "A reinforced prosthetic left leg."
+	id = "upgraded_l_leg"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(/datum/material/iron = 6000, /datum/material/glass = 3500, /datum/material/gold = 500, /datum/material/titanium = 800)
-	construction_time = 40
-	build_path = /obj/item/bodypart/l_leg/robot/surplus_upgraded
+	materials = list(/datum/material/iron = 10000, /datum/material/plasma = 1000, /datum/material/titanium = 5000)
+	construction_time = 160
+	build_path = /obj/item/bodypart/l_leg/robot/upgraded
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
-/datum/design/adv_l_arm
-	name = "Advanced prosthetic left arm"
-	desc = "A renforced prosthetic left arm."
-	id = "adv_l_arm"
+/datum/design/upgraded_l_arm
+	name = "Upgraded prosthetic left arm"
+	desc = "A reinforced prosthetic left arm."
+	id = "upgraded_l_arm"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(/datum/material/iron = 6000, /datum/material/glass = 3500, /datum/material/gold = 500, /datum/material/titanium = 800)
-	construction_time = 40
-	build_path = /obj/item/bodypart/l_arm/robot/surplus_upgraded
+	materials = list(/datum/material/iron = 10000, /datum/material/plasma = 1000, /datum/material/titanium = 5000)
+	construction_time = 160
+	build_path = /obj/item/bodypart/l_arm/robot/upgraded
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/adv_r_arm
-	name = "Advanced prosthetic right arm"
-	desc = "A renforced prosthetic right arm."
-	id = "adv_r_arm"
+	name = "Upgraded prosthetic right arm"
+	desc = "A reinforced prosthetic right arm."
+	id = "upgraded_r_arm"
 	build_type = PROTOLATHE | MECHFAB
-	materials = list(/datum/material/iron = 6000, /datum/material/glass = 3500, /datum/material/gold = 500, /datum/material/titanium = 800)
-	construction_time = 40
-	build_path = /obj/item/bodypart/r_arm/robot/surplus_upgraded
+	materials = list(/datum/material/iron = 10000, /datum/material/plasma = 1000, /datum/material/titanium = 5000)
+	construction_time = 160
+	build_path = /obj/item/bodypart/r_arm/robot/upgraded
 	category = list("Misc","Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
+/datum/design/upgraded_torso
+	name = "Upgraded prosthetic torso"
+	desc = "A reinforced prosthetic torso."
+	id = "upgraded_torso"
+	build_type = PROTOLATHE | MECHFAB
+	materials = list(/datum/material/iron = 40000, /datum/material/plasma = 1000, /datum/material/titanium = 20000)
+	construction_time = 160
+	build_path = /obj/item/bodypart/chest/robot/upgraded
+	category = list("Misc","Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/upgraded_head
+	name = "Upgraded prosthetic head"
+	desc = "A reinforced prosthetic head."
+	id = "upgraded_head"
+	build_type = PROTOLATHE | MECHFAB
+	materials = list(/datum/material/iron = 5000, /datum/material/plasma = 1000, /datum/material/titanium = 2500)
+	construction_time = 160
+	build_path = /obj/item/bodypart/head/robot/upgraded
+	category = list("Misc","Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /////////////////////////////////////////
 ////////////     Plumbing      //////////

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -51,13 +51,13 @@
 	prereq_ids = list("biotech")
 	design_ids = list("basic_l_arm", "basic_r_arm", "basic_r_leg", "basic_l_leg")
 
-/datum/techweb_node/advance_limbs
-	id = "advance_limbs"
+/datum/techweb_node/upgraded_limbs
+	id = "upgraded_limbs"
 	display_name = "Upgraded Prosthetics"
 	description = "Reinforced prosthetics for the impaired."
-	prereq_ids = list("adv_biotech", "surplus_limbs")
-	design_ids = list("adv_l_arm", "adv_r_arm", "adv_r_leg", "adv_l_leg")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1250)
+	prereq_ids = list("adv_biotech", "surplus_limbs", "cyber_implants")
+	design_ids = list("upgraded_l_arm", "upgraded_r_arm", "upgraded_r_leg", "upgraded_l_leg", "upgraded_torso", "upgraded_head")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/subdermal_implants
 	id = "subdermal_implants"

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -34,9 +34,6 @@
 	var/max_damage = 0
 	var/stam_heal_tick = 0		//per Life(). Defaults to 0 due to citadel changes
 
-	var/brute_reduction = 0 //Subtracted to brute damage taken
-	var/burn_reduction = 0	//Subtracted to burn damage taken
-
 	//Coloring and proper item icon update
 	var/skin_tone = ""
 	var/body_gender = ""
@@ -197,8 +194,6 @@
 	brute = round(max(brute * dmg_mlt, 0),DAMAGE_PRECISION)
 	burn = round(max(burn * dmg_mlt, 0),DAMAGE_PRECISION)
 	stamina = round(max((stamina * dmg_mlt) * incoming_stam_mult, 0),DAMAGE_PRECISION)
-	brute = max(0, brute - brute_reduction)
-	burn = max(0, burn - burn_reduction)
 	//No stamina scaling.. for now..
 
 	if(!brute && !burn && !stamina)

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -315,14 +315,14 @@
 /obj/item/bodypart/chest/robot/upgraded
 	name = "reinforced prosthetic torso"
 	desc = "A robotic torso, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
-	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
-	threshhold_passed_mindamage = 40
+	easy_heal_threshhold = 60 //Since this is a core body part, this gets a much higher easy heal threshold and singificantly lower mindamage
+	threshhold_passed_mindamage = 10
 
 /obj/item/bodypart/head/robot/upgraded
 	name = "reinforced prosthetic head"
 	desc = "A robotic braincase, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
-	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
-	threshhold_passed_mindamage = 40
+	easy_heal_threshhold = 60 //Since this is a core body part, this gets a much higher easy heal threshold and singificantly lower mindamage
+	threshhold_passed_mindamage = 10
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG
 #undef ROBOTIC_MEDIUM_BRUTE_MSG

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -20,8 +20,7 @@
 	icon_state = "borg_l_arm"
 	status = BODYPART_ROBOTIC
 
-	brute_reduction = 2
-	burn_reduction = 1
+	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -43,8 +42,7 @@
 	icon_state = "borg_r_arm"
 	status = BODYPART_ROBOTIC
 
-	brute_reduction = 2
-	burn_reduction = 1
+	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -66,8 +64,7 @@
 	icon_state = "borg_l_leg"
 	status = BODYPART_ROBOTIC
 
-	brute_reduction = 2
-	burn_reduction = 1
+	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -89,8 +86,7 @@
 	icon_state = "borg_r_leg"
 	status = BODYPART_ROBOTIC
 
-	brute_reduction = 2
-	burn_reduction = 1
+	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -111,9 +107,8 @@
 	icon_state = "borg_chest"
 	status = BODYPART_ROBOTIC
 
-	brute_reduction = 2
-	burn_reduction = 1
-	easy_heal_threshhold = 40 //Resistant against damage, but high mindamage once the threshhold is passed
+	wound_resistance = 10
+	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
@@ -174,10 +169,9 @@
 	icon_state = "borg_head"
 	status = BODYPART_ROBOTIC
 
-	brute_reduction = 5
-	burn_reduction = 4
-	easy_heal_threshhold = 40 //Resistant against damage, but high mindamage once the threshhold is passed
-	threshhold_passed_mindamage = 20
+	wound_resistance = 10
+	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
+	threshhold_passed_mindamage = 25
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -251,82 +245,100 @@
 	name = "surplus prosthetic left arm"
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
-	max_damage = 20
-	easy_heal_threshhold = 15 //Weak. Low threshhold, but also relatively low mindamage
-	threshhold_passed_mindamage = 10
+	max_damage = 25
+	max_stamina_damage = 25
+	wound_resistance = -20
+	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
+	threshhold_passed_mindamage = 15
 
 /obj/item/bodypart/r_arm/robot/surplus
 	name = "surplus prosthetic right arm"
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
-	max_damage = 20
-	easy_heal_threshhold = 15 //Weak. Low threshhold, but also relatively low mindamage
-	threshhold_passed_mindamage = 10
+	max_damage = 25
+	max_stamina_damage = 25
+	wound_resistance = -20
+	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
+	threshhold_passed_mindamage = 15
 
 /obj/item/bodypart/l_leg/robot/surplus
 	name = "surplus prosthetic left leg"
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
-	max_damage = 20
-	easy_heal_threshhold = 15 //Weak. Low threshhold, but also relatively low mindamage
-	threshhold_passed_mindamage = 10
+	max_damage = 25
+	max_stamina_damage = 25
+	wound_resistance = -20
+	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
+	threshhold_passed_mindamage = 15
 
 /obj/item/bodypart/r_leg/robot/surplus
 	name = "surplus prosthetic right leg"
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
-	max_damage = 20
-	easy_heal_threshhold = 15 //Weak. Low threshhold, but also relatively low mindamage
-	threshhold_passed_mindamage = 10
+	max_damage = 25
+	max_stamina_damage = 25
+	wound_resistance = -20
+	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
+	threshhold_passed_mindamage = 15
 
-// Upgraded Surplus lims - Better then robotic limbs
-/obj/item/bodypart/l_arm/robot/surplus_upgraded
-	name = "reinforced surplus prosthetic left arm"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of parts with more fallbacks against internal damage."
-	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
-	max_damage = 55
-	easy_heal_threshhold = 20 //Lower threshhold than true robotic limbs, but very low mindamage too.
-	threshhold_passed_mindamage = 5
+// Upgraded Prosthesics - Harder to hurt, harder to fix
+/obj/item/bodypart/l_arm/robot/upgraded
+	name = "reinforced prosthetic left arm"
+	desc = "A robotic limb, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
+	max_damage = 70
+	max_stamina_damage = 70
+	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
+	stam_damage_coeff = 0.5
+	wound_resistance = 25
+	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
+	threshhold_passed_mindamage = 40
 
-/obj/item/bodypart/r_arm/robot/surplus_upgraded
-	name = "reinforced surplus prosthetic right arm"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of parts with more fallbacks against internal damage."
-	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
-	max_damage = 55
-	easy_heal_threshhold = 20 //Lower threshhold than true robotic limbs, but very low mindamage too.
-	threshhold_passed_mindamage = 5
+/obj/item/bodypart/r_arm/robot/upgraded
+	name = "reinforced prosthetic right arm"
+	desc = "A robotic limb, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
+	max_damage = 70
+	max_stamina_damage = 70
+	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
+	stam_damage_coeff = 0.5
+	wound_resistance = 25
+	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
+	threshhold_passed_mindamage = 40
 
-/obj/item/bodypart/l_leg/robot/surplus_upgraded
-	name = "reinforced surplus prosthetic left leg"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of parts with more fallbacks against internal damage."
-	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
-	max_damage = 55
-	easy_heal_threshhold = 20 //Lower threshhold than true robotic limbs, but very low mindamage too.
-	threshhold_passed_mindamage = 5
+/obj/item/bodypart/l_leg/robot/upgraded
+	name = "reinforced prosthetic left leg"
+	desc = "A robotic limb, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
+	max_damage = 70
+	max_stamina_damage = 70
+	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
+	stam_damage_coeff = 0.5
+	wound_resistance = 25
+	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
+	threshhold_passed_mindamage = 40
 
-/obj/item/bodypart/r_leg/robot/surplus_upgraded
-	name = "reinforced surplus prosthetic right leg"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of parts with more fallbacks against internal damage."
-	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 3
-	burn_reduction = 2
-	max_damage = 55
-	easy_heal_threshhold = 20 //Lower threshhold than true robotic limbs, but very low mindamage too.
-	threshhold_passed_mindamage = 5
+/obj/item/bodypart/r_leg/robot/upgraded
+	name = "reinforced prosthetic right leg"
+	desc = "A robotic limb, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
+	max_damage = 70
+	max_stamina_damage = 70
+	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
+	stam_damage_coeff = 0.5
+	wound_resistance = 25
+	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
+	threshhold_passed_mindamage = 40
+
+/obj/item/bodypart/chest/robot/upgraded
+	name = "reinforced prosthetic torso"
+	desc = "A robotic torso, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
+	wound_resistance = 25
+	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
+	threshhold_passed_mindamage = 40
+
+/obj/item/bodypart/head/robot/upgraded
+	name = "reinforced prosthetic head"
+	desc = "A robotic braincase, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
+	wound_resistance = 25
+	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
+	threshhold_passed_mindamage = 40
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG
 #undef ROBOTIC_MEDIUM_BRUTE_MSG

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -20,7 +20,6 @@
 	icon_state = "borg_l_arm"
 	status = BODYPART_ROBOTIC
 
-	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -42,7 +41,6 @@
 	icon_state = "borg_r_arm"
 	status = BODYPART_ROBOTIC
 
-	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -64,7 +62,6 @@
 	icon_state = "borg_l_leg"
 	status = BODYPART_ROBOTIC
 
-	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -86,7 +83,6 @@
 	icon_state = "borg_r_leg"
 	status = BODYPART_ROBOTIC
 
-	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -107,7 +103,6 @@
 	icon_state = "borg_chest"
 	status = BODYPART_ROBOTIC
 
-	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -169,7 +164,6 @@
 	icon_state = "borg_head"
 	status = BODYPART_ROBOTIC
 
-	wound_resistance = 10
 	easy_heal_threshhold = 35 //Resistant against damage, but high mindamage once the threshhold is passed
 	threshhold_passed_mindamage = 25
 
@@ -247,7 +241,6 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	max_damage = 25
 	max_stamina_damage = 25
-	wound_resistance = -20
 	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
 	threshhold_passed_mindamage = 15
 
@@ -257,7 +250,6 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	max_damage = 25
 	max_stamina_damage = 25
-	wound_resistance = -20
 	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
 	threshhold_passed_mindamage = 15
 
@@ -267,7 +259,6 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	max_damage = 25
 	max_stamina_damage = 25
-	wound_resistance = -20
 	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
 	threshhold_passed_mindamage = 15
 
@@ -277,7 +268,6 @@
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
 	max_damage = 25
 	max_stamina_damage = 25
-	wound_resistance = -20
 	easy_heal_threshhold = 15 //Weak. Low threshhold, requiring specialized repair once damaged
 	threshhold_passed_mindamage = 15
 
@@ -289,7 +279,6 @@
 	max_stamina_damage = 70
 	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
 	stam_damage_coeff = 0.5
-	wound_resistance = 25
 	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
 	threshhold_passed_mindamage = 40
 
@@ -300,7 +289,6 @@
 	max_stamina_damage = 70
 	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
 	stam_damage_coeff = 0.5
-	wound_resistance = 25
 	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
 	threshhold_passed_mindamage = 40
 
@@ -311,7 +299,6 @@
 	max_stamina_damage = 70
 	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
 	stam_damage_coeff = 0.5
-	wound_resistance = 25
 	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
 	threshhold_passed_mindamage = 40
 
@@ -322,21 +309,18 @@
 	max_stamina_damage = 70
 	body_damage_coeff = 0.5 //keeps core damage contribution cap roughly equivalent despite higher actual health
 	stam_damage_coeff = 0.5
-	wound_resistance = 25
 	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
 	threshhold_passed_mindamage = 40
 
 /obj/item/bodypart/chest/robot/upgraded
 	name = "reinforced prosthetic torso"
 	desc = "A robotic torso, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
-	wound_resistance = 25
 	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
 	threshhold_passed_mindamage = 40
 
 /obj/item/bodypart/head/robot/upgraded
 	name = "reinforced prosthetic head"
 	desc = "A robotic braincase, reinforced to protect the internals from impact, but also significantly harder to repair without assistance."
-	wound_resistance = 25
 	easy_heal_threshhold = 40 //Can take significantly higher amounts of damage, but once you hit the threshold, cable and welding won't cut it.
 	threshhold_passed_mindamage = 40
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The majority of the cyberlimbs were all over the shop, numbers wise, so this tries to bring them more in line with some of their intent.

**1) Flat damage reduction is removed**

There was a balance change to prevent augmented people from being spaceproof, and that spaceproofedness was due to cyberlimbs simply reducing any incoming brute/burn by a flat amount, not ACTUAL space immunity.

The current numbers are so tiny as to be pretty much pointless, so instead of trying to work out what a reasonable number might be. So in the bin it goes.

**2) Alters the health values of the limbs based on tier, as well as their damage thresholds**

Surplus limbs have slightly higher health, but much worse thresholds for damage caps. As a result, getting hit a few times too hard in those limbs will permanently cap you at half limb health. In addition, surplus limbs aren't resilient against stamina damage anymore. A disabler shot WILL take out your limb without armor.

Normal cyber limbs are unchanged for health/thresholding, but the head and chest have been brought into line with the rest of the body. Why these were left untouched is entirely beyond me, but there you go.

Upgraded limbs are now significantly more material hungry and a little deeper in the tree, but are much beefier than a standard limb, with much higher thresholding, max health and more forgiving damage-to-core health ratio (which is an effective damage reduction just fyi). It does, however, cap at a much higher value than the other limbs if you hit the damage threshold, which can become a significant liability. 

The upgraded torso and head, however, are strictly an upgrade on basic cybernetic torsos and heads, with a hefty easy heal threshold and very small minimum damage point.


## Why It's Good For The Game

Cybernetics are kind of a mess and it might have something to do with mixed intentions with a **reinforced** _surplus_ limb still being harder to damage, yet not more durable.

## Changelog
:cl:
balance: The tiers for cybernetic limbs have been largely overhauled.
balance: Surplus are slightly more durable but break far more easily, and more vulnerable to stamina damage.
balance: Cyber torsos and heads no longer get oddly disproportionate values to their limbs.
balance: Upgraded cyber limbs are very hard to destroy, but once they break, they require specialized help.
balance: Upgraded cyber torsos and heads are much easier to maintain and even MORE difficult to permanently damage than their limbs. (mostly because they're part of core health and don't have inherent damage reductions as a result)
balance: Upgraded prosthetics require more tech and a lot, lot more materials to make.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
