### PR TITLE
Supermatter surge rework: consequential for N2, won't explode immediately for CO2

### DIFF
--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -157,6 +157,8 @@
 	id = GAS_METHANE
 	specific_heat = 30
 	name = "Methane"
+	powerloss_inhibition = 1
+	heat_resistance = 3
 	breath_results = GAS_METHYL_BROMIDE
 	fire_products = list(GAS_CO2 = 1, GAS_H2O = 2)
 	fire_burn_rate = 0.5
@@ -177,6 +179,8 @@
 	id = GAS_METHYL_BROMIDE
 	specific_heat = 42
 	name = "Methyl Bromide"
+	powermix = 1
+	heat_penalty = -1
 	flags = GAS_FLAG_DANGEROUS
 	breath_alert_info = list(
 		not_enough_alert = list(

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -27,13 +27,27 @@
 				if(prob(low_threat_perc))
 					severity = "low; the supermatter should return to normal operation shortly."
 				else
-					severity = "medium; the supermatter should return to normal operation, but check NT CIMS to ensure this."
+					severity = "medium; the supermatter should return to normal operation, but regardless, check if the emitters may need to be turned off temporarily."
 			else
-				severity = "high; if the supermatter's cooling is not fortified, coolant may need to be added."
+				severity = "high; the emitters likely need to be turned off, and if the supermatter's cooling loop is not fortified, pre-cooled gas may need to be added."
 		if(100000 to INFINITY)
-			severity = "extreme; emergency action is likely to be required even if coolant loop is fine."
+			severity = "extreme; emergency action is likely to be required even if coolant loop is fine. Turn off the emitters and make sure the loop is properly cooling gases."
 	if(power > 20000 || prob(round(power/200)))
 		priority_announce("Supermatter surge detected. Estimated severity is [severity]", "Anomaly Alert")
 
 /datum/round_event/supermatter_surge/start()
-	GLOB.main_supermatter_engine.matter_power += power
+	var/obj/machinery/power/supermatter_crystal/supermatter = GLOB.main_supermatter_engine
+	var/power_proportion = supermatter.powerloss_inhibitor/2 // what % of the power goes into matter power, at most 50%
+	// we reduce the proportion that goes into actual matter power based on powerloss inhibitor
+	// primarily so the supermatter doesn't tesla the instant these happen
+	supermatter.matter_power += power * power_proportion
+	var/datum/gas_mixture/methane_puff = new
+	var/selected_gas = pick(4;GAS_CO2, 10;GAS_METHANE, 4;GAS_H2O, 1;GAS_BZ, 1;GAS_METHYL_BROMIDE)
+	methane_puff.set_moles(selected_gas, 500)
+	methane_puff.set_temperature(500)
+	var/energy_ratio = (power * 500 * (1-power_proportion)) / methane_puff.thermal_energy()
+	if(energy_ratio < 1) // energy output we want is lower than current energy, reduce the amount of gas we puff out
+		methane_puff.set_moles(GAS_METHANE, energy_ratio * 500)
+	else // energy output we want is higher than current energy, increase its actual heat
+		methane_puff.set_temperature(energy_ratio * 500)
+	supermatter.assume_air(methane_puff)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -500,7 +500,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		powerloss_dynamic_scaling = clamp(powerloss_dynamic_scaling + clamp(powerloss_inhibition_gas - powerloss_dynamic_scaling, -0.02, 0.02), 0, 1)
 	else
 		powerloss_dynamic_scaling = clamp(powerloss_dynamic_scaling - 0.05, 0, 1)
-	//Ranges from 0 to 1(1-(value between 0 and 1 * ranges from 1 to 1.5(mol / 500)))
+	//Ranges from 0 to 1 (1-(value between 0 and 1 * ranges from 1 to 1.5(mol / 500)))
+	//0 means full inhibition, 1 means no inhibition
 	//We take the mol count, and scale it to be our inhibitor
 	powerloss_inhibitor = clamp(1-(powerloss_dynamic_scaling * clamp(combined_gas/POWERLOSS_INHIBITION_MOLE_BOOST_THRESHOLD, 1, 1.5)), 0, 1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Supermatter surge now comes in two parts: up to 50% of the power goes into matter power (the current method) and the rest goes into hot gas. This means that **high-level and above supermatter surges require intervention, in the form of turning off emitters (at least)**.
  a. Hot gas has a 50% chance of being methane, 20% of being CO2, 20% of being water vapor, 5% of being BZ and 5% methyl bromide.
  b. "Hot gas" here means gas with a temperature of at least 500 kelvins. Up to 500 moles of this gas will be generated. Low power surges will generate less gas, high power surges will generate hotter gas.
  c. The ratio between matter power and hot gas depends on the "powerloss inhibitor" of the supermatter: in other words, how much power the supermatter can actually shuck off each tick. A pure CO2 and/or methane setup would have 0 power increase, instead just having a surge of (very) hot gas.
2. Methane now has an effect on the supermatter: it prevents gasmix power loss, just like CO2, but provides heat resistance like N2O, though to a lesser extent. It's ideal as a supplement to extremely-high-power (i.e. anomaly farm) CO2 setups: it doesn't actually let the supermatter generate power on its own like CO2 does, but it doesn't hamper CO2's power-stabilizing effect.
3. Methyl bromide also has an effect on the supermatter: it adds to the power mix, but lowers the heat penalty. Essentially, it's a safety gas that not only doesn't hamper but *actively improves* the gas mix's power generating properties. Very useful for various reasons; an example new safe emitterless supermatter setup would be 60% CO2, 25% methyl bromide, 15% methane, which would have good power due to CO2/methyl bromide, not *lose* much power due to methane/CO2, generate little oxygen due to methyl bromide and will be resistant to sudden spikes in heat due to methane.

## Why It's Good For The Game

Supermatter surge is either "does nothing" or "everything explodes", depending on setup. This balances it out so that surges are basically just as bad for all setup types and the worst surges actually require intervention.

## Changelog
:cl:
tweak: Supermatter surge is actually interesting now
/:cl: