### PR TITLE
Delta ce office rearrangement

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -86423,6 +86423,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -86985,10 +86988,24 @@
 /turf/closed/wall/r_wall,
 /area/security/office)
 "jxc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/ce";
-	name = "Chief Engineer's APC";
-	pixel_y = -26
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	desc = "It looks really dirty.";
+	name = "maintenance microwave";
+	pixel_y = 5
+	},
+/obj/structure/sign/poster/official/help_others{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -91616,7 +91633,7 @@
 	dir = 8
 	},
 /obj/structure/cable/white{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -94345,9 +94362,6 @@
 /obj/item/gps/engineering{
 	gpstag = "CE0"
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -94360,6 +94374,14 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/command/heads_quarters/ce";
+	name = "Chief Engineer's APC";
+	pixel_y = 32
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -109302,24 +109324,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"rts" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 0;
-	pixel_x = 0;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/command/heads_quarters/ce)
 "rtx" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase{
@@ -110207,11 +110211,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/ce";
-	name = "Chief Engineer's APC";
-	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -111785,6 +111784,9 @@
 /area/command/meeting_room/council)
 "sjF" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /obj/machinery/button/door{
 	id = "ceblast";
 	name = "Lockdown Control";
@@ -111807,15 +111809,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/ce";
-	dir = 1;
-	name = "Chief Engineer's APC";
-	pixel_y = 23
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -116162,6 +116155,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engineering/storage/tech)
+"tGF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/command/heads_quarters/ce)
 "tGL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -151667,13 +151673,13 @@ mMB
 pRP
 kkO
 mcs
-mHG
+tGF
 xKr
 lLv
 lCx
 vBq
 ikP
-rts
+iLR
 qjg
 ine
 vJe

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -111785,9 +111785,6 @@
 /area/command/meeting_room/council)
 "sjF" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/button/door{
 	id = "ceblast";
 	name = "Lockdown Control";

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -72141,24 +72141,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"exg" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/command/heads_quarters/ce)
 "exo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -79857,20 +79839,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)
-"hkJ" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/command/heads_quarters/ce)
 "hkK" = (
 /obj/structure/table/reinforced,
 /obj/item/electronics/firelock,
@@ -87017,24 +86985,10 @@
 /turf/closed/wall/r_wall,
 /area/security/office)
 "jxc" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	desc = "It looks really dirty.";
-	name = "maintenance microwave";
-	pixel_y = 5
-	},
-/obj/structure/sign/poster/official/help_others{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/power/apc{
+	areastring = "/area/command/heads_quarters/ce";
+	name = "Chief Engineer's APC";
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
@@ -91661,6 +91615,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "laA" = (
@@ -92991,9 +92948,6 @@
 /area/engineering/break_room)
 "lCx" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /obj/item/clipboard,
 /obj/item/toy/figure/ce,
 /obj/effect/turf_decal/tile/neutral{
@@ -93526,9 +93480,6 @@
 /area/service/abandoned_gambling_den)
 "lLv" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
 /obj/item/folder/blue{
 	pixel_x = 3;
 	pixel_y = 3
@@ -109352,12 +109303,6 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "rts" = (
-/obj/structure/cable/white,
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/ce";
-	name = "Chief Engineer's APC";
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -109367,6 +109312,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 0;
+	pixel_x = 0;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -110257,6 +110207,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/command/heads_quarters/ce";
+	name = "Chief Engineer's APC";
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -111855,6 +111810,15 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/command/heads_quarters/ce";
+	dir = 1;
+	name = "Chief Engineer's APC";
+	pixel_y = 23
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -117812,9 +117776,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -117828,6 +117789,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -121250,9 +121215,6 @@
 /area/service/chapel/office)
 "vBq" = (
 /obj/structure/table/reinforced,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /obj/item/cartridge/engineering{
 	pixel_x = 6
 	},
@@ -124083,10 +124045,6 @@
 /obj/item/cartridge/atmos,
 /obj/item/cartridge/atmos,
 /obj/item/cartridge/atmos,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/item/stamp/ce,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -151717,7 +151675,7 @@ xKr
 lLv
 lCx
 vBq
-hkJ
+ikP
 rts
 qjg
 ine
@@ -151971,7 +151929,7 @@ kkO
 nZq
 jpC
 ivQ
-exg
+tbI
 tbI
 ilG
 hbc
@@ -152485,7 +152443,7 @@ kkO
 jKf
 prr
 qPW
-xSN
+kkO
 sSa
 jry
 pTd

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -94378,7 +94378,7 @@
 /obj/machinery/power/apc{
 	areastring = "/area/command/heads_quarters/ce";
 	name = "Chief Engineer's APC";
-	pixel_y = 32
+	pixel_y = 30
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -94377,6 +94377,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/command/heads_quarters/ce";
+	dir = 1;
 	name = "Chief Engineer's APC";
 	pixel_y = 30
 	},
@@ -122229,6 +122230,22 @@
 /obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
+"vXq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/heads_quarters/ce)
 "vXw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -151679,7 +151696,7 @@ lLv
 lCx
 vBq
 ikP
-iLR
+vXq
 qjg
 ine
 vJe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rearranges the ce office on delta station so the only thing emped by the singulo is a fire alarm.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having a valuable head of staff's office being constantly emped and panic syphoned is a bit too rude for our employees. So instead the fire alarm will randomly go off.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Delta CE office rearranged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
