### PR TITLE
Various Fixes (freelance)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -73891,6 +73891,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/commons/dorms)
+"ffl" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower";
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "ffE" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -76403,18 +76412,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/kitchen)
-"fXv" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "fXy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 4
@@ -81744,6 +81741,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
+"hMb" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "hMm" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
@@ -91804,15 +91813,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"ldW" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower";
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel,
-/area/science/xenobiology)
 "ldX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -95312,18 +95312,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hop)
-"mqk" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "mqL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/hydroponics/soil,
@@ -101595,6 +101583,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/engineering/break_room)
+"oCd" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "oCi" = (
 /obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/wood,
@@ -157551,7 +157551,7 @@ cQv
 cRY
 cTJ
 tXb
-mqk
+oCd
 cYS
 dax
 dci
@@ -159093,7 +159093,7 @@ kiv
 cSc
 cTO
 hDD
-fXv
+hMb
 oJE
 dav
 dcm
@@ -160890,7 +160890,7 @@ cNh
 cOQ
 cQy
 cSh
-ldW
+ffl
 cVR
 cXk
 cYZ

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -43566,22 +43566,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"cXc" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/shower{
-	dir = 4;
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "cXd" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -43617,22 +43601,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"cXg" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/shower{
-	dir = 8;
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cXh" = (
@@ -76435,6 +76403,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/kitchen)
+"fXv" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "fXy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 4
@@ -91824,6 +91804,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"ldW" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower";
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/science/xenobiology)
 "ldX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -95323,6 +95312,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hop)
+"mqk" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mqL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/hydroponics/soil,
@@ -157550,7 +157551,7 @@ cQv
 cRY
 cTJ
 tXb
-cXc
+mqk
 cYS
 dax
 dci
@@ -159092,7 +159093,7 @@ kiv
 cSc
 cTO
 hDD
-cXg
+fXv
 oJE
 dav
 dcm
@@ -160889,7 +160890,7 @@ cNh
 cOQ
 cQy
 cSh
-cTT
+ldW
 cVR
 cXk
 cYZ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12451,6 +12451,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
+"aUY" = (
+/obj/machinery/light/small,
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "aVf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52531,10 +52536,6 @@
 	dir = 8
 	},
 /area/service/chapel/main)
-"fwH" = (
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "fxb" = (
 /obj/machinery/vending/engivend,
 /obj/structure/cable/yellow{
@@ -53288,10 +53289,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
-"fXs" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "fXZ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -57096,10 +57093,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"iqT" = (
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "iqU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/chair/stool,
@@ -58229,6 +58222,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
+"jaQ" = (
+/obj/machinery/light/small,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "jbv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -58338,6 +58336,11 @@
 "jdV" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
+/area/engineering/atmos)
+"jdY" = (
+/obj/machinery/light/small,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "jfa" = (
 /obj/structure/window/reinforced{
@@ -59323,12 +59326,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/service/bar)
-"jGW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine/n2o,
-/area/engineering/atmos)
 "jIg" = (
 /obj/structure/sign/directions/evac,
 /obj/structure/sign/directions/medical{
@@ -59636,6 +59633,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
+"jPK" = (
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "jPO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59875,6 +59876,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engineering/main)
+"jVJ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "jVR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59960,6 +59968,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
+"kaw" = (
+/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "kbg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -60383,10 +60395,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/bar)
-"kro" = (
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -62374,10 +62382,6 @@
 	dir = 5
 	},
 /area/service/kitchen)
-"lwJ" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
 "lwL" = (
 /turf/open/floor/plasteel,
 /area/service/janitor)
@@ -62806,6 +62810,13 @@
 	},
 /turf/open/floor/engine/cult,
 /area/service/library)
+"lKD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/mix_tank,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "lLt" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -63714,12 +63725,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage_wing)
-"mkz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine/vacuum,
-/area/engineering/atmos)
 "mkS" = (
 /obj/structure/closet/boxinggloves,
 /obj/effect/turf_decal/tile/neutral{
@@ -63960,6 +63965,13 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"mrN" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "msf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -64408,12 +64420,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/qm)
-"mEw" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine/plasma,
-/area/engineering/atmos)
 "mEE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64896,10 +64902,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/chapel,
 /area/service/chapel/main)
-"mWu" = (
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
-/area/engineering/atmos)
 "mWy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -65067,10 +65069,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"naS" = (
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engineering/atmos)
 "nbl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -65112,6 +65110,10 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
 /area/service/library)
+"ndW" = (
+/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "nee" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -65730,10 +65732,6 @@
 /obj/machinery/bookbinder,
 /turf/open/floor/wood,
 /area/service/library)
-"nFp" = (
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
-/area/engineering/atmos)
 "nFz" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -68497,10 +68495,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
-"pii" = (
-/obj/machinery/light/small,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "piB" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -69950,6 +69944,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/nuke_storage)
+"pZj" = (
+/obj/effect/turf_decal/vg_decals/atmos/air,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "pZP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -74817,10 +74815,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"sZg" = (
-/obj/machinery/air_sensor/atmos/mix_tank,
-/turf/open/floor/engine/vacuum,
-/area/engineering/atmos)
 "sZz" = (
 /obj/structure/table,
 /obj/item/paper/fluff/holodeck/disclaimer,
@@ -76314,12 +76308,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"tUr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/engine/co2,
-/area/engineering/atmos)
 "tUN" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2";
@@ -77114,6 +77102,10 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/security/checkpoint/supply)
+"usz" = (
+/obj/effect/turf_decal/vg_decals/atmos/mix,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "usB" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -79909,6 +79901,10 @@
 "wjR" = (
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"wjV" = (
+/obj/effect/turf_decal/vg_decals/atmos/plasma,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "wki" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment,
@@ -81035,6 +81031,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"wQr" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "wQw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -82996,6 +82999,10 @@
 "xQZ" = (
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
+"xRn" = (
+/obj/effect/turf_decal/vg_decals/atmos/oxygen,
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "xRM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -125234,9 +125241,9 @@ rVI
 qHn
 aaf
 dYX
-fwH
+jPK
 sTB
-fXs
+jaQ
 dPI
 aaf
 aaa
@@ -126262,9 +126269,9 @@ rSI
 uKL
 aaf
 dYX
-kro
+xRn
 eFn
-lwJ
+jdY
 dPI
 aaf
 aaa
@@ -127290,9 +127297,9 @@ rSI
 uKL
 aaf
 dYX
-iqT
+pZj
 wFX
-pii
+aUY
 dPI
 aaf
 aaa
@@ -129068,19 +129075,19 @@ aaa
 aaf
 dPI
 xXd
-sZg
+usz
 pAr
 dPI
 qGy
-nFp
+kaw
 kNs
 dPI
 iiP
-mWu
+wjV
 lBv
 dPI
 ipG
-naS
+ndW
 ktS
 dPI
 aaf
@@ -129582,19 +129589,19 @@ aaf
 aaf
 dPI
 jQT
-mkz
+lKD
 gdM
 dPI
 izZ
-jGW
+jVJ
 mMU
 dPI
 oMq
-mEw
+wQr
 erE
 dPI
 hGX
-tUr
+mrN
 rxl
 dPI
 aaf

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4911,22 +4911,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"anj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ank" = (
 /obj/structure/table,
 /obj/item/storage/box/evidence,
@@ -12451,11 +12435,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/fore)
-"aUY" = (
-/obj/machinery/light/small,
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "aVf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29470,19 +29449,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ckg" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "ckh" = (
 /obj/machinery/light{
 	dir = 4
@@ -30072,21 +30038,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"clH" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "clI" = (
@@ -50270,6 +50221,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"egm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "egt" = (
 /obj/machinery/camera/autoname,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51285,6 +51251,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
+"eHV" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "eJd" = (
 /obj/structure/closet/secure_closet/RD,
 /obj/machinery/keycard_auth{
@@ -51454,6 +51427,15 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"eOP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ePg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52881,6 +52863,10 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
+"fId" = (
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "fIC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -53606,6 +53592,11 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
 /turf/open/floor/engine,
 /area/engineering/main)
+"gim" = (
+/obj/machinery/light/small,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "gin" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -55480,6 +55471,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
+"htG" = (
+/obj/effect/turf_decal/vg_decals/atmos/air,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "htH" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -58222,11 +58217,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
-"jaQ" = (
-/obj/machinery/light/small,
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "jbv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -58336,11 +58326,6 @@
 "jdV" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
-/area/engineering/atmos)
-"jdY" = (
-/obj/machinery/light/small,
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "jfa" = (
 /obj/structure/window/reinforced{
@@ -59633,10 +59618,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/command/storage/eva)
-"jPK" = (
-/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
-/turf/open/floor/engine/n2,
-/area/engineering/atmos)
 "jPO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59876,13 +59857,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"jVJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
-/area/engineering/atmos)
 "jVR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59968,10 +59942,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/bridge)
-"kaw" = (
-/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide,
-/turf/open/floor/engine/n2o,
-/area/engineering/atmos)
 "kbg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -62597,6 +62567,13 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"lCt" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "lDu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -62636,6 +62613,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
+"lFn" = (
+/obj/effect/turf_decal/vg_decals/atmos/mix,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "lFD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -62810,13 +62791,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/service/library)
-"lKD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/air_sensor/atmos/mix_tank,
-/turf/open/floor/engine/vacuum,
-/area/engineering/atmos)
 "lLt" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -62894,6 +62868,10 @@
 	dir = 1
 	},
 /area/command/gateway)
+"lNP" = (
+/obj/effect/turf_decal/vg_decals/atmos/plasma,
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "lOi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -63965,13 +63943,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"mrN" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
-/area/engineering/atmos)
 "msf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -65110,10 +65081,6 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
 /area/service/library)
-"ndW" = (
-/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
-/turf/open/floor/engine/co2,
-/area/engineering/atmos)
 "nee" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -65607,6 +65574,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"nyA" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "nzp" = (
 /obj/structure/urinal{
 	pixel_y = 29
@@ -69702,6 +69681,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/miningoffice)
+"pSz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/mix_tank,
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "pSE" = (
 /obj/effect/landmark/start/captain,
 /obj/machinery/airalarm{
@@ -69944,10 +69930,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/command/nuke_storage)
-"pZj" = (
-/obj/effect/turf_decal/vg_decals/atmos/air,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "pZP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -72065,6 +72047,11 @@
 /obj/item/storage/dice,
 /turf/open/floor/plasteel,
 /area/commons/locker)
+"rjT" = (
+/obj/machinery/light/small,
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "rkx" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
@@ -73805,6 +73792,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/command/heads_quarters/cmo)
+"smL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "smU" = (
 /turf/closed/wall,
 /area/engineering/storage/tech)
@@ -74469,6 +74463,10 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/engineering/main)
+"sLx" = (
+/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide,
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "sLW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -77102,10 +77100,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/security/checkpoint/supply)
-"usz" = (
-/obj/effect/turf_decal/vg_decals/atmos/mix,
-/turf/open/floor/engine/vacuum,
-/area/engineering/atmos)
 "usB" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -79901,10 +79895,6 @@
 "wjR" = (
 /turf/open/floor/plasteel,
 /area/commons/dorms)
-"wjV" = (
-/obj/effect/turf_decal/vg_decals/atmos/plasma,
-/turf/open/floor/engine/plasma,
-/area/engineering/atmos)
 "wki" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment,
@@ -79924,6 +79914,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/sorting)
+"wlz" = (
+/obj/machinery/light/small,
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "wlC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
@@ -80969,6 +80964,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wNX" = (
+/obj/effect/turf_decal/vg_decals/atmos/oxygen,
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "wOW" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -81031,13 +81030,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"wQr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
-/area/engineering/atmos)
 "wQw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -81793,6 +81785,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"xlP" = (
+/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "xlU" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -82999,10 +82995,6 @@
 "xQZ" = (
 /turf/open/floor/plasteel/dark,
 /area/commons/fitness/recreation)
-"xRn" = (
-/obj/effect/turf_decal/vg_decals/atmos/oxygen,
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
 "xRM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -108983,7 +108975,7 @@ aiw
 ajp
 akz
 ajQ
-anj
+egm
 aot
 apG
 apG
@@ -114192,8 +114184,8 @@ bZo
 bZo
 chp
 iTm
-ckg
-clH
+eOP
+nyA
 bZn
 coa
 cpl
@@ -125241,9 +125233,9 @@ rVI
 qHn
 aaf
 dYX
-jPK
+fId
 sTB
-jaQ
+wlz
 dPI
 aaf
 aaa
@@ -126269,9 +126261,9 @@ rSI
 uKL
 aaf
 dYX
-xRn
+wNX
 eFn
-jdY
+gim
 dPI
 aaf
 aaa
@@ -127297,9 +127289,9 @@ rSI
 uKL
 aaf
 dYX
-pZj
+htG
 wFX
-aUY
+rjT
 dPI
 aaf
 aaa
@@ -129075,19 +129067,19 @@ aaa
 aaf
 dPI
 xXd
-usz
+lFn
 pAr
 dPI
 qGy
-kaw
+sLx
 kNs
 dPI
 iiP
-wjV
+lNP
 lBv
 dPI
 ipG
-ndW
+xlP
 ktS
 dPI
 aaf
@@ -129589,19 +129581,19 @@ aaf
 aaf
 dPI
 jQT
-lKD
+pSz
 gdM
 dPI
 izZ
-jVJ
+eHV
 mMU
 dPI
 oMq
-wQr
+lCt
 erE
 dPI
 hGX
-mrN
+smL
 rxl
 dPI
 aaf

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -46715,15 +46715,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"cda" = (
-/obj/structure/reflector/single/anchored{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engineering/main)
 "cdc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57098,6 +57089,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lTd" = (
+/obj/structure/reflector/single/anchored{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -57216,6 +57213,19 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"mfn" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "mfC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -58846,12 +58856,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"pCo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engineering/main)
 "pDP" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/tile/neutral{
@@ -61199,6 +61203,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"vhf" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "vhk" = (
 /obj/structure/chair,
 /turf/open/floor/carpet,
@@ -93554,8 +93567,8 @@ bYT
 bZB
 caq
 cbk
-aac
-ccY
+bXk
+vhf
 cdT
 ccY
 cbX
@@ -94068,8 +94081,8 @@ bYV
 bZA
 cam
 ccW
-bXk
-cda
+aac
+lTd
 wcs
 wcs
 wcs
@@ -94582,8 +94595,8 @@ bYX
 bZA
 cam
 lfx
-bXk
-pCo
+aac
+cbX
 wcs
 wcs
 wcs
@@ -95096,8 +95109,8 @@ wjm
 bZF
 cbm
 mgz
-aac
-oHa
+bXk
+mfn
 oHa
 eWi
 cbX

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -57089,12 +57089,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lTd" = (
-/obj/structure/reflector/single/anchored{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engineering/main)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -57213,19 +57207,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
-"mfn" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engineering/main)
 "mfC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -57572,6 +57553,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mQB" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "mSc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -58933,6 +58923,19 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pKU" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "pMG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -61203,15 +61206,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"vhf" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engineering/main)
 "vhk" = (
 /obj/structure/chair,
 /turf/open/floor/carpet,
@@ -61615,6 +61609,12 @@
 /area/engineering/main)
 "wcs" = (
 /turf/open/floor/plasteel/dark,
+/area/engineering/main)
+"wcE" = (
+/obj/structure/reflector/single/anchored{
+	dir = 10
+	},
+/turf/open/floor/plating,
 /area/engineering/main)
 "wdx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -93568,7 +93568,7 @@ bZB
 caq
 cbk
 bXk
-vhf
+mQB
 cdT
 ccY
 cbX
@@ -94082,7 +94082,7 @@ bZA
 cam
 ccW
 aac
-lTd
+wcE
 wcs
 wcs
 wcs
@@ -95110,7 +95110,7 @@ bZF
 cbm
 mgz
 bXk
-mfn
+pKU
 oHa
 eWi
 cbX


### PR DESCRIPTION

## About The Pull Request

Makes several changes to three maps (Meta, Delta, Pubby) that fix several issues and complaints brought up in #mappingdev, including.

![image](https://user-images.githubusercontent.com/39163353/122321251-90665d80-cef1-11eb-89a9-a9f8cc28d161.png)
Rogue pipe here in Security Hall (Meta)

![image](https://user-images.githubusercontent.com/39163353/122321290-9f4d1000-cef1-11eb-9313-0f783fa2fe49.png)
Previously freestanding shower and sink in Science airlock (Meta)

![image](https://user-images.githubusercontent.com/39163353/122321337-b1c74980-cef1-11eb-8347-17f030a26dc4.png)
Added VG tiledecals for atmos tanks (Meta)

![image](https://user-images.githubusercontent.com/39163353/122321392-cb689100-cef1-11eb-9fe3-bc087736bbaa.png)
Changes layout of wall placement in reflector room, so that lights don't get broken when they're turned on. (Pubby)

![image](https://user-images.githubusercontent.com/39163353/122321458-e6d39c00-cef1-11eb-86db-7f64daf6590a.png)
Removes two freestanding showers in Xenobio, and puts one next to the kill chamber in case of emergency.
![image](https://user-images.githubusercontent.com/39163353/122321532-fe128980-cef1-11eb-86a9-65bc6963c2d6.png)


## Why It's Good For The Game

People complained and brought up several issues. I have fixed them.

## Changelog
:cl: Nanotrasen Structual Engineering Division
add: Added lables to the atmos tanks on Metastation.
add: Adjusted Pubbystation's emitter room wall layout to prevent light-breakage on startup of emitters.
del: Removed frestanding sink and showers from Metastation science airlock, and Deltastation Xenobio. Added an emergency shower next to the kill room.
fix: Removed a leftover pipe in Metastation security hallway.
/:cl:
