### PR TITLE
Makes orbit menu show antags if DNR

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -84,7 +84,7 @@
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A
 					var/mob/dead/observer/O = user
-					if (A.show_to_ghosts || O && !O.can_reenter_corpse)
+					if (A && A.show_to_ghosts || O && !O.can_reenter_corpse)
 						was_antagonist = TRUE
 						serialized["antag"] = A.name
 						antagonists += list(serialized)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -84,7 +84,7 @@
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A
 					var/mob/dead/observer/O = user
-					if (A && A.show_to_ghosts || O && !O.can_reenter_corpse)
+					if (A?.show_to_ghosts || !O?.can_reenter_corpse)
 						was_antagonist = TRUE
 						serialized["antag"] = A.name
 						antagonists += list(serialized)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -83,7 +83,8 @@
 
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A
-					if (A.show_to_ghosts)
+					var/mob/dead/observer/O = user
+					if (A.show_to_ghosts || O && !O.can_reenter_corpse)
 						was_antagonist = TRUE
 						serialized["antag"] = A.name
 						antagonists += list(serialized)

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -165,7 +165,7 @@ export const Orbit = (props, context) => {
           </Flex>
         </Section>
         {antagonists.length > 0 && (
-          <Section title="Ghost-Visible Antagonists">
+          <Section title="Visible Antagonists">
             {sortedAntagonists.map(([name, antags]) => (
               <Section key={name} title={name} level={2}>
                 {antags


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the orbit menu show all antags if the ghost is DNR
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a better method to see antags than the previous method
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak:Orbit menu now show's antags if you are DNR
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
