### PR TITLE
Fixes phantom mob-holder items

### DIFF
--- a/code/datums/elements/mob_holder.dm
+++ b/code/datums/elements/mob_holder.dm
@@ -141,7 +141,7 @@
 
 /obj/item/clothing/head/mob_holder/dropped(mob/user)
 	. = ..()
-	if(held_mob && !ismob(loc))//don't release on soft-drops
+	if(held_mob && !ismob(loc) && !istype(loc,/obj/item/storage))//don't release on soft-drops
 		release()
 
 /obj/item/clothing/head/mob_holder/proc/release()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When pulling out mobs (via the mob holder element) from your backpack or wherever, you'll end up dropping the mob to the ground, and leaving a phantom invisible mob item in your hand until it's dropped.

This fixes that.

this is something you broke when fixing the gear painter stuff by the way, @silicons.

## Why It's Good For The Game

fixes #14417
fixes #14365

## Changelog
:cl:
fix: Fixed phantom mob-holder items. You can now grab Ian from your backpack without any issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
