### PR TITLE
Makes it so AIs can plasmaflood in pubby

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -24652,12 +24652,6 @@
 	},
 /turf/open/space,
 /area/solars/starboard)
-"beW" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "beY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Central";
@@ -40389,8 +40383,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Unfiltered to Mix"
+	dir = 4;
+	name = "Ports to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -41430,6 +41424,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bPW" = (
@@ -42132,7 +42129,9 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bRw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "bRx" = (
@@ -55286,15 +55285,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"hEi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "hEX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -61354,12 +61344,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"uST" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Ports"
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -100505,7 +100489,7 @@ bOr
 bPU
 kWG
 bRw
-beW
+bMf
 bMf
 bMf
 bMf
@@ -100761,8 +100745,8 @@ bKV
 bOX
 eEd
 bQL
-uST
 pEM
+bMf
 bMf
 qQu
 qQu
@@ -101019,7 +101003,7 @@ bMg
 bNj
 bOp
 bPV
-hEi
+sGJ
 sGJ
 bUw
 bUw


### PR DESCRIPTION
## About The Pull Request

I didn't pipe it goodily enough so that way AIs can plasmaflood without having to change pumps around, my bad.

## Why It's Good For The Game

Lets people make adjustments that are needed.

## Changelog
:cl:
tweak: Swaps some pumps around so you can put pure into mix in pubby atmos
/:cl: