### PR TITLE
Tweaks to auxmos compile on linux

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,7 +11,7 @@ export BYOND_MINOR=1536
 export RUST_G_VERSION=0.4.8
 
 #auxmos git tag
-export AUXMOS_VERSION=0.2.0
+export AUXMOS_VERSION=v0.2.0
 
 #node version
 export NODE_VERSION=12

--- a/tools/build/build.sh
+++ b/tools/build/build.sh
@@ -58,7 +58,7 @@ fi
 #Compile and move auxmos binary to repo root
 echo "Deploying auxmos..."
 git checkout "$AUXMOS_VERSION"
-env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --target=i686-unknown-linux-gnu
+env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo rustc --release --target=i686-unknown-linux-gnu --features "all_reaction_hooks" -- -C target-cpu=native
 mv target/i686-unknown-linux-gnu/release/libauxmos.so ../../../../libauxmos.so
 cd ../..
 

--- a/tools/tgs4_scripts/PreCompile.sh
+++ b/tools/tgs4_scripts/PreCompile.sh
@@ -83,8 +83,8 @@ else
 fi
 
 echo "Deploying auxmos..."
-git pull origin master 
-env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --target=i686-unknown-linux-gnu
+git checkout "$AUXMOS_VERSION"
+env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo rustc --release --target=i686-unknown-linux-gnu --features "all_reaction_hooks" -- -C target-cpu=native
 mv -f target/i686-unknown-linux-gnu/release/libauxmos.so "$1/libauxmos.so"
 cd ..
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Makes it grab a specified auxmos tag instead of just updating from master, since I can change that whenever and it might break
2. Adds -C target-cpu=native to compilation, since this is performance-critical code and, being compiled on the spot, it's reasonable

## Why It's Good For The Game

Don't want to randomly break peoples' auxmos by doing stuff with it

## Changelog
:cl:
server: Auxmos pull now uses a tag instead of pulling straight from the main branch
/:cl: