### PR TITLE
Makes species/antag trait blacklist no longer remove ALL traits

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -164,11 +164,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/remove_blacklisted_quirks()
 	var/mob/living/L = owner.current
 	if(istype(L))
-		var/list/my_quirks = L.client?.prefs.all_quirks.Copy()
-		SSquirks.filter_quirks(my_quirks,blacklisted_quirks)
 		for(var/q in L.roundstart_quirks)
 			var/datum/quirk/Q = q
-			if(!(SSquirks.quirk_name_by_path(Q.type) in my_quirks))
+			if(Q.type in blacklisted_quirks)
 				if(initial(Q.antag_removal_text))
 					to_chat(L, "<span class='boldannounce'>[initial(Q.antag_removal_text)]</span>")
 				L.remove_quirk(Q.type)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 			if(Q.type in blacklisted_quirks)
 				if(initial(Q.antag_removal_text))
 					to_chat(L, "<span class='boldannounce'>[initial(Q.antag_removal_text)]</span>")
-				L.remove_quirk(Q.type)
+				qdel(Q)
 
 //Returns the team antagonist belongs to if any.
 /datum/antagonist/proc/get_team()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -572,7 +572,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		for(var/q in L.roundstart_quirks)
 			var/datum/quirk/Q = q
 			if(Q.type in blacklisted_quirks)
-				L.remove_quirk(Q.type)
+				qdel(Q)
 				removed_quirks += Q.type
 
 // restore any quirks that we removed

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -569,11 +569,9 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 /datum/species/proc/remove_blacklisted_quirks(mob/living/carbon/C)
 	var/mob/living/L = C.mind?.current
 	if(istype(L))
-		var/list/my_quirks = L.client?.prefs.all_quirks.Copy()
-		SSquirks.filter_quirks(my_quirks, blacklisted_quirks)
 		for(var/q in L.roundstart_quirks)
 			var/datum/quirk/Q = q
-			if(!(SSquirks.quirk_name_by_path(Q.type) in my_quirks))
+			if(Q.type in blacklisted_quirks)
 				L.remove_quirk(Q.type)
 				removed_quirks += Q.type
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. I made a bad. Someone *copied* my bad for use in species trait blacklisting, oh dear. This fixes them both. Closes #14589.

## Why It's Good For The Game

Fixes: good

## Changelog
:cl:
fix: Antag and species no longer remove all traits if one has a blacklisted trait
/:cl: