### PR TITLE
Revenant changes port from TG - revenants no longer spend their current essence to unlock new abilities; a fix

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -63,6 +63,7 @@
 	var/essence_regenerating = TRUE //If the revenant regenerates essence or not
 	var/essence_regen_amount = 5 //How much essence regenerates
 	var/essence_accumulated = 0 //How much essence the revenant has stolen
+	var/essence_excess = 0 //How much stolen essence available for unlocks
 	var/revealed = FALSE //If the revenant can take damage from normal sources.
 	var/unreveal_time = 0 //How long the revenant is revealed for, is about 2 seconds times this var.
 	var/unstun_time = 0 //How long the revenant is stunned for, is about 2 seconds times this var.
@@ -138,6 +139,7 @@
 	. = ..()
 	. += "Current essence: [essence]/[essence_regen_cap]E"
 	. += "Stolen essence: [essence_accumulated]E"
+	. += "Unused stolen essence: [essence_excess]E)"
 	. += "Stolen perfect souls: [perfectsouls]"
 
 /mob/living/simple_animal/revenant/update_health_hud()
@@ -304,16 +306,24 @@
 		return FALSE
 	return TRUE
 
+/mob/living/simple_animal/revenant/proc/unlock(essence_cost)
+	if(essence_excess < essence_cost)
+		return FALSE
+	essence_excess -= essence_cost
+	update_action_buttons_icon()
+	return TRUE
+
 /mob/living/simple_animal/revenant/proc/change_essence_amount(essence_amt, silent = FALSE, source = null)
 	if(!src)
 		return
-	if(essence + essence_amt <= 0)
+	if(essence + essence_amt < 0)
 		return
 	essence = max(0, essence+essence_amt)
-	update_action_buttons_icon()
 	update_health_hud()
 	if(essence_amt > 0)
 		essence_accumulated = max(0, essence_accumulated+essence_amt)
+		essence_excess = max(0, essence_excess+essence_amt)
+	update_action_buttons_icon()
 	if(!silent)
 		if(essence_amt > 0)
 			to_chat(src, "<span class='revennotice'>Gained [essence_amt]E[source ? " from [source]":""].</span>")

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -61,6 +61,8 @@
 				to_chat(src, "<span class='revenminor'>You begin siphoning essence from [target]'s soul.</span>")
 				if(target.stat != DEAD)
 					to_chat(target, "<span class='warning'>You feel a horribly unpleasant draining sensation as your grip on life weakens...</span>")
+				if(target.stat == SOFT_CRIT)
+					target.Stun(46)
 				reveal(46)
 				stun(46)
 				target.visible_message("<span class='warning'>[target] suddenly rises slightly into the air, [target.p_their()] skin turning an ashy gray.</span>")
@@ -144,7 +146,7 @@
 	if(user.inhibited)
 		return FALSE
 	if(locked)
-		if(user.essence <= unlock_amount)
+		if(user.essence_excess <= unlock_amount)
 			return FALSE
 	if(user.essence <= cast_amount)
 		return FALSE
@@ -158,7 +160,7 @@
 			locked = FALSE
 		return TRUE
 	if(locked)
-		if(!user.castcheck(-unlock_amount))
+		if(!user.unlock(unlock_amount))
 			charge_counter = charge_max
 			return FALSE
 		name = "[initial(name)] ([cast_amount]E)"
@@ -185,6 +187,7 @@
 	range = 5
 	stun = 30
 	cast_amount = 40
+	unlock_amount = 25
 	var/shock_range = 2
 	var/shock_damage = 15
 	action_icon_state = "overload_lights"
@@ -197,7 +200,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/revenant/overload/proc/overload(turf/T, mob/user)
 	for(var/obj/machinery/light/L in T)
 		if(!L.on)
-			return
+			continue
 		L.visible_message("<span class='warning'><b>\The [L] suddenly flares brightly and begins to spark!</span>")
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(4, 0, L)
@@ -226,7 +229,7 @@
 	range = 4
 	stun = 20
 	reveal = 40
-	unlock_amount = 75
+	unlock_amount = 10
 	cast_amount = 30
 	action_icon_state = "defile"
 
@@ -277,7 +280,7 @@
 	charge_max = 200
 	range = 4
 	cast_amount = 60
-	unlock_amount = 200
+	unlock_amount = 125
 	action_icon_state = "malfunction"
 
 //A note to future coders: do not replace this with an EMP because it will wreck malf AIs and everyone will hate you.
@@ -324,7 +327,7 @@
 	charge_max = 200
 	range = 3
 	cast_amount = 50
-	unlock_amount = 200
+	unlock_amount = 75
 	action_icon_state = "blight"
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/blight/cast(list/targets, mob/living/simple_animal/revenant/user = usr)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following:
tgstation/tgstation#41221
tgstation/tgstation#51823

From Kriskog's PR:

> Revenant spell unlocks always felt off to me. Currently, you use a combination of your capped essence plus stolen essence over the cap to unlock spells. Since the most expensive spells cost 200, this means you need to extract 125 essence on top of the 75 normal cap without using any spells in between draining and unlocking. In other words, worst case you need to have 8-9 corpses ready to drain in order to reach the 200. Better hope noone interrupts you. "Wasting" a corpse by draining before you regen to max cap is also a thing.
> 
> With this, you can use your unlocked spells to help you drain corpses. Spell costs have been reduced to be in line with not using the free 75 capped essence, ie malfunction reduced from 200 to 125. In addition, blight was reduced to 75, since effectively all it does is apply a small amount of toxin damage.

Which is to say with this change, the revenants are now allowed to be **a lot more aggressive than usual.**

## Why It's Good For The Game

Probably an agreeable change to revenants from my personal thoughts, but we'll have to see what everyone else thinks of bringing this to Citadel.

## Changelog
:cl:
balance: (TGport-Kriskog) Reduced blight cost to 75, more in line with its underwhelming nature.
tweak: (TGport-Kriskog) Revenants now only use stolen essence to unlock new spells. No more counting corpses or waiting for regen before draining.
tweak: (TGport-Kriskog) Spell unlock costs adjusted accordingly, defile upped from 0 to a cost of 10.
tweak: (TGport-Kriskog) Drain targets in soft-crit will be stunned, to prevent them crawling away.
fix: (TGport-ShizCalev) Fixed revenant's light overload ability not blowing lights in a square if there was another broken/burnt out/empty light in it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
