### PR TITLE
saltpr to let janitors put their trash bags on their belts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -594,7 +594,8 @@
 		/obj/item/paint/paint_remover,
 		/obj/item/assembly/mousetrap,
 		/obj/item/screwdriver,
-		/obj/item/stack/cable_coil
+		/obj/item/stack/cable_coil,
+		/obj/item/storage/bag/trash
 		))
 
 /obj/item/storage/belt/bandolier


### PR DESCRIPTION
## About The Pull Request

1 line webedit tier salt

adds trash bags as a possible addition to janitor belts like the rest of their supplies because why wasnt this already a thing?? trash bags were added 4 days after janibelts but weirdly never added to the list of things they could be stored into smh


## Changelog
:cl:
tweak: janibelt can now hold trash bags, too
/:cl:

