### PR TITLE
theoretically makes mob examine tooltips respect examine tooltips pref

### DIFF
--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -137,7 +137,7 @@ Notes:
 /atom/movable/MouseEntered(location, control, params)
 	. = ..()
 	if(tooltips)
-		if(!QDELETED(src))
+		if(!QDELETED(src) && usr.client.prefs.enable_tips)
 			var/list/tooltip_data = get_tooltip_data()
 			if(length(tooltip_data))
 				var/examine_data = tooltip_data.Join("<br />")


### PR DESCRIPTION
## About The Pull Request
see title
note: examine tooltips pref is only in the preferences tab -> "toggle examine tooltips", and not in the...game settings?? not sure why

## Why It's Good For The Game
i hate mob tooltips
## Changelog
:cl:
tweak: Mob examine tooltips now respect the examine tooltips preference, located in the Preference tab.
/:cl:
