### PR TITLE
Fixed drones nullspacing things they try to place on tables and in closets

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -6,7 +6,7 @@
 //Drone hands
 
 
-/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, silent = FALSE)
+/mob/living/simple_animal/drone/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE, silent = FALSE)
 	if(..())
 		update_inv_hands()
 		if(I == head)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What the title says.

Explanation: If you're going to override a proc and you're calling the parent proc make sure that all the parameters are accounted for or else garbage like this happens. 

Was gonna wait for LetterN to fix this since this was an issue that popped up due to TGS hardsync 1.5 but since I play drone every so often, I figured I'd tackle it myself.

## Why It's Good For The Game

Yes.
fixes #14490

## Changelog
:cl:
fix: Fixed drones nullspacing things they try to place on tables and in closets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
