### PR TITLE
Removes flammable gases from planet atmos

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -12,9 +12,7 @@
 		GAS_CO2=10,
 	)
 	restricted_gases = list(
-		GAS_PLASMA=0.1,
-		GAS_BZ=1.2,
-		GAS_METHANE=1.0,
+		GAS_BZ=0.1,
 		GAS_METHYL_BROMIDE=0.1,
 	)
 	restricted_chance = 30
@@ -23,7 +21,7 @@
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 
 	minimum_temp = BODYTEMP_COLD_DAMAGE_LIMIT + 1
-	maximum_temp = 350
+	maximum_temp = 320
 
 /datum/atmosphere/icemoon
 	id = ICEMOON_DEFAULT_ATMOS
@@ -38,8 +36,6 @@
 		GAS_CO2=10,
 	)
 	restricted_gases = list(
-		GAS_PLASMA=0.1,
-		GAS_METHANE=1.0,
 		GAS_METHYL_BROMIDE=0.1,
 	)
 	restricted_chance = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

it's clearly causing major issues repeatedly, to which nobody has deigned to actually tell me, the person responsible

## Why It's Good For The Game

apparently it's a repeat issue that atmos on lavaland is "buggy and fucked" but it's actually just intentional and bad. this makes it intentional and not bad

## Changelog
:cl:
tweak: lavaland atmos can no longer be flammable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
