### PR TITLE
Sylvan and Mushroom languages now tongueless, EaL learnable

### DIFF
--- a/code/modules/language/machine.dm
+++ b/code/modules/language/machine.dm
@@ -12,6 +12,7 @@
 	default_priority = 90
 
 	icon_state = "eal"
+	chooseable_roundstart = TRUE
 
 /datum/language/machine/get_random_name()
 	if(prob(70))

--- a/code/modules/language/mushroom.dm
+++ b/code/modules/language/mushroom.dm
@@ -6,6 +6,7 @@
 	exclaim_verb = "poofs loudly"
 	whisper_verb = "puffs quietly"
 	key = "y"
+	flags = TONGUELESS_SPEECH
 	sentence_chance = 0
 	default_priority = 80
 	syllables = list("poof", "pff", "pFfF", "piff", "puff", "pooof", "pfffff", "piffpiff", "puffpuff", "poofpoof", "pifpafpofpuf")

--- a/code/modules/language/sylvan.dm
+++ b/code/modules/language/sylvan.dm
@@ -6,6 +6,7 @@
 	ask_verb = "inquires"
 	exclaim_verb = "declares"
 	key = "h"
+	flags = TONGUELESS_SPEECH
 	space_chance = 20
 	syllables = list(
 		"fii", "sii", "rii", "rel", "maa", "ala", "san", "tol", "tok", "dia", "eres",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What the title says. Sylvan and Mushroom are now tongueless, and Encoded Audio Language is now learnable.

## Why It's Good For The Game

They feel like languages that could be replicated and spoken by the typical human who doesn't have omnitongue traits. Encoded Audio Language seems like something synthetics and certain unique non-synths might know. Whether they could speak it is debatable, but if someone wants to set something up to where they can speak it, be my guest.

Understandably EaL was originally AI/pAI exclusive up to this point, but the AI and cyborgs obviously have other means of speaking privately, and their robotic talk channel is always available regardless of where they are or the circumstances of communication availability on the station. Besides, it'd seem stupid for an AI to openly discuss malicious plans on the radio especially if a curator is around anyways.

## Changelog
:cl:
add: Sylvan and Mushroom languages are now tongueless, and Encoded Audio Language is now learnable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
