### PR TITLE
Once again makes all heads able to message centcom

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -51,6 +51,11 @@
 		return FALSE
 	return ACCESS_CAPTAIN in authorize_access
 
+/obj/machinery/computer/communications/proc/authenticated_as_non_silicon_command(mob/user)
+	if (issilicon(user))
+		return FALSE
+	return ACCESS_HEADS in authorize_access	//Should always be the case if authorized as it usually needs head access to log in, buut lets be sure.
+
 /// Are we a silicon, OR we're logged in as the captain?
 /obj/machinery/computer/communications/proc/authenticated_as_silicon_or_captain(mob/user)
 	if (issilicon(user))
@@ -160,7 +165,7 @@
 				return
 			make_announcement(usr)
 		if ("messageAssociates")
-			if (!authenticated_as_non_silicon_captain(usr))
+			if (!authenticated_as_non_silicon_command(usr))
 				return
 			if (!COOLDOWN_FINISHED(src, important_action_cooldown))
 				return
@@ -361,9 +366,9 @@
 				data["shuttleCanEvacOrFailReason"] = SSshuttle.canEvac(user, TRUE)
 
 				if (authenticated_as_non_silicon_captain(user))
-					data["canMessageAssociates"] = TRUE
 					data["canRequestNuke"] = TRUE
-
+				if (authenticated_as_non_silicon_command(user))
+					data["canMessageAssociates"] = TRUE
 				if (can_send_messages_to_other_sectors(user))
 					data["canSendToSectors"] = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I PRd this a long time ago and it got merged but one of the tgui PRs reverted it so here we go again.
Allows messaging of central command if the one logged in has head access instead of requiring captain access.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I dunno all heads being able to talk to central ~~and subsequently get BSAd for wasting their time~~ sounds like a good thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: All heads of staff can now message centcom, again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
