### PR TITLE
the loadout now recognises collars as polychromic items

### DIFF
--- a/modular_citadel/code/modules/client/loadout/neck.dm
+++ b/modular_citadel/code/modules/client/loadout/neck.dm
@@ -21,6 +21,8 @@
 /datum/gear/neck/collar
 	name = "Collar"
 	path = /obj/item/clothing/neck/petcollar
+	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION | LOADOUT_CAN_COLOR_POLYCHROMIC
+	loadout_initial_colors = list("#00BBBB")
 
 /datum/gear/neck/leathercollar
 	name = "Leather collar"


### PR DESCRIPTION
## About The Pull Request
did you know collars are polychromic? i did not, and thus didn't mark them as one in the cool colouring changes

this means when colouring pet collars in the loadout, you will colour them as you would naturally in-game

## Why It's Good For The Game
someone was asking about why they got coloured wrong and bugs are bad

## Changelog
:cl:
fix: the loadout now colours pet collars correctly
/:cl:
