### PR TITLE
No more Suicidal Parrots! (Ready)

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -64,7 +64,6 @@
 	friendly_verb_simple = "groom"
 	mob_size = MOB_SIZE_SMALL
 	movement_type = FLYING
-	gold_core_spawnable = HOSTILE_SPAWN
 
 	var/parrot_damage_upper = 10
 	var/parrot_state = PARROT_WANDER //Hunt for a perch when created

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -64,7 +64,7 @@
 	friendly_verb_simple = "groom"
 	mob_size = MOB_SIZE_SMALL
 	movement_type = FLYING
-	gold_core_spawnable = FRIENDLY_SPAWN
+	gold_core_spawnable = HOSTILE_SPAWN
 
 	var/parrot_damage_upper = 10
 	var/parrot_state = PARROT_WANDER //Hunt for a perch when created


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, the stabilized Golden slime extract spawns a random simple animal from the comprehensive list of parrots and maybe a dog or a cat sometimes. ...Jokes aside, the amount of parrots in the code is enormous and that is a bit of a problem...
The extract summons a familiar while the extract is held and deletes it when the extract is dropped.
Parrots are scripted to steal small, held items. When they steal the extract, they delete themselves and the extract with them.
In order to mitigate this, I moved them to the hostile spawns instead, making the stabilized gold extract unable to summon them now. Arguably, kleptomania isn't exactly "friendly", now is it?

edit: I removed them from gold extracts completely for now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Xenobiologists won't randomly lose their work due to self-destructive animal behaviour anymore.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: removed parrots from gold extract spawns altogether.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
