### PR TITLE
Removes causes_dirt_buildup_on_floor and replaces it with just making humans do that in their Move

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -15,7 +15,6 @@
 
 	block_parry_data = /datum/block_parry_data/unarmed/human
 	default_block_parry_data = /datum/block_parry_data/unarmed/human
-	causes_dirt_buildup_on_floor = TRUE
 
 	//Hair colour and style
 	var/hair_color = "000"

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -98,7 +98,7 @@
 		return TRUE
 	return ..()
 
-/mob/living/carbon/human/proc/dirt_buildup(strength)
+/mob/living/carbon/human/proc/dirt_buildup(strength = 1)
 	if(!shoes || !(shoes.body_parts_covered & FEET))
 		return	// barefoot advantage
 	var/turf/open/T = loc

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -90,6 +90,24 @@
 				//End bloody footprints
 
 				S.step_action()
+	if(movement_type & GROUNDED)
+		var/turf/open/T = loc
+		if(!istype(T) || !T.dirt_buildup_allowed)
+			return
+		var/area/A = T.loc
+		if(!A.dirt_buildup_allowed)
+			return
+		var/multiplier = CONFIG_GET(number/turf_dirty_multiplier)
+		strength *= multiplier
+		var/obj/effect/decal/cleanable/dirt/D = locate() in T
+		if(D)
+			D.dirty(strength)
+		else
+			T.dirtyness += strength
+			if(T.dirtyness >= (isnull(T.dirt_spawn_threshold)? CONFIG_GET(number/turf_dirt_threshold) : T.dirt_spawn_threshold))
+				D = new /obj/effect/decal/cleanable/dirt(T)
+				D.dirty(T.dirt_spawn_threshold - T.dirtyness)
+				T.dirtyness = 0		// reset.
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0) //Temporary laziness thing. Will change to handles by species reee.
 	if(dna.species.space_move(src))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -90,31 +90,31 @@
 				//End bloody footprints
 
 				S.step_action()
-	if(movement_type & GROUNDED)
-		var/turf/open/T = loc
-		if(!istype(T) || !T.dirt_buildup_allowed)
-			return
-		var/area/A = T.loc
-		if(!A.dirt_buildup_allowed)
-			return
-		var/multiplier = CONFIG_GET(number/turf_dirty_multiplier)
-		strength *= multiplier
-		var/obj/effect/decal/cleanable/dirt/D = locate() in T
-		if(D)
-			D.dirty(strength)
-		else
-			T.dirtyness += strength
-			if(T.dirtyness >= (isnull(T.dirt_spawn_threshold)? CONFIG_GET(number/turf_dirt_threshold) : T.dirt_spawn_threshold))
-				D = new /obj/effect/decal/cleanable/dirt(T)
-				D.dirty(T.dirt_spawn_threshold - T.dirtyness)
-				T.dirtyness = 0		// reset.
+	if(movement_type & GROUND)
+		dirt_buildup()
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0) //Temporary laziness thing. Will change to handles by species reee.
 	if(dna.species.space_move(src))
 		return TRUE
 	return ..()
 
-/mob/living/carbon/human/dirt_buildup(strength)
+/mob/living/carbon/human/proc/dirt_buildup(strength)
 	if(!shoes || !(shoes.body_parts_covered & FEET))
 		return	// barefoot advantage
-	return ..()
+	var/turf/open/T = loc
+	if(!istype(T) || !T.dirt_buildup_allowed)
+		return
+	var/area/A = T.loc
+	if(!A.dirt_buildup_allowed)
+		return
+	var/multiplier = CONFIG_GET(number/turf_dirty_multiplier)
+	strength *= multiplier
+	var/obj/effect/decal/cleanable/dirt/D = locate() in T
+	if(D)
+		D.dirty(strength)
+	else
+		T.dirtyness += strength
+		if(T.dirtyness >= (isnull(T.dirt_spawn_threshold)? CONFIG_GET(number/turf_dirt_threshold) : T.dirt_spawn_threshold))
+			D = new /obj/effect/decal/cleanable/dirt(T)
+			D.dirty(T.dirt_spawn_threshold - T.dirtyness)
+			T.dirtyness = 0		// reset.

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -67,8 +67,6 @@
 	//Allows mobs to move through dense areas without restriction. For instance, in space or out of holder objects.
 	var/incorporeal_move = FALSE //FALSE is off, INCORPOREAL_MOVE_BASIC is normal, INCORPOREAL_MOVE_SHADOW is for ninjas
 								 //and INCORPOREAL_MOVE_JAUNT is blocked by holy water/salt
-	/// Do we make floors dirty as we move?
-	var/causes_dirt_buildup_on_floor = FALSE
 
 	var/list/roundstart_quirks = list()
 

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -102,31 +102,6 @@
 	if(lying && !buckled && prob(getBruteLoss()*200/maxHealth))
 		makeTrail(newloc, T, old_direction)
 
-	if(causes_dirt_buildup_on_floor && (movement_type & GROUND))
-		dirt_buildup()
-
-/**
- * Attempts to make the floor dirty.
- */
-/mob/living/proc/dirt_buildup(strength = 1)
-	var/turf/open/T = loc
-	if(!istype(T) || !T.dirt_buildup_allowed)
-		return
-	var/area/A = T.loc
-	if(!A.dirt_buildup_allowed)
-		return
-	var/multiplier = CONFIG_GET(number/turf_dirty_multiplier)
-	strength *= multiplier
-	var/obj/effect/decal/cleanable/dirt/D = locate() in T
-	if(D)
-		D.dirty(strength)
-	else
-		T.dirtyness += strength
-		if(T.dirtyness >= (isnull(T.dirt_spawn_threshold)? CONFIG_GET(number/turf_dirt_threshold) : T.dirt_spawn_threshold))
-			D = new /obj/effect/decal/cleanable/dirt(T)
-			D.dirty(T.dirt_spawn_threshold - T.dirtyness)
-			T.dirtyness = 0		// reset.
-
 /mob/living/Move_Pulled(atom/A)
 	. = ..()
 	if(!. || !isliving(A))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

causes_dirt_buildup_on_floor caused a snowflake proc to be run if and only if that particular var was true, which it was if and only if the mob in question was a human. With that in mind, I just... made human movement do that.

## Why It's Good For The Game

Fewer vars is good.

## Changelog
:cl:
refactor: causes_dirt_buildup_on_floor is now just a thing humans do instead of a weird var only true for humans
/:cl: