### PR TITLE
Xenobio regenerative extract nerfing - Hold still for 5 seconds to use on others, 1 second for self, adds stackable disgust when used

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -21,14 +21,16 @@ Regenerative extracts:
 			to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
 			return TRUE //returning TRUE preemptively ends the attack chain and thus doesn't call afterattack, this is noteworthy for below as well
 		//inform the target that they're about to have a regenerative extract used on them
-		if(M != user)
+		if(M != user) //targeting someone else
 			M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [M] and guiding it to the center of [M.p_their()] mass...</span>",
 				"<span class='notice'>[user] readies [src], holding it steady near you and guiding it to the center of your mass...</span>")
-		else
+			if(!do_after(user, 50, target = M)) //5 seconds
+				return TRUE
+		else //targeting self
 			M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [user.p_them()]self and guiding it to the center of [user.p_their()] mass...</span>",
 				"<span class='notice'>You ready [src], holding it steady near you and guiding it to the center of your mass...</span>")
-		if(!do_after(user, 50, target = M)) //5 seconds
-			return TRUE
+			if(!do_after(user, 10, target = M)) //1 second
+				return TRUE
 		. = ..()
 	else
 		. = ..()
@@ -58,6 +60,7 @@ Regenerative extracts:
 	playsound(target, 'sound/effects/splat.ogg', 40, 1)
 	//warn receivers of the extract about the disgust if they're carbon, making it clear that the regenerative extract is causing this.
 	if(iscarbon(M))
+		var/obj/item/organ/stomach/S = M.getorganslot(ORGAN_SLOT_STOMACH) //for getting the stummy name
 		switch(new_disgust_level)
 			if(0 to DISGUST_LEVEL_GROSS)
 				to_chat(M,"<span class='warning'>While you recovered from [src], you feel a little nauseous.</span>")
@@ -66,7 +69,7 @@ Regenerative extracts:
 			if(DISGUST_LEVEL_VERYGROSS to DISGUST_LEVEL_DISGUSTED)
 				to_chat(M,"<span class='warning'>While you recovered from [src], you feel like you're about to vomit!</span>")
 			if(DISGUST_LEVEL_DISGUSTED to INFINITY)
-				to_chat(M,"<span class='userdanger'>You feel absolutely sick. Maybe you should lay off the regenerative extracts until your stomach settles!</span>")
+				to_chat(M,"<span class='userdanger'>You feel absolutely sick. Maybe you should lay off the regenerative extracts until your [(S ? S.name : "stomach")] settles!</span>")
 	qdel(src)
 
 /obj/item/slimecross/regenerative/grey

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -14,25 +14,58 @@ Regenerative extracts:
 /obj/item/slimecross/regenerative/proc/core_effect_before(mob/living/carbon/human/target, mob/user)
 	return
 
+/obj/item/slimecross/regenerative/pre_attack(atom/A, mob/living/user, params, attackchain_flags, damage_multiplier)
+	if(!isliving(A))
+		return TRUE //returning TRUE preemptively ends the attack chain and thus doesn't call afterattack, this is noteworthy for below as well
+	var/mob/living/M = A
+	if(M.stat == DEAD)
+		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
+		return TRUE
+	//inform the target that they're about to have a regenerative extract used on them
+	if(M != user)
+		M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [M] and guiding it to the center of [M.p_their()] mass...</span>",
+			"<span class='notice'>[user] readies [src], holding it steady near you and guiding it to the center of your mass...</span>")
+	else
+		M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [user.p_them()]self and guiding it to the center of [user.p_their()] mass...</span>",
+			"<span class='notice'>You ready [src], holding it steady near you and guiding it to the center of your mass...</span>")
+	if(!do_after(user, 50, target = M)) //5 seconds
+		return TRUE
+	. = ..()
 
 /obj/item/slimecross/regenerative/afterattack(atom/target,mob/user,prox)
 	. = ..()
 	if(!prox || !isliving(target))
 		return
-	var/mob/living/H = target
-	if(H.stat == DEAD)
-		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
+	var/mob/living/M = target
+	if(M.stat == DEAD)
+		to_chat(user, "<span class='warning'>[M] died before you could apply [src]!</span>")
 		return
-	if(H != user)
-		user.visible_message("<span class='notice'>[user] crushes the [src] over [H], the milky goo quickly regenerating all of [H.p_their()] injuries!</span>",
-			"<span class='notice'>You squeeze the [src], and it bursts over [H], the milky goo regenerating [H.p_their()] injuries.</span>")
+	if(M != user)
+		user.visible_message("<span class='notice'>[user] crushes the [src] over [M], the milky goo quickly regenerating all of [M.p_their()] injuries!</span>",
+			"<span class='notice'>You squeeze the [src], and it bursts over [M], the milky goo regenerating [M.p_their()] injuries.</span>")
 	else
 		user.visible_message("<span class='notice'>[user] crushes the [src] over [user.p_them()]self, the milky goo quickly regenerating all of [user.p_their()] injuries!</span>",
 			"<span class='notice'>You squeeze the [src], and it bursts in your hand, splashing you with milky goo which quickly regenerates your injuries!</span>")
-	core_effect_before(H, user)
-	H.revive(full_heal = 1)
-	core_effect(H, user)
+	core_effect_before(M, user)
+	var/new_disgust_level = 0
+	if(iscarbon(M)) //simpler mobs don't have a disgust variable and we need to grab that.
+		var/mob/living/carbon/C = M
+		new_disgust_level = C.disgust + DISGUST_LEVEL_GROSS
+	M.revive(full_heal = 1)
+	M.set_disgust(new_disgust_level)
+	core_effect(M, user)
 	playsound(target, 'sound/effects/splat.ogg', 40, 1)
+	//warn receivers of the extract about the disgust if they're carbon, making it clear that the regenerative extract is causing this.
+	if(iscarbon(M))
+		switch(new_disgust_level)
+			if(0 to DISGUST_LEVEL_GROSS)
+				to_chat(M,"<span class='warning'>While you recovered from [src], you feel a little nauseous.</span>")
+			if(DISGUST_LEVEL_GROSS to DISGUST_LEVEL_VERYGROSS)
+				to_chat(M,"<span class='warning'>While you recovered from [src], you feel quite queasy.</span>")
+			if(DISGUST_LEVEL_VERYGROSS to DISGUST_LEVEL_DISGUSTED)
+				to_chat(M,"<span class='warning'>While you recovered from [src], you feel like you're about to vomit!</span>")
+			if(DISGUST_LEVEL_DISGUSTED to INFINITY)
+				to_chat(M,"<span class='userdanger'>You feel absolutely sick. Maybe you should lay off the regenerative extracts until your stomach settles!</span>")
 	qdel(src)
 
 /obj/item/slimecross/regenerative/grey

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -15,22 +15,23 @@ Regenerative extracts:
 	return
 
 /obj/item/slimecross/regenerative/pre_attack(atom/A, mob/living/user, params, attackchain_flags, damage_multiplier)
-	if(!isliving(A))
-		return TRUE //returning TRUE preemptively ends the attack chain and thus doesn't call afterattack, this is noteworthy for below as well
-	var/mob/living/M = A
-	if(M.stat == DEAD)
-		to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
-		return TRUE
-	//inform the target that they're about to have a regenerative extract used on them
-	if(M != user)
-		M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [M] and guiding it to the center of [M.p_their()] mass...</span>",
-			"<span class='notice'>[user] readies [src], holding it steady near you and guiding it to the center of your mass...</span>")
+	if(isliving(A))
+		var/mob/living/M = A
+		if(M.stat == DEAD)
+			to_chat(user, "<span class='warning'>[src] will not work on the dead!</span>")
+			return TRUE //returning TRUE preemptively ends the attack chain and thus doesn't call afterattack, this is noteworthy for below as well
+		//inform the target that they're about to have a regenerative extract used on them
+		if(M != user)
+			M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [M] and guiding it to the center of [M.p_their()] mass...</span>",
+				"<span class='notice'>[user] readies [src], holding it steady near you and guiding it to the center of your mass...</span>")
+		else
+			M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [user.p_them()]self and guiding it to the center of [user.p_their()] mass...</span>",
+				"<span class='notice'>You ready [src], holding it steady near you and guiding it to the center of your mass...</span>")
+		if(!do_after(user, 50, target = M)) //5 seconds
+			return TRUE
+		. = ..()
 	else
-		M.visible_message("<span class='notice'>[user] readies [src], holding it steady near [user.p_them()]self and guiding it to the center of [user.p_their()] mass...</span>",
-			"<span class='notice'>You ready [src], holding it steady near you and guiding it to the center of your mass...</span>")
-	if(!do_after(user, 50, target = M)) //5 seconds
-		return TRUE
-	. = ..()
+		. = ..()
 
 /obj/item/slimecross/regenerative/afterattack(atom/target,mob/user,prox)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

So I was going to do this eventually, but the recent PR had me decide to prioritize this. This is intended to be a better alternative to #15165... which doesn't break anything in the process as well. Which, Hatter's code currently does as of this PR.

## About The Pull Request

This does three things to all regenerative extracts:

- Requires a 5 second windup before it's used on others
- Requires a 1 second windup before it's used on self
- Adds 25 disgust to carbon mobs when used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Sometime yesterday, a regenerative bluespace extract was used in an unconventional way outside of its intended use, and that was forcefully teleporting an antagonist off the shuttle, essentially denying them their greentext. Because of the instant use, there was no way for that player to counteract that extract. It was basically as overpowered as cultstuns, to put it simply - a one click instant win button, placed in the hands of a crew member.

There's also how abusable these extracts can be. They are a much more powerful healing item that could be used in the middle of combat. Having a one second requirement puts them on the level of sutures for the amount of downtime that's required to use it for healing.

Also with critique of the regen extracts, there was the complaint that they can be spammed. This is where disgust comes in.

It adds 25 disgust every time you use it. With enough time between usages, you can use another one safely. But given it's disgust, if you use too many at once, disgust can make you **vomit**.

Vomiting, as we should know from the nerf to the voice of god, _**hardstuns**_. The disgust factor is designed to punish regenerative abuse. One is perfectly fine, but using another one recently can be risky, and a third one can definitely make you have a chance to start vomiting. So if you're some bad guy that's getting chased around by sec and they're keeping you tightly choked with lethals, you better hope to have enough downtime when you manage to lose them to have that disgust lowered enough for another regenerative dose.

Why I consider this better than Hatter's proposal is that nerfing it to something that's pretty much weaker than legion cores is not only pretty much salt tier nerfing _(the commit messages you gave in your PR are especially pretty sus of your intent Hatter, just saying)_, it otherwise offers a better response to the critique it's been given while keeping it useful in many regards still. Let's try to hold back from doing kneejerk nerf PRs from now on, please.

## Changelog
:cl:
balance: Slime regenerative extracts now require five seconds of wait before they are used. They add 25 disgust when used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
