### PR TITLE
adds PANIC_BUNKER_LIVING_VPN option (READ, THIS IS NOT A VPN BAN)

### DIFF
--- a/code/controllers/configuration/entries/connections.dm
+++ b/code/controllers/configuration/entries/connections.dm
@@ -1,6 +1,12 @@
 /datum/config_entry/flag/panic_bunker	// prevents people the server hasn't seen before from connecting
 
-/datum/config_entry/number/panic_bunker_living // living time in minutes that a player needs to pass the panic bunker
+/datum/config_entry/number/panic_bunker_living // living time in minutes that a player needs to pass the panic bunker. they pass **if they are above this amount**
+	config_entry_value = 0		// default: <= 0 meaning any playtime works. -1 to disable criteria.
+	integer = TRUE
+
+/datum/config_entry/number/panic_bunker_living_vpn
+	config_entry_value = 0		// default: <= 0 meaning anytime works. -1 to disable criteria.
+	integer = TRUE
 
 /datum/config_entry/string/panic_bunker_message
 	config_entry_value = "Sorry but the server is currently not accepting connections from never before seen players."

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -578,9 +578,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	//If we aren't an admin, and the flag is set
 	if(CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey] && !(ckey in GLOB.bunker_passthrough))
 		var/living_recs = CONFIG_GET(number/panic_bunker_living)
+		var/vpn_living_recs = CONFIG_GET(number/panic_bunker_living_vpn)
 		//Relies on pref existing, but this proc is only called after that occurs, so we're fine.
 		var/minutes = get_exp_living(pure_numeric = TRUE)
-		if(minutes <= living_recs) // && !CONFIG_GET(flag/panic_bunker_interview)
+		if((minutes <= living_recs) || (IsVPN() && (minutes < vpn_living_recs)))
 			var/reject_message = "Failed Login: [key] - Account attempting to connect during panic bunker, but they do not have the required living time [minutes]/[living_recs]"
 			log_access(reject_message)
 			message_admins("<span class='adminnotice'>[reject_message]</span>")

--- a/code/modules/client/client_vpn_detect.dm
+++ b/code/modules/client/client_vpn_detect.dm
@@ -1,0 +1,3 @@
+/client/proc/IsVPN()
+	var/datum/ipintel/res = get_ip_intel(address)
+	return res.intel >= CONFIG_GET(number/ipintel_rating_bad)

--- a/config/entries/connections.txt
+++ b/config/entries/connections.txt
@@ -2,8 +2,11 @@
 ##	Requires database
 #PANIC_BUNKER
 
-## If a player connects during a bunker with less then or this amount of living time (Minutes), we deny the connection
+## If a player connects during a bunker with less then or this amount of living time (Minutes), we deny the connection. Set to -1 to disable criteria.
 #PANIC_BUNKER_LIVING 90
+
+## The above but for VPN connections. Set to -1 to disable criteria. You can set the above to disabled and set this to only enforce bunker on VPNs.
+#PANIC_BUNKER_LIVING_VPN 120
 
 ## The message the Panic Bunker gives when someone is rejected by it
 ## %minutes% is replaced with PANIC_BUNKER_LIVING on runtime, remove it if you don't want this

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1973,6 +1973,7 @@
 #include "code\modules\client\client_colour.dm"
 #include "code\modules\client\client_defines.dm"
 #include "code\modules\client\client_procs.dm"
+#include "code\modules\client\client_vpn_detect.dm"
 #include "code\modules\client\message.dm"
 #include "code\modules\client\player_details.dm"
 #include "code\modules\client\preferences.dm"


### PR DESCRIPTION
tl;dr

adds an option to only bunker-block people with vpns

**THIS IS NOT A VPN BAN**. Hell, I play on a VPN (no i'm not a ban evader haha haha.. right...)
This means that if you **don't have the required number of minutes**, you will be bounced off the bunker if you have a VPN.
This means established players or those that access request (which they'll be redirected to if they bounce off) **may always play with a VPN.**