### PR TITLE
handcuffs now require you to stand still to break out of again. Buffs bolas and energy snares breakout time because I forgot to do that when I made you able to move while breaking out of it 

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -245,6 +245,7 @@
 	throwforce = 0
 	w_class = WEIGHT_CLASS_NORMAL
 	slowdown = 7
+	allow_breakout_movement = TRUE
 	breakouttime = 300	//Deciseconds = 30s = 0.5 minute
 
 /obj/item/restraints/legcuffs/proc/on_removed()
@@ -314,7 +315,7 @@
 	trap_damage = 0
 	item_flags = DROPDEL
 	flags_1 = NONE
-	breakouttime = 25
+	breakouttime = 50
 
 /obj/item/restraints/legcuffs/beartrap/energy/New()
 	..()
@@ -330,7 +331,7 @@
 	. = ..()
 
 /obj/item/restraints/legcuffs/beartrap/energy/cyborg
-	breakouttime = 20 // Cyborgs shouldn't have a strong restraint
+	breakouttime = 40 // Cyborgs shouldn't have a strong restraint
 
 /obj/item/restraints/legcuffs/bola
 	name = "bola"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -382,7 +382,7 @@
 	icon_state = "ebola"
 	hitsound = 'sound/weapons/taserhit.ogg'
 	w_class = WEIGHT_CLASS_SMALL
-	breakouttime = 25
+	breakouttime = 50
 
 /obj/item/restraints/legcuffs/bola/energy/on_removed()
 	do_sparks(1, TRUE, src)

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -1,6 +1,8 @@
 /obj/item/restraints
 	breakouttime = 600
 	var/demoralize_criminals = TRUE // checked on carbon/carbon.dm to decide wheter to apply the handcuffed negative moodlet or not.
+	/// allow movement at all during breakout
+	var/allow_breakout_movement = FALSE
 
 /obj/item/restraints/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] is strangling [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -358,7 +358,7 @@
 		return
 	I.item_flags |= BEING_REMOVED
 	breakouttime = I.breakouttime
-	var/datum/cuffbreak_checker/cuffbreak_checker = new(get_turf(src))
+	var/datum/cuffbreak_checker/cuffbreak_checker = new(get_turf(src), istype(I, /obj/item/restraints)? I : null)
 	if(!cuff_break)
 		visible_message("<span class='warning'>[src] attempts to remove [I]!</span>")
 		to_chat(src, "<span class='notice'>You attempt to remove [I]... (This will take around [DisplayTimeText(breakouttime)] and you need to stand still.)</span>")
@@ -384,16 +384,22 @@
 
 /datum/cuffbreak_checker
 	var/turf/last
+	var/obj/item/restraints/cuffs
 
-/datum/cuffbreak_checker/New(turf/initial_turf)
+/datum/cuffbreak_checker/New(turf/initial_turf, obj/item/restraints/R)
 	last = initial_turf
+	if(R)
+		cuffs = R
 
 /datum/cuffbreak_checker/proc/check_movement(atom/user, delay, atom/target, time_left, do_after_flags, required_mobility_flags, required_combat_flags, mob_redirect, stage, initially_held_item, tool, list/passed_in)
 	if(get_turf(user) != last)
 		last = get_turf(user)
 		passed_in[1] = 0.5
+		if(R && !R.allow_breakout_movement)
+			return DO_AFTER_STOP
 	else
 		passed_in[1] = 1
+	return DO_AFTER_CONTINUE
 
 /mob/living/carbon/proc/uncuff()
 	if (handcuffed)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -395,7 +395,7 @@
 	if(get_turf(user) != last)
 		last = get_turf(user)
 		passed_in[1] = 0.5
-		if(R && !R.allow_breakout_movement)
+		if(cuffs && !cuffs.allow_breakout_movement)
 			return DO_AFTER_STOP
 	else
 		passed_in[1] = 1


### PR DESCRIPTION
I'm really starting to regret blindly letting through every security salt nerf in history.