### PR TITLE
Allows borgs to move pulled stuff around like a human

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -169,5 +169,9 @@
 	A.attack_robot(src)
 
 /atom/proc/attack_robot(mob/user)
+	if((isturf(src) || istype(src, /obj/structure/table) || istype(src, /obj/machinery/conveyor)) && get_dist(user, src) <= 1)
+		user.Move_Pulled(src)
+		return
+
 	attack_ai(user)
 	return

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -93,6 +93,9 @@
 				user.stop_pulling()
 	return ..()
 
+/obj/structure/table/attack_robot(mob/user)
+	on_attack_hand(user)
+
 /obj/structure/table/attack_tk()
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![bflr3aXDcj](https://user-images.githubusercontent.com/43283559/112643916-9f260280-8e23-11eb-81e5-dbf955d319ac.gif)
![GG8BNkuguJ](https://user-images.githubusercontent.com/43283559/112643949-a64d1080-8e23-11eb-956f-5095c906e617.gif)
![3B4QvlFBVq](https://user-images.githubusercontent.com/43283559/112644000-b107a580-8e23-11eb-810f-715bfc05444f.gif)
*those pictures were taken on my codebase and i'm lazy to take it here, so that explains the borg model*
Also this might not be the best way of doing this, in which i ask anyone if you have a better way of doing it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's so nice that borgs can't move stuff right? not even a person onto the surgery table?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Borgs can move pulled stuff like humans do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
