### PR TITLE
Fixes a runtime in activity tracking

### DIFF
--- a/code/datums/components/activity.dm
+++ b/code/datums/components/activity.dm
@@ -16,7 +16,7 @@
 	RegisterSignal(L, list(COMSIG_MOB_ITEM_ATTACK, COMSIG_MOB_ATTACK_RANGED, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_THROW, COMSIG_MOVABLE_TELEPORTED, COMSIG_LIVING_GUN_PROCESS_FIRE, COMSIG_MOB_APPLY_DAMAGE), .proc/minor_activity)
 
 /datum/component/activity/proc/log_activity()
-	historical_activity_levels[world.time] = activity_level
+	historical_activity_levels["[world.time]"] = activity_level
 
 /datum/component/activity/proc/minor_activity(datum/source)
 	activity_level += 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

you can't just use numbers as associative indices, dummy

## Why It's Good For The Game

runtimes are bad, especially ones that happen CONSTANTLY

## Changelog
:cl:
/:cl: