### PR TITLE
adds a neutral trash eating quirk

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -101,6 +101,7 @@
 #define NO_AUTO_WAG			(1<<12)
 #define GENITAL_EXAMINE		(1<<13)
 #define VORE_EXAMINE		(1<<14)
+#define TRASH_FORCEFEED		(1<<15)
 #define TOGGLES_CITADEL 0
 
 //belly sound pref things

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -221,6 +221,7 @@
 #define TRAIT_LIVING_NO_DENSITY			"living_no_density"
 /// forces us to not render our overlays
 #define TRAIT_HUMAN_NO_RENDER			"human_no_render"
+#define TRAIT_TRASHCAN					"trashcan"
 
 // mobility flag traits
 // IN THE FUTURE, IT WOULD BE NICE TO DO SOMETHING SIMILAR TO https://github.com/tgstation/tgstation/pull/48923/files (ofcourse not nearly the same because I have my.. thoughts on it)

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -112,6 +112,7 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/storage/box/marshmallow = 2,
 	/obj/item/clothing/gloves/tackler/offbrand = 1,
 	/obj/item/stack/sticky_tape = 1,
+	/obj/effect/spawner/lootdrop/grille_or_trash = 15,
 	"" = 3
 	))
 

--- a/code/datums/elements/trash.dm
+++ b/code/datums/elements/trash.dm
@@ -1,0 +1,18 @@
+/datum/element/trash
+	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
+
+/datum/element/trash/Attach(datum/target)
+	RegisterSignal(target, COMSIG_ITEM_ATTACK, .proc/UseFromHand)
+
+/datum/element/trash/proc/UseFromHand(obj/item/source, mob/living/M, mob/living/user)
+	if((M == user || user.vore_flags & TRASH_FORCEFEED) && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(HAS_TRAIT(H, TRAIT_TRASHCAN))
+			playsound(H.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+			if(H.vore_selected)
+				H.visible_message("<span class='notice'>[H] [H.vore_selected.vore_verb]s the [source] into their [H.vore_selected]</span>",
+					"<span class='notice'>You [H.vore_selected.vore_verb]s the [source] into your [H.vore_selected]</span>")
+				source.forceMove(H.vore_selected)
+			else
+				H.visible_message("<span class='notice'>[H] consumes the [source].")
+				qdel(source)

--- a/code/datums/elements/trash.dm
+++ b/code/datums/elements/trash.dm
@@ -2,6 +2,7 @@
 	element_flags = ELEMENT_BESPOKE|ELEMENT_DETACH
 
 /datum/element/trash/Attach(datum/target)
+	. = ..()
 	RegisterSignal(target, COMSIG_ITEM_ATTACK, .proc/UseFromHand)
 
 /datum/element/trash/proc/UseFromHand(obj/item/source, mob/living/M, mob/living/user)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -154,3 +154,11 @@
 /datum/quirk/longtimer/on_spawn()
 	var/mob/living/carbon/C = quirk_holder
 	C.generate_fake_scars(rand(min_scars, max_scars))
+
+/datum/quirk/trashcan
+	name = "Trashcan"
+	desc = "You are able to consume and digest trash."
+	value = 0
+	gain_text = "<span class='notice'>You feel like munching on a can of soda.</span>"
+	lose_text = "<span class='notice'>You no longer feel like you should be eating trash.</span>"
+	mob_trait = TRAIT_TRASHCAN

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -387,6 +387,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	throwforce = 0
 	grind_results = list(/datum/reagent/carbon = 2)
 
+/obj/item/cigbutt/Initialize()
+	. = ..()
+	AddElement(/datum/element/trash)
+
 /obj/item/cigbutt/cigarbutt
 	name = "cigar butt"
 	desc = "A manky old cigar butt."

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -87,9 +87,10 @@
 		if(HAS_TRAIT(H, TRAIT_TRASHCAN))
 			playsound(H.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 			if(H.vore_selected)
-				H.visible_message("<span class='notice'>[H] [H.vore_selected.vore_verb]s the [src] into their [H.vore_selected]</span>")
+				H.visible_message("<span class='notice'>[H] [H.vore_selected.vore_verb]s the [src] into their [H.vore_selected]</span>",
+					"<span class='notice'>You [H.vore_selected.vore_verb]s the [src] into your [H.vore_selected]</span>")
 				forceMove(H.vore_selected)
 			else
-				H.visible_message("<span class='notice'>[H] consumes the [src]")
+				H.visible_message("<span class='notice'>[H] consumes the [src].")
 				qdel(src)
 

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -7,6 +7,9 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 
+/obj/item/trash/Initialize()
+	AddElement(/datum/element/trash)
+
 /obj/item/trash/raisins
 	name = "\improper 4no raisins"
 	icon_state= "4no_raisins"
@@ -80,17 +83,3 @@
 	name = "boritos bag"
 	icon_state = "boritos"
 	grind_results = list(/datum/reagent/aluminium = 1) //from the mylar bag
-
-/obj/item/trash/attack(mob/M, mob/living/user)
-	if((M == user || user.vore_flags & TRASH_FORCEFEED) && ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(HAS_TRAIT(H, TRAIT_TRASHCAN))
-			playsound(H.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
-			if(H.vore_selected)
-				H.visible_message("<span class='notice'>[H] [H.vore_selected.vore_verb]s the [src] into their [H.vore_selected]</span>",
-					"<span class='notice'>You [H.vore_selected.vore_verb]s the [src] into your [H.vore_selected]</span>")
-				forceMove(H.vore_selected)
-			else
-				H.visible_message("<span class='notice'>[H] consumes the [src].")
-				qdel(src)
-

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -82,4 +82,14 @@
 	grind_results = list(/datum/reagent/aluminium = 1) //from the mylar bag
 
 /obj/item/trash/attack(mob/M, mob/living/user)
-	return
+	if((M == user || user.vore_flags & TRASH_FORCEFEED) && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(HAS_TRAIT(H, TRAIT_TRASHCAN))
+			playsound(H.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
+			if(H.vore_selected)
+				H.visible_message("<span class='notice'>[H] [H.vore_selected.vore_verb]s the [src] into their [H.vore_selected]</span>")
+				forceMove(H.vore_selected)
+			else
+				H.visible_message("<span class='notice'>[H] consumes the [src]")
+				qdel(src)
+

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -8,6 +8,7 @@
 	resistance_flags = FLAMMABLE
 
 /obj/item/trash/Initialize()
+	. = ..()
 	AddElement(/datum/element/trash)
 
 /obj/item/trash/raisins

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1068,6 +1068,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Voracious MediHound sleepers:</b> <a href='?_src_=prefs;preference=hound_sleeper'>[(cit_toggles & MEDIHOUND_SLEEPER) ? "Yes" : "No"]</a><br>"
 			dat += "<b>Hear Vore Sounds:</b> <a href='?_src_=prefs;preference=toggleeatingnoise'>[(cit_toggles & EATING_NOISES) ? "Yes" : "No"]</a><br>"
 			dat += "<b>Hear Vore Digestion Sounds:</b> <a href='?_src_=prefs;preference=toggledigestionnoise'>[(cit_toggles & DIGESTION_NOISES) ? "Yes" : "No"]</a><br>"
+			dat += "<b>Allow trash forcefeeding (requires Trashcan quirk)</b> <a href='?_src_=prefs;preference=toggleforcefeedtrash'>[(cit_toggles & TRASH_FORCEFEED) ? "Yes" : "No"]</a><br>"
 			dat += "<b>Forced Feminization:</b> <a href='?_src_=prefs;preference=feminization'>[(cit_toggles & FORCED_FEM) ? "Allowed" : "Disallowed"]</a><br>"
 			dat += "<b>Forced Masculinization:</b> <a href='?_src_=prefs;preference=masculinization'>[(cit_toggles & FORCED_MASC) ? "Allowed" : "Disallowed"]</a><br>"
 			dat += "<b>Lewd Hypno:</b> <a href='?_src_=prefs;preference=hypno'>[(cit_toggles & HYPNO) ? "Allowed" : "Disallowed"]</a><br>"
@@ -2799,6 +2800,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("toggledigestionnoise")
 					cit_toggles ^= DIGESTION_NOISES
+
+				if("toggleforcefeedtrash")
+					cit_toggles ^= TRASH_FORCEFEED
 
 				if("breast_enlargement")
 					cit_toggles ^= BREAST_ENLARGEMENT

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -639,6 +639,7 @@
 #include "code\datums\elements\swimming.dm"
 #include "code\datums\elements\sword_point.dm"
 #include "code\datums\elements\tactical.dm"
+#include "code\datums\elements\trash.dm"
 #include "code\datums\elements\turf_transparency.dm"
 #include "code\datums\elements\update_icon_blocker.dm"
 #include "code\datums\elements\update_icon_updates_onmob.dm"


### PR DESCRIPTION
## About The Pull Request
only objects under the trash object type are considered 'trash'
the quirk is neutral as the items don't affect gameplay it's just a flavor thing

it ties into the vore system by changing the consume text if you have it enabled to your current preferred vore verb and belly name and putting the item into the belly, otherwise it qdel's the item and shows regular text

at some point ill make 'trash' be a object flag

oh also you can't forcefeed garbage to people unless they have a pref for it enabled (because it uses their selected vore verb and belly name if applicable and some people might not want to see that or have it be seen?)

also trash is now an element and cigbutts count as trash

and trash is in the maint pool at 15 weight

## Why It's Good For The Game
let the garbage gremlins exist

## Changelog
:cl:
add: new quirk that allows you to eat trash
/:cl:
