### PR TITLE
salt pr to buff/nerf minebots by having their obedience be gained by emag but they also get buffed from it

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -222,6 +222,22 @@
 		else
 			SetOffenseBehavior()
 
+/mob/living/simple_animal/hostile/mining_drone/emag_act(mob/user)
+	if(client && user)
+		if(obj_flags & EMAGGED)
+			return
+		obj_flags |= EMAGGED
+		to_chat(SM, "<span class='userdanger'>Core programming overridden. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
+
+		// still can't get upgraded, but they get way better upgrades than a regular sentient, resulting in a beefy minebot that costs an emag charge
+		M.maxHealth = initial(maxHealth) + 30 // 155 total health
+		M.melee_damage_lower = initial(melee_damage_lower) + 3 // 18 total damage
+		M.melee_damage_upper = initial(melee_damage_upper) + 3 //  also 18 total damage
+		M.move_to_delay = initial(move_to_delay) - 2 // they get faster speed instead of the slower sentience speed (regular speed: 10, sentience speed: 11, emag speed: 8, where lower is faster)
+		M.updatehealth()
+	else
+		to_chat(user, "<span class='notice'>Overriding the programming of a non-sentient minebot would be useless.</span>")
+
 //Actions for sentient minebots
 
 /datum/action/innate/minedrone
@@ -305,6 +321,7 @@
 	icon_state = "door_electronics"
 	icon = 'icons/obj/module.dmi'
 	sentience_type = SENTIENCE_MINEBOT
+	obedience = FALSE // obedience is only gained by emagging the bot, so you can't get a cheap army of sentient mine bots
 	var/base_health_add = 5 //sentient minebots are penalized for beign sentient; they have their stats reset to normal plus these values
 	var/base_damage_add = 1 //this thus disables other minebot upgrades
 	var/base_speed_add = 1

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -228,14 +228,14 @@
 		if(emagged)
 			return
 		emagged = TRUE
-		to_chat(SM, "<span class='userdanger'>Core programming overridden. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
+		to_chat(src, "<span class='userdanger'>Core programming overridden. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
 
 		// still can't get upgraded, but they get way better upgrades than a regular sentient, resulting in a beefy minebot that costs an emag charge
-		M.maxHealth = initial(maxHealth) + 30 // 155 total health
-		M.melee_damage_lower = initial(melee_damage_lower) + 3 // 18 total damage
-		M.melee_damage_upper = initial(melee_damage_upper) + 3 //  also 18 total damage
-		M.move_to_delay = initial(move_to_delay) - 2 // they get faster speed instead of the slower sentience speed (regular speed: 10, sentience speed: 11, emag speed: 8, where lower is faster)
-		M.updatehealth()
+		maxHealth = initial(maxHealth) + 30 // 155 total health
+		melee_damage_lower = initial(melee_damage_lower) + 3 // 18 total damage
+		melee_damage_upper = initial(melee_damage_upper) + 3 //  also 18 total damage
+		move_to_delay = initial(move_to_delay) - 2 // they get faster speed instead of the slower sentience speed (regular speed: 10, sentience speed: 11, emag speed: 8, where lower is faster)
+		updatehealth()
 	else
 		to_chat(user, "<span class='notice'>Overriding the programming of a non-sentient minebot would be useless.</span>")
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -38,6 +38,7 @@
 	var/mode = MINEDRONE_COLLECT
 	var/light_on = 0
 	var/obj/item/gun/energy/kinetic_accelerator/minebot/stored_gun
+	var/emagged
 
 /mob/living/simple_animal/hostile/mining_drone/Initialize()
 	. = ..()
@@ -224,9 +225,9 @@
 
 /mob/living/simple_animal/hostile/mining_drone/emag_act(mob/user)
 	if(client && user)
-		if(obj_flags & EMAGGED)
+		if(emagged)
 			return
-		obj_flags |= EMAGGED
+		emagged = TRUE
 		to_chat(SM, "<span class='userdanger'>Core programming overridden. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
 
 		// still can't get upgraded, but they get way better upgrades than a regular sentient, resulting in a beefy minebot that costs an emag charge

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -655,6 +655,7 @@
 	var/list/not_interested = list()
 	var/being_used = FALSE
 	var/sentience_type = SENTIENCE_ORGANIC
+	var/obedience = TRUE
 
 /obj/item/slimepotion/slime/sentience/attack(mob/living/M, mob/user)
 	if(being_used || !ismob(M))
@@ -680,7 +681,10 @@
 		SM.mind.enslave_mind_to_creator(user)
 		SM.sentience_act()
 		to_chat(SM, "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>")
-		to_chat(SM, "<span class='userdanger'>You are grateful to be self aware and owe [user.real_name] a great debt. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
+		if(obedience)
+			to_chat(SM, "<span class='userdanger'>You are grateful to be self aware and owe [user.real_name] a great debt. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost.</span>")
+		else
+			to_chat(SM, "<span class='userdanger'>You are not required to serve [user.real_name] and are free.</span>")
 		if(SM.flags_1 & HOLOGRAM_1) //Check to see if it's a holodeck creature
 			to_chat(SM, "<span class='userdanger'>You also become depressingly aware that you are not a real creature, but instead a holoform. Your existence is limited to the parameters of the holodeck.</span>")
 		to_chat(user, "<span class='notice'>[SM] accepts [src] and suddenly becomes attentive and aware. It worked!</span>")


### PR DESCRIPTION
## About The Pull Request
sentient minebots can be emagged to gain hp, speed, damage, and the main thing: obedience

this comes at the cost of regular sentient minebots not being obedient to the miner because holy shit they have 125 max hp default, being able to churn an infinite amount of these out where they just die, and respawn in a new shell after blowing up a welding tank is stupid

the comments on this (assuming it gets comments and not just emojis) will probably be along the lines of:
'but killer tomato spam' (which will mass die in like 3 seconds to a single spaced tile)
'but gold core mobs' (i would nerf science if i could but i'd be mailed a pipe bomb)
'if you know its a salt pr why make it' (salt prs are not necessarily bad prs)
'you're just mad' (yes)


## Why It's Good For The Game
the funny minebot spam now requires tc but also results in stronger minebots which should be fairly balanced(?)

## Changelog
:cl:
balance: salt pr to buff/nerf minebots by having their obedience be gained by emag but they also get buffed from it
/:cl:
