### PR TITLE
lesspopcrates(this one works)

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_bundles.dm
+++ b/code/modules/uplink/uplink_items/uplink_bundles.dm
@@ -135,7 +135,7 @@
 			but you never know. Contents are sorted to always be worth 50 TC."
 	item = /obj/structure/closet/crate
 	cost = 20
-	player_minimum = 25
+	player_minimum = 20
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
 	cant_discount = TRUE
 	var/starting_crate_value = 50
@@ -145,7 +145,7 @@
 	desc = "A dusty SUPER-SIZED from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
 			but you never know. Contents are sorted to always be worth 125 TC."
 	cost = 40
-	player_minimum = 40
+	player_minimum = 30
 	starting_crate_value = 125
 
 /datum/uplink_item/bundles_TC/surplus/purchase(mob/user, datum/component/uplink/U)


### PR DESCRIPTION
less population required for surplus crates, everyone loves them. I don't see how this could affect gameplay in any negative way :)

regular surplus lowered to 20 (still pretty hard to get ingame)
super crate is 30 (pretty much unheard of lately on cit)