### PR TITLE
solars plastitanium glass fix

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -272,7 +272,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	. = ..()
 	. += GLOB.plastitaniumglass_recipes
 
-/obj/item/stack/sheet/titaniumglass/on_solar_construction(obj/machinery/power/solar/S)
+/obj/item/stack/sheet/plastitaniumglass/on_solar_construction(obj/machinery/power/solar/S)
 	S.max_integrity *= 2
 	S.efficiency *= 2
 


### PR DESCRIPTION
## About The Pull Request
plastitanium glass now properly applies the *2 integrity/efficiency modifier

also theres probably more than a few bugs when it comes to prying the glass out of solars or something. poor solars. never got all too much love
## Why It's Good For The Game
woo consistency with glass quality
## Changelog
:cl:
fix: Plastitanium glass now properly applies the *2 bonus for integrity and efficiency when used as a solar panel.
/:cl: