### PR TITLE
reverts d287835 "Made quirk blacklisting antag-sided" and fixes antags losing ALL their traits

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -8,7 +8,6 @@
 	var/gain_text
 	var/lose_text
 	var/medical_record_text //This text will appear on medical records for the trait. Not yet implemented
-	var/antag_removal_text // Text will be given to the quirk holder if they get an antag that has it blacklisted.
 	var/mood_quirk = FALSE //if true, this quirk affects mood and is unavailable if moodlets are disabled
 	var/mob_trait //if applicable, apply and remove this mob trait
 	/// should we immediately call on_spawn or add a timer to trigger

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -6,7 +6,6 @@
 	value = -2
 	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
 	lose_text = "<span class='notice'>You feel vigorous again.</span>"
-	antag_removal_text = "Your antagonistic nature has removed your blood deficiency."
 	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
 
 /datum/quirk/blooddeficiency/on_process()
@@ -173,7 +172,11 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	gain_text = "<span class='danger'>You feel repulsed by the thought of violence!</span>"
 	lose_text = "<span class='notice'>You think you can defend yourself again.</span>"
 	medical_record_text = "Patient is unusually pacifistic and cannot bring themselves to cause physical harm."
-	antag_removal_text = "Your antagonistic nature has caused you to renounce your pacifism."
+
+/datum/quirk/nonviolent/on_process()
+	if(quirk_holder.mind && LAZYLEN(quirk_holder.mind.antag_datums))
+		to_chat(quirk_holder, "<span class='boldannounce'>Your antagonistic nature has caused you to renounce your pacifism.</span>")
+		qdel(src)
 
 /datum/quirk/paraplegic
 	name = "Paraplegic"
@@ -348,8 +351,12 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	gain_text = "<span class='danger'>You find yourself unable to speak!</span>"
 	lose_text = "<span class='notice'>You feel a growing strength in your vocal chords.</span>"
 	medical_record_text = "Functionally mute, patient is unable to use their voice in any capacity."
-	antag_removal_text = "Your antagonistic nature has caused your voice to be heard."
 	var/datum/brain_trauma/severe/mute/mute
+
+/datum/quirk/mute/on_process()
+	if(quirk_holder.mind && LAZYLEN(quirk_holder.mind.antag_datums))
+		to_chat(quirk_holder, "<span class='boldannounce'>Your antagonistic nature has caused your voice to be heard.</span>")
+		qdel(src)
 
 /datum/quirk/mute/add()
 	var/mob/living/carbon/human/H = quirk_holder

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -23,7 +23,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/show_in_antagpanel = TRUE	//This will hide adding this antag type in antag panel, use only for internal subtypes that shouldn't be added directly but still show if possessed by mind
 	var/antagpanel_category = "Uncategorized"	//Antagpanel will display these together, REQUIRED
 	var/show_name_in_check_antagonists = FALSE //Will append antagonist name in admin listings - use for categories that share more than one antag type
-	var/list/blacklisted_quirks = list(/datum/quirk/nonviolent,/datum/quirk/mute) // Quirks that will be removed upon gaining this antag. Pacifist and mute are default.
 	var/threat = 0 // Amount of threat this antag poses, for dynamic mode
 	var/show_to_ghosts = FALSE // Should this antagonist be shown as antag to ghosts? Shouldn't be used for stealthy antagonists like traitors
 
@@ -102,7 +101,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 		greet()
 	apply_innate_effects()
 	give_antag_moodies()
-	remove_blacklisted_quirks()
 	if(is_banned(owner.current) && replace_banned)
 		replace_banned_player()
 	if(skill_modifiers)
@@ -158,18 +156,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	if(!antag_moodlet)
 		return
 	SEND_SIGNAL(owner.current, COMSIG_CLEAR_MOOD_EVENT, "antag_moodlet")
-
-/datum/antagonist/proc/remove_blacklisted_quirks()
-	var/mob/living/L = owner.current
-	if(istype(L))
-		var/list/my_quirks = L.client?.prefs.all_quirks.Copy()
-		SSquirks.filter_quirks(my_quirks,blacklisted_quirks)
-		for(var/q in L.roundstart_quirks)
-			var/datum/quirk/Q = q
-			if(!(SSquirks.quirk_name_by_path(Q.type) in my_quirks))
-				if(initial(Q.antag_removal_text))
-					to_chat(L, "<span class='boldannounce'>[initial(Q.antag_removal_text)]</span>")
-				L.remove_quirk(Q.type)
 
 //Returns the team antagonist belongs to if any.
 /datum/antagonist/proc/get_team()

--- a/code/modules/antagonists/collector/collector.dm
+++ b/code/modules/antagonists/collector/collector.dm
@@ -2,7 +2,6 @@
 	name = "Contraband Collector"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = FALSE
-	blacklisted_quirks = list() // no blacklist, these guys are harmless
 
 /datum/antagonist/collector/proc/forge_objectives()
 	var/datum/objective/hoard/collector/O = new

--- a/code/modules/antagonists/survivalist/survivalist.dm
+++ b/code/modules/antagonists/survivalist/survivalist.dm
@@ -2,7 +2,6 @@
 	name = "Survivalist"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
-	blacklisted_quirks = list(/datum/quirk/nonviolent) // mutes are allowed
 	threat = 1
 	var/greet_message = ""
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

reverts a pr that was snuck into an antag objective rework
(https://github.com/Citadel-Station-13/Citadel-Station-13/commit/d287835d1427a4a9b7a9f448676d046e5d51318d)
and subsequently removed the on_process() check to remove pacifism and mute traits from antags in favor of a blacklist system
the blacklist system also removed every single other trait regardless of if the antagonist had a blacklisted trait or not; resulting in every single antagonist lacking traits

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

technically this is a fix but if putnam wants to step in and make a pr fixing their error that would be much better

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: antagonists losing their traits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
