### PR TITLE
fixes photosynthesis stopping nutrition going past well fed from non-photosynthesis means

### DIFF
--- a/code/datums/elements/photosynthesis.dm
+++ b/code/datums/elements/photosynthesis.dm
@@ -59,7 +59,7 @@
 			var/mob/living/L = AM
 			if(L.stat == DEAD)
 				continue
-			if(light_nutrition_gain)
+			if(light_nutrition_gain && L.nutrition < NUTRITION_LEVEL_WELL_FED)
 				L.adjust_nutrition(light_amount * light_nutrition_gain * attached_atoms[AM], NUTRITION_LEVEL_WELL_FED)
 			if(light_amount > bonus_lum || light_amount < malus_lum)
 				var/mult = ((light_amount > bonus_lum) ? 1 : -1) * attached_atoms[AM]


### PR DESCRIPTION
## About The Pull Request
it's supposed to give you nutrition up to well-fed, not reduce it if you go past well-fed from other means

## Why It's Good For The Game
bug fix

## Changelog
:cl:
fix: fixes photosynthesis stopping nutrition going past well fed from non-photosynthesis means
/:cl:
