### PR TITLE
comedically controversial stunbaton """"buff""""

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -65,6 +65,8 @@
 /// Blocks sprint
 #define STATUS_EFFECT_STAGGERED /datum/status_effect/staggered
 
+#define STATUS_EFFECT_TASED_WEAK_NODMG /datum/status_effect/electrode/no_damage     // no damage
+
 #define STATUS_EFFECT_TASED_WEAK /datum/status_effect/electrode				//not as crippling, just slows down
 
 #define STATUS_EFFECT_TASED /datum/status_effect/electrode/no_combat_mode //the affected has been tased, preventing fine muscle control

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -194,6 +194,9 @@
 			C.adjustStaminaLoss(max(0, stamdmg_per_ds * diff)) //if you really want to try to stamcrit someone with a taser alone, you can, but it'll take time and good timing.
 	last_tick = world.time
 
+/datum/status_effect/electrode/no_damage
+	stamdmg_per_ds = 0
+
 /datum/status_effect/electrode/no_combat_mode
 	id = "tased_strong"
 	movespeed_mod = /datum/movespeed_modifier/status_effect/tased/no_combat_mode

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -16,8 +16,9 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 	attack_speed = CLICK_CD_MELEE
 
-	var/stamina_loss_amount = 40
+	var/stamina_loss_amount = 35
 	var/turned_on = FALSE
+	var/armor_pen = 100
 	var/knockdown = TRUE
 	/// block percent needed to prevent knockdown/disarm
 	var/block_percent_to_counter = 50
@@ -79,16 +80,6 @@
 	if(turned_on && (!copper_top || !copper_top.charge || (chargecheck && copper_top.charge < (hitcost * STUNBATON_CHARGE_LENIENCY))))
 		//we're below minimum, turn off
 		switch_status(FALSE)
-
-///Check for our cell to determine how much penetration our weapon does.
-/obj/item/melee/baton/proc/get_cell_zap_pen()
-	var/obj/item/stock_parts/cell/copper_top = get_cell()
-	if(copper_top)
-		var/chargepower = copper_top.maxcharge
-		var/zap_penetration = (chargepower/1000) //This is our effective penetration. Every 1000 max charge, we get 1 pen power. A high capacity cell is equal to 10 armor pen, as an example.
-		return zap_penetration
-	else
-		return 0
 
 /obj/item/melee/baton/proc/switch_status(new_status = FALSE, silent = FALSE)
 	if(turned_on != new_status)
@@ -198,7 +189,7 @@
 		return FALSE
 	var/final_stamina_loss_amount = stamina_loss_amount //Our stunning power for the baton
 	var/shoved = FALSE //Did we succeed on knocking our target over?
-	var/zap_penetration = get_cell_zap_pen() //Find out what kind of cell we have, and calculating the resultant armor pen we get from it
+	var/zap_penetration = armor_pen
 	var/zap_block = L.run_armor_check(BODY_ZONE_CHEST, "melee", null, null, zap_penetration) //armor check, including calculation for armor penetration, for our attack
 	final_stamina_loss_amount = block_calculate_resultant_damage(final_stamina_loss_amount, return_list)
 
@@ -333,7 +324,8 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 3
 	throwforce = 5
-	stamina_loss_amount = 25
+	stamina_loss_amount = 30
+	armor_pen = 35
 	hitcost = 1000
 	throw_hit_chance = 10
 	slot_flags = ITEM_SLOT_BACK

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -26,8 +26,8 @@
 	var/hitcost = 750
 	var/throw_hit_chance = 35
 	var/preload_cell_type //if not empty the baton starts with this type of cell
-	var/cooldown_duration = 3.5 SECONDS //How long our baton rightclick goes on cooldown for after applying a knockdown
-	var/status_duration = 5 SECONDS //how long our status effects last for otherwise
+	var/cooldown_duration = 2.5 SECONDS //How long our baton rightclick goes on cooldown for after applying a knockdown
+	var/status_duration = 3 SECONDS //how long our status effects last for otherwise
 	COOLDOWN_DECLARE(shove_cooldown)
 
 /obj/item/melee/baton/examine(mob/user)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -214,7 +214,7 @@
 
 	if(shoving && COOLDOWN_FINISHED(src, shove_cooldown) && !HAS_TRAIT(L, TRAIT_IWASBATONED)) //Rightclicking applies a knockdown, but only once every couple of seconds, based on the cooldown_duration var. If they were recently knocked down, they can't be knocked down again by a baton.
 		L.DefaultCombatKnockdown(50, override_stamdmg = 0)
-		L.apply_status_effect(STATUS_EFFECT_TASED_WEAK, status_duration) //Even if they shove themselves up, they're still slowed.
+		L.apply_status_effect(STATUS_EFFECT_TASED_WEAK_NODMG, status_duration) //Even if they shove themselves up, they're still slowed.
 		L.apply_status_effect(STATUS_EFFECT_OFF_BALANCE, status_duration) //They're very likely to drop items if shoved briefly after a knockdown.
 		shoved = TRUE
 		COOLDOWN_START(src, shove_cooldown, cooldown_duration)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Raises stunprod to 30 stamina from 25
Lowers stunbaton to 35 stamina from 40.
**Lowers stunbaton right click taser effect to 30 from 50.**

**DoT removed from right click**

Instead of scaling armor penetration from 0 to 40 based on cell charge max / 1000 (meaning most of the time you have 10), stunbatons now have 100% armor penetration again with 35% penetration on stunprods.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stunbatons are not nearly as some game ender melee weapon as they were on sprint days when the game was to turn on sprint and dodge someone's shots to close distance and hit them.
I think it's better to return to them being an invariable staple of security instead of one that gets better if you remember to upgrade the cell to 40k, and **one of the few things in security's arsenal (as well as anyone else who steals one) that is more or less unaffected by late round powergaming.**
Furthermore, without sprint, closing the distance in melee is far more of a risky proposition, and should give a good reward for being able to *stay* in melee range.
This actually nerfs their effect on unarmored targets, requiring 5 hits instead of 4 to down from full health (though right click is, actually, hilariously strong due to the 30 DoT **along with the normal damage that also applies** that might need to be nerfed at some point), but this means closing the distance with a heavily armed and armored target is once again viable, regardless of what baton cell you have.

The reason the right click is being nerfed is to make up for the fact that it is *also* full armor penetrating, **and you should probably be able to keep up the melee hits if you are in melee range anyways.**
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Stunbatons and stunprods now have massively increased/full armor penetration in exchange for slightly less damage overall. Stunbaton right click now does normal damage + slow over 3 seconds instead of 50 DoT + slow over 5 seconds.
balance: Stunprods got buffed. Viva la revolution.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
