### PR TITLE
Makes supermatter zaps not explode stuff

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1058,9 +1058,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(zapdir)
 			. = zapdir
 
-		//Going boom should be rareish
-		if(prob(80))
-			zap_flags &= ~ZAP_MACHINE_EXPLOSIVE
+		//Going boom causes the supermatter to save itself too much
+		zap_flags &= ~ZAP_MACHINE_EXPLOSIVE
 		if(target_type == COIL)
 			//In the best situation we can expect this to grow up to 2120kw before a delam/IT'S GONE TOO FAR FRED SHUT IT DOWN
 			//The formula for power gen is zap_str * zap_mod / 2 * capacitor rating, between 1 and 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yeah the pipe thing wasn't good enough. i probably should've expected this since the only things in the chambers are vents and scrubbers haha.

EDIT: #15113 already does this

## Why It's Good For The Game

the supermatter saves itself when it explodes, which is hopelessly lame

## Changelog
:cl:
tweak: supermatter zaps no longer blow stuff up
/:cl: