### PR TITLE
Makes diagonal movement euclidean

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -4,6 +4,8 @@
 
 #define NUM_E 2.71828183
 
+#define SQRT_2 1.414214
+
 #define PI						3.1416
 #define INFINITY				1e31	//closer then enough
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -95,7 +95,7 @@
 	. = ..()
 
 	if((direction & (direction - 1)) && mob.loc == n) //moved diagonally successfully
-		add_delay *= 2
+		add_delay *= SQRT_2
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay), FALSE)
 	move_delay += add_delay
 	if(.) // If mob is null here, we deserve the runtime


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now, diagonal movement takes twice as long as orthogonal movement. In other words, in terms of mob movement, SS13 treats the tile grid as a taxicab geometry. The issue here is that much of the game *doesn't*. Projectiles are euclidean: it takes just as much time to move 10 meters diagonally as it does to move 10 meters orthogonally. The thing is, 10 meters diagonally is just under 7 meters north/south and 7 meters east/west, which always takes the equivalent of *14* orthogonal tile movements for units.

In other words: on diagonals, projectiles move `sqrt(2)` times as fast as mobs do. This fixes that.

## Why It's Good For The Game

Actually questionable, based on what people in OOC chat when I brought this up say. There is some orthogonal stuff in-game right now, mind--gas movement, for one. But the most pertinent other moving thing in combat is projectiles, so I figure this might be better.

## Changelog
:cl:
tweak: Diagonal movement now takes √2 as long instead of twice as long as orthogonal movement
/:cl:
