### PR TITLE
Colors species names depending on traits

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -381,8 +381,8 @@ GENETICS SCANNER
 		else if (S.mutantstomach != initial(S.mutantstomach))
 			mutant = TRUE
 
-		msg += "\t<span class='info'>Reported Species: [H.dna.custom_species ? H.dna.custom_species : S.name]</span>\n"
-		msg += "\t<span class='info'>Base Species: [S.name]</span>\n"
+		msg += "\t<span class='info'>Reported Species: [H.spec_trait_examine_font()][H.dna.custom_species ? H.dna.custom_species : S.name]</font></span>\n"
+		msg += "\t<span class='info'>Base Species: [H.spec_trait_examine_font()][S.name]</font></span>\n"
 		if(mutant)
 			msg += "\t<span class='info'>Subject has mutations present.</span>\n"
 	msg += "\t<span class='info'>Body temperature: [round(M.bodytemperature-T0C,0.1)] &deg;C ([round(M.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>\n"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -28,7 +28,7 @@
 	if(skipface || get_visible_name() == "Unknown")
 		. += "You can't make out what species they are."
 	else
-		. += "[t_He] [t_is] a [dna.custom_species ? dna.custom_species : dna.species.name]!"
+		. += "[t_He] [t_is] a [spec_trait_examine_font()][dna.custom_species ? dna.custom_species : dna.species.name]</font>!"
 
 	//uniform
 	if(w_uniform && !(SLOT_W_UNIFORM in obscured))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1087,16 +1087,23 @@
  * # `spec_trait_examine_font()`
  *
  * This gets a humanoid's special examine font, which is used to color their species name during examine / health analyzing.
+ * The first of these that applies is returned.
  * Returns:
- * Metallic font if robotic
- * Cyan if a toxinlover
- * Green if none of the others apply (aka, generic organic)
+ * * Metallic font if robotic
+ * * Cyan if a toxinlover
+ * * Purple if plasmaperson
+ * * Rock / Brownish if a golem
+ * * Green if none of the others apply (aka, generic organic)
 */
 /mob/living/carbon/human/proc/spec_trait_examine_font() 
 	if(HAS_TRAIT(src, TRAIT_ROBOTIC_ORGANISM))
 		return "<font color='#aaa9ad'>"
 	if(HAS_TRAIT(src, TRAIT_TOXINLOVER))
 		return "<font color='#00ffff'>"
+	if(isplasmaman(src))
+		return "<font color='#800080'"
+	if(isgolem(src))
+		return "<font color='#8b4513'"
 	return "<font color='#18d855'>"
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1096,7 +1096,7 @@
 	if(HAS_TRAIT(src, TRAIT_ROBOTIC_ORGANISM))
 		return "<font color='#aaa9ad'>"
 	if(HAS_TRAIT(src, TRAIT_TOXINLOVER))
-		return "<font color='0#0ffff'>"
+		return "<font color='#00ffff'>"
 	return "<font color='#18d855'>"
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1083,6 +1083,23 @@
 	. = ..()
 	set_species(race)
 
+/**
+ * # `spec_trait_examine_font()`
+ *
+ * This gets a humanoid's special examine font, which is used to color their species name during examine / health analyzing.
+ * Returns:
+ * Metallic font if robotic
+ * Cyan if a toxinlover
+ * Green if none of the others apply (aka, generic organic)
+*/
+/mob/living/carbon/human/proc/spec_trait_examine_font() 
+	if(HAS_TRAIT(src, TRAIT_ROBOTIC_ORGANISM))
+		return "<font color='#aaa9ad'>"
+	if(HAS_TRAIT(src, TRAIT_TOXINLOVER))
+		return "<font color='0#0ffff'>"
+	return "<font color='#18d855'>"
+
+
 /mob/living/carbon/human/get_tooltip_data()
 	var/t_He = p_they(TRUE)
 	var/t_is = p_are()
@@ -1091,7 +1108,7 @@
 	if(skipface || get_visible_name() == "Unknown")
 		. += "You can't make out what species they are."
 	else
-		. += "[t_He] [t_is] a [dna.custom_species ? dna.custom_species : dna.species.name]"
+		. += "[t_He] [t_is] a [spec_trait_examine_font()][dna.custom_species ? dna.custom_species : dna.species.name]</font>"
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, usr, .)
 
 /mob/living/carbon/human/species/abductor


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone on the discord had the genius idea to have species names colored depending on their type to make them more distinguishable, while not having to bloat any part of examine text. This implements that.

Robot species have a Metallic font (#aaa9ad)
Toxinlovers (aka, slimes / jellypeople) have a Cyan font (#00ffff)
Plasmapeople have Purple (#800080)
Golems got Brown (#8b4513)
All other normal-ish organics are green (#18d855)
This applies to normal examines (provided their face is uncovered, otherwise you'd not see their species text), hover examine (same restriction) and health analyzers (since those always show species, it always colors)


Feel free to suggest different colors, I don't have a strong feel on any of them.
This should be testmerged for a while to see if it helps & if the colors are acceptable to a sufficient level.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More distinguishability for species with special mechanics, while not having to bloat any of the text messages.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Species names are now colored depending on special traits, for examining and health analyzers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
