### PR TITLE
Makes antags actually get activity properly

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 			var/datum/skill_modifier/job/M = GLOB.skill_modifiers[GET_SKILL_MOD_ID(A, type)]
 			if(istype(M))
 				M.name = "[name] Training"
-	owner.AddComponent(/datum/component/activity)
+	owner.current.AddComponent(/datum/component/activity)
 	SEND_SIGNAL(owner.current, COMSIG_MOB_ANTAG_ON_GAIN, src)
 
 /datum/antagonist/proc/is_banned(mob/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yeah I accidentally started adding it to a mind instead of to the owner of that mind.

## Why It's Good For The Game

It can't hurt.

## Changelog
:cl:
fix: Fixed activity being attached to minds instead of mobs on antag attach.
/:cl: