### PR TITLE
Changes the cost of the holoparasite injector and the ricochet eyepatch

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_clothing.dm
+++ b/code/modules/uplink/uplink_items/uplink_clothing.dm
@@ -104,7 +104,7 @@
 	name = "Mechanical Eyepatch"
 	desc = "An eyepatch that connects itself to your eye socket, enhancing your shooting to an impossible degree, allowing your bullets to ricochet far more often than usual."
 	item = /obj/item/clothing/glasses/eyepatch/syndicate
-	cost = 5
+	cost = 4
 
 /datum/uplink_item/device_tools/ablative_armwraps
 	name = "Ablative Armwraps"

--- a/code/modules/uplink/uplink_items/uplink_clothing.dm
+++ b/code/modules/uplink/uplink_items/uplink_clothing.dm
@@ -104,7 +104,7 @@
 	name = "Mechanical Eyepatch"
 	desc = "An eyepatch that connects itself to your eye socket, enhancing your shooting to an impossible degree, allowing your bullets to ricochet far more often than usual."
 	item = /obj/item/clothing/glasses/eyepatch/syndicate
-	cost = 8
+	cost = 5
 
 /datum/uplink_item/device_tools/ablative_armwraps
 	name = "Ablative Armwraps"

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -189,7 +189,7 @@
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
 	item = /obj/item/storage/box/syndie_kit/guardian
-	cost = 15
+	cost = 12
 	limited_stock = 1 // you can only have one holopara apparently?
 	refundable = TRUE
 	cant_discount = TRUE
@@ -204,7 +204,7 @@
 	desc = "Though capable of near sorcerous feats via use of hardlight holograms and nanomachines, they require an \
 			organic host as a home base and source of fuel. Holoparasites come in various types and share damage with their host."
 	item = /obj/item/storage/box/syndie_kit/nukieguardian
-	cost = 15
+	cost = 8
 	refundable = TRUE
 	surplus = 50
 	refund_path = /obj/item/guardiancreator/tech/choose/nukie


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the cost of the holoparasite injector and the ricochet eyepatch, and including the operative price variation.
Holoparasites for traitors had cost 15 crystals, now 12, and operatives it had cost 15, and now 8.
The eyepatch now costs 4 from 8.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because it's more of a bad thing for them due to having really heavy armor, and the holoparasite who can't wear their armor, and anyways neither of them almost ever use holoparasites due to the player aspect and them using most of their crystals.
And the eyepatch is a really funny gimmick thing to get, but it's just not worth it for the minor effect of sometimes ricocheting, so it was never thought to be really good enough to make it worth the large cost
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Holoparasites for traitors now cost 12 crystals, for operatives 8, the ricochet eyepath traitor item now 4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
