### PR TITLE
kills the 50 towercap crate, closes #14563

### DIFF
--- a/code/modules/cargo/packs/materials.dm
+++ b/code/modules/cargo/packs/materials.dm
@@ -69,18 +69,6 @@
 	cost = 600
 	contains = list(/obj/item/rcd_ammo/large)
 
-/datum/supply_pack/materials/rawlumber
-	name = "50 Towercap Logs"
-	desc = "Raw logs from towercaps. Contains fifty logs."
-	cost = 1000
-	contains = list(/obj/item/grown/log)
-	crate_name = "lumber crate"
-
-/datum/supply_pack/materials/rawlumber/generate()
-	. = ..()
-	for(var/i in 1 to 49)
-		new /obj/item/grown/log(.)
-
 //////////////////////////////////////////////////////////////////////////////
 ///////////////////////////// Canisters //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request
closes #14563 by deleting the 50 log crate
## Why It's Good For The Game
interdepartmental cooperation

## Changelog
:cl:
balance: After a sudden crash in the tower-cap log slash wooden plank economy, NanoTrasen has decided to stop selling tower-cap logs to Cargo.
/:cl: