### PR TITLE
Zaps don't explode pipes

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -75,6 +75,9 @@
 /obj/machinery/atmospherics/pipe/setPipenet(datum/pipeline/P)
 	parent = P
 
+/obj/machinery/atmospherics/pipe/zap_act(power, zap_flags)
+	return 0 // they're not really machines in the normal sense, probably shouldn't explode
+
 /obj/machinery/atmospherics/pipe/Destroy()
 	QDEL_NULL(parent)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Zaps exploding pipes causes a bit of a "supermatter spaces itself a LOT" thing, so this makes it less of a problem. Bit ridiculous that pipes, perfectly inert objects, are made of explodium anyway. I didn't even remove the ability for the AI to blow them up, nor did I remove e.g. pumps or valves exploding.

## Why It's Good For The Game

supermatter's been a bit ridiculous lately, might need to make other changes to fix that if this doesn't work

## Changelog
:cl:
tweak: Pipes don't explode when zapped anymore
/:cl: