### PR TITLE
what if launchpad remote illegal tech :flushed:

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -272,6 +272,15 @@
 	var/sending = TRUE
 	var/obj/machinery/launchpad/briefcase/pad
 
+/obj/item/launchpad_remote/sci
+	name = "launchpad remote"
+	desc = "A remote for bluespace launchpads. Nice and compact, at least."
+	icon_state = "gangtool-purple"
+	item_state = "electronic"
+	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+	icon = 'icons/obj/device.dmi'
+
 /obj/item/launchpad_remote/Initialize(mapload, pad) //remote spawns linked to the briefcase pad
 	. = ..()
 	src.pad = pad

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -86,6 +86,16 @@
 	category = list("Bluespace Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/launchpadremote
+	name = "Launchpad Remote"
+	desc = "A device that can control linked bluespace launchpads from a long distance."
+	id = "launchpadremote"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500, /datum/material/silver = 1500, /datum/material/gold = 1000)
+	build_path = /obj/item/launchpad_remote/sci
+	category = list("Bluespace Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/miningsatchel_holding
 	name = "Mining Satchel of Holding"
 	desc = "A mining satchel that can hold an infinite amount of ores."

--- a/code/modules/research/techweb/nodes/bluespace_nodes.dm
+++ b/code/modules/research/techweb/nodes/bluespace_nodes.dm
@@ -69,7 +69,7 @@
 	display_name = "Unregulated Bluespace Research"
 	description = "Bluespace technology using unstable or unbalanced procedures, prone to damaging the fabric of bluespace. Outlawed by galactic conventions."
 	prereq_ids = list("bluespace_warping", "syndicate_basic")
-	design_ids = list("desynchronizer")
+	design_ids = list("desynchronizer", "launchpadremote")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /////////////////////////shuttle tech/////////////////////////


### PR DESCRIPTION
## About The Pull Request
adds a bluespace launchpad remote to unregulated bluespace tech. it looks like the science door remote.

## Why It's Good For The Game
launchpads are cool and giving them a remote locked behind the annoying to obtain illegal tech is kinda epic

## Changelog
:cl:
add: Unregulated Bluespace Technology now has a design for a launchpad remote.
/:cl: