### PR TITLE
pov: you're watching zero ruin megafauna by making them DDR raves one pr at a time (ports epic tg bubblegum)

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -36,7 +36,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/magic/PopulateContents()
-	var/loot = rand(1,9)
+	var/loot = rand(1,10)
 	switch(loot)
 		if(1)
 			new /obj/item/soulstone/anybody(src)
@@ -57,6 +57,8 @@
 			new /obj/item/immortality_talisman(src)
 		if(9)
 			new /obj/item/gun/magic/wand/book/healing(src)
+		if(10)
+			new /obj/item/guardiancreator(src)
 
 /obj/structure/closet/crate/necropolis/tendril/weapon_armor/PopulateContents()
 	var/loot = rand(1,11)
@@ -128,7 +130,7 @@
 				new /obj/item/disk/design_disk/modkit_disc/rapid_repeater(src)
 
 /obj/structure/closet/crate/necropolis/tendril/all/PopulateContents()
-	var/loot = rand(1,28)
+	var/loot = rand(1,29)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -192,6 +194,8 @@
 			new /obj/item/immortality_talisman(src)
 		if(28)
 			new /obj/item/gun/magic/wand/book/healing(src)
+		if(29)
+			new /obj/item/guardiancreator(src)
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc
@@ -1094,14 +1098,12 @@
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
-	var/loot = rand(1,3)
+	var/loot = rand(1,2)
 	switch(loot)
 		if(1)
 			new /obj/item/mayhem(src)
 		if(2)
 			new /obj/item/book/granter/spell/asura(src)
-		if(3)
-			new /obj/item/guardiancreator(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -71,7 +71,7 @@ Difficulty: Hard
 	desc = "You're not quite sure how a signal can be bloody."
 	invisibility = 100
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, only_robotic = FALSE, only_organic = TRUE)
 	. = ..()
 	if(. > 0 && prob(25))
 		var/obj/effect/decal/cleanable/blood/gibs/bubblegum/B = new /obj/effect/decal/cleanable/blood/gibs/bubblegum(loc)
@@ -473,7 +473,7 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Life()
 	return
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE, only_robotic = FALSE, only_organic = TRUE)
 	return
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/OpenFire()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -1,5 +1,3 @@
-#define MEDAL_PREFIX "Bubblegum"
-
 /*
 
 BUBBLEGUM
@@ -7,17 +5,18 @@ BUBBLEGUM
 Bubblegum spawns randomly wherever a lavaland creature is able to spawn. It is the most powerful slaughter demon in existence.
 Bubblegum's footsteps are heralded by shaking booms, proving its tremendous size.
 
-It acts as a melee creature, chasing down and attacking its target while also using different attacks to augment its power that increase as it takes damage.
+It acts as a melee creature, chasing down and attacking its target while also using different attacks to augment its power
 
-It often charges, dealing massive damage to anything unfortunate enough to be standing where it's aiming.
-Whenever it isn't chasing something down, it will sink into nearby blood pools (if possible) and springs out of the closest one to its target.
-To make this possible, it sprays streams of blood at random.
-From these blood pools Bubblegum may summon slaughterlings - weak, low-damage minions designed to impede the target's progress.
+It leaves blood trails behind wherever it goes, its clones do as well.
+It tries to strike at its target through any bloodpools under them; if it fails to do that.
+If it does warp it will enter an enraged state, becoming immune to all projectiles, becoming much faster, and dealing damage and knockback to anything that gets in the cloud around it.
+It may summon clones charging from all sides, one of these charges being bubblegum himself.
+It can charge at its target, and also heavily damaging anything directly hit in the charge.
+If at half health it will start to charge from all sides with clones.
 
-When Bubblegum dies, it leaves behind a H.E.C.K. suit+helmet as well as a chest that can contain three things:
- 1. A spellblade that can slice off limbs at range
- 2. A bottle that, when activated, drives everyone nearby into a frenzy
- 3. A super double-barrel shotgun that shoots both shells at the same time.
+When Bubblegum dies, it leaves behind a H.E.C.K. mining suit as well as a chest that can contain three things:
+ 1. A bottle that, when activated, drives everyone nearby into a frenzy
+ 2. A scroll that teaches the reader a martial art that sacrifices health for raw demonic power with their bare hands.
 
 Difficulty: Hard
 
@@ -42,15 +41,20 @@ Difficulty: Hard
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
-	move_to_delay = 10
-	ranged_cooldown_time = 10
+	move_to_delay = 5
+	retreat_distance = 5
+	minimum_distance = 5
+	rapid_melee = 8 // every 1/4 second
+	melee_queue_distance = 20 // as far as possible really, need this because of blood warp
 	ranged = 1
 	pixel_x = -32
 	gender = MALE
 	del_on_death = 1
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/crusher)
 	loot = list(/obj/structure/closet/crate/necropolis/bubblegum)
+	blood_volume = BLOOD_VOLUME_MAXIMUM //BLEED FOR ME
 	var/charging = 0
+	var/enrage_till = null
 
 	achievement_type = /datum/award/achievement/boss/bubblegum_kill
 	crusher_achievement_type = /datum/award/achievement/boss/bubblegum_crusher
@@ -67,36 +71,60 @@ Difficulty: Hard
 	desc = "You're not quite sure how a signal can be bloody."
 	invisibility = 100
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/BiologicalLife(seconds, times_fired)
-	if(!(. = ..()))
-		return
-	move_to_delay = clamp(round((health/maxHealth) * 10), 3, 10)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+	. = ..()
+	if(. > 0 && prob(25))
+		var/obj/effect/decal/cleanable/blood/gibs/bubblegum/B = new /obj/effect/decal/cleanable/blood/gibs/bubblegum(loc)
+		if(prob(40))
+			step(B, pick(GLOB.cardinals))
+		else
+			B.setDir(pick(GLOB.cardinals))
+
+/obj/effect/decal/cleanable/blood/gibs/bubblegum
+	name = "thick blood"
+	desc = "Thick, splattered blood."
+	random_icon_states = list("gib3", "gib5", "gib6")
+	bloodiness = 20
+
+/obj/effect/decal/cleanable/blood/gibs/bubblegum/can_bloodcrawl_in()
+	return TRUE
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/OpenFire()
-	anger_modifier = clamp(((maxHealth - health)/50),0,20)
+	anger_modifier = clamp(((maxHealth - health)/60),0,20)
 	if(charging)
 		return
-	ranged_cooldown = world.time + ranged_cooldown_time
+	ranged_cooldown = world.time + 50
+	if(!try_bloodattack())
+		blood_warp()
 
-	blood_warp()
-
-	if(prob(25))
-		INVOKE_ASYNC(src, .proc/blood_spray)
-
-	else if(prob(5+anger_modifier/2))
-		slaughterlings()
-	else
-		if(health > maxHealth/2 && !client)
-			INVOKE_ASYNC(src, .proc/charge)
+	if(health > maxHealth * 0.5)
+		if(prob(50 + anger_modifier))
+			charge(delay = 6)
+			charge(delay = 4) // The FitnessGram Pacer Test is a multistage aerobic capacity test that progressively gets more difficult as it continues.
+			charge(delay = 2)
+			SetRecoveryTime(15)
 		else
-			INVOKE_ASYNC(src, .proc/triple_charge)
+			hallucination_charge_around(times = 6, delay = 10 - anger_modifier / 5)
+			SetRecoveryTime(10)
+	else
+		if(prob(50 - anger_modifier))
+			hallucination_charge_around(times = 4, delay = 9)
+			hallucination_charge_around(times = 4, delay = 8)
+			hallucination_charge_around(times = 4, delay = 7)
+			SetRecoveryTime(15)
+		else
+			for(var/i = 1 to 5)
+				INVOKE_ASYNC(src, .proc/hallucination_charge_around, 2, 10, 2, 0)
+				sleep(5)
+			SetRecoveryTime(10)
 
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Initialize()
 	. = ..()
-	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in GLOB.mob_list)
-		if(B != src)
-			return INITIALIZE_HINT_QDEL //There can be only one
+	if(istype(src, /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination))
+		return
+	for(var/mob/living/simple_animal/hostile/megafauna/bubblegum/B in GLOB.mob_living_list)		if(B != src)
+		return INITIALIZE_HINT_QDEL //There can be only one
 	var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new
 	AddSpell(bloodspell)
 	if(istype(loc, /obj/effect/dummy/phased_mob/slaughter))
@@ -108,53 +136,79 @@ Difficulty: Hard
 	if(.)
 		SSshuttle.shuttle_purchase_requirements_met |= "bubblegum"
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
-	if(charging)
-		return
-	..()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A, visual_effect_icon)
+	if(!charging)
+		..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/AttackingTarget()
-	if(charging)
+	if(!charging)
+		. = ..()
+		if(.)
+			recovery_time = world.time + 20 // can only attack melee once every 2 seconds but rapid_melee gives higher priority
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/item/projectile/P)
+	if(is_enraged())
+		visible_message("<span class='danger'>[src] deflects the projectile; [p_they()] can't be hit with ranged weapons while enraged!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
+		playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 300, 1)
+		return 0
+	return ..()
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/ex_act(severity, target)
+	if(severity >= EXPLODE_LIGHT)
 		return
-	..()
+	severity = EXPLODE_LIGHT // puny mortals
+	return ..()
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover, /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination))
+		return 1
+	return ..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Goto(target, delay, minimum_distance)
-	if(charging)
-		return
-	..()
+	if(!charging)
+		..()
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/MoveToTarget(list/possible_targets)
+	if(!charging)
+		..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Move()
-	if(!stat)
-		playsound(src.loc, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
 	if(charging)
-		new/obj/effect/temp_visual/decoy/fading(loc,src)
+		new /obj/effect/temp_visual/decoy/fading(loc,src)
 		DestroySurroundings()
-	. = ..()
+	..()
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/Moved()
+	new /obj/effect/decal/cleanable/blood(src.loc)
 	if(charging)
 		DestroySurroundings()
+	playsound(src, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
+	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/triple_charge()
-	charge()
-	sleep(10)
-	charge()
-	sleep(10)
-	charge()
-
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge()
-	var/turf/T = get_turf(target)
-	if(!T || T == loc)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(var/atom/chargeat = target, var/delay = 3, var/chargepast = 2)
+	if(!chargeat)
 		return
-	new /obj/effect/temp_visual/dragon_swoop(T)
+	var/chargeturf = get_turf(chargeat)
+	if(!chargeturf)
+		return
+	var/dir = get_dir(src, chargeturf)
+	var/turf/T = get_ranged_target_turf(chargeturf, dir, chargepast)
+	if(!T)
+		return
+	new /obj/effect/temp_visual/dragon_swoop/bubblegum(T)
 	charging = 1
 	DestroySurroundings()
 	walk(src, 0)
-	setDir(get_dir(src, T))
+	setDir(dir)
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(loc,src)
-	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 5)
-	sleep(5)
-	throw_at(T, get_dist(src, T), 1, src, 0)
+	animate(D, alpha = 0, color = "#FF0000", transform = matrix()*2, time = 3)
+	sleep(delay)
+	var/movespeed = 0.7
+	walk_towards(src, T, movespeed)
+	sleep(get_dist(src, T) * movespeed)
+	walk(src, 0) // cancel the movement
+	try_bloodattack()
 	charging = 0
-	Goto(target, move_to_delay, minimum_distance)
 
 /**
  * Attack by override for bubblegum
@@ -176,36 +230,147 @@ Difficulty: Hard
 		if(isturf(A) || isobj(A) && A.density)
 			A.ex_act(EXPLODE_HEAVY)
 		DestroySurroundings()
+		if(isliving(A))
+			var/mob/living/L = A
+			L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] tramples you into the ground!</span>")
+			src.forceMove(get_turf(L))
+			L.apply_damage(istype(src, /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination) ? 15 : 30, BRUTE)
+			playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, 1)
+			shake_camera(L, 4, 3)
+			shake_camera(src, 2, 3)
 	..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	if(!charging)
-		return ..()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/get_mobs_on_blood()
+	var/list/targets = ListTargets()
+	. = list()
+	for(var/mob/living/L in targets)
+		var/list/bloodpool = get_pools(get_turf(L), 0)
+		if(bloodpool.len && (!faction_check_mob(L) || L.stat == DEAD))
+			. += L
 
-	else if(isliving(hit_atom))
-		var/mob/living/L = hit_atom
-		L.visible_message("<span class='danger'>[src] slams into [L]!</span>", "<span class='userdanger'>[src] slams into you!</span>")
-		L.apply_damage(40, BRUTE)
-		playsound(get_turf(L), 'sound/effects/meteorimpact.ogg', 100, 1)
-		shake_camera(L, 4, 3)
-		shake_camera(src, 2, 3)
-		var/throwtarget = get_edge_target_turf(src, get_dir(src, get_step_away(L, src)))
-		L.throw_at(throwtarget, 3)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/try_bloodattack()
+	var/list/targets = get_mobs_on_blood()
+	if(targets.len)
+		INVOKE_ASYNC(src, .proc/bloodattack, targets, prob(50))
+		return TRUE
+	return FALSE
 
-	charging = 0
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodattack(list/targets, handedness)
+	var/mob/living/target_one = pick_n_take(targets)
+	var/turf/target_one_turf = get_turf(target_one)
+	var/mob/living/target_two
+	if(targets.len)
+		target_two = pick_n_take(targets)
+		var/turf/target_two_turf = get_turf(target_two)
+		if(target_two.stat != CONSCIOUS || prob(10))
+			bloodgrab(target_two_turf, handedness)
+		else
+			bloodsmack(target_two_turf, handedness)
 
+	if(target_one)
+		var/list/pools = get_pools(get_turf(target_one), 0)
+		if(pools.len)
+			target_one_turf = get_turf(target_one)
+			if(target_one_turf)
+				if(target_one.stat != CONSCIOUS || prob(10))
+					bloodgrab(target_one_turf, !handedness)
+				else
+					bloodsmack(target_one_turf, !handedness)
+
+	if(!target_two && target_one)
+		var/list/poolstwo = get_pools(get_turf(target_one), 0)
+		if(poolstwo.len)
+			target_one_turf = get_turf(target_one)
+			if(target_one_turf)
+				if(target_one.stat != CONSCIOUS || prob(10))
+					bloodgrab(target_one_turf, handedness)
+				else
+					bloodsmack(target_one_turf, handedness)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodsmack(turf/T, handedness)
+	if(handedness)
+		new /obj/effect/temp_visual/bubblegum_hands/rightsmack(T)
+	else
+		new /obj/effect/temp_visual/bubblegum_hands/leftsmack(T)
+	sleep(4)
+	for(var/mob/living/L in T)
+		if(!faction_check_mob(L))
+			to_chat(L, "<span class='userdanger'>[src] rends you!</span>")
+			playsound(T, attack_sound, 100, 1, -1)
+			var/limb_to_hit = L.get_bodypart(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
+			L.apply_damage(10, BRUTE, limb_to_hit, L.run_armor_check(limb_to_hit, "melee", null, null, armour_penetration))
+	sleep(3)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/bloodgrab(turf/T, handedness)
+	if(handedness)
+		new /obj/effect/temp_visual/bubblegum_hands/rightpaw(T)
+		new /obj/effect/temp_visual/bubblegum_hands/rightthumb(T)
+	else
+		new /obj/effect/temp_visual/bubblegum_hands/leftpaw(T)
+		new /obj/effect/temp_visual/bubblegum_hands/leftthumb(T)
+	sleep(6)
+	for(var/mob/living/L in T)
+		if(!faction_check_mob(L))
+			if(L.stat != CONSCIOUS)
+				to_chat(L, "<span class='userdanger'>[src] drags you through the blood!</span>")
+				playsound(T, 'sound/magic/enter_blood.ogg', 100, 1, -1)
+				var/turf/targetturf = get_step(src, dir)
+				L.forceMove(targetturf)
+				playsound(targetturf, 'sound/magic/exit_blood.ogg', 100, 1, -1)
+				addtimer(CALLBACK(src, .proc/devour, L), 2)
+	sleep(1)
+
+/obj/effect/temp_visual/dragon_swoop/bubblegum
+	duration = 10
+
+/obj/effect/temp_visual/bubblegum_hands
+	icon = 'icons/effects/bubblegum.dmi'
+	duration = 9
+
+/obj/effect/temp_visual/bubblegum_hands/rightthumb
+	icon_state = "rightthumbgrab"
+
+/obj/effect/temp_visual/bubblegum_hands/leftthumb
+	icon_state = "leftthumbgrab"
+
+/obj/effect/temp_visual/bubblegum_hands/rightpaw
+	icon_state = "rightpawgrab"
+	layer = BELOW_MOB_LAYER
+
+/obj/effect/temp_visual/bubblegum_hands/leftpaw
+	icon_state = "leftpawgrab"
+	layer = BELOW_MOB_LAYER
+
+/obj/effect/temp_visual/bubblegum_hands/rightsmack
+	icon_state = "rightsmack"
+
+/obj/effect/temp_visual/bubblegum_hands/leftsmack
+	icon_state = "leftsmack"
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_warp()
+	if(Adjacent(target) || (enrage_till + 30 > world.time))
+		return FALSE
+	var/list/can_jaunt = get_pools(get_turf(src), 1)
+	if(!can_jaunt.len)
+		return FALSE
+
+	var/list/pools = get_pools(get_turf(target), 2)
+	var/list/pools_to_remove = get_pools(get_turf(target), 1)
+	pools -= pools_to_remove
+	if(!pools.len)
+		return FALSE
+
+	var/obj/effect/temp_visual/decoy/DA = new /obj/effect/temp_visual/decoy(loc,src)
+	DA.color = "#FF0000"
+	var/oldtransform = DA.transform
+	DA.transform = matrix()*2
+	animate(DA, alpha = 255, color = initial(DA.color), transform = oldtransform, time = 3)
+	sleep(3)
+	qdel(DA)
 	var/obj/effect/decal/cleanable/blood/found_bloodpool
-	var/list/pools = list()
-	var/can_jaunt = FALSE
-	for(var/obj/effect/decal/cleanable/blood/nearby in view(src,2))
-		can_jaunt = TRUE
-		break
-	if(!can_jaunt)
-		return
-	for(var/obj/effect/decal/cleanable/blood/nearby in view(get_turf(target),2))
-		pools += nearby
+	pools = get_pools(get_turf(target), 2)
+	pools_to_remove = get_pools(get_turf(target), 1)
+	pools -= pools_to_remove
 	if(pools.len)
 		shuffle_inplace(pools)
 		found_bloodpool = pick(pools)
@@ -215,48 +380,110 @@ Difficulty: Hard
 		forceMove(get_turf(found_bloodpool))
 		playsound(get_turf(src), 'sound/magic/exit_blood.ogg', 100, 1, -1)
 		visible_message("<span class='danger'>And springs back out!</span>")
+		blood_enrage()
+		return TRUE
+	return FALSE
 
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_enrage(var/boost_time = 30)
+	enrage_till = world.time + boost_time
+	retreat_distance = null
+	minimum_distance = 1
+	change_move_delay(3.75)
+	var/newcolor = rgb(149, 10, 10)
+	add_atom_colour(newcolor, TEMPORARY_COLOUR_PRIORITY)
+	var/datum/callback/cb = CALLBACK(src, .proc/blood_enrage_end)
+	addtimer(cb, boost_time)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_spray()
-	visible_message("<span class='danger'>[src] sprays a stream of gore!</span>")
-	var/turf/E = get_edge_target_turf(src, src.dir)
-	var/range = 10
-	var/turf/previousturf = get_turf(src)
-	for(var/turf/J in getline(src,E))
-		if(!range)
-			break
-		new /obj/effect/temp_visual/dir_setting/bloodsplatter(previousturf, get_dir(previousturf, J))
-		if(!previousturf.CanAtmosPass(J))
-			break
-		playsound(J,'sound/effects/splat.ogg', 100, 1, -1)
-		new /obj/effect/decal/cleanable/blood(J)
-		range--
-		previousturf = J
-		sleep(1)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/blood_enrage_end(var/newcolor = rgb(149, 10, 10))
+	retreat_distance = initial(retreat_distance)
+	minimum_distance = initial(minimum_distance)
+	change_move_delay()
+	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, newcolor)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/slaughterlings()
-	visible_message("<span class='danger'>[src] summons a shoal of slaughterlings!</span>")
-	for(var/obj/effect/decal/cleanable/blood/H in range(src, 10))
-		if(prob(25))
-			new /mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter(H.loc)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/is_enraged()
+	return (enrage_till > world.time)
 
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter
-	name = "slaughterling"
-	desc = "Though not yet strong enough to create a true physical form, it's nonetheless determined to murder you."
-	icon_state = "bloodbrood"
-	icon_living = "bloodbrood"
-	icon_aggro = "bloodbrood"
-	attack_verb_continuous = "pierces"
-	attack_verb_simple = "pierce"
-	color = "#C80000"
-	density = FALSE
-	faction = list("mining", "boss")
-	weather_immunities = list("lava","ash")
-	has_field_of_vision = FALSE
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/change_move_delay(var/newmove = initial(move_to_delay))
+	move_to_delay = newmove
+	handle_automated_action() // need to recheck movement otherwise move_to_delay won't update until the next checking aka will be wrong speed for a bit
 
-/mob/living/simple_animal/hostile/asteroid/hivelordbrood/slaughter/CanPass(atom/movable/mover, turf/target)
-	if(istype(mover, /mob/living/simple_animal/hostile/megafauna/bubblegum))
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/get_pools(turf/T, range)
+	. = list()
+	for(var/obj/effect/decal/cleanable/nearby in view(T, range))
+		if(nearby.can_bloodcrawl_in())
+			. += nearby
+
+/obj/effect/decal/cleanable/blood/bubblegum
+	bloodiness = 0
+
+/obj/effect/decal/cleanable/blood/bubblegum/can_bloodcrawl_in()
+	return TRUE
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/hallucination_charge_around(var/times = 4, var/delay = 6, var/chargepast = 0, var/useoriginal = 1)
+	var/startingangle = rand(1, 360)
+	if(!target)
+		return
+	var/turf/chargeat = get_turf(target)
+	var/srcplaced = 0
+	for(var/i = 1 to times)
+		var/ang = (startingangle + 360/times * i)
+		if(!chargeat)
+			return
+		var/turf/place = locate(chargeat.x + cos(ang) * times, chargeat.y + sin(ang) * times, chargeat.z)
+		if(!place)
+			continue
+		if(!srcplaced && useoriginal)
+			forceMove(place)
+			srcplaced = 1
+			continue
+		var/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/B = new /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination(src.loc)
+		B.forceMove(place)
+		INVOKE_ASYNC(B, .proc/charge, chargeat, delay, chargepast)
+	if(useoriginal)
+		charge(chargeat, delay, chargepast)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination
+	name = "bubblegum's hallucination"
+	desc = "Is that really just a hallucination?"
+	health = 1
+	maxHealth = 1
+	alpha = 127.5
+	crusher_loot = null
+	loot = null
+	deathmessage = "Explodes into a pool of blood!"
+	deathsound = 'sound/effects/splat.ogg'
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Initialize()
+	..()
+	toggle_ai(AI_OFF)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/charge()
+	..()
+	qdel(src)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Destroy()
+	new /obj/effect/decal/cleanable/blood(get_turf(src))
+	. = ..()
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/CanPass(atom/movable/mover, turf/target)
+	if(istype(mover, /mob/living/simple_animal/hostile/megafauna/bubblegum)) // hallucinations should not be stopping bubblegum or eachother
 		return 1
-	return 0
+	return ..()
 
-#undef MEDAL_PREFIX
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/Life()
+	return
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
+	return
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/OpenFire()
+	return
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/AttackingTarget()
+	return
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/try_bloodattack()
+	return
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/grant_achievement(medaltype,scoretype)
+	return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -136,7 +136,7 @@ Difficulty: Hard
 	if(.)
 		SSshuttle.shuttle_purchase_requirements_met |= "bubblegum"
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A, visual_effect_icon)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect)
 	if(!charging)
 		..()
 
@@ -185,7 +185,7 @@ Difficulty: Hard
 	playsound(src, 'sound/effects/meteorimpact.ogg', 200, 1, 2, 1)
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(var/atom/chargeat = target, var/delay = 3, var/chargepast = 2)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/proc/charge(atom/chargeat = target, delay = 3, chargepast = 2)
 	if(!chargeat)
 		return
 	var/chargeturf = get_turf(chargeat)
@@ -457,7 +457,7 @@ Difficulty: Hard
 	..()
 	toggle_ai(AI_OFF)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/charge()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination/charge(atom/chargeat = target, delay = 3, chargepast = 2)
 	..()
 	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://youtu.be/uXtZ3Un2hV4?t=43

https://github.com/tgstation/tgstation/pull/41778
https://github.com/tgstation/tgstation/pull/45087

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bubblegum is now less of a total pushover that drops the best nonadmin armor currently avaialble

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
🆑 Whoneedspacee and Skoglol
add: Reverts back to the bubblegum before TG PR #38306, was an unfinished pr and generally this bubblegum has more stuff to work with.
add: Enrage mode, while in this mode bubblegum is colored a deep red, moves faster, doesn't retreat, and is immune to projectiles. All while throwing out ground slam attacks around him that throw people around.
add: Clones, basically fake bubblegums that do one attack and disappear afterwards.
add: Ground slam attack, only happens when bubblegum is enraged, throws enemies around. Beware being thrown into a wall or you might be stunned because this is how throws work in this game.
add: Bubblegum can now continue to charge through enemies without stopping.
del: Bubblegum's anger modifier no longer determines his movement speed, instead having a constant speed and changing on enragement.
tweak: Blood spray is now a directional move and can move diagonally towards its target
tweak: Bubblegums charge no longer uses throws to calculate being hit.
balance: Bubblegum now retreats in his standard phase while not using moves, generally he was hard to get hit by in this phase anyways so this is a much smarter play on his part.
balance: Blood spray can now move through walls and goes further, this was pretty easily cheesed because it couldn't move through walls with just hugging the edges of walls and just made him too hard to balance.
balance: Bubblegum now procs melee checks much more often, though he has the same cooldown for his melee attacks. This means you're much less likely to stand next to him and not get hit.
balance: Bubblegum now charges 2 tiles past you, makes it slightly more difficult to predict where he's going to go and makes it so he can catch up to you easier.
balance: Bubblegum now moves faster during his charge.
balance: Bubblegum now only takes 50 damage from explosions, taking many bombs to kill him instead of just 10.
del: Removed Bubblegums ability to summon slaughterlings.
/🆑
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
