### PR TITLE
slimes can be delimbed

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -240,7 +240,13 @@
 				wounding_dmg *= (easy_dismember ? 1 : 0.75)
 			if((mangled_state & BODYPART_MANGLED_BONE) && try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus))
 				return
-		// note that there's no handling for BIO_JUST_FLESH since we don't have any that are that right now (slimepeople maybe someday)
+		// if we're flesh only, all blunt attacks become weakened slashes in terms of wound damage
+		if(BIO_JUST_FLESH)
+			if(wounding_type == WOUND_BLUNT)
+				wounding_type = WOUND_SLASH
+				wounding_dmg *= (easy_dismember ? 0.5 : 0.3)
+			if((mangled_state & BODYPART_MANGLED_FLESH) && try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus))
+				return
 		// standard humanoids
 		if(BIO_FLESH_BONE)
 			// if we've already mangled the skin (critical slash or piercing wound), then the bone is exposed, and we can damage it with sharp weapons at a reduced rate

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -244,7 +244,7 @@
 		if(BIO_JUST_FLESH)
 			if(wounding_type == WOUND_BLUNT)
 				wounding_type = WOUND_SLASH
-				wounding_dmg *= (easy_dismember ? 0.5 : 0.3)
+				wounding_dmg *= (easy_dismember ? 1 : 0.3)
 			if((mangled_state & BODYPART_MANGLED_FLESH) && try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus))
 				return
 		// standard humanoids


### PR DESCRIPTION
## About The Pull Request
title
blunt attacks will do 0.3x wound damage but become slash to anyone who is only flesh (slimes), whereas before it'd just kind of do nothing because they don't have bones so blunt wounds wouldn't affect them

if they have easy dismember it's 1x wound damage, which for slimes is only possible if you have the surgery that gives you limb attachment

aside from that small change, they can also get delimbed now as long as their flesh is mangled, just like how bone/flesh species can get delimbed as long as their bone and flesh is mangled

overall this isn't really a 'nerf' to slimes but i wouldn't call it a buff either, not being able to be delimbed was not intended in the first place

## Why It's Good For The Game
the lizard in the discord will hopefully stop (understandably) yelling at me

## Changelog
:cl:
fix: slimes can be delimbed
/:cl:
