### PR TITLE
21/79 not 20/80 the revenge

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -21,7 +21,7 @@
 	air_contents.set_volume(volume)
 	air_contents.set_temperature(T20C)
 	if(gas_type)
-		air_contents.set_moles(AIR_CONTENTS)
+		air_contents.set_moles(gas_type, AIR_CONTENTS)
 		name = "[name] ([GLOB.meta_gas_names[gas_type]])"
 	setPipingLayer(piping_layer)
 
@@ -32,8 +32,8 @@
 /obj/machinery/atmospherics/components/unary/tank/air/New()
 	..()
 	var/datum/gas_mixture/air_contents = airs[1]
-	air_contents.set_moles(/datum/gas/oxygen, AIR_CONTENTS * 0.2)
-	air_contents.set_moles(/datum/gas/nitrogen, AIR_CONTENTS * 0.8)
+	air_contents.set_moles(/datum/gas/oxygen, AIR_CONTENTS * 0.21)
+	air_contents.set_moles(/datum/gas/nitrogen, AIR_CONTENTS * 0.79)
 
 /obj/machinery/atmospherics/components/unary/tank/carbon_dioxide
 	gas_type = /datum/gas/carbon_dioxide


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
21/79 air tanks along with fixies for gas tanks
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes gas tanks and brings air tanks inline with a standard earth mix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Pressure tanks other then air tanks start with gas!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
