### PR TITLE
da moon outpost nest nerf

### DIFF
--- a/_maps/RandomZLevels/away_mission/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/away_mission/moonoutpost19.dmm
@@ -3664,7 +3664,8 @@
 /area/awaymission/moonoutpost19/research)
 "hk" = (
 /obj/structure/alien/weeds,
-/obj/structure/alien/egg,
+/obj/structure/bed/nest,
+/obj/item/clothing/mask/facehugger/impregnated,
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251"
@@ -26666,7 +26667,7 @@ ac
 ad
 ad
 ad
-hk
+ag
 ag
 ad
 ad
@@ -26925,7 +26926,7 @@ ai
 ag
 ag
 ai
-hk
+ag
 ai
 ad
 ad
@@ -27178,10 +27179,10 @@ ac
 ac
 ad
 ad
-hk
+ag
 ai
 ai
-hk
+ag
 aM
 ai
 ag
@@ -27437,7 +27438,7 @@ ad
 ai
 ai
 aD
-aj
+hk
 ai
 ai
 aD
@@ -27693,7 +27694,7 @@ ac
 ad
 ai
 ai
-aj
+hk
 ai
 aT
 av


### PR DESCRIPTION
## About The Pull Request
kills off the live eggs in the moon outpost gateway
## Why It's Good For The Game
a gateway with the potential impact of "lol xeno outbreak with no tells" seems like a shit concept, and yet here it is
xeno in da vents event: has a centcomm announcement
some goblin getting an egg sac: needs someone else to jam it into their organs
the live eggs in the gateway: apply monkey, ruin round

moon outpost is a boring gateway anyway since the only notable pieces of gear i can remember off the top of my head are, like - a stechkin, a 4+1 shotgun, and then whatever clothes/armor is scattered around in the nest. and you can rush that shotgun
## Changelog
:cl:
del: The xenomorph infestation on Moon Outpost 19 is significantly less prone to outbreaks, theoretically.
/:cl: