### PR TITLE
Reworks supermatter gas output to be less cascade-y, more risky

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -222,6 +222,10 @@
 /// k is the rate at which is approaches L, x_0 is the point where the function = 0
 #define LOGISTIC_FUNCTION(L,k,x,x_0) (L/(1+(NUM_E**(-k*(x-x_0)))))
 // )
+/// A function that "linearly" approaches a maximum value of L
+/// k is the rate at which it approaches L (), x_0 is the point where the function = 0
+#define HYPERBOLIC_GROWTH(L,k,x,x_0) ((-(L * L) / ((k * x) + L - (k * x_0))) + L)
+// )
 /// Make sure something is a boolean TRUE/FALSE 1/0 value, since things like bitfield & bitflag doesn't always give 1s and 0s.
 #define FORCE_BOOLEAN(x) ((x)? TRUE : FALSE)
 // )

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -41,8 +41,9 @@
 
 #define THERMAL_RELEASE_MODIFIER 350         //Higher == more heat released during reaction, not to be confused with the above values
 #define THERMAL_RELEASE_CAP_MODIFIER 250     //Higher == lower cap on how much heat can be released per tick--currently 1.3x old value
-#define PLASMA_RELEASE_MODIFIER 750        //Higher == less plasma released by reaction
-#define OXYGEN_RELEASE_MODIFIER 325        //Higher == less oxygen released at high temperature/power
+#define GAS_RELEASE_MODIFIER 500        //Higher == less gas released by reaction
+#define MAX_OXY_MULT 3                  //The ratio between oxygen and plasma will approach this as temperature increases
+#define OXY_POINT 80                    // the temperature above which oxygen output > plasma output
 
 #define REACTION_POWER_MODIFIER 0.55       //Higher == more overall power
 
@@ -538,14 +539,19 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	//Power * 0.55 * a value between 1 and 0.8
 	var/device_energy = power * REACTION_POWER_MODIFIER
 
-	var/effective_temperature = min(removed.return_temperature(), 2500 * dynamic_heat_modifier)
+	var/cur_temp = removed.return_temperature() // more readable, better-performing anyway
 
-	var/max_temp_increase = effective_temperature + ((device_energy * dynamic_heat_modifier) / THERMAL_RELEASE_CAP_MODIFIER)
-	//Calculate how much gas to release
-	//Varies based on power and gas content
-	removed.adjust_moles(GAS_PLASMA, max((device_energy * dynamic_heat_modifier) / PLASMA_RELEASE_MODIFIER, 0))
-	//Varies based on power, gas content, and heat
-	removed.adjust_moles(GAS_O2, max(((device_energy + effective_temperature * dynamic_heat_modifier) - T0C) / OXYGEN_RELEASE_MODIFIER, 0))
+	// we don't want to cap the temperature like the old supermatter but we do want to stop adding more when it's too hot
+	var/max_temp_increase = min(cur_temp, 2500 * dynamic_heat_modifier) + ((device_energy * dynamic_heat_modifier) / THERMAL_RELEASE_CAP_MODIFIER)
+
+	// oxygen ratio increases as temperature does
+	var/oxy_ratio = HYPERBOLIC_GROWTH(MAX_OXY_MULT, 1 / OXY_POINT, cur_temp, (-OXY_POINT / 2))
+	// total moles also increases as temperature does
+	var/released_plasma = max((device_energy**2 * dynamic_heat_modifier + (cur_temp - T0C)) / GAS_RELEASE_MODIFIER ** 2, 0) / (1+oxy_ratio)
+
+	removed.adjust_moles(GAS_PLASMA, released_plasma)
+
+	removed.adjust_moles(GAS_O2, released_plasma * oxy_ratio)
 
 	if(removed.return_temperature() < max_temp_increase)
 		removed.adjust_heat(device_energy * dynamic_heat_modifier * THERMAL_RELEASE_MODIFIER)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -41,8 +41,8 @@
 
 #define THERMAL_RELEASE_MODIFIER 350         //Higher == more heat released during reaction, not to be confused with the above values
 #define THERMAL_RELEASE_CAP_MODIFIER 250     //Higher == lower cap on how much heat can be released per tick--currently 1.3x old value
-#define GAS_RELEASE_MODIFIER 500        //Higher == less gas released by reaction
-#define MAX_OXY_MULT 1.5                  //The ratio between oxygen and plasma will approach this as temperature increases
+#define GAS_RELEASE_MODIFIER 800        //Higher == less gas released by reaction
+#define MAX_OXY_MULT 2                  //The ratio between oxygen and plasma will approach this as temperature increases
 #define OXY_POINT 80                    // the temperature above which oxygen output > plasma output
 
 #define REACTION_POWER_MODIFIER 0.55       //Higher == more overall power
@@ -547,7 +547,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	// oxygen ratio increases as temperature does
 	var/oxy_ratio = HYPERBOLIC_GROWTH(MAX_OXY_MULT, 1 / OXY_POINT, cur_temp, (-OXY_POINT / 2))
 	// total moles also increases as temperature does
-	var/released_plasma = min(max((device_energy * dynamic_heat_modifier) / GAS_RELEASE_MODIFIER, 0) / (1+oxy_ratio), 3)
+	var/released_plasma = min(max((device_energy * dynamic_heat_modifier) / GAS_RELEASE_MODIFIER, 0) / (1+oxy_ratio), 2)
 
 	removed.adjust_moles(GAS_PLASMA, released_plasma)
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -547,7 +547,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	// oxygen ratio increases as temperature does
 	var/oxy_ratio = HYPERBOLIC_GROWTH(MAX_OXY_MULT, 1 / OXY_POINT, cur_temp, (-OXY_POINT / 2))
 	// total moles also increases as temperature does
-	var/released_plasma = max((device_energy**2 * dynamic_heat_modifier + (cur_temp - T0C)) / GAS_RELEASE_MODIFIER ** 2, 0) / (1+oxy_ratio)
+	var/released_plasma = min(max((device_energy * dynamic_heat_modifier + (cur_temp - T0C)) / GAS_RELEASE_MODIFIER, 0) / (1+oxy_ratio), 3)
 
 	removed.adjust_moles(GAS_PLASMA, released_plasma)
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -42,7 +42,7 @@
 #define THERMAL_RELEASE_MODIFIER 350         //Higher == more heat released during reaction, not to be confused with the above values
 #define THERMAL_RELEASE_CAP_MODIFIER 250     //Higher == lower cap on how much heat can be released per tick--currently 1.3x old value
 #define GAS_RELEASE_MODIFIER 500        //Higher == less gas released by reaction
-#define MAX_OXY_MULT 3                  //The ratio between oxygen and plasma will approach this as temperature increases
+#define MAX_OXY_MULT 1.5                  //The ratio between oxygen and plasma will approach this as temperature increases
 #define OXY_POINT 80                    // the temperature above which oxygen output > plasma output
 
 #define REACTION_POWER_MODIFIER 0.55       //Higher == more overall power
@@ -547,7 +547,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	// oxygen ratio increases as temperature does
 	var/oxy_ratio = HYPERBOLIC_GROWTH(MAX_OXY_MULT, 1 / OXY_POINT, cur_temp, (-OXY_POINT / 2))
 	// total moles also increases as temperature does
-	var/released_plasma = min(max((device_energy * dynamic_heat_modifier + (cur_temp - T0C)) / GAS_RELEASE_MODIFIER, 0) / (1+oxy_ratio), 3)
+	var/released_plasma = min(max((device_energy * dynamic_heat_modifier) / GAS_RELEASE_MODIFIER, 0) / (1+oxy_ratio), 3)
 
 	removed.adjust_moles(GAS_PLASMA, released_plasma)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically it's less likely to cause forever runaway trit fires... but it can still get runaway, it's just more power-based than temperature-based. In other words, for a runaway trit fire, the emitters need to stay on and you need to add CO2, i.e. it basically requires sabotage.

I did this by making gas output quadratic with respect to power and linear with respect to temperature, and by making the O2/plasma ratio increase with temperature as before, but not *infinitely* like it was. Before, oxygen would increase with temperature and power while plasma would with only power. This essentially meant trit fires were guaranteed, because you'd be making *dozens* of moles of oxygen per mole of plasma. Now, the ratio approaches 3 as temperature increases--enough to sustain a trit fire, but not enough that it'll cause disasters. Also, gas output is overall increased, at high powers, but decreased at low powers--so now you have a really good reason to dump nitrogen into the chamber to save it.

## Why It's Good For The Game

it's exploding too much, but I don't want to hugbox it too hard

## Changelog
:cl:
tweak: Supermatter gas output rework
/:cl: