### PR TITLE
inelastic exports no longer uselessly multiply their price by e^0 every tick

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -84,17 +84,19 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 
 /datum/export/New()
 	..()
-	SSprocessing.processing += src
+	START_PROCESSING(SSprocessing, src)
 	init_cost = cost
 	export_types = typecacheof(export_types)
 	exclude_types = typecacheof(exclude_types)
 
 /datum/export/Destroy()
-	SSprocessing.processing -= src
+	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
 /datum/export/process()
-	..()
+	. = ..()
+	if(!k_elasticity)
+		return PROCESS_KILL
 	cost *= NUM_E**(k_elasticity * (1/30))
 	if(cost > init_cost)
 		cost = init_cost


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's a bunch of exports that process every single tick that do literally nothing because they're multiplying something by e^0, which is 1. This makes those exports just not process.

## Why It's Good For The Game

Because the single highest self CPU proc in the entire game under "normal" conditions with auxmos is /datum/controller/subsystem/processing/fire and 43.8% of that subsystem's operation is in no-ops.

(Okay, so technically this also counts for every single processing subsystem, since all of them call ..(). It's not actually a 40% improvement. But it is an improvement.)

## Changelog
:cl:
fix: inelastic exports no longer uselessly do exponential functions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
