### PR TITLE
sawing off a lever-action rifle makes it WEAPON_MEDIUM (allowing one-handed firing)

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -361,6 +361,7 @@
 
 /obj/item/gun/ballistic/shotgun/leveraction/on_sawoff(mob/user)
 	magazine.max_ammo-- // sawing off drops from 7+1 to 6+1
+	weapon_weight = WEAPON_MEDIUM // but what kind of mares leg isnt one-handed
 
 /obj/item/gun/ballistic/shotgun/leveraction/update_icon_state()
 	if(current_skin)


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
well if you're gonna saw it off to lose a round of capacity and make it normal size you might as well gain some sort of benefit to it
(note: i should probably make the capacity suffer a bit more if you do, though...)
## Changelog
:cl:
balance: Sawing-off a lever-action rifle now lets you fire it one-handed. This may not have been wise.
/:cl: