### PR TITLE
wheely heelies finally have that downside people have been telling me about

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -256,7 +256,7 @@
 /obj/vehicle/ridden/scooter/wheelys/Initialize()
 	. = ..()
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
-	D.vehicle_move_delay = 0
+	D.vehicle_move_delay = 1
 	D.set_vehicle_dir_layer(SOUTH, ABOVE_MOB_LAYER)
 	D.set_vehicle_dir_layer(NORTH, OBJ_LAYER)
 	D.set_vehicle_dir_layer(EAST, OBJ_LAYER)
@@ -280,7 +280,7 @@
 		unbuckle_mob(H)
 		H.throw_at(throw_target, 4, 3)
 		H.DefaultCombatKnockdown(30)
-		H.adjustStaminaLoss(10)
+		H.adjustStaminaLoss(30)
 		var/head_slot = H.get_item_by_slot(SLOT_HEAD)
 		if(!head_slot || !(istype(head_slot,/obj/item/clothing/head/helmet) || istype(head_slot,/obj/item/clothing/head/hardhat)))
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1)

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -52,6 +52,24 @@
 
 			<h2 class="date">06 June 2021</h2>
 			<h3 class="author">bunny232 updated:</h3>
+			<h2 class="date">14 March 2021</h2>
+			<h3 class="author">Adelphon updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">messy2</li>
+				<li class="bugfix">papermask</li>
+			</ul>
+			<h3 class="author">Hatterhat updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Robotic limb repair surgery now has tiers.</li>
+				<li class="rscadd">Pubby and Delta now have roundstart limb-growers relatively close to, if not in, the operating theaters. tweak: Box QM's console now can announce things.</li>
+			</ul>
+			<h3 class="author">Putnam3145 updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="bugfix">chaos loads now</li>
+			</ul>
+
+			<h2 class="date">12 March 2021</h2>
+			<h3 class="author">R3dtail updated:</h3>
 			<ul class="changes bgimages16">
 				<li class="rscadd">Pools are capable of mist at lower temperatures</li>
 			</ul>
@@ -72,6 +90,8 @@
 
 			<h2 class="date">04 June 2021</h2>
 			<h3 class="author">MrJWhit updated:</h3>
+			<h2 class="date">10 March 2021</h2>
+			<h3 class="author">Hatterhat updated:</h3>
 			<ul class="changes bgimages16">
 				<li class="rscadd">Adds a missing pipe</li>
 			</ul>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

to my memory, every time someone talks about wheely-heelies being overpowered, they're always going "it has a downside though!" 10 stamina damage, a little bit of brute and a knockdown is not anywhere close to the same downside of a skateboard or even hoverboard, especially when you can toggle them on-and-off. 

also slowed it down to skateboard speeds since going as fast as a bike is goofy, especially since we removed sprint.

## Why It's Good For The Game

that downside people always tell me about is finally here

## Changelog
:cl:
add: a downside to wheely heelies ((made it actually detrimental))
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
