### PR TITLE
calling upon the Rusted Hills no longer pokes at bluespace

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -69,7 +69,7 @@
 /datum/action/innate/heretic_shatter/Activate()
 	if(do_after(holder,10, target = holder))
 		var/turf/safe_turf = find_safe_turf(zlevels = sword.z, extended_safety_checks = TRUE)
-		do_teleport(holder,safe_turf,forceMove = TRUE)
+		do_teleport(holder,safe_turf,forceMove = TRUE,channel=TELEPORT_CHANNEL_MAGIC)
 		to_chat(holder,"<span class='warning'>You feel a gust of energy flow through your body... the Rusted Hills heard your call...</span>")
 		qdel(sword)
 

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -178,7 +178,7 @@
 /datum/eldritch_knowledge/summon/stalker
 	name = "Lonely Ritual"
 	gain_text = "I was able to combine my greed and desires to summon an eldritch beast I had never seen before. An ever shapeshifting mass of flesh, it knew well my goals."
-	desc = "You can now summon a Stalker by transmutating a pair of eyes, a candle, a pen and a piece of paper. Stalkers can shapeshift into harmless animals to get close to the victim."
+	desc = "You can now summon a Stalker by transmutating a kitchen knife, a candle, a pen and a piece of paper. Stalkers can shapeshift into harmless animals to get close to the victim."
 	cost = 1
 	required_atoms = list(/obj/item/kitchen/knife,/obj/item/candle,/obj/item/pen,/obj/item/paper)
 	mob_to_summon = /mob/living/simple_animal/hostile/eldritch/stalker


### PR DESCRIPTION
## About The Pull Request
shattering heretic blade now uses TELEPORT_CHANNEL_MAGIC and not TELEPORT_CHANNEL_BLUESPACE
## Why It's Good For The Game
i'm pretty sure the mansus isn't bluespace, actually
## Changelog
:cl:
fix: As a heretic, shattering your blade no longer interferes with bluespace.
/:cl: