### PR TITLE
(wip) ports decal.dm from tg; subsequently fixes all decals disappearing on shuttle movement

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -198,6 +198,8 @@
 #define COMSIG_TURF_MULTIZ_DEL "turf_multiz_del"
 ///from base of turf/multiz_turf_new: (turf/source, direction)
 #define COMSIG_TURF_MULTIZ_NEW "turf_multiz_new"
+///from base of turf/proc/onShuttleMove(): (turf/new_turf)
+#define COMSIG_TURF_ON_SHUTTLE_MOVE "turf_on_shuttle_move"
 
 // /atom/movable signals
 #define COMSIG_MOVABLE_PRE_MOVE "movable_pre_move"					///from base of atom/movable/Moved(): (/atom)

--- a/code/datums/elements/decal.dm
+++ b/code/datums/elements/decal.dm
@@ -3,76 +3,128 @@
 	id_arg_index = 2
 	var/cleanable
 	var/description
+	/// If true this was initialized with no set direction - will follow the parent dir.
+	var/directional
 	var/mutable_appearance/pic
-	var/list/num_decals_per_atom
 
-	var/first_dir // This stores the direction of the decal compared to the parent facing NORTH
+/// Remove old decals and apply new decals after rotation as necessary
+/datum/controller/subsystem/processing/dcs/proc/rotate_decals(datum/source, old_dir, new_dir)
+	SIGNAL_HANDLER
 
-/datum/element/decal/Attach(datum/target, _icon, _icon_state, _dir, _cleanable=CLEAN_GOD, _color, _layer=TURF_LAYER, _description, _alpha=255)
-	. = ..()
-	if(. == ELEMENT_INCOMPATIBLE || !_icon || !_icon_state || !isatom(target))
-		return ELEMENT_INCOMPATIBLE
-	var/atom/A = target
-	if(!pic)
-		// It has to be made from an image or dir breaks because of a byond bug
-		var/temp_image = image(_icon, null, _icon_state, _layer, _dir)
-		pic = new(temp_image)
-		pic.color = _color
-		pic.alpha = _alpha
-	first_dir = _dir
-	description = _description
-	cleanable = _cleanable
-
-	LAZYINITLIST(num_decals_per_atom)
-
-	if(!num_decals_per_atom[A])
-		if(first_dir)
-			RegisterSignal(A, COMSIG_ATOM_DIR_CHANGE, .proc/rotate_react)
-		if(cleanable)
-			RegisterSignal(A, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_react)
-		if(description)
-			RegisterSignal(A, COMSIG_PARENT_EXAMINE, .proc/examine)
-		RegisterSignal(A, COMSIG_ATOM_UPDATE_OVERLAYS, .proc/apply_overlay, TRUE)
-
-	num_decals_per_atom[A]++
-	apply(A)
-
-/datum/element/decal/Detach(datum/target)
-	var/atom/A = target
-	num_decals_per_atom[A]--
-	if(!num_decals_per_atom[A])
-		UnregisterSignal(A, list(COMSIG_ATOM_DIR_CHANGE, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZE,
-								COMSIG_COMPONENT_CLEAN_ACT, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_OVERLAYS))
-		LAZYREMOVE(num_decals_per_atom, A)
-	apply(A)
-	return ..()
-
-/datum/element/decal/proc/apply(atom/target)
-	if(target.flags_1 & INITIALIZED_1)
-		target.update_icon() //could use some queuing here now maybe.
-	else if(!QDELETED(target) && num_decals_per_atom[target] == 1)
-		RegisterSignal(target, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZE, .proc/late_update_icon)
-	if(isitem(target))
-		addtimer(CALLBACK(target, /obj/item/.proc/update_slot_icon), 0, TIMER_UNIQUE)
-
-/datum/element/decal/proc/late_update_icon(atom/source)
-	source.update_icon()
-	UnregisterSignal(source,COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZE)
-
-/datum/element/decal/proc/apply_overlay(atom/source, list/overlay_list)
-	if(first_dir)
-		pic.dir = first_dir == SOUTH ? source.dir : turn(first_dir, dir2angle(source.dir)-180) //Never turn a dir by 0.
-	for(var/i in 1 to num_decals_per_atom[source])
-		overlay_list += pic
-
-/datum/element/decal/proc/rotate_react(atom/source, old_dir, new_dir)
 	if(old_dir == new_dir)
 		return
-	source.update_icon()
+	var/list/resulting_decals_params = list() // param lists
+	var/list/old_decals = list() //instances
+
+	if(!source.comp_lookup || !source.comp_lookup[COMSIG_ATOM_UPDATE_OVERLAYS])
+		//should probably also unregister itself
+		return
+
+	if(length(source.comp_lookup[COMSIG_ATOM_UPDATE_OVERLAYS]))
+		for(var/datum/element/decal/decal in source.comp_lookup[COMSIG_ATOM_UPDATE_OVERLAYS])
+			old_decals += decal
+			resulting_decals_params += list(decal.get_rotated_parameters(old_dir,new_dir))
+	else
+		var/datum/element/decal/decal = source.comp_lookup[COMSIG_ATOM_UPDATE_OVERLAYS]
+		if(!istype(decal))
+			return
+		old_decals += decal
+		resulting_decals_params += list(decal.get_rotated_parameters(old_dir,new_dir))
+
+	//Instead we could generate ids and only remove duplicates to save on churn on four-corners symmetry ?
+	for(var/datum/element/decal/decal in old_decals)
+		decal.Detach(source)
+
+	for(var/result in resulting_decals_params)
+		source.AddElement(/datum/element/decal, result["icon"], result["icon_state"], result["dir"], result["cleanable"], result["color"], result["layer"], result["desc"], result["alpha"])
+
+
+/datum/element/decal/proc/get_rotated_parameters(old_dir,new_dir)
+	var/rotation = 0
+	if(directional) //Even when the dirs are the same rotation is coming out as not 0 for some reason
+		rotation = SIMPLIFY_DEGREES(dir2angle(new_dir)-dir2angle(old_dir))
+		new_dir = turn(pic.dir,-rotation)
+	return list(
+		"icon" = pic.icon,
+		"icon_state" = pic.icon_state,
+		"dir" = new_dir,
+		"cleanable" = cleanable,
+		"color" = pic.color,
+		"layer" = pic.layer,
+		"desc" = description,
+		"alpha" = pic.alpha
+	)
+
+
+
+/datum/element/decal/Attach(atom/target, _icon, _icon_state, _dir, _cleanable=FALSE, _color, _layer=TURF_LAYER, _description, _alpha=255, mutable_appearance/_pic)
+	. = ..()
+	if(!isatom(target) || !generate_appearance(_icon, _icon_state, _dir, _layer, _color, _alpha, target))
+		return ELEMENT_INCOMPATIBLE
+	if(_pic)
+		pic = _pic
+	description = _description
+	cleanable = _cleanable
+	directional = _dir
+
+	RegisterSignal(target,COMSIG_ATOM_UPDATE_OVERLAYS,.proc/apply_overlay, TRUE)
+	if(target.flags_1 & INITIALIZED_1)
+		target.update_appearance() //could use some queuing here now maybe.
+	else
+		RegisterSignal(target,COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZE,.proc/late_update_icon, TRUE)
+	if(isitem(target))
+		INVOKE_ASYNC(target, /obj/item/.proc/update_slot_icon, TRUE)
+	if(_dir)
+		SSdcs.RegisterSignal(target,COMSIG_ATOM_DIR_CHANGE, /datum/controller/subsystem/processing/dcs/proc/rotate_decals, TRUE)
+	if(_cleanable)
+		RegisterSignal(target, COMSIG_COMPONENT_CLEAN_ACT, .proc/clean_react,TRUE)
+	if(_description)
+		RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/examine,TRUE)
+
+	RegisterSignal(target, COMSIG_TURF_ON_SHUTTLE_MOVE, .proc/shuttle_move_react,TRUE)
+
+/datum/element/decal/proc/generate_appearance(_icon, _icon_state, _dir, _layer, _color, _alpha, source)
+	if(!_icon || !_icon_state)
+		return FALSE
+	var/temp_image = image(_icon, null, _icon_state, _layer, _dir)
+	pic = new(temp_image)
+	pic.color = _color
+	pic.alpha = _alpha
+	return TRUE
+
+/datum/element/decal/Detach(atom/source, force)
+	UnregisterSignal(source, list(COMSIG_ATOM_DIR_CHANGE, COMSIG_COMPONENT_CLEAN_ACT, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_TURF_ON_SHUTTLE_MOVE))
+	source.update_appearance()
+	if(isitem(source))
+		INVOKE_ASYNC(source, /obj/item/.proc/update_slot_icon)
+	return ..()
+
+/datum/element/decal/proc/late_update_icon(atom/source)
+	SIGNAL_HANDLER
+
+	if(source && istype(source))
+		source.update_appearance()
+		UnregisterSignal(source,COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZE)
+
+
+/datum/element/decal/proc/apply_overlay(atom/source, list/overlay_list)
+	SIGNAL_HANDLER
+
+	overlay_list += pic
 
 /datum/element/decal/proc/clean_react(datum/source, strength)
 	if(strength >= cleanable)
 		Detach(source)
 
 /datum/element/decal/proc/examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
 	examine_list += description
+
+/datum/element/decal/proc/shuttle_move_react(datum/source, turf/new_turf)
+	SIGNAL_HANDLER
+
+	if(new_turf == source)
+		return
+	Detach(source)
+	new_turf.AddElement(/datum/element/decal, pic.icon, pic.icon_state, directional, cleanable, pic.color, pic.layer, description, pic.alpha)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -54,7 +54,6 @@ All ShuttleMove procs go here
 		CRASH("A turf queued to move via shuttle somehow had no skipover in baseturfs. [src]([type]):[loc]")
 	var/depth = baseturfs.len - shuttle_boundary + 1
 	newT.CopyOnTop(src, 1, depth, TRUE)
-	//Air stuff
 	newT.blocks_air = TRUE
 	newT.air_update_turf(TRUE)
 	blocks_air = TRUE
@@ -62,6 +61,7 @@ All ShuttleMove procs go here
 	if(isopenturf(newT))
 		var/turf/open/new_open = newT
 		new_open.copy_air_with_tile(src)
+	SEND_SIGNAL(src, COMSIG_TURF_ON_SHUTTLE_MOVE, newT)
 
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

ports tg's decal.dm file for the most part probably fucking up performance in some way or another
unfortunately this was the only way i could find that fixes the aforementioned issue
unfortunately this also makes tiles that have dirs (like the tiles with side decals already attached to them; the white corner tiles you see in arrivals for example) break and rotate the decals attached to them a second time upon load so you end up with vertical decals ontop of normal tiles

hence why this is work in progress until i fix that I'm just making the pr to keep track and look at code easier tm

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bug bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: decals vanishing on shutles
code: ported tg's decal.dm file
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
