### PR TITLE
ghost cafe 'disguise' now removes the offset of the object you disguise as

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -722,6 +722,8 @@
 						var/image/I = image(icon = initial(disguise_item.icon), icon_state = initial(disguise_item.icon_state), loc = H)
 						I.override = TRUE
 						I.layer = ABOVE_MOB_LAYER
+						I.pixel_x -= initial(disguise_item.pixel_x)
+						I.pixel_y -= initial(disguise_item.pixel_y)
 						H.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/everyone, "ghost_cafe_disguise", I)
 						currently_disguised = TRUE
 	else


### PR DESCRIPTION
## About The Pull Request
title

so people can disguise as narsie and stuff without being weirdly offset

**untested (testing it currently)**

## Why It's Good For The Game
someone asked me to do it and i can't see why not, let the people erp as ratvar/narsie if they really want i guess

## Changelog
:cl:
tweak: ghost cafe 'disguise' now removes the offset of the object you disguise as
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
