### PR TITLE
Supernovae now announce when over, + other supernova tweaks

### DIFF
--- a/code/modules/events/supernova.dm
+++ b/code/modules/events/supernova.dm
@@ -17,15 +17,20 @@
 	announceWhen = rand(4, 60)
 	supernova = new
 	SSsun.suns += supernova
-	if(prob(20))
-		power = rand(5,100) / 100
-	else
-		power = rand(5,5000) / 100
+	switch(rand(1,5))
+		if(1)
+			power = rand(5,100) / 100
+		if(2)
+			power = rand(5,500) / 100
+		if(3)
+			power = rand(5,1000) / 100
+		if(4, 5)
+			power = rand(5,5000) / 100
 	supernova.azimuth = rand(0, 359)
 	supernova.power_mod = 0
 
 /datum/round_event/supernova/announce()
-	var/message = "Our tachyon-doppler array has detected a supernova in your vicinity. Peak flux from the supernova estimated to be [round(power,0.1)] times current solar flux. [power > 1 ? "Short burts of radiation may be possible, so please prepare accordingly." : ""]"
+	var/message = "[station_name()]: Our tachyon-doppler array has detected a supernova in your vicinity. Peak flux from the supernova estimated to be [round(power,0.1)] times current solar flux; if the supernova is close to your sun in the sky, your solars may receive this as a power boost.[power > 1 ? " Short burts of radiation may be possible, so please prepare accordingly." : ""] We hope you enjoy the light."
 	if(prob(power * 25))
 		priority_announce(message, sender_override = "Nanotrasen Meteorology Division")
 	else
@@ -34,7 +39,7 @@
 
 /datum/round_event/supernova/start()
 	supernova.power_mod = 0.001 * power
-	var/explosion_size = rand(1000000000, 999999999)
+	var/explosion_size = rand(1000000000, 10000000000)
 	var/turf/epicenter = get_turf_in_angle(supernova.azimuth, SSmapping.get_station_center(), round(world.maxx * 0.45))
 	for(var/array in GLOB.doppler_arrays)
 		var/obj/machinery/doppler_array/A = array
@@ -51,7 +56,7 @@
 		supernova.power_mod = min(supernova.power_mod*1.2, power)
 	if(activeFor > endWhen-10)
 		supernova.power_mod /= 4
-	if(prob(round(supernova.power_mod)) && prob(3) && storm_count < 5 && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
+	if(prob(round(supernova.power_mod*2)) && prob(3) && storm_count < 5 && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
 		SSweather.run_weather(/datum/weather/rad_storm/supernova)
 		storm_count++
 

--- a/code/modules/events/supernova.dm
+++ b/code/modules/events/supernova.dm
@@ -27,7 +27,7 @@
 /datum/round_event/supernova/announce()
 	var/message = "Our tachyon-doppler array has detected a supernova in your vicinity. Peak flux from the supernova estimated to be [round(power,0.1)] times current solar flux. [power > 1 ? "Short burts of radiation may be possible, so please prepare accordingly." : ""]"
 	if(prob(power * 25))
-		priority_announce(message)
+		priority_announce(message, sender_override = "Nanotrasen Meteorology Division")
 	else
 		print_command_report(message)
 
@@ -51,13 +51,15 @@
 		supernova.power_mod = min(supernova.power_mod*1.2, power)
 	if(activeFor > endWhen-10)
 		supernova.power_mod /= 4
-	if(prob(round(supernova.power_mod)) && prob(5) && storm_count < 5 && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
+	if(prob(round(supernova.power_mod)) && prob(3) && storm_count < 5 && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
 		SSweather.run_weather(/datum/weather/rad_storm/supernova)
 		storm_count++
 
 /datum/round_event/supernova/end()
 	SSsun.suns -= supernova
 	qdel(supernova)
+	priority_announce("The supernova's flux is now negligible. Radiation storms have ceased. Have a pleasant shift, [station_name()], and thank you for bearing with nature.",
+	sender_override = "Nanotrasen Meteorology Division")
 
 /datum/weather/rad_storm/supernova
 	weather_duration_lower = 50

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -152,7 +152,7 @@
 		else
 			//dot product of sun and panel -- Lambert's Cosine Law
 			cur_pow = cos(azimuth_current - sun_azimuth) * sun.power_mod
-			cur_pow = clamp(round(cur_pow, 0.01), 0, 1)
+			cur_pow = clamp(round(cur_pow, 0.01), 0, sun.power_mod)
 		total_flux += cur_pow
 
 /obj/machinery/power/solar/process()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Supernova now announces when it's no longer going to cause storms. Rejoice.
2. Some weirdness with rand causes a lot of the storms to be in the absolute top 2% of storms (49 and above), so I've tweaked it so that it only has a 20% chance to roll <1, 20% chance to roll <5, 20% to roll <10 and 40% to roll .05-5000, instead of just 20% <1 and 80% .05-5000.
3. Rewrote the messages to be more in-line with the other meteorology department messages, cause I think it's kinda funny how enthusiastic they are.
4. Made the tachyon-doppler array detection not always have the exact same values (I forgot a 9 and odd integers don't go that high in 32-bit floats anyway) and made it dependent somewhat on how powerful the supernova actually is.
5. Made the rad storm chance lower on average, but higher for higher powered supernovae, since those happen less often now. Only 1.2x as often, now, mind, and due to the changes, such stormy supernovae are less common.
6. Fixed solars not to have their power from supernovae capped at 1 if the supernova isn't on top of the sun.

## Why It's Good For The Game

Event's annoying. Make it less annoying.

## Changelog
:cl:
tweak: Supernova made less annoying
/:cl: