### PR TITLE
Fixes circular reference in genitals on Destroy()

### DIFF
--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -28,7 +28,7 @@
 		update()
 
 /obj/item/organ/genital/Destroy()
-	if(linked_organ.linked_organ == src)
+	if(linked_organ?.linked_organ == src)
 		linked_organ.linked_organ = null
 	linked_organ = null
 	. = ..()

--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -27,6 +27,12 @@
 	if(do_update)
 		update()
 
+/obj/item/organ/genital/Destroy()
+	if(linked_organ.linked_organ == src)
+		linked_organ.linked_organ = null
+	linked_organ = null
+	. = ..()
+
 /obj/item/organ/genital/proc/set_aroused_state(new_state,cause = "manual toggle")
 	if(!(genital_flags & GENITAL_CAN_AROUSE))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

there's a circular reference wrt linked organs with genitals, this fixes it

## Why It's Good For The Game

hard dels are bad

## Changelog
:cl:
fix: makes certain organs no longer have circular references
/:cl: