### PR TITLE
removes passkey from access circuits as it's not used anymore

### DIFF
--- a/code/modules/integrated_electronics/subtypes/access.dm
+++ b/code/modules/integrated_electronics/subtypes/access.dm
@@ -8,13 +8,10 @@
 	outputs = list(
 		"registered name" = IC_PINTYPE_STRING,
 		"assignment" = IC_PINTYPE_STRING,
-		"passkey" = IC_PINTYPE_STRING
 	)
 	activators = list(
 		"on read" = IC_PINTYPE_PULSE_OUT
 	)
-
-	var/cipherkey
 
 /obj/item/integrated_circuit/input/card_reader/Initialize()
 	cipherkey = uppertext(random_string(2000+rand(0,10), GLOB.alphabet)) // the same way SScircuit.cipherkey is generated
@@ -39,11 +36,6 @@
 	else
 		return FALSE
 
-	set_pin_data(IC_OUTPUT, 3, passkey)
-
 	push_data()
 	activate_pin(1)
 	return TRUE
-
-/obj/item/integrated_circuit/input/card_reader/set_pin_data(pin_type, pin_number, datum/new_data)
-	cipherkey = uppertext(random_string(2000+rand(0,10), GLOB.alphabet)) // NEVER REUSE THE SAME KEY

--- a/code/modules/integrated_electronics/subtypes/access.dm
+++ b/code/modules/integrated_electronics/subtypes/access.dm
@@ -14,10 +14,16 @@
 		"on read" = IC_PINTYPE_PULSE_OUT
 	)
 
+	var/cipherkey
+
+/obj/item/integrated_circuit/input/card_reader/Initialize()
+	cipherkey = uppertext(random_string(2000+rand(0,10), GLOB.alphabet)) // the same way SScircuit.cipherkey is generated
+	..()
+
 /obj/item/integrated_circuit/input/card_reader/attackby_react(obj/item/I, mob/living/user, intent)
 	var/obj/item/card/id/card = I.GetID()
 	var/list/access = I.GetAccess()
-	var/passkey = strtohex(XorEncrypt(json_encode(access), SScircuit.cipherkey))
+	var/passkey = strtohex(XorEncrypt(json_encode(access), cipherkey))
 
 	if(assembly)
 		assembly.access_card.access |= access
@@ -38,3 +44,6 @@
 	push_data()
 	activate_pin(1)
 	return TRUE
+
+/obj/item/integrated_circuit/input/card_reader/set_pin_data(pin_type, pin_number, datum/new_data)
+	cipherkey = uppertext(random_string(2000+rand(0,10), GLOB.alphabet)) // NEVER REUSE THE SAME KEY

--- a/code/modules/integrated_electronics/subtypes/access.dm
+++ b/code/modules/integrated_electronics/subtypes/access.dm
@@ -13,14 +13,9 @@
 		"on read" = IC_PINTYPE_PULSE_OUT
 	)
 
-/obj/item/integrated_circuit/input/card_reader/Initialize()
-	cipherkey = uppertext(random_string(2000+rand(0,10), GLOB.alphabet)) // the same way SScircuit.cipherkey is generated
-	..()
-
 /obj/item/integrated_circuit/input/card_reader/attackby_react(obj/item/I, mob/living/user, intent)
 	var/obj/item/card/id/card = I.GetID()
 	var/list/access = I.GetAccess()
-	var/passkey = strtohex(XorEncrypt(json_encode(access), cipherkey))
 
 	if(assembly)
 		assembly.access_card.access |= access


### PR DESCRIPTION
## About The Pull Request
title

this is nothing to do with regular usage of the circuit, copying id access, etc, you can still do that

tested on local to work with existing circuits, makes no change to them

## Why It's Good For The Game
its not used by anything due to an old pr making circuit stuff look at the assembly access id which is written to by the card reader, the passkey just exists letting people work out the cipherkey which is bad considering some other stuff relies on it

## Changelog
:cl:
fix: removes passkey from access circuits as its not used anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
