### PR TITLE
More supernova adjustments

### DIFF
--- a/code/modules/events/supernova.dm
+++ b/code/modules/events/supernova.dm
@@ -25,7 +25,7 @@
 	supernova.power_mod = 0
 
 /datum/round_event/supernova/announce()
-	var/message = "Our tachyon-doppler array has detected a supernova in your vicinity. Peak flux from the supernova estimated to be [round(power,0.1)] times current solar flux. [power > 4 ? "Short burts of radiation may be possible, so please prepare accordingly." : ""]"
+	var/message = "Our tachyon-doppler array has detected a supernova in your vicinity. Peak flux from the supernova estimated to be [round(power,0.1)] times current solar flux. [power > 1 ? "Short burts of radiation may be possible, so please prepare accordingly." : ""]"
 	if(prob(power * 25))
 		priority_announce(message)
 	else
@@ -47,12 +47,11 @@
 
 /datum/round_event/supernova/tick()
 	var/midpoint = round((endWhen-startWhen)/2)
-	switch(activeFor)
-		if(startWhen to midpoint)
-			supernova.power_mod = min(supernova.power_mod*1.2, power)
-		if(endWhen-10 to endWhen)
-			supernova.power_mod /= 4
-	if(prob(round(supernova.power_mod / 2)) && storm_count < 4 && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
+	if(activeFor < midPoint)
+		supernova.power_mod = min(supernova.power_mod*1.2, power)
+	if(activeFor > endWhen-10)
+		supernova.power_mod /= 4
+	if(prob(round(supernova.power_mod)) && prob(5) && storm_count < 5 && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
 		SSweather.run_weather(/datum/weather/rad_storm/supernova)
 		storm_count++
 
@@ -63,5 +62,7 @@
 /datum/weather/rad_storm/supernova
 	weather_duration_lower = 50
 	weather_duration_upper = 100
-	telegraph_duration = 100
-	radiation_intensity = 50
+	telegraph_duration = 200
+	radiation_intensity = 1000
+	weather_sound = null
+	telegraph_message = "<span class='userdanger'>The air begins to grow very warm!</span>"

--- a/code/modules/events/supernova.dm
+++ b/code/modules/events/supernova.dm
@@ -47,7 +47,7 @@
 
 /datum/round_event/supernova/tick()
 	var/midpoint = round((endWhen-startWhen)/2)
-	if(activeFor < midPoint)
+	if(activeFor < midpoint)
 		supernova.power_mod = min(supernova.power_mod*1.2, power)
 	if(activeFor > endWhen-10)
 		supernova.power_mod /= 4


### PR DESCRIPTION
## About The Pull Request

1. Makes it so that any supernova of power more than 1 can cause rad storms.
2. Makes the rad storms more intense, though just as long.
3. Makes the rad storms have a way louder telegraph.
4. Makes the rad storms not make a blaring noise every time they happen.
5. Tries to make the supernova actually gain in power over time.
6. Makes it so that rad storms are way less common on supernovae powerful enough to cause them (right now it's basically constant).

## Why It's Good For The Game

Supernova's a bit broken and super annoying right now, so this tries to mitigate that.

## Changelog
:cl:
tweak: Lots of supernova tweaks.
/:cl: