### PR TITLE
makes medihound sleeper toggle do something

### DIFF
--- a/code/game/objects/items/devices/dogborg_sleeper.dm
+++ b/code/game/objects/items/devices/dogborg_sleeper.dm
@@ -81,7 +81,7 @@
 		to_chat(user, "<span class='warning'>The user has opted out of the use of your [src].")
 		return
 	var/voracious = TRUE
-	if(!target.client || !(target.client.prefs.cit_toggles & MEDIHOUND_SLEEPER) || !hound.client || !(hound.client.prefs.cit_toggles & MEDIHOUND_SLEEPER))
+	if(!hound.client || !(hound.client.prefs.cit_toggles & MEDIHOUND_SLEEPER))
 		voracious = FALSE
 	if(target.buckled)
 		to_chat(user, "<span class='warning'>The user is buckled and can not be put into your [src].</span>")

--- a/code/game/objects/items/devices/dogborg_sleeper.dm
+++ b/code/game/objects/items/devices/dogborg_sleeper.dm
@@ -78,6 +78,7 @@
 	if(!iscarbon(target))
 		return
 	if(!(target?.client?.prefs?.cit_toggles & MEDIHOUND_SLEEPER))
+		to_chat(user, "<span class='warning'>The user has opted out of the use of your [src].")
 		return
 	var/voracious = TRUE
 	if(!target.client || !(target.client.prefs.cit_toggles & MEDIHOUND_SLEEPER) || !hound.client || !(hound.client.prefs.cit_toggles & MEDIHOUND_SLEEPER))

--- a/code/game/objects/items/devices/dogborg_sleeper.dm
+++ b/code/game/objects/items/devices/dogborg_sleeper.dm
@@ -77,6 +77,8 @@
 		return
 	if(!iscarbon(target))
 		return
+	if(!(target?.client?.prefs?.cit_toggles & MEDIHOUND_SLEEPER))
+		return
 	var/voracious = TRUE
 	if(!target.client || !(target.client.prefs.cit_toggles & MEDIHOUND_SLEEPER) || !hound.client || !(hound.client.prefs.cit_toggles & MEDIHOUND_SLEEPER))
 		voracious = FALSE


### PR DESCRIPTION
## About The Pull Request

Turns out it just changes some minor flavor text to be less fetishy instead of actually doing what you might think it does.

Also makes it so that bodies can't be carried in sleepers at all, which... might be bad? I don't know? Pretty sure you can still buckle people, so.

## Why It's Good For The Game

i'm not sure i need to explain this. one might object on grounds of balance, but I'm not sure medihounds are supposed to be balanced in the first place

## Changelog
:cl:
tweak: "Vocarious Medihound Sleeper" toggle now actually makes you not able to be medihound sleeper'd
/:cl: