### PR TITLE
[ATMOS CHANGE TESTMERGE THIS OH GOD] adds multiz_accessible_levels infinite loop guard, reworks atmos adjacent turfs proc 

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -44,7 +44,7 @@
 	return FALSE
 
 /turf/proc/ImmediateCalculateAdjacentTurfs()
-	var/canpass = CANATMOSPASS(src, src) 
+	var/canpass = CANATMOSPASS(src, src)
 	var/canvpass = CANVERTICALATMOSPASS(src, src)
 	for(var/direction in GLOB.cardinals_multiz)
 		var/turf/T = get_step_multiz(src, direction)
@@ -79,31 +79,27 @@
 	if (atmos_adjacent_turfs)
 		adjacent_turfs = atmos_adjacent_turfs.Copy()
 	else
-		adjacent_turfs = list()
+		return list()		// don't bother checking diagonals, diagonals are going to be cardinal checks anyways.
 
 	if (!alldir)
 		return adjacent_turfs
 
-	var/turf/curloc = src
-
-	for (var/direction in GLOB.diagonals_multiz)
-		var/matchingDirections = 0
-		var/turf/S = get_step_multiz(curloc, direction)
-		if(!S)
+	var/turf/other
+	var/turf/mid
+	for (var/d in GLOB.diagonals)
+		other = get_step(src, d)
+		if(!other)
 			continue
-
-		for (var/checkDirection in GLOB.cardinals_multiz)
-			var/turf/checkTurf = get_step(S, checkDirection)
-			if(!S.atmos_adjacent_turfs || !S.atmos_adjacent_turfs[checkTurf])
-				continue
-
-			if (adjacent_turfs[checkTurf])
-				matchingDirections++
-
-			if (matchingDirections >= 2)
-				adjacent_turfs += S
-				break
-
+		// NS step
+		mid = get_step(src, NSCOMPONENT(d))
+		if((mid in adjacent_turfs) && (get_step(mid, EWCOMPONENT(d)) in adjacent_turfs))
+			adjacent_turfs += other
+			continue
+		// EW step
+		mid = get_step(src, EWCOMPONENT(d))
+		if((mid in adjacent_turfs) && (get_step(mid, NSCOMPONENT(d)) in adjacent_turfs))
+			adjacent_turfs += other
+			continue
 	return adjacent_turfs
 
 /atom/proc/air_update_turf(command = 0)

--- a/code/modules/mapping/space_management/multiz_helpers.dm
+++ b/code/modules/mapping/space_management/multiz_helpers.dm
@@ -13,13 +13,15 @@
 	var/offset
 	while((offset = SSmapping.level_trait(other_z, ZTRAIT_DOWN)))
 		other_z += offset
+		if(other_z in .)
+			break	// no infinite loops
 		. += other_z
 	other_z = center_z
 	while((offset = SSmapping.level_trait(other_z, ZTRAIT_UP)))
 		other_z += offset
+		if(other_z in .)
+			break	// no infinite loops
 		. += other_z
-	return .
-
 
 /proc/get_dir_multiz(turf/us, turf/them)
 	us = get_turf(us)
@@ -46,4 +48,4 @@
 
 /turf/proc/below()
 	return get_step_multiz(src, DOWN)
-	
+


### PR DESCRIPTION
- atmos adjacent proc no longer scans multiz and is probably more efficient in general
- get_multiz_accessible_levels is now guarded against infinite loops

the gains of multiz scans are heavily outweighed by the following:

because we don't have a realistic canatmospass that won't be horrific in performance for diagonals (or god forbid, multiz diagonals) that isn't going to be slow as sin, 
each diagonal check on the same zlevel requires 2 steps. when doing 4 diagonals, you're doing a best case of 4 checks to a worst case of 8 checks.

each up/down diagonal check is just as expensive. you have 4 + 4 = 8 of these. this brings access count up to 16 + 8 = 24
now, for the CORNERS of a 3x3x3 blocks, you are now doing: 3 possible first steps, 2 possible second steps, and 1 possible third steps.
3 + 3 * 2 + 3 * 1 = 12 possible checks. 12 * 8 corners = !!48!! checks, **bringing the access count up to 72.**

it's not worth it.
it just isn't.

@Putnam3145 please check my code.