### PR TITLE
Some hallucination tweaks

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	if(!hallucination)
 		return
 
-	hallucination--
+	hallucination = max(hallucination-1, 0)
 
 	if(world.time < next_hallucination)
 		return

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -241,7 +241,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	///How much the bullets damage should be multiplied by when it is added to the internal variables
 	var/bullet_energy = 2
 	///How much hallucination should we produce per unit of power?
-	var/hallucination_power = 0.1
+	var/hallucination_power = 0.05 // 2 seconds per second at a distance of 7 with a typical nitrogen setup
 
 	///Our internal radio
 	var/obj/item/radio/radio
@@ -648,6 +648,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for(var/mob/living/carbon/human/l in fov_viewers(src, HALLUCINATION_RANGE(power))) // If they can see it without mesons on.  Bad on them.
 		if(!istype(l.glasses, /obj/item/clothing/glasses/meson))
 			var/D = sqrt(1 / max(1, get_dist(l, src)))
+			if(!l.hallucination)
+				to_chat(l, "<span class='warning'>Looking at the supermatter unprotected gives you a headache...</span>")
 			l.hallucination += power * hallucination_power * D
 			l.hallucination = clamp(l.hallucination, 0, 200)
 	for(var/mob/living/l in range(src, round((power / 100) ** 0.25)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. makes hallucinations not last literally forever if something (supermatter) decides to add a fractional hallucination amount
2. makes the supermatter's hallucinations half as powerful, since right now they are basically perma-hallucinations the instant you see them at all
3. gives you a message when the supermatter starts making you hallucinate

## Why It's Good For The Game

1. bugfix
2. supermatter hallucinations are kinda annoying and shouldn't last for 6 minutes the instant you stare at it
3. some conveyance it happens at all would be good

## Changelog
:cl:
fix: hallucination now bottoms out at 0
balance: supermatter now causes only half the hallucinations
/:cl: