### PR TITLE
shotgun shell clips now have melee click delay (0.8s) with this one weird trick

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -24,6 +24,7 @@
 		playsound(user, 'sound/weapons/shotguninsert.ogg', 60, 1)
 		A.update_icon()
 		update_icon()
+		user.SetNextAction(CLICK_CD_MELEE)
 
 /obj/item/gun/ballistic/shotgun/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..() //changed argument value


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
reloading 4 shells in a second is kinda weirdchamp
## Changelog
:cl:
balance: Reloading a shotgun with a shell clip now inflicts melee click delay.
/:cl:
