### PR TITLE
makes a config option off by default

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -382,7 +382,7 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 #PANIC_SERVER_NAME [Put the name here]
 
 ##Automated age verification, comment this out to not ask new users if they are 18+
-AGE_VERIFICATION
+#AGE_VERIFICATION
 
 ## Uncomment to have the changelog file automatically open when a user connects and hasn't seen the latest changelog
 #AGGRESSIVE_CHANGELOG


### PR DESCRIPTION
## About The Pull Request
title its the one that asks your DoB if you're a new player who isnt registered to the bunker

i'd put it in the title but people would just take it out of context when it's the default value, not the current value, and its just so people can have people connect to their server without having a db

## Why It's Good For The Game
kevin told me to

## Changelog
:cl:
config: makes AGE_VERIFICATION option off by default
/:cl:
