### PR TITLE
Removes Ichor Crates from chest rolls

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -36,7 +36,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/magic/PopulateContents()
-	var/loot = rand(1,10)
+	var/loot = rand(1,9)
 	switch(loot)
 		if(1)
 			new /obj/item/soulstone/anybody(src)
@@ -57,10 +57,6 @@
 			new /obj/item/immortality_talisman(src)
 		if(9)
 			new /obj/item/gun/magic/wand/book/healing(src)
-		if(10)
-			new /obj/item/reagent_containers/glass/bottle/ichor/red(src)
-			new /obj/item/reagent_containers/glass/bottle/ichor/blue(src)
-			new /obj/item/reagent_containers/glass/bottle/ichor/green(src)
 
 /obj/structure/closet/crate/necropolis/tendril/weapon_armor/PopulateContents()
 	var/loot = rand(1,11)
@@ -132,7 +128,7 @@
 				new /obj/item/disk/design_disk/modkit_disc/rapid_repeater(src)
 
 /obj/structure/closet/crate/necropolis/tendril/all/PopulateContents()
-	var/loot = rand(1,29)
+	var/loot = rand(1,28)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -196,10 +192,6 @@
 			new /obj/item/immortality_talisman(src)
 		if(28)
 			new /obj/item/gun/magic/wand/book/healing(src)
-		if(29)
-			new /obj/item/reagent_containers/glass/bottle/ichor/red(src)
-			new /obj/item/reagent_containers/glass/bottle/ichor/blue(src)
-			new /obj/item/reagent_containers/glass/bottle/ichor/green(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc


### PR DESCRIPTION
Does what it says on the tin

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the three ichor crates from lavaland loot drops and adjusts the rolls accordingly
## Why It's Good For The Game

People started abusing the pills in a way that's just a bit too...powerful for how prolific the meds were once properly divided up into pills.  Additionally, the items were in a horribly untested state and this was a requested removal from silicons.  Thus, voila, crates gone.

## Changelog
:cl:
del: Removed ichor creates
balance: Removed ichor crates and adjusted crate rolling appropriately
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
