### PR TITLE
it turns out i accidentally buffed glowshrooms by a factor of 21. this should probably be fixed.

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -73,6 +73,8 @@
 		myseed.adjust_yield(rand(-3,2))
 		myseed.adjust_production(rand(-3,3))
 		myseed.endurance = clamp(myseed.endurance + rand(-3,2), 0, 100) // adjust_endurance has a min value of 10, need to edit directly
+	// Scale health to endurance
+	max_integrity = integrity = 10 + endurance / 2
 	delay_spread = delay_spread - myseed.production * 100 //So the delay goes DOWN with better stats instead of up. :I
 	var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
 	if(ispath(G)) // Seeds were ported to initialize so their genes are still typepaths here, luckily their initializer is smart enough to handle us doing this

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -74,7 +74,7 @@
 		myseed.adjust_production(rand(-3,3))
 		myseed.endurance = clamp(myseed.endurance + rand(-3,2), 0, 100) // adjust_endurance has a min value of 10, need to edit directly
 	// Scale health to endurance
-	max_integrity = integrity = 10 + endurance / 2
+	max_integrity = obj_integrity = 10 + myseed.endurance / 2
 	delay_spread = delay_spread - myseed.production * 100 //So the delay goes DOWN with better stats instead of up. :I
 	var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
 	if(ispath(G)) // Seeds were ported to initialize so their genes are still typepaths here, luckily their initializer is smart enough to handle us doing this
@@ -196,13 +196,13 @@
 	if (spread) // Decay due to spread
 		myseed.endurance -= amount
 		max_integrity = min(max_integrity, 10 + myseed.endurance / 2)
-		if(integrity > max_integrity)
-			integrity = max_integrity
+		if(obj_integrity > max_integrity)
+			obj_integrity = max_integrity
 	else // Timed decay
 		myseed.endurance -= 1
 		max_integrity = min(max_integrity, 10 + myseed.endurance / 2)
-		if(integrity > max_integrity)
-			integrity = max_integrity
+		if(obj_integrity > max_integrity)
+			obj_integrity = max_integrity
 		if (myseed.endurance > 0)
 			addtimer(CALLBACK(src, .proc/Decay), delay_decay, FALSE) // Recall decay timer
 			return

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -195,8 +195,14 @@
 /obj/structure/glowshroom/proc/Decay(spread, amount)
 	if (spread) // Decay due to spread
 		myseed.endurance -= amount
+		max_integrity = min(max_integrity, 10 + myseed.endurance / 2)
+		if(integrity > max_integrity)
+			integrity = max_integrity
 	else // Timed decay
 		myseed.endurance -= 1
+		max_integrity = min(max_integrity, 10 + myseed.endurance / 2)
+		if(integrity > max_integrity)
+			integrity = max_integrity
 		if (myseed.endurance > 0)
 			addtimer(CALLBACK(src, .proc/Decay), delay_decay, FALSE) // Recall decay timer
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Restores glowshroom health scaling to endurance
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

300 health glowshrooms on citadel's buffed spread mechanics (when it was a compromise to make buffed spread, actually) is godawful
old scaling: maximum of 14.5 health on max endurance 
new scaling: 10 + endurance / 2, allowing for a max of 60.
the new scaling is stronger than the old scaling by a factor of 4. this is honestly pretty reasonable given that the original was clearly made terribly.

decaying glowshrooms will also have their health adjusted.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: glowshroom scaling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
