### PR TITLE
Brings back the prayer ding

### DIFF
--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -48,6 +48,8 @@
 			if(C.prefs.toggles & SOUND_PRAYERS)
 				if(usr.job == "Chaplain")
 					SEND_SOUND(C, sound('sound/effects/pray.ogg'))
+				else
+					SEND_SOUND(C, sound('sound/effects/ding.ogg'))
 	to_chat(usr, "<span class='info'>You pray to the gods: \"[msg_tmp]\"</span>", confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Prayer") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This brings back the prayer ding that was introduced in #13968, but @LetterN ended up removing it accidentally with the TG 1.5 port that they done.

## Why It's Good For The Game

I actually found that ding a little reliable. If nothing else, to smite people with cream pies containing 15 units of space drugs.

## Changelog
:cl:
admin: Admins get to hear the prayer ding again unless they have prayer sounds turned off.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
