### PR TITLE
fixes afk detection

### DIFF
--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -187,3 +187,6 @@
 	var/list/block_parry_hinted = list()
 	/// moused over objects, currently capped at 7. this is awful, and should be replaced with a component to track it using signals for parrying at some point.
 	var/list/moused_over_objects = list()
+
+	/// AFK tracking
+	var/last_activity = 0

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -83,6 +83,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			log_href("[src] (usr:[usr]\[[COORD(usr)]\]) : [hsrc ? "[hsrc] " : ""][href]")
 		return
 
+	last_activity = world.time
+
 	//Logs all hrefs
 	log_href("[src] (usr:[usr]\[[COORD(usr)]\]) : [hsrc ? "[hsrc] " : ""][href]")
 
@@ -850,6 +852,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 /client/Click(atom/object, atom/location, control, params, ignore_spam = FALSE, extra_info)
 	if(last_click > world.time - world.tick_lag)
 		return
+	last_activity = world.time
 	last_click = world.time
 	var/ab = FALSE
 	var/list/L = params2list(params)
@@ -922,6 +925,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 //checks if a client is afk
 //3000 frames = 5 minutes
 /client/proc/is_afk(duration = CONFIG_GET(number/inactivity_period))
+	var/inactivity = world.time - last_activity
 	if(inactivity > duration)
 		return inactivity
 	return FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -224,6 +224,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	///////////
 
 /client/New(TopicData)
+	last_activity = world.time
 	world.SetConfig("APP/admin", ckey, "role=admin")
 	var/tdata = TopicData //save this for later use
 	TopicData = null							//Prevent calls to client.Topic from connect

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -6,6 +6,7 @@
 	set hidden = TRUE
 
 	client_keysend_amount += 1
+	last_activity = world.time
 
 	var/cache = client_keysend_amount
 
@@ -89,6 +90,7 @@
 	set hidden = TRUE
 
 	keys_held -= _key
+	last_activity = world.time
 	var/movement = movement_keys[_key]
 	if(!(next_move_dir_add & movement))
 		next_move_dir_sub |= movement

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -4,6 +4,7 @@
 	set name = "say_indicator"
 	set hidden = TRUE
 	set category = "IC"
+	client?.last_activity = world.time
 	display_typing_indicator()
 	var/message = input(usr, "", "say") as text|null
 	// If they don't type anything just drop the message.
@@ -21,12 +22,16 @@
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	clear_typing_indicator()		// clear it immediately!
+
+	client?.last_activity = world.time
+
 	say(message)
 
 /mob/verb/me_typing_indicator()
 	set name = "me_indicator"
 	set hidden = TRUE
 	set category = "IC"
+	client?.last_activity = world.time
 	display_typing_indicator()
 	var/message = input(usr, "", "me") as message|null
 	// If they don't type anything just drop the message.
@@ -52,6 +57,8 @@
 	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	clear_typing_indicator()		// clear it immediately!
 
+	client?.last_activity = world.time
+
 	usr.emote("me",1,message,TRUE)
 
 /mob/say_mod(input, message_mode)
@@ -73,6 +80,7 @@
 		return lowertext(copytext_char(input, 1, customsayverb))
 
 /mob/proc/whisper_keybind()
+	client?.last_activity = world.time
 	var/message = input(src, "", "whisper") as text|null
 	if(!length(message))
 		return
@@ -89,6 +97,7 @@
 	whisper(message)
 
 /mob/proc/whisper(message, datum/language/language=null)
+	client?.last_activity = world.time
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
 /mob/proc/say_dead(var/message)
@@ -132,6 +141,7 @@
 	message = emoji_parse(message)
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[emoji_parse(spanned)]</span></span>"
 	log_talk(message, LOG_SAY, tag="DEAD")
+	client?.last_activity = world.time
 	deadchat_broadcast(rendered, follow_target = src, speaker_key = key)
 
 /mob/proc/check_emote(message)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -295,6 +295,7 @@
 		process_status()
 		if(src_object.ui_act(act_type, payload, src, state))
 			SStgui.update_uis(src_object)
+		usr?.client?.last_activity = world.time
 		return FALSE
 	switch(type)
 		if("ready")


### PR DESCRIPTION
tl;dr we manually track this since byond doesn't work with the chat pings.

the following counts as activity:

- ui actions that aren't chat
- clicking
- keypresses
- say and emote