### PR TITLE
chaplain runspeed holy weapon will now only give a random slowdown/speedup of 6 tiles which for the most part ignores all other slowdowns/speedups, instead of randomizing between slowing to a crawl and running faster than the speed of light

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -769,12 +769,30 @@
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
+/obj/item/nullrod/tribal_knife/pickup(mob/user)
+	. = ..()
+	reroll()
+
 /obj/item/nullrod/tribal_knife/process()
-	slowdown = rand(-2, 2)
+	reroll()
+
+/obj/item/nullrod/tribal_knife
 	if(iscarbon(loc))
 		var/mob/living/carbon/wielder = loc
 		if(wielder.is_holding(src))
-			wielder.update_equipment_speed_mods()
+			wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife, multiplicative_slowdown = pick(-10, 0, ((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 3) / 10))
+
+/obj/item/nullrod/tribal_knife/dropped(mob/user)
+	user.remove_movespeed_modifier(/datum/movespeed_modifier/item/arrhythmic_knife)
+	return ..()
+
+/datum/movespeed_modifier/item/arrhythmic_knife
+	variable = TRUE
+	flags = IGNORE_NOSLOW
+	movetypes = ~FLOATING
+	priority = 750
+	absolute_max_tiles_per_second = 20
+	max_tiles_per_second_boost = 3
 
 /obj/item/nullrod/pitchfork
 	icon_state = "pitchfork0"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -780,14 +780,19 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/wielder = loc
 		if(wielder.is_holding(src))
-			var/datum/movespeed_modifier/M = wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife, multiplicative_slowdown = 
-			pick(
-				-10,
-				-10,
-				0,
-				((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 2) / 10),
-				((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 4) / 10))
+			var/datum/movespeed_modifier/M = wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife,
+			update = FALSE,
+			multiplicative_slowdown = 
+				pick(
+					-10,
+					-10,
+					0,
+					((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 2) / 10),
+					((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 4) / 10)
+				)
+			)
 			M.max_tiles_per_second_boost = pick(3, 6)
+			wielder.update_movespeed()		// update movespeed manually
 
 /obj/item/nullrod/tribal_knife/dropped(mob/user)
 	user.remove_movespeed_modifier(/datum/movespeed_modifier/item/arrhythmic_knife)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -780,7 +780,14 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/wielder = loc
 		if(wielder.is_holding(src))
-			wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife, multiplicative_slowdown = pick(-10, 0, ((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 3) / 10))
+			var/datum/movespeed_modifier/M = wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife, multiplicative_slowdown = 
+			pick(
+				-10,
+				-10,
+				0,
+				((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 2) / 10),
+				((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 4) / 10))
+			M.max_tiles_per_second_boost = pick(3, 6)
 
 /obj/item/nullrod/tribal_knife/dropped(mob/user)
 	user.remove_movespeed_modifier(/datum/movespeed_modifier/item/arrhythmic_knife)
@@ -792,7 +799,7 @@
 	movetypes = ~FLOATING
 	priority = 750
 	absolute_max_tiles_per_second = 20
-	max_tiles_per_second_boost = 3
+	max_tiles_per_second_boost = 6
 
 /obj/item/nullrod/pitchfork
 	icon_state = "pitchfork0"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -776,7 +776,7 @@
 /obj/item/nullrod/tribal_knife/process()
 	reroll()
 
-/obj/item/nullrod/tribal_knife
+/obj/item/nullrod/tribal_knife/proc/reroll()
 	if(iscarbon(loc))
 		var/mob/living/carbon/wielder = loc
 		if(wielder.is_holding(src))

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -780,17 +780,8 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/wielder = loc
 		if(wielder.is_holding(src))
-			var/datum/movespeed_modifier/M = wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife,
-			update = FALSE,
-			multiplicative_slowdown = 
-				pick(
-					-10,
-					-10,
-					0,
-					((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 2) / 10),
-					((10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag) - 4) / 10)
-				)
-			)
+			var/current_tiles = 10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag)
+			var/datum/movespeed_modifier/M = wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife, update = FALSE, multiplicative_slowdown = pick(-10, -10, 0, (current_tiles - 2) / 10, (current_tiles - 4) / 10))
 			M.max_tiles_per_second_boost = pick(3, 6)
 			wielder.update_movespeed()		// update movespeed manually
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -780,8 +780,8 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/wielder = loc
 		if(wielder.is_holding(src))
-			var/current_tiles = 10 / max(wielder.cached_multiplicative_movespeed, world.tick_lag)
-			var/datum/movespeed_modifier/M = wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrythmic_knife, update = FALSE, multiplicative_slowdown = pick(-10, -10, 0, (current_tiles - 2) / 10, (current_tiles - 4) / 10))
+			var/current_tiles = 10 / max(wielder.cached_multiplicative_slowdown, world.tick_lag)
+			var/datum/movespeed_modifier/M = wielder.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/item/arrhythmic_knife, update = FALSE, multiplicative_slowdown = pick(-10, -10, 0, (current_tiles - 2) / 10, (current_tiles - 4) / 10))
 			M.max_tiles_per_second_boost = pick(3, 6)
 			wielder.update_movespeed()		// update movespeed manually
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes arrythmic knife from randomizing -2 to 2 slowdown to randomizing between -4, -2, 0, 3, and 6.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This item's movespeed randomization is a little too wild for our current general movespeed.
This actually makes it slightly more useful when you are in a hardsuit. Slightly.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Rebalanced chaplain movespeed 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
