### PR TITLE
Pubby atmos Mixing will no longer auto-suck gasses

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -24647,6 +24647,12 @@
 	},
 /turf/open/space,
 /area/solars/starboard)
+"beW" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "beY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Central";
@@ -40355,8 +40361,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Unfiltered to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -40803,25 +40810,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"bOo" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "bOp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Unfiltered to Mix"
+	name = "Pure to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bOq" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -41396,10 +41397,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Mix"
-	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bPW" = (
@@ -41778,6 +41775,9 @@
 /area/engineering/atmos)
 "bQK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bQL" = (
@@ -55197,6 +55197,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hEX" = (
@@ -56741,10 +56744,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "kWG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kWQ" = (
@@ -57452,8 +57454,11 @@
 /turf/closed/wall,
 /area/maintenance/department/engine)
 "mAR" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -58864,9 +58869,7 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "pEM" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Ports"
-	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "pFe" = (
@@ -60141,9 +60144,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "sIK" = (
@@ -61068,7 +61069,9 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "uST" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Ports"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "uUQ" = (
@@ -99688,9 +99691,9 @@ bJN
 bKS
 bMe
 bNh
-bOo
-kWG
-mAR
+pEM
+bOX
+bMf
 bMf
 bMf
 bMf
@@ -99947,7 +99950,7 @@ bWM
 bNi
 bQK
 bOZ
-bOn
+bMf
 bMf
 bMf
 bMf
@@ -100202,10 +100205,10 @@ bHw
 bKU
 bOr
 bPU
+kWG
 bRw
-bRw
-bOo
-mAR
+beW
+bMf
 bMf
 bMf
 bMf
@@ -100460,9 +100463,9 @@ bKV
 bOX
 eEd
 bQL
-bQL
-pEM
 uST
+pEM
+bMf
 qQu
 qQu
 bSU
@@ -100973,8 +100976,8 @@ bHw
 cqG
 bOX
 bOq
-bOq
-bVY
+mAR
+bPd
 bPW
 bPW
 bPW

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -40355,15 +40355,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Ports"
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"bNk" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -40372,8 +40365,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Unfiltered & Air to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -40810,22 +40804,24 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bOo" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bOp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Unfiltered to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bOq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -41086,13 +41082,6 @@
 "bOZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
-"bPa" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -41407,7 +41396,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Mix"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bPW" = (
@@ -41785,14 +41777,13 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bQK" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bQL" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bQM" = (
@@ -41800,9 +41791,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Unfiltered to Mix"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -42109,8 +42099,7 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bRw" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bRx" = (
@@ -53829,6 +53818,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"eEd" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "eEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -55198,6 +55193,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"hEi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "hEX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -56739,6 +56740,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"kWG" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "kWQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -57443,6 +57451,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"mAR" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "mCe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -58849,6 +58863,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"pEM" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Ports"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "pFe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -59370,6 +59390,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"qQu" = (
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "qRl" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -60110,6 +60137,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"sGJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "sIK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61031,6 +61067,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"uST" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -99649,8 +99689,8 @@ bKS
 bMe
 bNh
 bOo
-bOX
-bMf
+kWG
+mAR
 bMf
 bMf
 bMf
@@ -99907,7 +99947,7 @@ bWM
 bNi
 bQK
 bOZ
-bMf
+bOn
 bMf
 bMf
 bMf
@@ -100163,9 +100203,9 @@ bKU
 bOr
 bPU
 bRw
-bPa
-bMf
-bMf
+bRw
+bOo
+mAR
 bMf
 bMf
 bMf
@@ -100418,13 +100458,13 @@ bIF
 bHw
 bKV
 bOX
-bUv
+eEd
 bQL
-bPa
-bMf
-bMf
-bMf
-bMf
+bQL
+pEM
+uST
+qQu
+qQu
 bSU
 bTT
 bUv
@@ -100678,10 +100718,10 @@ bMg
 bNj
 bOp
 bPV
-bPV
-bPV
-bPV
-bPV
+hEi
+sGJ
+bUw
+bUw
 bUw
 bUw
 bUw
@@ -100932,9 +100972,9 @@ bIH
 bHw
 cqG
 bOX
-bNk
 bOq
-bPd
+bOq
+bVY
 bPW
 bPW
 bPW


### PR DESCRIPTION
## About The Pull Request

Adjusts pubby atmos hellpipes so mixing has a pump leading to the mixing chamber. This comes at the cost of less playspace and more spaghetti.

## Why It's Good For The Game

I was asked very politely and thought it was a good change, it moves atmos in line with all of the other atmoses on the maps.

## Changelog
:cl:
tweak: Pubby atmos room has a pump leading to the mixing chamber now.
/:cl:
