### PR TITLE
Atmos resin buff? fix?

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -341,6 +341,9 @@
 		return TRUE
 	. = ..()
 
+/obj/structure/foamedmetal/resin/BlockSuperconductivity()
+	return TRUE
+
 #undef ALUMINUM_FOAM
 #undef IRON_FOAM
 #undef RESIN_FOAM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The resin deployed from the atmos backpacks now blocks heat transfer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Filling half a room with foam only to see the heat soak back in from the burnt side is extremely disheartening and frustrating. Example: Toxin's catches fire as it does, atmos tech uses firefighting backpack to fill every single tile with foam... Room is still hot.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Atmos resin now properly prevents all atmos from moving
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
