### PR TITLE
Fixes certain skirty uniforms not having the FEMALE_UNIFORM_TOP fitted flag

### DIFF
--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -280,23 +280,21 @@
 	item_state = "qipao"
 	body_parts_covered = CHEST|GROIN
 	can_adjust = FALSE
+	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_NO_ANTHRO_ICON
+	
 
 /obj/item/clothing/under/costume/qipao/white
 	name = "White Qipao"
 	desc = "A Qipao, traditionally worn in ancient Earth China by women during social events and lunar new years. This one is white."
 	icon_state = "qipao_white"
 	item_state = "qipao_white"
-	body_parts_covered = CHEST|GROIN
-	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/qipao/red
 	name = "Red Qipao"
 	desc = "A Qipao, traditionally worn in ancient Earth China by women during social events and lunar new years. This one is red."
 	icon_state = "qipao_red"
 	item_state = "qipao_red"
-	body_parts_covered = CHEST|GROIN
-	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/cheongsam
 	name = "Black Cheongsam"

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -330,9 +330,11 @@
 
 /obj/item/clothing/under/costume/kimono
 	name = "Kimono"
-	desc = "A traditional piece of clothing from japan"
+	desc = "A traditional piece of clothing from Japan."
 	icon_state = "kimono"
 	item_state = "kimono"
+	fitted = FEMALE_UNIFORM_TOP
+	can_adjust = FALSE
 
 /obj/item/clothing/under/costume/kimono/black
 	name = "Black Kimono"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -322,12 +322,14 @@
 	desc = "A small black dress"
 	icon_state = "littleblackdress_s"
 	item_state = "littleblackdress_s"
+	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/misc/pinktutu
 	name = "pink tutu"
 	desc = "A pink tutu"
 	icon_state = "pinktutu_s"
 	item_state = "pinktutu_s"
+	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/misc/bathrobe
 	name = "bathrobe"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -336,6 +336,7 @@
 	desc = "A blue bathrobe."
 	icon_state = "bathrobe"
 	item_state = "bathrobe"
+	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/misc/mechsuitred
 	name = "red mech suit"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -323,6 +323,7 @@
 	icon_state = "littleblackdress_s"
 	item_state = "littleblackdress_s"
 	fitted = FEMALE_UNIFORM_TOP
+	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/pinktutu
 	name = "pink tutu"
@@ -330,6 +331,7 @@
 	icon_state = "pinktutu_s"
 	item_state = "pinktutu_s"
 	fitted = FEMALE_UNIFORM_TOP
+	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/bathrobe
 	name = "bathrobe"
@@ -337,22 +339,26 @@
 	icon_state = "bathrobe"
 	item_state = "bathrobe"
 	fitted = FEMALE_UNIFORM_TOP
+	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/mechsuitred
 	name = "red mech suit"
 	desc = "What are you, stupid?"
 	icon_state = "red_mech_suit"
 	item_state = "red_mech_suit"
+	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/mechsuitwhite
 	name = "white mech suit"
 	desc = "...Mom?"
 	icon_state = "white_mech_suit"
 	item_state = "white_mech_suit"
+	can_adjust = FALSE
 
 /obj/item/clothing/under/misc/mechsuitblue
 	name = "blue mech suit"
 	desc = "Get in the damn robot already!"
 	icon_state = "blue_mech_suit"
 	item_state = "blue_mech_suit"
+	can_adjust = FALSE
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -319,14 +319,14 @@
 
 /obj/item/clothing/under/misc/black_dress
 	name = "little black dress"
-	desc = "A small black dress"
+	desc = "A small black dress."
 	icon_state = "littleblackdress_s"
 	item_state = "littleblackdress_s"
 	fitted = FEMALE_UNIFORM_TOP
 
 /obj/item/clothing/under/misc/pinktutu
 	name = "pink tutu"
-	desc = "A pink tutu"
+	desc = "A pink tutu."
 	icon_state = "pinktutu_s"
 	item_state = "pinktutu_s"
 	fitted = FEMALE_UNIFORM_TOP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reminder to future clothing makers implementing clothing into the game: If the uniform has a skirt, make sure to add:
fitted = FEMALE_UNIFORM_TOP
to your outfit.

or maybe just make your uniform a subset of skirt so that we don't have this problem maybe.

this was a webedit change but I know it checks out.

If anyone has noticed this with any other outfits than what I changed, do inform me before this PR gets merged. I merely noticed this while I was customizing a character's loadout so I only went for loadout items that I spotted.

## Why It's Good For The Game

stupid annoying missing pixel at the crotch level due to an activated mask when wearing clothes meant to be a skirt that shouldn't be there. go away.

## Changelog
:cl:
fix: The black dress, pink tutu, the bathrobe, the kimonos, and the qipaos no longer have a missing pixel when wearing them with the feminine bodytype. They're also no longer adjustable (they have no sprite for the adjusted variant and therefore it would just make an error if someone did that.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
