### PR TITLE
The most important map update for the 5x5 SM.

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_5x5.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm_5x5.dmm
@@ -323,6 +323,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "fa" = (
@@ -1790,6 +1793,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/main)


### PR DESCRIPTION
## About The Pull Request

Adds some missing decals.

## Why It's Good For The Game

FIVE THOUSAND YEARS AGO AND THREETHOUSAND MORE THERE WAS A TIME WHEN THIS MAP WAS MISSING DECALS FROM BEING PERFECT.
I, THE PERSON WHO PLAYS JUSTIN PHILLIPS, LOOKED UPON THIS CURSED ARTIFACT OF AN ANCIENT TIME, AND SAID "NO MORE". 
NO MORE SHALL THERE BE MISSING DECALS.
LET LIGHT SHINE UPON THIS BARREN WASTELAND OF FLOORS WITHOUT DECALS, AND THE LIGHT SHALL CURE YOU OF YOUR MISSING DECALS.

Anyway the map needs it.

## Changelog
:cl:
add: Adds two missing decals to the 5x5 SM.
/:cl: