### PR TITLE
makes Pride Month not affect the station name

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -484,9 +484,6 @@
 	begin_month = JUNE
 	end_day = 30
 
-/datum/holiday/pride/getStationPrefix()
-	return pick("Pride", "Gay", "Bi", "Trans", "Lesbian", "Ace", "Aro", "Agender", pick("Enby", "Enbie"), "Pan", "Intersex", "Demi", "Poly", "Closeted", "Genderfluid")
-
 /datum/holiday/stonewall
 	name = "Stonewall Riots Anniversary"
 	begin_day = 28


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title says it all.

## Why It's Good For The Game

I just
think "Genderfluid Course 93" and stuff like that sounds dumb.

That's it.

## Changelog
:cl:
del: Pride Month station names
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
