### PR TITLE
adds kinetic crusher safety override kits to the uplink

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -387,9 +387,8 @@
 	var/obj/item/kinetic_crusher/hammer_synced
 
 /datum/status_effect/crusher_mark/on_creation(mob/living/new_owner, obj/item/kinetic_crusher/new_hammer_synced)
-	. = ..()
-	if(.)
-		hammer_synced = new_hammer_synced
+	hammer_synced = new_hammer_synced
+	return ..()
 
 /datum/status_effect/crusher_mark/on_apply()
 	. = ..()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -393,7 +393,7 @@
 
 /datum/status_effect/crusher_mark/on_apply()
 	. = ..()
-	if(owner.mob_size >= MOB_SIZE_LARGE)
+	if(hammer_synced? hammer_synced.can_mark(owner) : (owner.mob_size >= MOB_SIZE_LARGE))
 		marked_underlay = mutable_appearance('icons/effects/effects.dmi', "shield2")
 		marked_underlay.pixel_x = -owner.pixel_x
 		marked_underlay.pixel_y = -owner.pixel_y

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -52,11 +52,12 @@
 	QDEL_LIST(trophies)
 	return ..()
 
-/obj/item/kinetic_crusher/emag_act()
+/obj/item/kinetic_crusher/emag_act(mob/user)
 	. = ..()
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
+	to_chat(user, "<span class='warning'>You override the safeties on [src]. It can now be used on anything.</span>")
 
 /obj/item/kinetic_crusher/proc/can_mark(mob/living/victim)
 	if(obj_flags & EMAGGED)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -28,9 +28,9 @@
 	var/brightness_on = 7
 	var/wielded = FALSE // track wielded status on item
 	/// Damage penalty factor to detonation damage to non simple mobs
-	var/human_damage_nerf = 1/3
+	var/human_damage_nerf = 0.25
 	/// Damage penalty factor to backstab bonus damage to non simple mobs
-	var/human_backstab_nerf = 1/3
+	var/human_backstab_nerf = 0.25
 
 /obj/item/kinetic_crusher/cyborg //probably give this a unique sprite later
 	desc = "An integrated version of the standard kinetic crusher with a grinded down axe head to dissuade mis-use against crewmen. Deals damage equal to the standard crusher against creatures, however."

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -1,3 +1,6 @@
+#define NO_CHANGE 1
+#define PREVENT_MARK 2
+#define FORCE_MARK 3
 /*********************Mining Hammer****************/
 /obj/item/kinetic_crusher
 	icon = 'icons/obj/mining.dmi'
@@ -52,17 +55,15 @@
 	QDEL_LIST(trophies)
 	return ..()
 
-/obj/item/kinetic_crusher/emag_act(mob/user)
-	. = ..()
-	if(obj_flags & EMAGGED)
-		return
-	obj_flags |= EMAGGED
-	to_chat(user, "<span class='warning'>You override the safeties on [src]. It can now be used on anything.</span>")
-
 /obj/item/kinetic_crusher/proc/can_mark(mob/living/victim)
-	if(obj_flags & EMAGGED)
-		return TRUE
-	return victim.mob_size >= MOB_SIZE_LARGE
+	. = victim.mob_size >= MOB_SIZE_LARGE
+	for(var/i in trophies)
+		var/obj/item/crusher_trophy/T = i
+		var/returned = T.attempt_mark(victim)
+		if(returned == PREVENT_MARK)
+			return FALSE
+		else if(returned == FORCE_MARK)
+			return TRUE
 
 /// triggered on wield of two handed item
 /obj/item/kinetic_crusher/proc/on_wield(obj/item/source, mob/user)
@@ -533,3 +534,18 @@
 
 /obj/effect/temp_visual/hierophant/wall/crusher
 	duration = 75
+
+// antag
+/obj/item/crusher_trophy/safety_bypass
+	name = "crusher safety override"
+	desc = "A set of modifications that allow a kinetic crusher to work on all living organisms, removing their size checks."
+	icon = 'icons/obj/objects.dmi'
+	icon_state = "modkit"
+	denied_type = /obj/item/crusher_trophy/safety_bypass
+
+// stealth
+/obj/item/crusher_trophy/effect_desc()
+	return
+
+/obj/item/crusher_trophy/attempt_mark(mob/living/victim)
+	return FORCE_MARK

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -27,6 +27,10 @@
 	var/light_on = FALSE
 	var/brightness_on = 7
 	var/wielded = FALSE // track wielded status on item
+	/// Damage penalty factor to detonation damage to non simple mobs
+	var/human_damage_nerf = 1/3
+	/// Damage penalty factor to backstab bonus damage to non simple mobs
+	var/human_backstab_nerf = 1/3
 
 /obj/item/kinetic_crusher/cyborg //probably give this a unique sprite later
 	desc = "An integrated version of the standard kinetic crusher with a grinded down axe head to dissuade mis-use against crewmen. Deals damage equal to the standard crusher against creatures, however."
@@ -47,6 +51,17 @@
 /obj/item/kinetic_crusher/Destroy()
 	QDEL_LIST(trophies)
 	return ..()
+
+/obj/item/kinetic_crusher/emag_act()
+	. = ..()
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+
+/obj/item/kinetic_crusher/proc/can_mark(mob/living/victim)
+	if(obj_flags & EMAGGED)
+		return TRUE
+	return victim.mob_size >= MOB_SIZE_LARGE
 
 /// triggered on wield of two handed item
 /obj/item/kinetic_crusher/proc/on_wield(obj/item/source, mob/user)
@@ -134,6 +149,8 @@
 			new /obj/effect/temp_visual/kinetic_blast(get_turf(L))
 			var/backstab_dir = get_dir(user, L)
 			var/def_check = L.getarmor(type = "bomb")
+			var/detonation_damage = src.detonation_damage * (isanimal(L)? 1 : human_damage_nerf)
+			var/backstab_bonus = src.backstab_bonus * (isanimal(L)? 1 : human_backstab_nerf)
 			if((user.dir & backstab_dir) && (L.dir & backstab_dir))
 				if(!QDELETED(C))
 					C.total_damage += detonation_damage + backstab_bonus //cheat a little and add the total before killing it, so certain mobs don't have much lower chances of giving an item

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -547,5 +547,5 @@
 /obj/item/crusher_trophy/effect_desc()
 	return
 
-/obj/item/crusher_trophy/attempt_mark(mob/living/victim)
+/obj/item/crusher_trophy/proc/attempt_mark(mob/living/victim)
 	return FORCE_MARK

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -175,6 +175,14 @@
 	limited_stock = 2 //you can't use more than two!
 	restricted_roles = list("Shaft Miner")
 
+/datum/uplink_item/role_restricted/crusher_override
+	name = "Kinetic Crusher Override Mod"
+	desc = "A modification kit that allows a kinetic crusher to work on all living things, regardless of size."
+	item = /obj/item/crusher_trophy/safety_bypass
+	cost = 6	// honestly if you're using this you're probably powergaming megafauna anyways so slightly more than pressuremod
+	limited_stock = 1	// let's not have someone pass this out to their buddies for free
+	restricted_roles = list("Shaft Miner")
+
 /datum/uplink_item/role_restricted/kitchen_gun
 	name = "Kitchen Gun (TM)"
 	desc = "A revolutionary .45 caliber cleaning solution! Say goodbye to daily stains and dirty surfaces with Kitchen Gun (TM)! \
@@ -257,4 +265,4 @@
 	item = /obj/item/storage/toolbox/emergency/turret
 	cost = 11
 	restricted_roles = list("Station Engineer")
-	
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
random horrible idea i cooked up 

## Why It's Good For The Game

creative and hopefully not too overpowered way (MARK DETONATION APPLIES TO TROPHIES STILL!!) for traitors to do the funny stabbing. you're usually better off with an esword if you really want to melee but then again this isn't factoring into how someone with this probably has megafauna loot (as well as the fact that an emag is a bit more multi use than an esword)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: kinetic crushers can now be emagged to use on people. around 0.25x damage multiplier to crusher detonation bonuses so no hitting people with 100 force backstabs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
