### PR TITLE
Color Labels the Operating Computer

### DIFF
--- a/tgui/packages/tgui/interfaces/OperatingComputer.js
+++ b/tgui/packages/tgui/interfaces/OperatingComputer.js
@@ -7,18 +7,22 @@ const damageTypes = [
   {
     label: 'Brute',
     type: 'bruteLoss',
+    color: 'red',
   },
   {
     label: 'Burn',
     type: 'fireLoss',
+    color: 'orange',
   },
   {
     label: 'Toxin',
     type: 'toxLoss',
+    color: 'green',
   },
   {
     label: 'Respiratory',
     type: 'oxyLoss',
+    color: 'blue',
   },
 ];
 
@@ -93,7 +97,7 @@ const PatientStateView = (props, context) => {
               <LabeledList.Item key={type.type} label={(patient.is_robotic_organism && type.label === 'Toxin') ? 'Corruption' : type.label}>
                 <ProgressBar
                   value={patient[type.type] / patient.maxHealth}
-                  color="bad">
+                  color={type.color}>
                   <AnimatedNumber value={patient[type.type]} />
                 </ProgressBar>
               </LabeledList.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, nothing else.
![image](https://user-images.githubusercontent.com/43283559/114749686-91301700-9d29-11eb-9171-1ddc9de0bb1f.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's way too good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: The operating computer shows color for each type of damage instead of red for every type.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
