### PR TITLE
Added "Diamond Ingots" for Blacksmithing

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -52,7 +52,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	name = "diamond"
 	desc = "Highly pressurized carbon"
 	color = list(48/255, 272/255, 301/255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0)
-	strength_modifier = 1.1
+	strength_modifier = 1.2
 	alpha = 132
 	categories = list(MAT_CATEGORY_ORE = TRUE, MAT_CATEGORY_RIGID = TRUE, MAT_CATEGORY_BASE_RECIPES = TRUE)
 	sheet_type = /obj/item/stack/sheet/mineral/diamond

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	new/datum/stack_recipe("Captain Statue", /obj/structure/statue/diamond/captain, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Hologram Statue", /obj/structure/statue/diamond/ai1, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Core Statue", /obj/structure/statue/diamond/ai2, 5, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("diamond ingot", /obj/item/ingot/diamond, 6, time = 100), \ 
+	new/datum/stack_recipe("diamond ingot", /obj/item/ingot/diamond, 6, time = 100), \
 	))
 
 /obj/item/stack/sheet/mineral/diamond/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	new/datum/stack_recipe("Captain Statue", /obj/structure/statue/diamond/captain, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Hologram Statue", /obj/structure/statue/diamond/ai1, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Core Statue", /obj/structure/statue/diamond/ai2, 5, one_per_turf = 1, on_floor = 1), \
-//	new/datum/stack_recipe("diamond brick", /obj/item/ingot/diamond, 6, time = 100), \ not yet
+	new/datum/stack_recipe("diamond brick", /obj/item/ingot/diamond, 6, time = 100), \ Diamond Sword is a'go
 	))
 
 /obj/item/stack/sheet/mineral/diamond/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	new/datum/stack_recipe("Captain Statue", /obj/structure/statue/diamond/captain, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Hologram Statue", /obj/structure/statue/diamond/ai1, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Core Statue", /obj/structure/statue/diamond/ai2, 5, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("diamond brick", /obj/item/ingot/diamond, 6, time = 100), \ Diamond Sword is a'go
+	new/datum/stack_recipe("diamond brick", /obj/item/ingot/diamond, 6, time = 100), \ 
 	))
 
 /obj/item/stack/sheet/mineral/diamond/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -117,7 +117,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	new/datum/stack_recipe("Captain Statue", /obj/structure/statue/diamond/captain, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Hologram Statue", /obj/structure/statue/diamond/ai1, 5, one_per_turf = 1, on_floor = 1), \
 	new/datum/stack_recipe("AI Core Statue", /obj/structure/statue/diamond/ai2, 5, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("diamond brick", /obj/item/ingot/diamond, 6, time = 100), \ 
+	new/datum/stack_recipe("diamond ingot", /obj/item/ingot/diamond, 6, time = 100), \ 
 	))
 
 /obj/item/stack/sheet/mineral/diamond/get_main_recipes()

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -50,7 +50,7 @@
 	custom_materials = list(/datum/material/iron=12000)
 
 /obj/item/ingot/diamond
-	custom_materials = list(/datum/material/diamond=12000) //yeah ok
+	custom_materials = list(/datum/material/diamond=12000) 
 
 /obj/item/ingot/uranium
 	custom_materials = list(/datum/material/uranium=12000)

--- a/code/modules/smithing/smithed_items.dm
+++ b/code/modules/smithing/smithed_items.dm
@@ -50,7 +50,7 @@
 	custom_materials = list(/datum/material/iron=12000)
 
 /obj/item/ingot/diamond
-	custom_materials = list(/datum/material/diamond=12000) 
+	custom_materials = list(/datum/material/diamond=12000)
 
 /obj/item/ingot/uranium
 	custom_materials = list(/datum/material/uranium=12000)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This adds "Diamond Ingots" to the game, which were already 'in' just not fully utilized, along with increasing it from 1.1x ForceMod on Diamond Crafted Items to 1.2x
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This gives a better balance for weaponry, Iron/Silver is 1.0x, Titanium is the step above at 1.1x, Diamond is the step beyond that at 1.2x, and then the big bois' Titanium/Runed/Brass at 1.3x. I might also add "Runite" later as a 1.3x, once I figure out the colormods for it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: removed comment on Diamond Ingots, changed "Diamond Bricks" to "Diamond Ingots"
balance: Diamond's forcemod was changed from 1.1x to 1.2x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
