### PR TITLE
Miasma now sterilizes into methane instead of oxygen

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -648,7 +648,7 @@
 	//Replace miasma with oxygen
 	var/cleaned_air = min(air.get_moles(GAS_MIASMA), 20 + (air.return_temperature() - FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 70) / 20)
 	air.adjust_moles(GAS_MIASMA, -cleaned_air)
-	air.adjust_moles(GAS_O2, cleaned_air)
+	air.adjust_moles(GAS_METHANE, cleaned_air)
 
 	//Possibly burning a bit of organic matter through maillard reaction, so a *tiny* bit more heat would be understandable
 	air.set_temperature(air.return_temperature() + cleaned_air * 0.002)


### PR DESCRIPTION
## About The Pull Request

Miasma dry heat sterilization now forms methane instead of oxygen. There's enough oxygen anyway. This counts as a miasma buff, I think.

## Why It's Good For The Game

Mostly just need a way to manufacture methane and nobody *ever* used the oxygen you get from sterilizing miasma

## Changelog
:cl:
tweak: Miasma sterilization now generates methane instead of oxygen
/:cl: