### PR TITLE
removes greytide lights shattering

### DIFF
--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -46,10 +46,7 @@
 /datum/round_event/grey_tide/end()
 	for(var/area/A in areasToOpen)
 		for(var/obj/O in A)
-			if(istype(O, /obj/machinery/power/apc))
-				var/obj/machinery/power/apc/temp = O
-				temp.overload_lighting()
-			else if(istype(O, /obj/structure/closet/secure_closet))
+			if(istype(O, /obj/structure/closet/secure_closet))
 				var/obj/structure/closet/secure_closet/temp = O
 				temp.locked = FALSE
 				temp.update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

stops greytide breaking lights

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

we have way too many light breaking events
just one is enough

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: greytide leaves lights alone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
