### PR TITLE
[Fix] Un-Spaces the Sunken Library.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_library.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_library.dmm
@@ -64,10 +64,6 @@
 /obj/item/paper/fluff/ruins/oldstation/protosing,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/buried_library)
-"av" = (
-/obj/structure/bookcase/random,
-/turf/open/space/basic,
-/area/ruin/unpowered/buried_library)
 "aw" = (
 /turf/open/floor/plating,
 /area/ruin/unpowered/buried_library)
@@ -220,7 +216,6 @@
 /area/ruin/unpowered/buried_library)
 "bq" = (
 /obj/structure/mineral_door/wood,
-/obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/wood,
 /area/ruin/unpowered/buried_library)
 "br" = (
@@ -369,7 +364,7 @@ bi
 aC
 ae
 aQ
-aq
+ah
 bi
 aq
 bg
@@ -394,7 +389,7 @@ ae
 bi
 aM
 ae
-aq
+ah
 bm
 aq
 aA
@@ -440,7 +435,7 @@ aa
 ad
 bi
 bi
-av
+aq
 aA
 bi
 aG
@@ -465,7 +460,7 @@ aa
 ad
 ac
 as
-av
+aq
 aF
 aD
 aD
@@ -550,7 +545,7 @@ aD
 bi
 ae
 bm
-ah
+aq
 ag
 br
 ac
@@ -573,9 +568,9 @@ ae
 af
 bp
 bi
-ah
+aq
 bi
-ah
+aq
 bp
 ac
 ad
@@ -596,9 +591,9 @@ ah
 ao
 ah
 az
-ah
+aq
 bi
-ah
+aq
 bi
 bn
 ao
@@ -621,7 +616,7 @@ ah
 aA
 ah
 ao
-ah
+aq
 bi
 bi
 bl
@@ -646,7 +641,7 @@ ah
 ao
 aV
 bi
-ah
+aq
 bp
 bi
 bm

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_mining_site.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_mining_site.dmm
@@ -53,8 +53,8 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "m" = (
-/obj/structure/barricade/wooden/crude/snow,
 /obj/structure/mineral_door/wood,
+/obj/effect/decal/cleanable/trail_holder,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "n" = (
@@ -68,6 +68,7 @@
 /obj/machinery/light/broken{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/trail_holder,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "q" = (
@@ -95,6 +96,10 @@
 /obj/effect/decal/cleanable/trail_holder,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
+"N" = (
+/obj/effect/decal/cleanable/trail_holder,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 i
@@ -569,7 +574,7 @@ b
 l
 f
 f
-f
+s
 s
 b
 b
@@ -595,7 +600,7 @@ b
 b
 b
 f
-f
+s
 p
 b
 b
@@ -622,7 +627,7 @@ i
 b
 b
 b
-f
+s
 b
 b
 b
@@ -649,7 +654,7 @@ i
 i
 i
 b
-f
+s
 b
 i
 i
@@ -676,7 +681,7 @@ i
 i
 i
 b
-f
+s
 b
 i
 i
@@ -703,7 +708,7 @@ i
 i
 i
 b
-f
+s
 b
 i
 i
@@ -757,7 +762,7 @@ i
 i
 n
 h
-n
+N
 h
 n
 i


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I missed a few tiles when replacing snow tiles with volcanic floor tiles. For SOME reason, I left some tiles under bookshelves exposed to space. Long story short, ... uh.. space tiles in lavaland aren't good. At all.
So I fixed it and made SURE this time:
<img src="https://cdn.discordapp.com/attachments/484846964605714432/883052415081906236/unknown.png">
...I only noticed it with this specific ruin, mind you.
Oh also, while I was on it I removed some planks that were the snowed-over ones, those didn't make sense on lavaland and should've been gone before, actually.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Space tiles on lavaland are bad, okay?<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Lavaland architects don't screw up so badly anymore and do in fact not somehow leave holes through the planet surface all the way into space under their bookshelves.
fix: Snow was removed from Lavaland Ruins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
