### PR TITLE
Space pirate sleepers can now be crowbared to be destroyed

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -642,6 +642,7 @@
 
 /obj/effect/mob_spawn/human/pirate/corpse/Destroy()
 	return ..()
+
 /obj/effect/mob_spawn/human/pirate/corpse/captain
 	rank = "Captain"
 	mob_name = "Dead Space Pirate Captain"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -631,6 +631,7 @@
 			user.visible_message("<span class='warning'>[user] pries open the [src], disrupting the sleep of the pirate within and killing them.</span>",
 				"<span class='notice'>You pry open the [src], disrupting the sleep of the pirate within and killing them.</span>",
 				"<span class='italics'>You hear prying, followed by the death rattling of bones.</span>")
+			log_game("[key_name(user)] has successfully pried open a [src] and disabled a space pirate spawner.")
 			W.play_tool_sound(src)
 			playsound(src.loc, 'modular_citadel/sound/voice/scream_skeleton.ogg', 50, 1, 4, 1.2)
 			if(rank == "Captain") new /obj/effect/mob_spawn/human/pirate/corpse/captain(get_turf(src))

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -623,19 +623,21 @@
 		if(user.mind.has_antag_datum(/datum/antagonist/pirate))
 			to_chat(user,"<span class='warning'>Why would you want to do that to your shipmate? That'd kill them.</span>")
 			return
-		user.visible_message("<span class='warning'>[user] start to pry open the [src]...</span>",
-				"<span class='notice'>You start to pry open the [src]...</span>",
+		user.visible_message("<span class='warning'>[user] start to pry open [src]...</span>",
+				"<span class='notice'>You start to pry open [src]...</span>",
 				"<span class='italics'>You hear prying...</span>")
 		W.play_tool_sound(src)
 		if(do_after(user, 100*W.toolspeed, target = src))
-			user.visible_message("<span class='warning'>[user] pries open the [src], disrupting the sleep of the pirate within and killing them.</span>",
-				"<span class='notice'>You pry open the [src], disrupting the sleep of the pirate within and killing them.</span>",
+			user.visible_message("<span class='warning'>[user] pries open [src], disrupting the sleep of the pirate within and killing them.</span>",
+				"<span class='notice'>You pry open [src], disrupting the sleep of the pirate within and killing them.</span>",
 				"<span class='italics'>You hear prying, followed by the death rattling of bones.</span>")
 			log_game("[key_name(user)] has successfully pried open [src] and disabled a space pirate spawner.")
 			W.play_tool_sound(src)
 			playsound(src.loc, 'modular_citadel/sound/voice/scream_skeleton.ogg', 50, 1, 4, 1.2)
-			if(rank == "Captain") new /obj/effect/mob_spawn/human/pirate/corpse/captain(get_turf(src))
-			else new /obj/effect/mob_spawn/human/pirate/corpse(get_turf(src))
+			if(rank == "Captain") 
+				new /obj/effect/mob_spawn/human/pirate/corpse/captain(get_turf(src))
+			else 
+				new /obj/effect/mob_spawn/human/pirate/corpse(get_turf(src))
 			qdel(src)
 	else
 		..()

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -590,7 +590,7 @@
 
 /obj/effect/mob_spawn/human/pirate
 	name = "space pirate sleeper"
-	desc = "A cryo sleeper smelling faintly of rum."
+	desc = "A cryo sleeper smelling faintly of rum. The sleeper looks unstable. <i>Perhaps the pirate within can be killed with the right tools...</i>"
 	job_description = "Space Pirate"
 	random = TRUE
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -607,6 +607,45 @@
 	flavour_text = "The station refused to pay for your protection, protect the ship, siphon the credits from the station and raid it for even more loot."
 	assignedrole = "Space Pirate"
 	var/rank = "Mate"
+
+/obj/effect/mob_spawn/human/pirate/on_attack_hand(mob/living/user, act_intent = user.a_intent, unarmed_attack_flags)
+	. = ..()
+	if(.)
+		return
+	if(user.mind.has_antag_datum(/datum/antagonist/pirate))
+		to_chat(user, "<span class='notice'>Your shipmate sails within their dreams for now. Perhaps they may wake up eventually.</span>")
+	else
+		to_chat(user, "<span class='notice'>If you want to kill the pirate off, something to pry open the sleeper might be the best way to do it.</span>")
+
+
+/obj/effect/mob_spawn/human/pirate/attackby(obj/item/W, mob/user, params)
+	if(W.tool_behaviour == TOOL_CROWBAR && user.a_intent != INTENT_HARM)
+		if(user.mind.has_antag_datum(/datum/antagonist/pirate))
+			to_chat(user,"<span class='warning'>Why would you want to do that to your shipmate? That'd kill them.</span>")
+			return
+		user.visible_message("<span class='warning'>[usr.name] pries open the [src], disrupting the sleep of the pirate within and killing them.</span>",
+			"<span class='notice'>You pry open the [src], disrupting the sleep of the pirate within and killing them.</span>",
+			"<span class='italics'>You hear prying, followed by the death rattling of bones.</span>")
+		W.play_tool_sound(src)
+		playsound(src.loc, 'modular_citadel/sound/voice/scream_skeleton.ogg', 50, 1, 4, 1.2)
+		if(rank == "Captain") new /obj/effect/mob_spawn/human/pirate/corpse/captain(get_turf(src))
+		else new /obj/effect/mob_spawn/human/pirate/corpse(get_turf(src))
+		qdel(src)
+	else
+		..()
+
+/obj/effect/mob_spawn/human/pirate/corpse //occurs when someone pries a pirate out of their sleeper.
+	mob_name = "Dead Space Pirate"
+	death = TRUE
+	instant = TRUE
+	random = FALSE
+
+/obj/effect/mob_spawn/human/pirate/corpse/Destroy()
+	return ..()
+/obj/effect/mob_spawn/human/pirate/corpse/captain
+	rank = "Captain"
+	mob_name = "Dead Space Pirate Captain"
+	outfit = /datum/outfit/pirate/space/captain
 
 /obj/effect/mob_spawn/human/pirate/special(mob/living/new_spawn)
 	new_spawn.fully_replace_character_name(new_spawn.real_name,generate_pirate_name())

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -623,14 +623,19 @@
 		if(user.mind.has_antag_datum(/datum/antagonist/pirate))
 			to_chat(user,"<span class='warning'>Why would you want to do that to your shipmate? That'd kill them.</span>")
 			return
-		user.visible_message("<span class='warning'>[usr.name] pries open the [src], disrupting the sleep of the pirate within and killing them.</span>",
-			"<span class='notice'>You pry open the [src], disrupting the sleep of the pirate within and killing them.</span>",
-			"<span class='italics'>You hear prying, followed by the death rattling of bones.</span>")
+		user.visible_message("<span class='warning'>[user] start to pry open the [src]...</span>",
+				"<span class='notice'>You start to pry open the [src]...</span>",
+				"<span class='italics'>You hear prying...</span>")
 		W.play_tool_sound(src)
-		playsound(src.loc, 'modular_citadel/sound/voice/scream_skeleton.ogg', 50, 1, 4, 1.2)
-		if(rank == "Captain") new /obj/effect/mob_spawn/human/pirate/corpse/captain(get_turf(src))
-		else new /obj/effect/mob_spawn/human/pirate/corpse(get_turf(src))
-		qdel(src)
+		if(do_after(user, 100*W.toolspeed, target = src))
+			user.visible_message("<span class='warning'>[user] pries open the [src], disrupting the sleep of the pirate within and killing them.</span>",
+				"<span class='notice'>You pry open the [src], disrupting the sleep of the pirate within and killing them.</span>",
+				"<span class='italics'>You hear prying, followed by the death rattling of bones.</span>")
+			W.play_tool_sound(src)
+			playsound(src.loc, 'modular_citadel/sound/voice/scream_skeleton.ogg', 50, 1, 4, 1.2)
+			if(rank == "Captain") new /obj/effect/mob_spawn/human/pirate/corpse/captain(get_turf(src))
+			else new /obj/effect/mob_spawn/human/pirate/corpse(get_turf(src))
+			qdel(src)
 	else
 		..()
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -631,7 +631,7 @@
 			user.visible_message("<span class='warning'>[user] pries open the [src], disrupting the sleep of the pirate within and killing them.</span>",
 				"<span class='notice'>You pry open the [src], disrupting the sleep of the pirate within and killing them.</span>",
 				"<span class='italics'>You hear prying, followed by the death rattling of bones.</span>")
-			log_game("[key_name(user)] has successfully pried open a [src] and disabled a space pirate spawner.")
+			log_game("[key_name(user)] has successfully pried open [src] and disabled a space pirate spawner.")
 			W.play_tool_sound(src)
 			playsound(src.loc, 'modular_citadel/sound/voice/scream_skeleton.ogg', 50, 1, 4, 1.2)
 			if(rank == "Captain") new /obj/effect/mob_spawn/human/pirate/corpse/captain(get_turf(src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes the otherwise indestructible space pirate sleepers able to be destroyed using a crowbar. How it works is you pry the sleeper open and abruptly end the pirate's sleep, which ends up killing them in the process.

The justification is that the pirate's sleepers are just low budget and unstable now.

## Why It's Good For The Game

People were having a discourse about pirates late to coming out of their sleepers getting gay baby jailed so I created a solution.

## Changelog
:cl:
add: Space pirate sleepers can now be crowbared to be destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
