### PR TITLE
Pubby mirror for the captains office

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9531,6 +9531,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/mirror{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/freezer,
 /area/command/heads_quarters/captain)
 "avJ" = (


### PR DESCRIPTION
## About The Pull Request

Adds a mirror in the captains bathroom.

## Why It's Good For The Game

Adds a mirror above the sink, so the captain can... I guess look at their face while washing their hands. Why do humans have mirrors above their sink?

## Changelog
:cl:
add: Adds a mirror above the sink in the captains bedroom in pubby
/:cl: