### PR TITLE
Makes HE pipe min temp diff 0.01 instead of 20

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -1,6 +1,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging
 	level = 2
-	var/minimum_temperature_difference = 20
+	var/minimum_temperature_difference = 0.01
 	var/thermal_conductivity = WINDOW_HEAT_TRANSFER_COEFFICIENT
 	color = "#404040"
 	buckle_lying = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Most obvious effect is that the space loop will now cool to 2.71 instead of 22.7 kelvins. Less obvious is that heat exchanger pipes are now actually feasible to use for station cooling.

## Why It's Good For The Game

This is an arbitrary limitation that isn't so much to do with balance as it is to do with atmospherics being "slow". Well, atmospherics is _not slow anymore_. We can afford to loosen these restrictions.

There should probably be a rework that adds up every HE pipe in the pipenet and does it all at once, but meh.

## Changelog
:cl:
tweak: HE pipes can now cool to within 0.1 kelvins of the environment instead of 20 kelvins
balance: A knock-on effect of the HE pipe change is that space cooling is ~8.4x as powerful
/:cl: