### PR TITLE
Update shelter_5.dmm

### DIFF
--- a/_maps/templates/shelter_5.dmm
+++ b/_maps/templates/shelter_5.dmm
@@ -81,6 +81,9 @@
 /area/survivalpod/nonpowered)
 "mN" = (
 /obj/machinery/power/rtg/advanced/fullupgrade,
+/obj/structure/cable/white{
+	icon_state = "0-8"
+	},
 /turf/open/floor/pod/dark,
 /area/survivalpod/nonpowered)
 "oo" = (
@@ -238,6 +241,12 @@
 	},
 /turf/open/floor/pod/dark,
 /area/survivalpod/nonpowered)
+"TI" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/dark,
+/area/survivalpod/nonpowered)
 "TQ" = (
 /obj/structure/fans,
 /turf/open/floor/pod/dark,
@@ -272,6 +281,9 @@
 "Xy" = (
 /obj/machinery/light,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
 /turf/open/floor/pod/dark,
 /area/survivalpod/nonpowered)
 "YH" = (
@@ -445,7 +457,7 @@ td
 FZ
 Fo
 Lv
-Lv
+TI
 FZ
 "}
 (12,1,1) = {"


### PR DESCRIPTION
Adds cables connecting RTG to APC in the penthouse survival pod

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
APC in penthouse survival pod was not getting power from the installed RTG. This PR corrects this by adding power cables to connect them. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
![wires](https://user-images.githubusercontent.com/73904284/126354755-e67d1bce-6391-4e5e-a596-3b571c76939b.jpg)

## Why It's Good For The Game
If a someone does all the work mining the points for this sweet pod then the least it should do is work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a few things - Added power wires to connect RTG to the APC on the Penthouse Survival Pod.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
