### PR TITLE
Random Boxstation Fixes (Space edition)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -50333,11 +50333,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/processing)
-"cxW" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "cxY" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Escape Pod 1";
@@ -53720,9 +53715,8 @@
 /turf/open/floor/wood/wood_large,
 /area/service/chapel/main)
 "fty" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
 "ftE" = (
@@ -56232,10 +56226,6 @@
 /obj/item/trash/candy,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"kvl" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "kvL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -86213,7 +86203,7 @@ bgO
 jBA
 btG
 aaa
-kvl
+iDo
 ctv
 iDo
 aaa
@@ -97522,7 +97512,7 @@ aaa
 aaa
 aaa
 aaa
-jAD
+fIs
 aaa
 aaa
 aaa
@@ -98784,7 +98774,7 @@ cCS
 bMK
 bMK
 bMK
-gXs
+gJi
 aaa
 aaa
 aaa
@@ -99298,7 +99288,7 @@ bMK
 bMK
 bMK
 bMK
-aaf
+aag
 aoV
 aoV
 aoV
@@ -103325,7 +103315,7 @@ aaf
 aaf
 aaf
 aaf
-cxW
+aag
 alO
 anf
 anf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -45501,6 +45501,9 @@
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "chP" = (


### PR DESCRIPTION
## About The Pull Request

A few things here and there that bugged me:
-Fixes latice-catwalk on the northeast space exit
-Removed a hidden r-wall behind a grill in space
-Removed a hidden floor behind a grill in space
-Makes the northmost airlocks /actually cycle now/

## Why It's Good For The Game

I'm not going to lie, I'm mostly doing this to check if my github is just cursed forever. But, these fixes should be done.

## Changelog
:cl:
fix: Fixes some minor mistakes around space near boxstation.
/:cl: