### PR TITLE
removes motivation player lock; halves the motivation's price; allows motivation to discount.

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -292,7 +292,5 @@
 	desc = "An ancient blade said to have ties with Lavaland's most inner demons. \
 			Allows you to cut from a far distance!"
 	item = /obj/item/gun/magic/staff/motivation
-	cost = 20
-	player_minimum = 20
+	cost = 10
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/traitor/internal_affairs)
-	cant_discount = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

read the next paragraph

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

okay so let's go over what you can buy INSTEAD of the motivation to explain why this is a godawful statement of its balance and a noob trap of a weapon; "oh this sword is really god damn expensive it must be good so i'll buy it"
here's the current and (postbuff from other pr https://github.com/Citadel-Station-13/Citadel-Station-13/pull/15198) versus the other most prominent melee weapons from fucking the syndicate uplink to see the trainwreck.

**DAMAGE**
1: Desword: 34
2: Esword: 30
5: (Motivation): 25
4: Motivation: 20
5: Rapier: 15 (stamina damage not included)
**AP**
1: Rapier: 200 (absolute; pierces rng block)
2: (Motivation): 100
3: Motivation: 50
4: Desword/Esword: 35
**BLOCK**
1: Desword: 60 innate block. Can parry; can't riposte. Can block.
2: Esword: 0 innate block. Can parry; can riposte. Can't block.
3: Rapier: 0 innate block. Can parry; can riposte. Can't block.
4: Motivation: 0 innate block. Can parry; can't riposte. Can't block.
**UTILITY**
1: Desword: Reflects all energy projectiles.
2: Rapier: Instantly wins fights in a couple of hits due to stamina, dizziness, and then sleep.
3: Esword: Incredible parry, and a very cheap cost for its relative force and size compared to others.
4: Motivation: Dogshit damage ranged attack, getting only a couple of charges before a comically long attack cooldown.
**CONCEALMENT**
1: Desword/Esword: Fits in pockets plus.
2: Motivation: Fits in backpacks and your belt.
3: Rapier: Fits in its sheath which subsequently fits on your belt.
**COST**
1: Esword/Rapier: 8 TC
2: Desword: 16 TC
3: Motivation: 20 TC

see what I'm saying.
dwell on it thanks.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: fucks the motivation's cost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
