### PR TITLE
Fixes shoddy math & assumptions causing APCs in sufficiently high-power-requiring rooms to work forever

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1389,13 +1389,7 @@
 			charging = APC_NOT_CHARGING
 			chargecount = 0
 			longtermpower = max(-10,longtermpower - 2)
-			if(cell.charge >= cur_used)
-				cell.use(GLOB.CELLRATE * cur_used)
-			else
-				// This turns everything off in the case that there is still a charge left on the battery, just not enough to run the room.
-				equipment = autoset(equipment, 0)
-				lighting = autoset(lighting, 0)
-				environ = autoset(environ, 0)
+			cell.use((GLOB.CELLRATE * cur_used, cell.charge))
 
 		// set channels based on remaining charge
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1389,7 +1389,7 @@
 			charging = APC_NOT_CHARGING
 			chargecount = 0
 			longtermpower = max(-10,longtermpower - 2)
-			cell.use((GLOB.CELLRATE * cur_used, cell.charge))
+			cell.use(min(GLOB.CELLRATE * cur_used, cell.charge))
 
 		// set channels based on remaining charge
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yeah, as title. I forgot a multiplication on the right hand side of a >= and didn't even need the >= in the first place, since the rest of the function was dedicated to auto-setting power *anyway*. Very silly of me.

## Why It's Good For The Game

Best that loss of power be consequential *at all*.

## Changelog
:cl:
fix: APCs aren't infinite power anymore
/:cl: