### PR TITLE
Adds another wall to the AM engine

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_am.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_am.dmm
@@ -1367,7 +1367,7 @@ JZ
 kK
 Ch
 Ch
-MJ
+Ch
 MJ
 MJ
 MJ


### PR DESCRIPTION
## About The Pull Request

Adds another wall to the east part of the AM engine on boxstation.

## Why It's Good For The Game

Turns out, when I extended all of the airlocks, the AM engines map made it so that it spaced part of the airlock accidentally, oops.

## Changelog
:cl:
add: Added another wall for the AM engine so it doesn't space the airlock roundstart.
/:cl: