### PR TITLE
adds art supplies to the fun vendor

### DIFF
--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -10,7 +10,9 @@
 					/obj/item/toy/cards/deck/unum = 3,
 					/obj/item/cardpack/series_one = 10,
 					/obj/item/dyespray=3,
-					/obj/item/tcgcard_binder = 5)
+					/obj/item/tcgcard_binder = 5,
+					/obj/item/canvas = 3,
+					/obj/item/toy/crayon/spraycan = 3)
 	contraband = list(/obj/item/dice/fudge = 9)
 	premium = list(/obj/item/melee/skateboard/pro = 3,
 					/obj/item/melee/skateboard/hoverboard = 1)


### PR DESCRIPTION
## About The Pull Request

because some maps don't have the canvas/easel present and i want to do art :)

## Changelog

:cl:
add: canvas and spray can are now sold in the fun vendor
/:cl:
