### PR TITLE
Fixing xenoruins floor

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
@@ -499,10 +499,6 @@
 /mob/living/simple_animal/hostile/alien,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"bD" = (
-/obj/structure/alien/weeds,
-/turf/template_noop,
-/area/ruin/unpowered/xenonest)
 "dE" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
@@ -1573,8 +1569,8 @@ aa
 aa
 aa
 ac
-bD
-bD
+ag
+ag
 aa
 "}
 (20,1,1) = {"
@@ -1625,7 +1621,7 @@ aa
 aa
 aa
 ac
-bD
+ag
 aa
 "}
 (21,1,1) = {"
@@ -1676,8 +1672,8 @@ ac
 aa
 aa
 ac
-bD
-bD
+ag
+ag
 "}
 (22,1,1) = {"
 ab
@@ -1727,8 +1723,8 @@ ac
 ac
 ac
 aW
-bD
-bD
+ag
+ag
 "}
 (23,1,1) = {"
 ab
@@ -1778,8 +1774,8 @@ ag
 aw
 ar
 ag
-bD
-bD
+ag
+ag
 "}
 (24,1,1) = {"
 ab
@@ -1829,8 +1825,8 @@ ag
 aw
 ar
 ag
-bD
-bD
+ag
+ag
 "}
 (25,1,1) = {"
 ab
@@ -1880,8 +1876,8 @@ ac
 ac
 ac
 ac
-bD
-bD
+ag
+ag
 "}
 (26,1,1) = {"
 ab


### PR DESCRIPTION
## About The Pull Request

There were some tiles that weren't given an ash flooring, so it defaulted to debug tiles that were visible through mesons.

## Why It's Good For The Game

Debug tiles in-game are bad.
![image](https://user-images.githubusercontent.com/48370570/120349882-795a2580-c2cc-11eb-8ab1-d3559052d3af.png)


## Changelog
:cl:
balance: Removed some debug tiles on the xenoruin.
/:cl: