### PR TITLE
removes delta_time from tgui process because it doesn't need it

### DIFF
--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -241,7 +241,7 @@
  * Run an update cycle for this UI. Called internally by SStgui
  * every second or so.
  */
-/datum/tgui/process(delta_time, force = FALSE)
+/datum/tgui/process(force = FALSE)
 	if(closing)
 		return
 	var/datum/host = src_object.ui_host(user)


### PR DESCRIPTION
it's different from most datums.