### PR TITLE
Buffs the genetic mutation Autotomy

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -283,7 +283,7 @@
 	desc = "Allows a creature to voluntary discard a random appendage."
 	quality = POSITIVE
 	text_gain_indication = "<span class='notice'>Your joints feel loose.</span>"
-	instability = 30
+	instability = 20
 	power = /obj/effect/proc_holder/spell/self/self_amputation
 
 	energy_coeff = 1
@@ -316,7 +316,7 @@
 		return
 
 	var/obj/item/bodypart/BP = pick(parts)
-	BP.dismember()
+	BP.dismember(harmless=TRUE)
 
 //spider webs
 /datum/mutation/human/webbing

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -160,7 +160,7 @@
 
 /obj/screen/alert/status_effect/mesmerized
 	name = "Mesmerized"
-	desc = "You cant tear your sight from who is in front of you... their gaze is simply too enthralling.."
+	desc = "You can't tear your sight from who is in front of you... their gaze is simply too enthralling.."
 	icon = 'icons/mob/actions/bloodsucker.dmi'
 	icon_state = "power_mez"
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -49,12 +49,12 @@
 	throw_at(target_turf, throw_range, throw_speed)
 	return TRUE
 
-/obj/item/bodypart/head/dismember()
+/obj/item/bodypart/head/dismember(dam_type = BRUTE, silent=TRUE, harmless=FALSE)
 	if(HAS_TRAIT(owner, TRAIT_NODECAP))
 		return FALSE
 	..()
 
-/obj/item/bodypart/chest/dismember()
+/obj/item/bodypart/chest/dismember(dam_type = BRUTE, silent=TRUE, harmless=FALSE)
 	if(!owner)
 		return FALSE
 	var/mob/living/carbon/C = owner

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -4,7 +4,7 @@
 		return TRUE
 
 //Dismember a limb
-/obj/item/bodypart/proc/dismember(dam_type = BRUTE, silent=TRUE)
+/obj/item/bodypart/proc/dismember(dam_type = BRUTE, silent=TRUE, harmless=FALSE)
 	if(!owner)
 		return FALSE
 	var/mob/living/carbon/C = owner
@@ -14,24 +14,28 @@
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
 		return FALSE
-	var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_CHEST)
-	affecting.receive_damage(clamp(brute_dam/2 * affecting.body_damage_coeff, 15, 50), clamp(burn_dam/2 * affecting.body_damage_coeff, 0, 50), wound_bonus=CANT_WOUND) //Damage the chest based on limb's existing damage
+	if(!harmless)
+		var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_CHEST)
+		affecting.receive_damage(clamp(brute_dam/2 * affecting.body_damage_coeff, 15, 50), clamp(burn_dam/2 * affecting.body_damage_coeff, 0, 50), wound_bonus=CANT_WOUND) //Damage the chest based on limb's existing damage
 	if(!silent)
 		C.visible_message("<span class='danger'><B>[C]'s [name] is violently dismembered!</B></span>")
-	C.emote("scream")
-	SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "dismembered", /datum/mood_event/dismembered)
+	if(!harmless)
+		C.emote("scream")
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "dismembered", /datum/mood_event/dismembered)
+	else C.emote("pain")
 	drop_limb()
 	C.update_equipment_speed_mods() // Update in case speed affecting item unequipped by dismemberment
 
-	C.bleed(40)
+	if(!harmless) C.bleed(40)
 
 	if(QDELETED(src)) //Could have dropped into lava/explosion/chasm/whatever
 		return TRUE
-	if(dam_type == BURN)
-		burn()
-		return TRUE
-	add_mob_blood(C)
-	C.bleed(rand(20, 40))
+	if(!harmless)
+		if(dam_type == BURN)
+			burn()
+			return TRUE
+		add_mob_blood(C)
+		C.bleed(rand(20, 40))
 	var/direction = pick(GLOB.cardinals)
 	var/t_range = rand(2,max(throw_range/2, 2))
 	var/turf/target_turf = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes Autotomy a bit.
- Instability reduced from 30 to 20
- Delimbing is now harmless instead of dealing damage to the chest area, making you suffer a mood loss, and making you bleed.

## Why It's Good For The Game

Why is it that we have mutations that seem like they're fun but aren't that worthwhile in getting? Voluntarily popping your limbs at best, could free you from handcuffs but it obviously comes at a cost of reducing your maximum health and well, leaving you with one less arm. I figure that'd be punishment enough, set aside the fact that Autotomy is also random in which limb it pops off, so if someone's trying to free themselves this way they'll be taking a gamble on if they lose an arm or a leg. They obviously may not be getting that limb back without external help unless they were a slimeperson or had Ligament Hook surgery. Autotomy is very situational, while other genes like Space Adaptation and Telekinesis have a lot more times where they're useful compared to when they're not.

This also will encourage the Ligament Hook experimental surgery to be more intriguing, because there's also the fact that you can't put a limb back on without help from someone else otherwise.

And yes, combined with being a slimeperson it has a lot of potential considering they can regrow limbs by themselves at the cost of nutrition and blood. Did you know you can attach slimeperson limbs to any other species?

I might potentially see if Tongue Spike/Chem Spike can be made more intriguing later on, but it'll also mean I'll need to rebalance that potentially because it does manage to at least have a worthwhile benefit to losing your tongue.

## Changelog
:cl:
balance: The genetics mutation Autotomy has been buffed to be 20 instability instead of 30, and harmless in delimbing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
