### PR TITLE
The cat surgeon event now prefers using "safe" turfs as spawn location

### DIFF
--- a/code/modules/events/cat_surgeon.dm
+++ b/code/modules/events/cat_surgeon.dm
@@ -10,8 +10,28 @@
 
 /datum/round_event/cat_surgeon/start()
     var/list/spawn_locs = list()
+    var/list/unsafe_spawn_locs = list()
     for(var/X in GLOB.xeno_spawn)
-        spawn_locs += X
+        if(!isfloorturf(X))
+            unsafe_spawn_locs += X
+            continue
+        var/turf/open/floor/F = X
+        var/datum/gas_mixture/A = F.air
+        var/oxy_moles = A.get_moles(GAS_O2)
+        if((oxy_moles < 16 || oxy_moles > 50) || A.get_moles(GAS_PLASMA) || A.get_moles(GAS_CO2) >= 10)
+            unsafe_spawn_locs += F
+            continue
+        if((A.return_temperature() <= 270) || (A.return_temperature() >= 360))
+            unsafe_spawn_locs += F
+            continue
+        var/pressure = A.return_pressure()
+        if((pressure <= 20) || (pressure >= 550))
+            unsafe_spawn_locs += F
+            continue
+        spawn_locs += F
+
+    if(!spawn_locs.len)
+        spawn_locs += unsafe_spawn_locs
 
     if(!spawn_locs.len)
         message_admins("No valid spawn locations found, aborting...")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
Previously, it used any xeno spawns as spawn location, which would sometimes place them in atmos tanks or similarely wacky locations.
Now it tries to use open turfs where humans should be able to live, only using unsafe ones if no safe ones are available.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Someone said "coders aren't going to fix this because it impacts them"
Yeah no I don't care about that.

Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Catsurgeons should now spawn at more reasonable locations if possible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
