### PR TITLE
makes the arm/leg markings for synthetic lizards appear as an option again

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/synthliz.dm
@@ -38,14 +38,14 @@
 	icon = 'modular_citadel/icons/mob/synthliz_body_markings.dmi'
 	name = "Synthetic Lizard - Pecs Light"
 	icon_state = "synthlizpecslight"
-	covered_limbs = list("Chest" = MATRIX_GREEN_BLUE)
+	covered_limbs = list("Chest" = MATRIX_GREEN_BLUE, "Left Arm" = MATRIX_BLUE, "Right Arm" = MATRIX_BLUE, "Left Leg" = MATRIX_GREEN, "Right Leg" = MATRIX_GREEN)
 
 /datum/sprite_accessory/mam_body_markings/synthliz
 	recommended_species = list("synthliz")
 	icon = 'modular_citadel/icons/mob/synthliz_body_markings.dmi'
 	name = "Synthetic Lizard - Plates"
 	icon_state = "synthlizscutes"
-	covered_limbs = list("Chest" = MATRIX_GREEN)
+	covered_limbs = list("Chest" = MATRIX_GREEN, "Left Leg" = MATRIX_GREEN, "Right Leg" = MATRIX_GREEN)
 
 //Synth tails
 /datum/sprite_accessory/tails/mam_tails/synthliz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i setup the markings wrong thinking they were chest only
closes #14998

## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: makes the arm/leg markings for synthetic lizards appear as an option again
/:cl:
