### PR TITLE
Blacklists incapacitated mobs from being sentience event candidates

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -37,7 +37,7 @@
 			continue
 		if(L.mob_biotypes & blacklisted_biotypes)		//hey can you don't
 			continue
-		if(!(L in GLOB.player_list) && !L.mind)
+		if(!(L in GLOB.player_list) && !L.mind && !L.incapacitated())
 			potential += L
 
 	if(!potential.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This blacklists incapacitated mobs from being sentience event candidates.

## Why It's Good For The Game

>Accept animal sentience event as ghost
>Become a slime in xenobio
>Realize you're stuck in a pen full of BZ in their big chamber
>Can't move
>Can't talk
>Can't do anything to inform the xenobiologist of your newfound sapience

**I HAVE NO MOUTH AND I MUST SCREAM.**

## Changelog
:cl:
fix: Incapacitated mobs are blacklisted from being human-level intelligence sentience event candidates. This is particularly important due to slimes in BZ stasis on the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
