### PR TITLE
Prevents Nightmares from being pulled OUT of jaunt from vendors and engraved messages.

### DIFF
--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -152,7 +152,7 @@
 	var/newcolor = copytext_char(hash, 1, 7)
 	add_atom_colour("#[newcolor]", FIXED_COLOUR_PRIORITY)
 	light_color = "#[newcolor]"
-	set_light(1)
+	set_light(0.3)
 
 /obj/structure/chisel_message/proc/pack()
 	var/list/data = list()

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -56,9 +56,9 @@
 /obj/effect/dummy/phased_mob/shadow/proc/check_light_level()
 	var/turf/T = get_turf(src)
 	var/light_amount = T.get_lumcount()
-	if(light_amount > 0.2) // jaunt ends
+	if(light_amount > 0.4) // jaunt ends
 		end_jaunt(TRUE)
-	else if (light_amount < 0.2 && (!QDELETED(jaunter))) //heal in the dark
+	else if (light_amount < 0.4 && (!QDELETED(jaunter))) //heal in the dark
 		jaunter.heal_overall_damage(1,1)
 
 /obj/effect/dummy/phased_mob/shadow/proc/end_jaunt(forced = FALSE)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -55,7 +55,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	armor = list("melee" = 20, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 70)
 	circuit = /obj/item/circuitboard/machine/vendor
 	payment_department = ACCOUNT_SRV
-	light_power = 0.5
+	light_power = 0.3
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 	/// Is the machine active (No sales pitches if off)!
 	var/active = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says.  With this PR, Engraved Messages and Vendors don't pull Nightmares out of jaunt, however they still cannot go INTO jaunt next to them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The amount of light that both a vendor and an engraved messages emits is very minimal.  The fact both of these pulled Nightmares out of jaunt is ridiculous, especially with a ton of hard to see engraved messages spread throughout a lot of maints.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Nightmare Shadow Jaunt threshold up to 0.4
balance: Vendor and Engraved message light down to 0.3
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
