### PR TITLE
pirate payoff minimum from 20k to 1k

### DIFF
--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -21,7 +21,6 @@
 	startWhen = 60 //2 minutes to answer
 	var/datum/comm_message/threat_msg
 	var/payoff = 0
-	var/payoff_min = 20000
 	var/paid_off = FALSE
 	var/pirate_type
 	var/ship_template
@@ -45,7 +44,7 @@
 	threat_msg = new
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
-		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
+		payoff = FLOOR(D.account_balance * 0.80, 1000)
 	switch(pirate_type)
 		if(PIRATES_ROGUES)
 			ship_template = /datum/map_template/shuttle/pirate/default

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -21,6 +21,7 @@
 	startWhen = 60 //2 minutes to answer
 	var/datum/comm_message/threat_msg
 	var/payoff = 0
+	var/payoff_min = 1000
 	var/paid_off = FALSE
 	var/pirate_type
 	var/ship_template
@@ -44,7 +45,7 @@
 	threat_msg = new
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
-		payoff = FLOOR(D.account_balance * 0.80, 1000)
+		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
 	switch(pirate_type)
 		if(PIRATES_ROGUES)
 			ship_template = /datum/map_template/shuttle/pirate/default


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
nobody plays cargo and i don't think this was a thing beforehand
## Changelog
:cl:
balance: Space pirates are now slightly more aware of how much money the station has, and will demand payment accordingly. (No more 20k minimum payouts and basically-confirmed three midround skeletons.)
/:cl: