### PR TITLE
[Ready] Cat Surgeon Warning

### DIFF
--- a/code/modules/events/cat_surgeon.dm
+++ b/code/modules/events/cat_surgeon.dm
@@ -2,8 +2,11 @@
     name = "Cat Surgeon"
     typepath = /datum/round_event/cat_surgeon
     max_occurrences = 1
-    weight = 10
+    weight = 8
 
+/datum/round_event/cat_surgeon/announce(fake)
+	priority_announce("One of our... ahem... 'special' cases has escaped. Our sensors now show their tracker implant on your station. On an unrelated note, has anyone seen our cats?",
+	sender_override = "Nanotrasen Psych Ward")
 
 /datum/round_event/cat_surgeon/start()
     var/list/spawn_locs = list()
@@ -16,7 +19,7 @@
 
     var/turf/T = get_turf(pick(spawn_locs))
     var/mob/living/simple_animal/hostile/cat_butcherer/S = new(T)
-    playsound(S, 'sound/misc/catscream.ogg', 50, 1, -1)
+    playsound(S, 'sound/misc/catscream.ogg', 75, 1, -1)
     message_admins("A cat surgeon has been spawned at [COORD(T)][ADMIN_JMP(T)]")
     log_game("A cat surgeon has been spawned at [COORD(T)]")
     return SUCCESSFUL_SPAWN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So uh, the event was very silent, much like a Floor Cluwne. As opposed to that one, people complained about a lack of an announcement, most likely because the Cat Surgeon is much less noisy. So to mitigate that I upped the volume of the spawn noise and added an announcement to the spawn. This one will also show if it's a false alarm now, at least it should. Also... I could've sworn the event had a weight slightly below 10 so I knocked it down to 8. Not sure why that changed.<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People wanna know when a cat surgeon spawns so now it's louder.<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: An announcement to let players know the Cat Surgeon has come to visit.
balance: Upped the Volume of his spawn noise and lowered the spawn weight slightly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
