### PR TITLE
the mind transfer spell now releases people from vore bellies prior to the mind transfer

### DIFF
--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -44,6 +44,13 @@
 		to_chat(user, "<span class='warning'>The devilish contract doesn't include the 'mind swappable' package, please try again another lifetime.</span>")
 		return
 
+	// lets not have people be mindswapped to/from people who have people currently in their vore bellies
+	if(has_vore_belly(user))
+		user.release_vore_contents(include_absorbed = TRUE, silent = TRUE)
+
+	if(has_vore_belly(victim))
+		victim.release_vore_contents(include_absorbed = TRUE, silent = TRUE)
+
 	//MIND TRANSFER BEGIN
 	var/mob/dead/observer/ghost = victim.ghostize()
 	user.mind.transfer_to(victim)


### PR DESCRIPTION
## About The Pull Request
affects both caster and victim
silently removes everything from vore bellies prior to the transfer (this means no message is given they just teleport out)

## Why It's Good For The Game
potential prefbreaking bad, pop is going back up slowly, lets cut this off before it ever becomes an issue

## Changelog
:cl:
tweak: the mind transfer spell now releases people from vore bellies prior to the mind transfer
/:cl:
