### PR TITLE
Pubby xenobiology atmospherics update among other things

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30155,12 +30155,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -46703,9 +46705,8 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "ccU" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air to Distro"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -53072,6 +53073,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/wrench,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cSJ" = (
@@ -53132,7 +53134,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "cXP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "cXW" = (
@@ -54905,11 +54909,12 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -55086,6 +55091,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "hgD" = (
@@ -55982,8 +55988,8 @@
 	},
 /area/maintenance/department/science)
 "iWV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -57399,7 +57405,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "mlr" = (
-/obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
@@ -57504,6 +57509,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -57703,6 +57711,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "mVM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "mXq" = (
@@ -58429,9 +58438,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "oBb" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air Outlet Pump"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -58860,6 +58868,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "pkM" = (
@@ -59094,8 +59103,8 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -59639,9 +59648,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qVP" = (
@@ -59859,6 +59865,7 @@
 /area/space/nearstation)
 "roc" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ros" = (
@@ -60574,6 +60581,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "tfx" = (
@@ -60850,6 +60858,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"tJW" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air Out"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "tLP" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -60986,10 +61000,10 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "ufa" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ugC" = (
@@ -106366,8 +106380,8 @@ oTl
 vzP
 vzP
 iWV
-aFi
-bpq
+tJW
+rxa
 bnj
 brT
 bxF
@@ -106620,7 +106634,7 @@ eCw
 aUC
 aUC
 qHI
-aKq
+bpq
 aEj
 wAI
 vzP
@@ -106883,7 +106897,7 @@ bkF
 bkF
 bkF
 bkF
-oBb
+bkF
 ume
 bkF
 bkF

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -55063,7 +55063,7 @@
 "hbl" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -57733,7 +57733,7 @@
 "nbu" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/maintenance/disposal/incinerator)
 "ncm" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4,8 +4,8 @@
 /area/space)
 "aab" = (
 /obj/effect/landmark/start/cyborg,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/machinery/holopad/secure,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aac" = (
@@ -28881,6 +28881,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bpt" = (
@@ -29492,6 +29493,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqF" = (
@@ -29515,6 +29517,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqH" = (
@@ -29545,6 +29548,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqJ" = (
@@ -29557,6 +29561,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqK" = (
@@ -29587,6 +29592,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bqO" = (
@@ -30150,9 +30156,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/structure/sign/departments/xenobio{
-	pixel_x = 32
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -30160,12 +30163,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"brV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "brW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30180,12 +30177,14 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "brX" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -30200,6 +30199,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bsb" = (
@@ -30231,6 +30231,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bsd" = (
@@ -30262,6 +30263,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bsf" = (
@@ -30272,14 +30274,14 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -30828,7 +30830,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -30857,15 +30859,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btA" = (
@@ -31421,6 +31421,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/sign/departments/xenobio{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "buL" = (
@@ -31442,8 +31445,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -31469,6 +31472,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "buQ" = (
@@ -32058,14 +32062,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
-"bwh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bwm" = (
@@ -32757,6 +32754,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bxN" = (
@@ -32789,6 +32787,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bxP" = (
@@ -32825,6 +32824,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bxS" = (
@@ -32856,6 +32856,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -33483,6 +33486,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzl" = (
@@ -33512,6 +33516,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzn" = (
@@ -33524,6 +33529,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzp" = (
@@ -33536,6 +33542,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzq" = (
@@ -33548,6 +33555,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bzr" = (
@@ -33577,8 +33585,15 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"bzv" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/tcommsat/computer)
 "bzy" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -34131,6 +34146,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bAI" = (
@@ -41095,6 +41111,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"bPa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "bPd" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -43902,13 +43924,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"bVh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "bVi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -44900,7 +44915,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bXx" = (
@@ -46687,6 +46702,13 @@
 /obj/item/gps/engineering,
 /turf/open/floor/plating,
 /area/engineering/main)
+"ccU" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air to Distro"
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "ccW" = (
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
@@ -47188,18 +47210,21 @@
 "ceT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/engineering/main)
-"ceU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/turf/open/floor/plating,
+/area/engineering/main)
+"ceU" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching telecomms.";
 	layer = 4;
 	name = "Telecomms Telescreen";
 	network = list("tcomms");
 	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
@@ -48807,6 +48832,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "clR" = (
@@ -48854,8 +48880,8 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "clX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
@@ -50666,15 +50692,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/office)
-"csu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "csv" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -52862,6 +52879,7 @@
 /area/engineering/main)
 "cBT" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "cBU" = (
@@ -53113,6 +53131,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"cXP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "cXW" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53188,6 +53210,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dgI" = (
@@ -53408,6 +53431,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "dye" = (
@@ -53450,6 +53474,19 @@
 "dFJ" = (
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"dHo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "dHr" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/machinery/button/door{
@@ -53485,9 +53522,7 @@
 /area/medical/chemistry)
 "dJk" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "dJm" = (
@@ -53795,9 +53830,6 @@
 "eAZ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /turf/open/space,
 /area/space/nearstation)
 "eCw" = (
@@ -53863,6 +53895,11 @@
 "eIL" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -53970,6 +54007,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"eUB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -53977,6 +54020,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "eWi" = (
@@ -53985,6 +54029,12 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"eWP" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -54054,6 +54104,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ffr" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -54356,6 +54414,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"fLz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "fLG" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating,
@@ -54384,6 +54448,13 @@
 "fRs" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
+"fRT" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "fTY" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -54460,6 +54531,16 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"geN" = (
+/obj/machinery/igniter{
+	id = "xenoigniter";
+	luminosity = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "geU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -54839,6 +54920,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "gKz" = (
@@ -54991,13 +55076,15 @@
 	},
 /area/maintenance/department/science)
 "hfZ" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = 32;
 	receive_ore_updates = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -55122,6 +55209,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "hwd" = (
@@ -55388,9 +55476,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "hVx" = (
@@ -55490,6 +55576,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "ihj" = (
@@ -55636,6 +55723,9 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -55985,6 +56075,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"jkv" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/closed/wall/r_wall,
+/area/tcommsat/computer)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -56062,6 +56156,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hos)
+"jvO" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "jwe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -56084,6 +56182,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "jxK" = (
@@ -56751,6 +56850,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"kUE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "kWG" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -56964,6 +57076,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lCN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lEn" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -57148,6 +57264,12 @@
 /obj/item/clothing/head/beret,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"lXt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lXJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -57281,8 +57403,13 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "mmv" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -57594,6 +57721,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "naS" = (
@@ -57632,6 +57762,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nfc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "nfi" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
@@ -57965,6 +58099,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"nNp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "nNJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57984,14 +58124,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -58098,6 +58238,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ofN" = (
@@ -58193,6 +58334,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"osC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "ous" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/button/door{
@@ -58278,9 +58429,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "oBb" = (
-/obj/structure/sign/warning/biohazard,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air Outlet Pump"
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -58424,6 +58575,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 3;
+	name = "Waste to Space"
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oPx" = (
@@ -58473,6 +58628,7 @@
 	id = "xenobio4";
 	name = "containment blast door"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oSL" = (
@@ -58485,9 +58641,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oTl" = (
@@ -58669,6 +58823,8 @@
 	dir = 4;
 	network = list("ss13","rd")
 	},
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "pgH" = (
@@ -58716,6 +58872,12 @@
 /obj/structure/musician/piano,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"pmf" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "pmB" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -58736,9 +58898,8 @@
 /area/science/xenobiology)
 "poP" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -58930,15 +59091,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "pMG" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -59008,6 +59164,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
 	name = "test chamber blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
@@ -59138,6 +59297,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "qdj" = (
@@ -59246,6 +59406,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qAk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "qAx" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -59262,6 +59428,11 @@
 /obj/item/clothing/head/ushanka,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qCu" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/space,
+/area/space/nearstation)
 "qDJ" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_circuit_printer,
@@ -59461,6 +59632,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
+"qVn" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "qVP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -59557,6 +59740,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
+"rbe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "rdB" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -59855,6 +60045,12 @@
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"rMB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "rMV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59975,6 +60171,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"sgt" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "shH" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -60189,6 +60392,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"sNk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "sNz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60346,15 +60556,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "tdB" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tdL" = (
@@ -60520,6 +60728,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "tuy" = (
@@ -60532,6 +60741,18 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
+/area/science/xenobiology)
+"tuR" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "tvj" = (
 /obj/structure/festivus{
@@ -60573,6 +60794,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"tzj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "tzH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "research_shutters_2";
@@ -60664,6 +60889,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"tUO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -60678,6 +60909,10 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air to Distro"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -60713,14 +60948,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"udl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60759,9 +60986,10 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "ufa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ugC" = (
@@ -60825,15 +61053,21 @@
 /area/engineering/main)
 "ume" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
 	req_access_txt = "55"
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
+"uof" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -60924,6 +61158,9 @@
 	id = "misclab";
 	name = "test chamber blast door"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "uvq" = (
@@ -60959,6 +61196,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"uyJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "uzh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/engineering/glass/critical{
@@ -60982,6 +61223,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"uzB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -61014,6 +61261,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "uIn" = (
@@ -61043,6 +61291,10 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"uLP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "uMe" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -61479,9 +61731,6 @@
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -62029,6 +62278,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "wYu" = (
@@ -62182,6 +62434,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "xlg" = (
@@ -62313,6 +62566,11 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"xAy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "xCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -90733,10 +90991,10 @@ gnq
 bXk
 ceU
 eVy
-bXk
-bXk
-bXk
-bXk
+ulY
+ulY
+ulY
+ulY
 tue
 pjH
 pjH
@@ -90761,9 +91019,9 @@ tfw
 pjH
 pjH
 uHG
-clw
-clw
-clw
+cme
+cme
+jkv
 clQ
 clX
 rsZ
@@ -91531,7 +91789,7 @@ fon
 fon
 aht
 aht
-ouv
+bzv
 clw
 clw
 clw
@@ -96891,13 +97149,13 @@ bJN
 bJN
 bJN
 bJN
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
 frj
-pYh
-pYh
-pYh
-pYh
-pYh
-pYh
 pYh
 pYh
 hUw
@@ -97148,13 +97406,13 @@ bUp
 bWI
 bXr
 bKQ
-udl
+acN
 bZK
 abI
 abI
 abI
 abI
-aaa
+pmf
 aaa
 aaa
 uaO
@@ -97405,13 +97663,13 @@ bMf
 bWJ
 bXs
 bJN
-cui
-bJP
-bJP
-bJP
-bJP
-bJP
 abI
+bJP
+bJP
+bJP
+bJP
+bJP
+cui
 abI
 aht
 pBJ
@@ -97668,7 +97926,7 @@ caz
 cbs
 cbs
 bJP
-aaa
+pmf
 aaa
 aaa
 uaO
@@ -97919,13 +98177,13 @@ bMf
 bMf
 bXu
 bLW
-cui
+abI
 bMi
 caA
 cbt
 ccm
 bJP
-aaa
+pmf
 aaa
 aaa
 pBJ
@@ -98175,14 +98433,14 @@ bMf
 bMf
 bWM
 bXv
-bVh
+bWc
 poP
 bZL
 caB
 cbs
 cbs
 bJP
-aaa
+pmf
 aaa
 aaa
 aht
@@ -98433,13 +98691,13 @@ hjk
 pmB
 bXw
 dJk
-cui
+sgt
 bJP
 bJP
 bJP
 bJP
 bJP
-aaa
+pmf
 aaa
 aaa
 aht
@@ -98696,7 +98954,7 @@ caC
 cbu
 cbu
 bJP
-aht
+fRT
 aht
 fon
 fon
@@ -98947,13 +99205,13 @@ bVZ
 bOX
 bXx
 bVi
-cui
+abI
 bMi
 caD
 cbv
 ccn
 bJP
-aaa
+pmf
 aaa
 fon
 shH
@@ -99204,13 +99462,13 @@ bVY
 bUs
 bVg
 bVm
-poP
+qCu
 bZL
 caE
 cbu
 cbu
 bJP
-aht
+fRT
 aht
 fon
 fon
@@ -99461,13 +99719,13 @@ bVZ
 bOX
 kas
 bNm
-cui
+abI
 bJP
 bJP
 bJP
 bJP
 bJP
-aaa
+pmf
 aaa
 aaa
 aaa
@@ -99718,13 +99976,13 @@ bVZ
 bWO
 bXA
 bQO
-poP
+qCu
 bZM
 caF
 cbw
 cby
 bJP
-aaa
+pmf
 aaa
 aaa
 fon
@@ -99975,13 +100233,13 @@ bVZ
 bMf
 bXB
 bNm
-cui
+abI
 bMi
 caG
 cbx
 cco
 bJP
-aht
+fRT
 aht
 aht
 fon
@@ -100232,13 +100490,13 @@ bVY
 bWP
 bXy
 bQO
-poP
+qCu
 bZN
 caH
 cby
 cby
 bJP
-aaa
+pmf
 aaa
 aaa
 fon
@@ -100489,13 +100747,13 @@ bTR
 bUt
 bXC
 bYs
-bVW
-bYw
-bYw
+jvO
+jvO
+jvO
 cBT
-bYw
-bYw
-bYw
+jvO
+jvO
+bVW
 aht
 aht
 fon
@@ -106369,7 +106627,7 @@ vzP
 vzP
 bqA
 brU
-bxF
+bPa
 buK
 dqw
 spz
@@ -106625,7 +106883,7 @@ bkF
 bkF
 bkF
 bkF
-brV
+oBb
 ume
 bkF
 bkF
@@ -106882,7 +107140,7 @@ lWH
 wfs
 pfP
 bqC
-brW
+qVn
 vMx
 ofN
 gdL
@@ -107140,7 +107398,7 @@ hEX
 brO
 bzg
 brX
-csu
+buI
 xzp
 ugC
 gdJ
@@ -107394,9 +107652,9 @@ bnd
 tdB
 bpn
 thW
-bpn
+tzj
 bqE
-brW
+kUE
 btu
 xpr
 ihk
@@ -108420,17 +108678,17 @@ aKq
 gfi
 bkF
 blX
-blX
+uyJ
 bpr
 oSc
 bsa
-btw
-buI
-bwe
+dHo
+sNk
+ffr
 bxM
 bzk
 bAH
-blX
+eUB
 blX
 bkF
 kgR
@@ -108934,8 +109192,8 @@ gfi
 aFi
 bkF
 bni
-blX
-blX
+lCN
+uLP
 hvW
 igE
 btx
@@ -108943,8 +109201,8 @@ dxc
 bwf
 bxO
 bzm
-blX
-blX
+uLP
+uzB
 blX
 bkF
 hTl
@@ -109448,17 +109706,17 @@ gfi
 ybX
 bkF
 blX
-blX
+uyJ
 bpr
 bqG
 bsa
-btw
+dHo
 buM
-bwh
+ffr
 bxM
 bzn
 bAH
-blX
+eUB
 blX
 bkF
 qIO
@@ -109962,8 +110220,8 @@ gfi
 ybX
 bkF
 bni
-blX
-blX
+lCN
+uLP
 bqI
 bsc
 btx
@@ -109971,8 +110229,8 @@ buO
 bwf
 bxR
 bzp
-blX
-blX
+uLP
+uzB
 blX
 bkF
 aaA
@@ -110476,17 +110734,17 @@ gfi
 bfM
 bkF
 blX
-blX
+uyJ
 bpr
 bqJ
 bsa
 gIG
-buN
-bwe
+osC
+ffr
 bxM
 bzq
 bAH
-blX
+eUB
 blX
 bkF
 wfc
@@ -110737,7 +110995,7 @@ blX
 blX
 bqK
 bsd
-gIG
+tuR
 buN
 bwe
 bxS
@@ -110990,8 +111248,8 @@ ntj
 fNv
 bkF
 blX
-blX
-blX
+lCN
+uLP
 bqL
 bse
 xjT
@@ -110999,8 +111257,8 @@ btE
 buW
 bxT
 bzs
-blX
-blX
+uLP
+uzB
 blX
 bkF
 ueV
@@ -111251,10 +111509,10 @@ bkF
 bkF
 bkF
 bkF
-bkF
+tUO
 qdi
-bkF
-bkF
+cXP
+nNp
 bkF
 bkF
 bkF
@@ -112537,11 +112795,11 @@ bnd
 kRK
 cPy
 dir
-mTS
+uof
 ufa
 oNE
 oep
-bnd
+xAy
 mlr
 sEB
 jEX
@@ -112795,7 +113053,7 @@ qcD
 xxw
 lhA
 lFh
-ufa
+ccU
 taA
 qcH
 bnd
@@ -113822,7 +114080,7 @@ bkF
 bkF
 bkF
 pbR
-blX
+rMB
 naq
 bkF
 bkF
@@ -114077,11 +114335,11 @@ aed
 aht
 bkF
 blX
-blX
-blX
-blX
-blX
-blX
+lXt
+nfc
+eWP
+rbe
+fLz
 blX
 bkF
 aht
@@ -114334,11 +114592,11 @@ aby
 aaa
 xKc
 blX
-blX
+qAk
 iPj
 tfP
-iPj
-blX
+geN
+qAk
 blX
 xKc
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tcomms scrubbers actually vent to space now. The n2 layer adaptor is now under a window along with the mix to engine loop being located beneath the o2/n2/air tanks. Xenobiology air/scrubbers is now isolated from the rest of the station. The scrubber located in the tiny starboard room before the secure pen is linked to the xenobiology scrubber loop while the vent in there goes to the rest of the station, giving slimes/xenomorphs a chance to escape.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the tcomms scrubber to space actually work (didnt have power before). Atmos no longer spawns with 1 pipe underneath the tiles (n2 tank output. Xenobiology is now logically (mostly) isolated from the rest of the station pipe wise.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The pubby xenobiology air/scrubber network is now isolated from the rest of the station
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
