### PR TITLE
Makes rod of asclepius usable for revival surgery

### DIFF
--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -25,7 +25,7 @@
 	return TRUE
 /datum/surgery_step/revive
 	name = "electrically stimulate brain"
-	implements = list(/obj/item/shockpaddles = 100, /obj/item/abductor/gizmo = 100, /obj/item/melee/baton = 75, /obj/item/organ/cyberimp/arm/baton = 75, /obj/item/organ/cyberimp/arm/gun/taser = 60, /obj/item/gun/energy/e_gun/advtaser = 60, /obj/item/gun/energy/taser = 60)
+	implements = list(/obj/item/shockpaddles = 100, /obj/item/abductor/gizmo = 100, /obj/item/rod_of_asclepius = 100, /obj/item/melee/baton = 75, /obj/item/organ/cyberimp/arm/baton = 75, /obj/item/organ/cyberimp/arm/gun/taser = 60, /obj/item/gun/energy/e_gun/advtaser = 60, /obj/item/gun/energy/taser = 60)
 	time = 120
 /datum/surgery_step/revive/tool_check(mob/user, obj/item/tool)
 	. = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now asclepius users are one-handed and can thus only use ghetto setups like stun batons for this surgery, even though the rod of asclepius is explicitly a surgery buffer, so this makes it so they can just use their dang rod

not changing the verb from "shock" because, honestly, i find the idea of this rod of ultimate pacifism and healing shooting a lightning bolt funny

## Why It's Good For The Game

Rod of asclepius is intended to buff surgery, so I'm buffing its surgery

## Changelog
:cl:
balance: Rod of asclepius can now be used for revival surgery
/:cl:
