### PR TITLE
blacklists cryogenics from anomaly spawns

### DIFF
--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -24,7 +24,8 @@
 		/area/holodeck,
 		/area/shuttle,
 		/area/maintenance,
-		/area/science/test_area)
+		/area/science/test_area,
+		/area/commons/cryopod)
 		)
 
 		//Subtypes from the above that actually should explode.


### PR DESCRIPTION
Blacklists cryo from anomaly spawns

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't know. Maybe the one area with completely unreplaceable machinery short of admin intervention that is also integral for freeing up job slots shouldn't be one of the areas that have candidacy for spawning a pyroclastic anomaly that will inevitably burn the entire room down within up to 20 seconds and burn *everything* to ash.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: cryogenics ain't a candidate for anomaly spawns anymore. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
