### PR TITLE
Remove arbitrary bomb research cap + tweak formula a little

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -197,10 +197,8 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	if(orig_light < 10)
 		say("Explosion not large enough for research calculations.")
 		return
-	else if(orig_light < 4500)
-		point_gain = (83300 * orig_light) / (orig_light + 3000)
 	else
-		point_gain = TECHWEB_BOMB_POINTCAP
+		point_gain = (100000 * orig_light) / (orig_light + 4500)
 
 	/*****The Point Capper*****/
 	if(point_gain > linked_techweb.largest_bomb_value)

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -198,7 +198,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		say("Explosion not large enough for research calculations.")
 		return
 	else
-		point_gain = (100000 * orig_light) / (orig_light + 4500)
+		point_gain = (100000 * orig_light) / (orig_light + 5000)
 
 	/*****The Point Capper*****/
 	if(point_gain > linked_techweb.largest_bomb_value)


### PR DESCRIPTION
## About The Pull Request

1. The arbitrary 50,000 point cap has been removed. It was completely pointless, the actual formula was actually capped anyway, at 83300.
2. Changed the formula to have a limit of 100,000, and require slightly more power to reach 50,000 points (before it was 4500, now it's 5000). A particularly good 2 : 1 oxy : trit bomb will make something like 52,500 points instead of 50,000, an average one will make 50,000, a slightly bad one will still make 47000. A mathematically perfect bomb will make something like 94,000. The best bomb I have ever personally made would be 93250.

Basically: if your trit bombs never reach 5,000 light range, your research points will be worse. If they always go above, they'll be better. Making hyper-nob bombs lets you squeeze an extra 40,000 or so out of bombs.

## Why It's Good For The Game

Because I kinda don't like there being absolutely no point to hyper-nob bombs. This adds a cool reason to do it. Research points are kind of a joke anyway?

## Changelog
:cl:
balance: Nerfed bad toxins bombs and buffed good toxins bombs. There's no longer an arbitrary hard research points cap.
/:cl: