### PR TITLE
Tweaks reagent speedups and taser slowdowns and fixes stabilzied light pink for those xenobio people

### DIFF
--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -32,7 +32,7 @@ Key procs
 	/// Unique ID. You can never have different modifications with the same ID. By default, this SHOULD NOT be set. Only set it for cases where you're dynamically making modifiers/need to have two types overwrite each other. If unset, uses path (converted to text) as ID.
 	var/id
 
-	/// Higher ones override lower priorities. This is NOT used for ID, ID must be unique, if it isn't unique the newer one overwrites automatically if overriding.
+	/// Determines order. Lower priorities are applied first.
 	var/priority = 0
 	var/flags = NONE
 

--- a/code/modules/movespeed/modifiers/reagents.dm
+++ b/code/modules/movespeed/modifiers/reagents.dm
@@ -7,7 +7,7 @@
 /datum/movespeed_modifier/reagent/ephedrine
 	// strong painkiller effect that caps out at slightly above runspeed
 	multiplicative_slowdown = -1.5
-	priority = -100
+	priority = 500
 	complex_calculation = TRUE
 	absolute_max_tiles_per_second = 7
 
@@ -21,14 +21,14 @@
 	// extremely strong painkiller effect: allows user to run at old sprint speeds but not over by cancelling out slowdowns.
 	// however, will not make user go faster than that
 	multiplicative_slowdown = -4
-	priority = -100
+	priority = 500
 	complex_calculation = TRUE
 	absolute_max_tiles_per_second = 8
 
 /datum/movespeed_modifier/reagent/methamphetamine
 	// very strong painkiller effect that caps out at slightly above runspeed
 	multiplicative_slowdown = -2.5
-	priority = -100
+	priority = 500
 	complex_calculation = TRUE
 	absolute_max_tiles_per_second = 7.5
 

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -19,14 +19,14 @@
 
 /datum/movespeed_modifier/status_effect/tased
 	multiplicative_slowdown = 1.5
-	priority = 50
+	priority = 1500
 
 /datum/movespeed_modifier/status_effect/domain
 	multiplicative_slowdown = 3
 
 /datum/movespeed_modifier/status_effect/tased/no_combat_mode
 	multiplicative_slowdown = 8
-	priority = 100
+	priority = 1500
 
 /datum/movespeed_modifier/status_effect/electrostaff
 	multiplicative_slowdown = 1

--- a/code/modules/movespeed/modifiers/status_effects.dm
+++ b/code/modules/movespeed/modifiers/status_effects.dm
@@ -55,7 +55,7 @@
 /datum/movespeed_modifier/status_effect/slime/light_pink
 	// decently good painkiller + speedup effect
 	blacklisted_movetypes = FLYING | FLOATING
-	priority = -150		// someday we really need to make these defines lmao
+	priority = 500		// someday we really need to make these defines lmao
 	multiplicative_slowdown = -2
 	complex_calculation = TRUE
 	absolute_max_tiles_per_second = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Woops
Priority for modifiers applies low to high.

This makes reagents actually act as a painkiller effect, and makes tasers actually able to shut down said reagents.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Making these things work as intended as right now tasers no longer do anything to shut down super speed (which they had the slowdown for initially) and reagents don't actually have a good slowdown cancel (which was why I changed them to this in the first place as opposed to just giving super speed!)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Reagent speedups buffed (it's far more complicated than this but I'll just say it because this is the most common effect)
tweak: Taser slowdowns buffed (it's far more complicated than this but I'll just say it because this is the most common effect)
tweak: stabilized light pink done too (same as reagents)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
