### PR TITLE
cuts the amount of essence revenant objective needs in half so it is actually feasibly possible

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -492,7 +492,7 @@
 	var/targetAmount = 100
 
 /datum/objective/revenant/New()
-	targetAmount = rand(350,600)
+	targetAmount = rand(200,400)
 	explanation_text = "Absorb [targetAmount] points of essence from humans."
 	..()
 

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -492,7 +492,7 @@
 	var/targetAmount = 100
 
 /datum/objective/revenant/New()
-	targetAmount = rand(200,400)
+	targetAmount = rand(150,400)
 	explanation_text = "Absorb [targetAmount] points of essence from humans."
 	..()
 

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -492,7 +492,7 @@
 	var/targetAmount = 100
 
 /datum/objective/revenant/New()
-	targetAmount = rand(150,400)
+	targetAmount = rand(150,300)
 	explanation_text = "Absorb [targetAmount] points of essence from humans."
 	..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

we're not nearly high pop enough for a revenant to get more than four hundred essence in one round let alone six hundred
even during highpop rounds are rarely generating enough corpses for this to be possible

the only feasible way is for a revenant to sneak down onto lavaland and abuse an oversight to just vore legion corpses

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

makes this antag actually possible to feasibly greentext

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: revenant essence objective reduced
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
