### PR TITLE
Makes plumbing no longer SS_TICKER

### DIFF
--- a/code/controllers/subsystem/fluid.dm
+++ b/code/controllers/subsystem/fluid.dm
@@ -1,5 +1,5 @@
 PROCESSING_SUBSYSTEM_DEF(fluids)
 	name = "Fluids"
-	wait = 20
+	wait = 10
 	stat_tag = "FD" //its actually Fluid Ducts
-	flags = SS_NO_INIT | SS_TICKER
+	flags = SS_NO_INIT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

plumbing is SS_TICKER, for some reason? it really doesn't need to be.

## Why It's Good For The Game

bad performance is bad

## Changelog
:cl:
tweak: plumbing is no longer SS_TICKER
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
