### PR TITLE
wooden planks sell for 8 now to stop the funny cargo lumbermill memes

### DIFF
--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -89,7 +89,7 @@
 	export_types = list(/obj/item/stack/sheet/mineral/plastitanium)
 
 /datum/export/stack/wood
-	cost = 15
+	cost = 8
 	unit_name = "wood plank"
 	export_types = list(/obj/item/stack/sheet/mineral/wood)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
profit from a log crate is now 200 instead of 1150

## Why It's Good For The Game
stops another cargo meme

## Changelog
:cl:
balance: wooden planks sell for 8 instead of 15 each
/:cl:
