### PR TITLE
Massively reduced oxygen req for bonfire

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -226,7 +226,7 @@
 		var/turf/open/O = loc
 		if(O.air)
 			var/datum/gas_mixture/loc_air = O.air
-			if(loc_air.get_moles(GAS_O2) > 13)
+			if(loc_air.get_moles(GAS_O2) > 3)
 				return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bonfires required 13 moles of oxygen to light. This is... a lot, actually. Lavaland can go all the way down to 5, so sometimes ashwalkers couldn't get it. This sets it to 3 instead of 13.

## Why It's Good For The Game

13 is a huge amount anyway and this barely does anything balance-wise

## Changelog
:cl:
tweak: Bonfires need only 3 moles of oxy to light instead of 13
/:cl: