### PR TITLE
adds _contents() wrapper for SELECT SDQL2 statements

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -238,3 +238,9 @@
 /proc/__nan()
 	var/list/L = json_decode("{\"value\":NaN}")
 	return L["value"]
+
+/**
+ * Wrapper to return a copy of contents, as SDQL2 can't tell an internal list from a normal list.
+ */
+/atom/proc/_contents()
+	return contents.Copy()


### PR DESCRIPTION
SDQL2_print can't tell if a list is a byond internal list that doesn't support associations (which will then just runtime.)
We can't fix the runtimes but we can make it workable.