### PR TITLE
This was going to just be a fix for slime puddles making mutation and cult visual indicators disappear but it ended up becoming more complicated than I thought

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -30,7 +30,8 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 
 //Human Overlays Indexes/////////
 //LOTS OF CIT CHANGES HERE. BE CAREFUL WHEN UPSTREAM ADDS MORE LAYERS
-#define MUTATIONS_LAYER			33		//mutations. Tk headglows, cold resistance glow, etc
+#define MUTATIONS_LAYER			34		//mutations. Tk headglows, cold resistance glow, etc
+#define ANTAG_LAYER 			33		//stuff for things like cultism indicators (clock cult glow, cultist red halos, whatever else new that comes up)
 #define GENITALS_BEHIND_LAYER	32		//Some genitalia needs to be behind everything, such as with taurs (Taurs use body_behind_layer
 #define BODY_BEHIND_LAYER		31		//certain mutantrace features (tail when looking south) that must appear behind the body parts
 #define BODYPARTS_LAYER			30		//Initially "AUGMENTS", this was repurposed to be a catch-all bodyparts flag
@@ -63,7 +64,7 @@ Will print: "/mob/living/carbon/human/death" (you can optionally embed it in a s
 #define HANDS_LAYER				3
 #define BODY_FRONT_LAYER		2
 #define FIRE_LAYER				1		//If you're on fire
-#define TOTAL_LAYERS			33		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
+#define TOTAL_LAYERS			34		//KEEP THIS UP-TO-DATE OR SHIT WILL BREAK ;_;
 
 //Human Overlay Index Shortcuts for alternate_worn_layer, layers
 //Because I *KNOW* somebody will think layer+1 means "above"

--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -129,7 +129,7 @@
 /datum/mutation/human/proc/get_spans()
 	return list()
 
-/mob/living/carbon/proc/update_mutations_overlay()
+/mob/living/proc/update_mutations_overlay()
 	return
 
 /mob/living/carbon/human/update_mutations_overlay()
@@ -142,13 +142,12 @@
 			if(overlays_standing[CM.layer_used])
 				mut_overlay = overlays_standing[CM.layer_used]
 			var/mutable_appearance/V = CM.get_visual_indicator()
-			if(!mut_overlay.Find(V)) //either we lack the visual indicator or we have the wrong one
-				remove_overlay(CM.layer_used)
-				for(var/mutable_appearance/MA in CM.visual_indicators[CM.type])
-					mut_overlay.Remove(MA)
-				mut_overlay |= V
-				overlays_standing[CM.layer_used] = mut_overlay
-				apply_overlay(CM.layer_used)
+			remove_overlay(CM.layer_used) //trying to find its existence defeats the point because if cut_overlays is called it doesn't bother reloading it.
+			for(var/mutable_appearance/MA in CM.visual_indicators[CM.type])
+				mut_overlay.Remove(MA)
+			mut_overlay |= V
+			overlays_standing[CM.layer_used] = mut_overlay
+			apply_overlay(CM.layer_used)
 
 /datum/mutation/human/proc/modify() //called when a genome is applied so we can properly update some stats without having to remove and reapply the mutation from someone
 	if(modified || !power || !owner)

--- a/code/datums/mutations/radioactive.dm
+++ b/code/datums/mutations/radioactive.dm
@@ -1,6 +1,6 @@
 /datum/mutation/human/radioactive
 	name = "Radioactivity"
-	desc = "A volatile mutation that causes the host to sent out deadly beta radiation. This affects both the hosts and their surroundings."
+	desc = "A volatile mutation that causes the host to send out deadly beta radiation. This affects both the hosts and their surroundings."
 	quality = NEGATIVE
 	text_gain_indication = "<span class='warning'>You can feel it in your bones!</span>"
 	time_coeff = 5

--- a/code/datums/mutations/space_adaptation.dm
+++ b/code/datums/mutations/space_adaptation.dm
@@ -1,7 +1,7 @@
 //Cold Resistance gives your entire body an orange halo, and makes you immune to the effects of vacuum and cold.
 /datum/mutation/human/space_adaptation
 	name = "Space Adaptation"
-	desc = "A strange mutation that renders the host immune to the vacuum if space. Will still need an oxygen supply."
+	desc = "A strange mutation that renders the host immune to the vacuum of space. Will still need an oxygen supply."
 	quality = POSITIVE
 	difficulty = 16
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -87,7 +87,7 @@
 		if(!M || !M.current)
 			continue
 		if(ishuman(M.current))
-			M.current.add_overlay(mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER))
+			M.current.add_overlay(mutable_appearance('icons/effects/genetics.dmi', "servitude", -ANTAG_LAYER))
 	var/turf/T = get_turf(src)
 	var/list/open_turfs = list()
 	for(var/turf/open/OT in orange(1, T))

--- a/code/modules/antagonists/clockcult/clockcult.dm
+++ b/code/modules/antagonists/clockcult/clockcult.dm
@@ -139,7 +139,7 @@
 	current.throw_alert("clockinfo", /obj/screen/alert/clockwork/infodump)
 	var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar
 	if(G && G.active && ishuman(current))
-		current.add_overlay(mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER))
+		current.add_overlay(mutable_appearance('icons/effects/genetics.dmi', "servitude", -ANTAG_LAYER))
 
 /datum/antagonist/clockcult/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/current = owner.current

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -332,7 +332,7 @@
 		var/mob/living/carbon/human/H = cultist
 		new /obj/effect/temp_visual/cult/sparks(get_turf(H), H.dir)
 		var/istate = pick("halo1","halo2","halo3","halo4","halo5","halo6")
-		H.add_overlay(mutable_appearance('icons/effects/32x64.dmi', istate, -BODY_FRONT_LAYER))
+		H.add_overlay(mutable_appearance('icons/effects/32x64.dmi', istate, -ANTAG_LAYER))
 
 /datum/team/cult/proc/setup_objectives()
 	//SAC OBJECTIVE , todo: move this to objective internals

--- a/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
+++ b/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
@@ -76,6 +76,7 @@
 				puddle_overlay.color = mutcolor
 				tracked_overlay = puddle_overlay
 				owner.add_overlay(puddle_overlay)
+				owner.update_antag_overlays()
 
 				transforming = FALSE
 				UpdateButtonIcon()

--- a/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
+++ b/code/modules/mob/living/carbon/human/innate_abilities/blobform.dm
@@ -47,6 +47,7 @@
 				owner.cut_overlays() //we dont show our normal sprite, we show a puddle sprite
 				var/obj/effect/puddle_effect = new puddle_into_effect(get_turf(owner), owner.dir)
 				puddle_effect.color = mutcolor
+				puddle_effect.transform = H.transform //copy mob size for consistent meltdown appearance
 				H.Stun(in_transformation_duration, ignore_canstun = TRUE) //cant move while transforming
 
 				//series of traits that make up the puddle behaviour
@@ -89,6 +90,7 @@
 	H.cut_overlay(tracked_overlay)
 	var/obj/effect/puddle_effect = new puddle_from_effect(get_turf(owner), owner.dir)
 	puddle_effect.color = tracked_overlay.color
+	puddle_effect.transform = H.transform //copy mob size for consistent transform size
 	H.Stun(out_transformation_duration, ignore_canstun = TRUE)
 	sleep(out_transformation_duration)
 	REMOVE_TRAIT(H, TRAIT_PARALYSIS_L_ARM, SLIMEPUDDLE_TRAIT)
@@ -106,5 +108,6 @@
 	is_puddle = FALSE
 	if(squeak)
 		squeak.RemoveComponent()
+	H.regenerate_icons()
 	transforming = FALSE
 	UpdateButtonIcon()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -100,9 +100,28 @@ There are several things that need to be remembered:
 			update_mutations_overlay()
 			//damage overlays
 			update_damage_overlays()
+			//antagonism
+			update_antag_overlays()
 
 /* --------------------------------------- */
 //vvvvvv UPDATE_INV PROCS vvvvvv
+
+
+/mob/living/carbon/human/update_antag_overlays()
+	remove_overlay(ANTAG_LAYER)
+	var/datum/antagonist/cult/D = src?.mind?.has_antag_datum(/datum/antagonist/cult) //check for cultism
+	if(D && D.cult_team?.cult_ascendent == TRUE)
+		var/istate = pick("halo1","halo2","halo3","halo4","halo5","halo6")
+		var/mutable_appearance/new_cult_overlay = mutable_appearance('icons/effects/32x64.dmi', istate, -ANTAG_LAYER)
+		overlays_standing[ANTAG_LAYER] = new_cult_overlay
+	var/datum/antagonist/clockcult/C = src?.mind?.has_antag_datum(/datum/antagonist/clockcult) //check for clockcultism - surely one can't be both cult and clockie, right?
+	if(C)
+		var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar
+		if(G && G.active && ishuman(src))
+			var/mutable_appearance/new_cult_overlay = mutable_appearance('icons/effects/genetics.dmi', "servitude", -ANTAG_LAYER)
+			overlays_standing[ANTAG_LAYER] = new_cult_overlay
+	apply_overlay(ANTAG_LAYER)
+
 
 /mob/living/carbon/human/update_inv_w_uniform()
 	if(!HAS_TRAIT(src, TRAIT_HUMAN_NO_RENDER))

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -69,3 +69,6 @@
 
 /mob/proc/update_inv_ears()
 	return
+
+/mob/proc/update_antag_overlays()
+	return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -330,7 +330,7 @@
 	name = "Hollow Water"
 	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen, but it looks kinda hollow."
 	color = "#88878777"
-	taste_description = "emptyiness"
+	taste_description = "emptiness"
 
 
 /datum/reagent/water/holywater


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The intention was for me to fix the slime puddles making mutation visual indicators disappear, as well as the cultism visual indicators disappear (red halos, clock cult glow, etc.) and I succeeded.

But how did I do that?

I had to pretty much make the antagonism overlays their own thing, which is specifically only the cult stuff as far as I know. Which is a good thing, because if the halos are ever lost for any reason, like puddles for instance, there's now a system in place that will let us refresh that from now on.

If other stuff comes up, I'll try to include that in the antag overlay system.

That aside, I corrected some spelling errors.

Oh yeah, the transformation animations are now resized to be consistent with the slimeperson's size.

## Why It's Good For The Game

The mutation visual indicators could be forgivable, but MAYBE cultslimes shouldn't be hiding their cult halos because they toggled their puddle on and off. That's a very, very bad thing. People exploiting this hasn't ever happened in-game as far as I understand, but just judging based on my research, this _can_ happen.

Honestly I could have told Teak to do this since he's the one who threw in puddle code but I felt like hurting myself.

## Changelog
:cl:
fix: Slime puddles will now show mutation visual indicators & cult indicators after exiting slime puddle form
fix: Slime puddle transformation animations are now resized to fit the slimeperson's current size, making it visually more consistent
spellcheck: Typo correction in some mutation descriptions and other things
code: Cult/clockcult layers moved from LAYER_MUTATION to LAYER_ANTAG, new update section for them specifically now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
