### PR TITLE
Pools now get misty at warm insteaed of scalding

### DIFF
--- a/code/modules/pool/pool_controller.dm
+++ b/code/modules/pool/pool_controller.dm
@@ -235,10 +235,10 @@
 			if(POOL_SCALDING) //Scalding
 				M.adjust_bodytemperature(50,0,500)
 			if(POOL_WARM) //Warm
-				M.adjust_bodytemperature(20,0,360) //Heats up mobs till the termometer shows up
+				M.adjust_bodytemperature(20,0,360) //Heats up mobs till the thermometer shows up
 			//Normal temp does nothing, because it's just room temperature water.
 			if(POOL_COOL)
-				M.adjust_bodytemperature(-20,250) //Cools mobs till the termometer shows up
+				M.adjust_bodytemperature(-20,250) //Cools mobs till the thermometer shows up
 			if(POOL_FRIGID) //Freezing
 				M.adjust_bodytemperature(-60) //cool mob at -35k per cycle, less would not affect the mob enough.
 				if(M.bodytemperature <= 50 && !M.stat)
@@ -290,10 +290,10 @@
 
 /obj/machinery/pool/controller/proc/update_temp()
 	if(mist_state)
-		if(temperature < POOL_SCALDING)
+		if(temperature < POOL_WARM)
 			mist_off()
 	else
-		if(temperature == POOL_SCALDING)
+		if(temperature >= POOL_WARM)
 			mist_on()
 	update_icon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pools now get misty when at warm or scalding instead of just scalding. The mist vanishes at normal tempatures
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pure fetish content. Also typo correcting.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Pools are capable of mist at lower temperatures
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
