### PR TITLE
Bumbles no longer has a number beside their name

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/bumbles.dm
+++ b/code/modules/mob/living/simple_animal/friendly/bumbles.dm
@@ -29,7 +29,6 @@
 	verb_yell = "buzzes intensely"
 	emote_see = list("buzzes.", "makes a loud buzz.", "rolls several times.", "buzzes happily.")
 	speak_chance = 1
-	unique_name = TRUE
 
 /mob/living/simple_animal/pet/bumbles/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/bumbles.dm
+++ b/code/modules/mob/living/simple_animal/friendly/bumbles.dm
@@ -29,6 +29,7 @@
 	verb_yell = "buzzes intensely"
 	emote_see = list("buzzes.", "makes a loud buzz.", "rolls several times.", "buzzes happily.")
 	speak_chance = 1
+	unique_name = FALSE
 
 /mob/living/simple_animal/pet/bumbles/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This removes the number besides the name of Bumbles, the hydroponics pet bee.

## Why It's Good For The Game

There is only one Bumbles, and obviously there's no way to get another Bumbles (aside from adminbus), so why is there a number beside Bumbles?

## Changelog
:cl:
fix: The hydroponics pet bee, Bumbles no longer has a number besides their name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
