### PR TITLE
Moves medical holodeck to restricted

### DIFF
--- a/code/game/area/areas/holodeck.dm
+++ b/code/game/area/areas/holodeck.dm
@@ -87,9 +87,6 @@
 /area/holodeck/rec_center/lounge
 	name = "Holodeck - Lounge"
 
-/area/holodeck/rec_center/medical
-	name = "Holodeck - Emergency Medical"
-
 /area/holodeck/rec_center/pet_lounge
 	name = "Holodeck - Pet Park"
 
@@ -126,6 +123,10 @@
 
 /area/holodeck/rec_center/bunker
 	name = "Holodeck - Holdout Bunker"
+	restricted = 1
+
+/area/holodeck/rec_center/medical
+	name = "Holodeck - Emergency Medical"
 	restricted = 1
 
 /area/holodeck/rec_center/anthophila


### PR DESCRIPTION
## About The Pull Request

Requires either an emag or a silicon to remove the restrictions on the holodeck to access emergency medical.

## Why It's Good For The Game

Look, this is a long time coming. This has been cutting away from ghetto surgery, giving chem/grinder access, and a straight up pandemic machine. 
It's for your own good, you can now even have a reasonable IC reason to ask for the restriction to be lifted from a silicon.

## Changelog
:cl:
balance: Moves medical holodeck to the restricted category
/:cl:
