### PR TITLE
Hey raspy why can plastic golems ventcrawl even with equipment?

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -807,11 +807,11 @@
 
 /datum/species/golem/plastic/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
-	C.AddElement(/datum/element/ventcrawling, given_tier = VENTCRAWLER_ALWAYS)
+	C.AddElement(/datum/element/ventcrawling, given_tier = VENTCRAWLER_NUDE)
 
 /datum/species/golem/plastic/on_species_loss(mob/living/carbon/C)
 	. = ..()
-	C.RemoveElement(/datum/element/ventcrawling, given_tier = VENTCRAWLER_ALWAYS)
+	C.RemoveElement(/datum/element/ventcrawling, given_tier = VENTCRAWLER_NUDE)
 
 /datum/species/golem/bronze
 	name = "Bronze Golem"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It got changed in the ventcrawling refactor PR and noone apparently noticed a -ventcrawler_nude +ventcrawler_always
This fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Plastic golems are back to ventcrawler_nude instead of ventcrawler_always
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
