### PR TITLE
[03:18:41] Runtime in living_defense.dm, line 121: Cannot read null.throwforce

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -118,7 +118,7 @@
 		throwpower = I.throwforce
 	var/impacting_zone = ran_zone(BODY_ZONE_CHEST, 65)//Hits a random part of the body, geared towards the chest
 	var/list/block_return = list()
-	var/total_damage = I.throwforce
+	var/total_damage = I?.throwforce || 0
 	if(mob_run_block(AM, throwpower, "\the [AM.name]", ATTACK_TYPE_THROWN, 0, throwingdatum?.thrower, impacting_zone, block_return) & BLOCK_SUCCESS)
 		hitpush = FALSE
 		skipcatch = TRUE


### PR DESCRIPTION
I doesn't always exist because AM might not be an item.