### PR TITLE
Shotgun Shell rebalance

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,7 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 50
+	damage = 30
+	armour_penetration = 30
 	sharpness = SHARP_POINTY
 	wound_bonus = 0
 

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -87,12 +87,13 @@
 	return BULLET_ACT_HIT
 
 /obj/item/projectile/bullet/pellet
-	var/tile_dropoff = 0.45
+	var/tile_dropoff = 0.5
 	var/tile_dropoff_s = 1.25
 
 /obj/item/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 7.5
+	damage = 8.5
+	armour_penetration = -10
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,6 +1,6 @@
 /obj/item/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
-	damage = 30
+	damage = 40
 	armour_penetration = 30
 	sharpness = SHARP_POINTY
 	wound_bonus = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces raw damage of slugs and gives them AP as compensation
Increases raw damage of buck and slightly increases damage falloff
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Slugs are just straight up the strongest ranged non antag weapon, kind of fucked up when it's so good nothing else gets used, this gives it AP so it's a viable alternative for armored targets instead of just better than everything. With buckshot now outdamaging slugs, before buckshot did 45 damage if every single pellet hit point blank, now it does 51 because rounding and has -10 AP.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced buckshot and and slugs to be more competitive to eachother
balance: Buckshot damage increase from 7.5 to 8.5 totaling 51 damage point blank -10 AP
balance: Slug damage decreased from 50 to 40, 30 AP given as compensation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
