### PR TITLE
is it really an augmentation if you're using a synthflesh-grown limb? no, probably not, but what if you could

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -178,6 +178,7 @@
 	limb.update_icon_dropped()
 	limb.name = "\improper synthetic [lowertext(selected.name)] [limb.name]"
 	limb.desc = "A synthetic [selected_category] limb that will morph on its first use in surgery. This one is for the [parse_zone(limb.body_zone)]."
+	limb.forcereplace = TRUE
 	for(var/obj/item/bodypart/BP in limb)
 		BP.base_bp_icon = selected.icon_limbs || DEFAULT_BODYPART_ICON_ORGANIC
 		BP.species_id = selected.limbs_id

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -99,6 +99,9 @@
 	var/generic_bleedstacks
 	/// If we have a gauze wrapping currently applied (not including splints)
 	var/obj/item/stack/current_gauze
+	/// does this limb have replacement capability, despite probably not being robotic?
+	// see code\modules\surgery\limb_augmentation.dm, or code\game\machinery\limbgrower.dm
+	var/forcereplace = FALSE
 
 /obj/item/bodypart/examine(mob/user)
 	. = ..()

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -10,7 +10,7 @@
 	if(istype(tool, /obj/item/organ_storage) && istype(tool.contents[1], /obj/item/bodypart))
 		tool = tool.contents[1]
 	var/obj/item/bodypart/aug = tool
-	if(!aug.is_robotic_limb())
+	if(!aug.is_robotic_limb() && !aug.forcereplace) // forcereplace used here to allow for replacing limbs with synthflesh variants
 		to_chat(user, "<span class='warning'>That's not an augment, silly!</span>")
 		return -1
 	if(aug.body_zone != target_zone)
@@ -18,9 +18,14 @@
 		return -1
 	L = surgery.operated_bodypart
 	if(L)
-		display_results(user, target, "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>",
-			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)] with [aug].",
-			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)].")
+		if(aug.is_robotic_limb())
+			display_results(user, target, "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>",
+				"[user] begins to augment [target]'s [parse_zone(user.zone_selected)] with [aug].",
+				"[user] begins to augment [target]'s [parse_zone(user.zone_selected)].")
+		else
+			display_results(user, target, "<span class ='notice'>You begin to replace [target]'s [parse_zone(user.zone_selected)]...</span>",
+				"[user] begins to replace [target]'s [parse_zone(user.zone_selected)] with [aug].",
+				"[user] begins to replace [target]'s [parse_zone(user.zone_selected)].")
 	else
 		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
 
@@ -47,10 +52,15 @@
 			tool = tool.contents[1]
 		if(istype(tool) && user.temporarilyRemoveItemFromInventory(tool))
 			tool.replace_limb(target, TRUE)
-		display_results(user, target, "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>",
-			"[user] successfully augments [target]'s [parse_zone(target_zone)] with [tool]!",
-			"[user] successfully augments [target]'s [parse_zone(target_zone)]!")
-		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
+		if(tool.is_robotic_limb())
+			display_results(user, target, "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>",
+				"[user] successfully augments [target]'s [parse_zone(target_zone)] with [tool]!",
+				"[user] successfully augments [target]'s [parse_zone(target_zone)]!")
+		else
+			display_results(user, target, "<span class='notice'>You successfully replace [target]'s [parse_zone(target_zone)].</span>",
+				"[user] successfully replaces [target]'s [parse_zone(target_zone)] with [tool]!",
+				"[user] successfully replaces [target]'s [parse_zone(target_zone)]!")
+		log_combat(user, target, "augmented", addition="by giving them a new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 	else
 		to_chat(user, "<span class='warning'>[target] has no organic [parse_zone(target_zone)] there!</span>")
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
allows limbgrower printed synthetic limbs to be used in augmentation surgeries, which is probably a good idea for catastrophic burns on chest or head (unless you just want to chuck their ass in cryo for a while or just duct tape a shitty prosthetic chest or head on them)
## Why It's Good For The Game
"uhh, limb's fucked mate" handling options:
a. replace with prosthetic
b. shove into cryo, if it's set
this pr adds a variant of a, "replace with synthflesh limb", in case you want to keep your fleshy bits fleshy but don't want to wait in cryo or w/e. or maybe you want to replace your perfectly good metal torso with a fleshy one? up to you i guess
## Changelog
:cl:
tweak: Limb grower-printed synthetic limbs can now be used to "augment" (or, more accurately, replace) limbs. Mainly the torso, I guess? Unless you wanted to replace your robot hand with a fleshy one. ...That's a weird thought, actually.
/:cl: