### PR TITLE
Ups minimum lavaland temperature

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -20,7 +20,7 @@
 	minimum_pressure = HAZARD_LOW_PRESSURE + 10
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 
-	minimum_temp = BODYTEMP_COLD_DAMAGE_LIMIT + 1
+	minimum_temp = 270
 	maximum_temp = 320
 
 /datum/atmosphere/icemoon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

lavaland temperature is set to `BODYTEMP_COLD_DAMAGE_LIMIT + 1`... which is then rounded down to dangerous levels anyway. Yeah, no, we're making it way higher.

## Why It's Good For The Game

ashwalkers shouldn't die on lavaland from environmental issues

## Changelog
:cl:
fix: Lavaland can no longer be too cold for its natives to surivive
/:cl: