### PR TITLE
Fixes a runtime in ghost update_icon

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -176,7 +176,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
  * Hair will always update its dir, so if your sprite has no dirs the haircut will go all over the place.
  * |- Ricotez
  */
-/mob/dead/observer/update_icon(new_form)
+/mob/dead/observer/update_icon(updates=ALL, new_form=null)
 	. = ..()
 	if(client) //We update our preferences in case they changed right before update_icon was called.
 		ghost_accs = client.prefs.ghost_accs


### PR DESCRIPTION
Please make sure that no overrides have arguments when you add a new argument to a method.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

someone added an argument to either observer update_icon not knowing that the parent already had one, or to parent update_icon not knowing observer had one

## Why It's Good For The Game

runtimes bad

## Changelog
:cl:
fix: Might've fixed some ghost sprite oddities nobody even knew about
/:cl: