### PR TITLE
Makes sniper zooming work

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -569,11 +569,16 @@
 	. = ..()
 	if(!.)
 		var/obj/item/gun/G = target
+		G.zoom(owner, owner.dir, FALSE)
+
+/datum/action/item_action/toggle_scope_zoom/Trigger()
+	. = ..()
+	if(.)
 		G.zoom(owner, owner.dir)
 
 /datum/action/item_action/toggle_scope_zoom/Remove(mob/living/L)
 	var/obj/item/gun/G = target
-	G.zoom(L, L.dir)
+	G.zoom(L, L.dir, FALSE)
 	return ..()
 
 /obj/item/gun/proc/rotate(atom/thing, old_dir, new_dir)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -574,6 +574,7 @@
 /datum/action/item_action/toggle_scope_zoom/Trigger()
 	. = ..()
 	if(.)
+		var/obj/item/gun/G = target
 		G.zoom(owner, owner.dir)
 
 /datum/action/item_action/toggle_scope_zoom/Remove(mob/living/L)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The sniper rifle's zoom action is intended to do the following:

1. On availability check, if not available, reset the user's zoom
2. On removal, reset the user's zoom
3. On toggle, toggle zoom on the rifle

What it does instead:

1. On availability check, if not available, toggle zoom
2. On removal, toggle zoom
3. Toggle was never even implemented, why

## Why It's Good For The Game

so people don't get their vision permanently and irrevocably ruined as soon as they pick up a sniper rifle with not even VV able to deal with it (seriously)

## Changelog
:cl:
fix: sniper rifle doesn't ruin your round instantly now
/:cl: