### PR TITLE
Weakens chemistry's revival chems

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -63,6 +63,9 @@
 
 #define THRESHOLD_UNHUSK 50 // health threshold for synthflesh/rezadone to unhusk someone
 
+#define SYNTHTISSUE_BORROW_CAP 250	//The cap for synthtissue's borrowed health value when used on someone dead or already having borrowed health.
+#define SYNTHTISSUE_DAMAGE_FLIP_CYCLES 45	//After how many cycles the damage will be pure toxdamage as opposed to clonedamage like initially. Gradually changes during its cycles.
+
 //reagent bitflags, used for altering how they works
 #define REAGENT_DEAD_PROCESS		(1<<0)	//calls on_mob_dead() if present in a dead body
 #define REAGENT_DONOTSPLIT			(1<<1)	//Do not split the chem at all during processing

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -423,7 +423,7 @@
 	if((!req_defib && grab_ghost) || (req_defib && defib.grab_ghost))
 		H.notify_ghost_cloning("Your heart is being defibrillated!")
 		H.grab_ghost() // Shove them back in their body.
-	else if(H.can_defib())
+	else if(H.can_revive())
 		H.notify_ghost_cloning("Your heart is being defibrillated. Re-enter your corpse if you want to be revived!", source = src)
 
 	do_help(H, user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -898,16 +898,16 @@
 	update_inv_handcuffed()
 	update_hud_handcuffed()
 
-/mob/living/carbon/proc/can_defib()
+/mob/living/carbon/proc/can_revive(ignore_timelimit = FALSE, maximum_brute_dam = MAX_REVIVE_BRUTE_DAMAGE, maximum_fire_dam = MAX_REVIVE_FIRE_DAMAGE, ignore_heart = FALSE)
 	var/tlimit = DEFIB_TIME_LIMIT * 10
 	var/obj/item/organ/heart = getorgan(/obj/item/organ/heart)
 	if(suiciding || hellbound || HAS_TRAIT(src, TRAIT_HUSK) || AmBloodsucker(src))
 		return
-	if((world.time - timeofdeath) > tlimit)
+	if(!ignore_timelimit && (world.time - timeofdeath) > tlimit)
 		return
 	if((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
 		return
-	if(!heart || (heart.organ_flags & ORGAN_FAILING))
+	if(!ignore_heart && (!heart || (heart.organ_flags & ORGAN_FAILING)))
 		return
 	var/obj/item/organ/brain/BR = getorgan(/obj/item/organ/brain)
 	if(QDELETED(BR) || BR.brain_death || (BR.organ_flags & ORGAN_FAILING) || suiciding)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -905,7 +905,7 @@
 		return
 	if(!ignore_timelimit && (world.time - timeofdeath) > tlimit)
 		return
-	if((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE))
+	if((getBruteLoss() >= maximum_brute_dam) || (getFireLoss() >= maximum_fire_dam))
 		return
 	if(!ignore_heart && (!heart || (heart.organ_flags & ORGAN_FAILING)))
 		return

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -199,6 +199,7 @@
 		var/transfer_amount = T.volume * part
 		if(preserve_data)
 			trans_data = copy_data(T)
+			post_copy_data(T)
 		transferred += "[T] - [transfer_amount]"
 
 		R.add_reagent(T.type, transfer_amount * multiplier, trans_data, chem_temp, T.purity, pH, no_react = TRUE, ignore_pH = TRUE) //we only handle reaction after every reagent has been transfered.
@@ -239,7 +240,8 @@
 		var/datum/reagent/T = reagent
 		var/copy_amount = T.volume * part
 		if(preserve_data)
-			trans_data = T.data
+			trans_data = copy_data(T)
+			post_copy_data(T)
 		R.add_reagent(T.type, copy_amount * multiplier, trans_data)
 
 	src.update_total()
@@ -266,7 +268,8 @@
 		var/datum/reagent/current_reagent = CR
 		if(current_reagent.type == reagent)
 			if(preserve_data)
-				trans_data = current_reagent.data
+				trans_data = copy_data(current_reagent)
+				post_copy_data(current_reagent)
 			R.add_reagent(current_reagent.type, amount, trans_data, chem_temp, current_reagent.purity, pH, no_react = TRUE)
 			remove_reagent(current_reagent.type, amount, 1)
 			if(log && amount > 0)
@@ -1115,6 +1118,11 @@
 		trans_data["viruses"] = v.Copy()
 
 	return trans_data
+
+///
+// Should be ran after using copy_data. Calls the reagent's post_copy_data, which usually does nothing.
+/datum/reagents/proc/post_copy_data(datum/reagent/current_reagent)
+	return current_reagent.post_copy_data()
 
 /datum/reagents/proc/get_reagent(type)
 	var/list/cached_reagents = reagent_list

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -178,6 +178,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 		M.reagents.add_reagent(impure_chem, impureVol, FALSE, other_purity = 1-cached_purity)
 		log_reagent("MOB ADD: on_merge() (mixed purity): merged [volume - impureVol] of [type] and [volume] of [impure_chem]")
 
+//Ran by a reagent holder on a specific reagent after copying its data.
+/datum/reagent/proc/post_copy_data()
+	return
+
 /datum/reagent/proc/on_update(atom/A)
 	return
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1000,6 +1000,10 @@
 					var/obj/item/organ/heart/H = C.getorganslot(ORGAN_SLOT_HEART)
 					if(H && H.organ_flags & ORGAN_FAILING)
 						H.applyOrganDamage(-15)
+					for(var/obj/item/organ/O as anything in C.internal_organs)
+						if(O.organ_flags & ORGAN_FAILING)
+							O.applyOrganDamage(-5)
+
 				M.adjustOxyLoss(-20, 0)
 				M.adjustToxLoss(-20, 0)
 				M.updatehealth()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -997,9 +997,9 @@
 					var/mob/living/carbon/C = M
 					if(!(C.dna && C.dna.species && (NOBLOOD in C.dna.species.species_traits)))
 						C.blood_volume = max(C.blood_volume, BLOOD_VOLUME_BAD*C.blood_ratio) //so you don't instantly re-die from a lack of blood. You'll still need help if you had none though.
-						var/obj/item/organ/heart/H = C.getorganslot(ORGAN_SLOT_HEART)
-						if(H && H.organ_flags & ORGAN_FAILING)
-							H.applyOrganDamage(-15)
+					var/obj/item/organ/heart/H = C.getorganslot(ORGAN_SLOT_HEART)
+					if(H && H.organ_flags & ORGAN_FAILING)
+						H.applyOrganDamage(-15)
 				M.adjustOxyLoss(-20, 0)
 				M.adjustToxLoss(-20, 0)
 				M.updatehealth()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -491,7 +491,7 @@
 		return
 
 	var/fp_verb = mode == HYPO_SPRAY ? "spray" : "inject"
-	var/method = mode == HYPO_SPRAY ? TOUCH : INJECT
+	var/method = mode == HYPO_SPRAY ? PATCH : INJECT	//Medsprays use patch when spraying, feels like an inconsistancy here.
 
 	if(L != user)
 		L.visible_message("<span class='danger'>[user] is trying to [fp_verb] [L] with [src]!</span>", \

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -234,7 +234,7 @@
 	var/mob/living/carbon/C = host_mob
 	if(C.get_ghost())
 		return FALSE
-	return C.can_defib()
+	return C.can_revive()
 
 /datum/nanite_program/defib/proc/zap()
 	var/mob/living/carbon/C = host_mob

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -98,8 +98,8 @@
 	description = "Synthetic tissue used for grafting onto damaged organs during surgery, or for treating limb damage. Has a very tight growth window between 305-320, any higher and the temperature will cause the cells to die. Additionally, growth time is considerably long, so chemists are encouraged to leave beakers with said reaction ongoing, while they tend to their other duties."
 	pH = 7.6
 	metabolization_rate = 0.05 //Give them time to graft
-	data = list("grown_volume" = 0, "injected_vol" = 0)
-	var/borrowed_health
+	data = list("grown_volume" = 0, "injected_vol" = 0, "borrowed_health" = 0)
+	var/borrowed_health = 0
 	color = "#FFDADA"
 	value = REAGENT_VALUE_COMMON
 
@@ -107,31 +107,44 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		var/healing_factor = (((data["grown_volume"] / 100) + 1)*reac_volume)
-		if(method in list(PATCH, TOUCH))
-			if (M.stat == DEAD)
-				M.visible_message("The synthetic tissue rapidly grafts into [M]'s wounds, attemping to repair the damage as quickly as possible.")
+		if(method == PATCH)	//Needs to actually be applied via patch / hypo / medspray and not just beakersplashed.
+			if (C.stat == DEAD)
+				C.visible_message("The synthetic tissue rapidly grafts into [M]'s wounds, attemping to repair the damage as quickly as possible.")
 				borrowed_health += healing_factor
-				M.adjustBruteLoss(-healing_factor*2)
-				M.adjustFireLoss(-healing_factor*2)
-				M.adjustToxLoss(-healing_factor)
-				M.adjustCloneLoss(-healing_factor)
-				M.updatehealth()
+				C.adjustBruteLoss(-healing_factor*2)
+				C.adjustFireLoss(-healing_factor*2)
+				C.adjustToxLoss(-healing_factor)
+				C.adjustCloneLoss(-healing_factor)
+				C.updatehealth()
 				if(data["grown_volume"] > 135 && ((C.health + C.oxyloss)>=80))
-					if(M.revive())
-						M.emote("gasp")
+					var/tplus = world.time - M.timeofdeath
+					if(C.can_revive(ignore_timelimit = TRUE, maximum_brute_dam = MAX_REVIVE_BRUTE_DAMAGE / 2, maximum_fire_dam = MAX_REVIVE_FIRE_DAMAGE / 2, ignore_heart = TRUE) && C.revive())
+						C.emote("gasp")
 						borrowed_health *= 2
 						if(borrowed_health < 100)
 							borrowed_health = 100
-						log_combat(M, M, "revived", src)
+						log_combat(C, C, "revived", src)
+						var/list/policies = CONFIG_GET(keyed_list/policy)
+						var/policy = policies[POLICYCONFIG_ON_DEFIB_LATE]	//Always causes memory loss due to the nature of synthtissue
+						if(policy)
+							to_chat(C, policy)
+						C.log_message("revived using synthtissue, [tplus] deciseconds from time of death, considered late revival due to usage of synthtissue.", LOG_GAME)
 			else
 				M.adjustBruteLoss(-healing_factor)
 				M.adjustFireLoss(-healing_factor)
-				to_chat(M, "<span class='danger'>You feel your flesh merge with the synthetic tissue! It stings like hell!</span>")
+				var/datum/reagent/synthtissue/active_tissue = M.reagents.has_reagent(/datum/reagent/synthtissue)
+				var/imperfect = FALSE 	//Merging with synthtissue that has borrowed health
+				if(active_tissue && active_tissue.borrowed_health)
+					borrowed_health += healing_factor
+					imperfect = TRUE
+				to_chat(M, "<span class='danger'>You feel your flesh [imperfect ? "partially and painfully" : ""] merge with the synthetic tissue! It stings like hell[imperfect ? " and is making you feel terribly sick." : ""]!</span>")
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
+			data["borrowed_health"] += borrowed_health //Preserve health offset
+			borrowed_health = 0	//We are applying this to someone else, so this info will be transferred via data.
 		if(method==INJECT)
 			data["injected_vol"] = reac_volume
 			var/obj/item/organ/heart/H = C.getorganslot(ORGAN_SLOT_HEART)
-			if(data["grown_volume"] > 50 && H.organ_flags & ORGAN_FAILING)
+			if(H && data["grown_volume"] > 50 && H.organ_flags & ORGAN_FAILING)
 				H.applyOrganDamage(-20)
 	..()
 
@@ -145,7 +158,7 @@
 					C.reagents.remove_reagent(type, 15)
 					to_chat(C, "<span class='notice'>You feel something reform inside of you!</span>")
 
-	data["injected_vol"] -= metabolization_rate
+	data["injected_vol"] = max(0, data["injected_vol"] - metabolization_rate * C.metabolism_efficiency)	//No negatives.
 	if(borrowed_health)
 		C.adjustToxLoss(1)
 		C.adjustCloneLoss(1)
@@ -155,6 +168,7 @@
 /datum/reagent/synthtissue/on_merge(passed_data)
 	if(!passed_data)
 		return ..()
+	borrowed_health += passed_data["borrowed_health"]
 	if(passed_data["grown_volume"] > data["grown_volume"])
 		data["grown_volume"] = passed_data["grown_volume"]
 	if(iscarbon(holder.my_atom))
@@ -166,10 +180,15 @@
 /datum/reagent/synthtissue/on_new(passed_data)
 	if(!passed_data)
 		return ..()
+	borrowed_health += passed_data["borrowed_health"]
 	if(passed_data["grown_volume"] > data["grown_volume"])
 		data["grown_volume"] = passed_data["grown_volume"]
 	update_name()
 	..()
+
+/datum/reagent/synthtissue/post_copy_data()
+	data["borrowed_health"] = 0	//We passed this along to something that needed it, set it back to 0 so we don't do it twice.
+	return ..()
 
 /datum/reagent/synthtissue/proc/update_name() //They are but babes on creation and have to grow unto godhood
 	switch(data["grown_volume"])

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -138,7 +138,7 @@
 				if(active_tissue && active_tissue.borrowed_health)
 					borrowed_health += healing_factor
 					imperfect = TRUE
-				to_chat(M, "<span class='danger'>You feel your flesh [imperfect ? "partially and painfully" : ""] merge with the synthetic tissue! It stings like hell[imperfect ? " and is making you feel terribly sick." : ""]!</span>")
+				to_chat(M, "<span class='danger'>You feel your flesh [imperfect ? "partially and painfully" : ""] merge with the synthetic tissue! It stings like hell[imperfect ? " and is making you feel terribly sick" : ""]!</span>")
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
 			data["borrowed_health"] += borrowed_health //Preserve health offset
 			borrowed_health = 0	//We are applying this to someone else, so this info will be transferred via data.

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -176,7 +176,7 @@
 /datum/reagent/synthtissue/on_merge(passed_data)
 	if(!passed_data)
 		return ..()
-	borrowed_health += passed_data["borrowed_health"]
+	borrowed_health += max(0, passed_data["borrowed_health"])
 	if(passed_data["grown_volume"] > data["grown_volume"])
 		data["grown_volume"] = passed_data["grown_volume"]
 	if(iscarbon(holder.my_atom))

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -119,6 +119,7 @@
 				if(data["grown_volume"] > 135 && ((C.health + C.oxyloss)>=80))
 					var/tplus = world.time - M.timeofdeath
 					if(C.can_revive(ignore_timelimit = TRUE, maximum_brute_dam = MAX_REVIVE_BRUTE_DAMAGE / 2, maximum_fire_dam = MAX_REVIVE_FIRE_DAMAGE / 2, ignore_heart = TRUE) && C.revive())
+						C.grab_ghost()
 						C.emote("gasp")
 						borrowed_health *= 2
 						if(borrowed_health < 100)

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -167,9 +167,10 @@
 
 	data["injected_vol"] = max(0, data["injected_vol"] - metabolization_rate * C.metabolism_efficiency)	//No negatives.
 	if(borrowed_health)
-		C.adjustToxLoss(1, forced = TRUE, toxins_type = TOX_OMNI)
-		C.adjustCloneLoss(1)
-		borrowed_health = max(borrowed_health - 2, 0)
+		var/payback = 2 * C.metabolism_efficiency	//How much borrowed health we are paying back. Half as clonedam, half as true omni toxdam
+		C.adjustToxLoss(payback / 2, forced = TRUE, toxins_type = TOX_OMNI)
+		C.adjustCloneLoss(payback / 2)
+		borrowed_health = max(borrowed_health - payback, 0)
 	..()
 
 /datum/reagent/synthtissue/on_merge(passed_data)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
By all that is holy testmerge this first so I don't have to notice I used a < instead of a > somewhere after it's merged or something like that (well actually mostly to see about the balancing and possible oversights)

Currently, medical has three main ways to revive people.
First of which is, clone someone, accept the memory loss and time need of that, then fix them up when it finishes.
Second, fix someone up via surgery and simillar, replace or repair their damaged organs, then defib them and fix their other conditions (with the last sometimes done before defibbing), then worry about the speed of this all due to the five minute memory disorder time mark.

Or, thirdly, use strange reagent or synthtissue, which sidestep all of that and instantly revive an individual with their memory usually intact (strange reagent five minutes as usual), synthtissue *always* apparently)
This third way is very easy to achieve, requiring some very minor preperation (acquiring holy water for strange reagent, setting up a tissue culture or multiple and then just letting it sit for synthtissue) with very little drawback, making them the perfect tools in every single situation if available.
This PR attempts to keep the both of them usable, whilst limiting their superiority over all other methods.

Lets talk about strange reagent first.
This one, previously, required you to be at less than 100 damage brute / burn, in which case it healed all your organs, restored all your blood, healed some oxy and toxdamage and revived you.
Now instead, it heals your blood levels enough to not immediately die and repairs your heart a bit if it's failing,but leaves your other organs alone meaning they'll still require treatment, though the slight tox and oxyloss healing is unaffected. It will also always cause memory loss simillar to reviving somebody too late. Revival of non-carbons (aka, simplemobs) is unaffected.
**Further Updates:**
Strange reagent heals more organs, all failing organs get healed 5 points (which, while leaving them messed up, stops them from being fully failed). The heart is still healed 15 points.

Synthtissue, this one's.. special. See, when healing (and subsequently reviving) somebody dead via synthtissue, it's supposed to slowly cause damage influenced by how much it healed, aka, "borrow" the health temporarily. This unfortunately has been broken ever since synthtissue was initially added due to this borrowed health never being preserved from the reagent applier to the actual person, so it never actually took that into account. This fixes that and therefore for the first time causes it to have actual drawbacks to this method. Additionally, using synthtissue on somebody while they are still recovering from this will drastically worsen this condition. This component of synthtissue also now is locked to being applied via PATCH method (aka, hyposprays, patches, medsprayers, that kinda stuff), instead of being usable via beakersplashing. Like strange reagent, it will cause memory loss when being revived by it, regardless of time passed since death. All other parts of synthtissue (organ healing / replacement, growth speed, healing normally while alive, etc.) are untouched.
**Further Updates:**
Borrowed health gets capped at 250 max and also gradually flips its damage from initially pure clonedamage over to toxdamage, which is far easier to treat (fully flips after 45 cycles total)

Edit: Additionally modifies Hyposprays to use "PATCH" when on sprays mode as normal medsprays already do that. Feels like an inconsistancy between the two (and I expected hypos to already do that)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These two chems currently are the nonplusultra of reviving people, whilst being available from shift start (or close to it, for synthtissue), bypassing a major part of consideration when reviving people due to their sheer superiority in pretty much every aspect when compared to other methods provided they are available.
This weakens them (or, for synthtissue, mostly fixes something that has been broken since forever, so I'll just call it balance change anyways), but should still keep them useful, with their own drawbacks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced synthtissue's and strange reagent's revival.
tweak: Hyposprays on spray mode now use "patch" as opposed to "touch" to mirror normal medsprays.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
