### PR TITLE
save hours of pain for new engineers with this one simple trick!! click here to find out

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -95,7 +95,7 @@
 /obj/item/wallframe/apc/try_build(turf/on_wall, user)
 	if(!..())
 		return
-	var/turf/T = get_turf(on_wall) //the user is not where it needs to be.
+	var/turf/T = get_turf(user)
 	var/area/A = get_area(T)
 	if(A.get_apc())
 		to_chat(user, "<span class='warning'>This area already has an APC!</span>")


### PR DESCRIPTION
## About The Pull Request

APCs now attempt to encapsulate the area for the turf that the player is on rather than the area that the wall's turf is in.

## Why It's Good For The Game

please stop making me build a wall in the middle of the room to place my apc

Summary of additional testing:
- Two APCs can go on the same wall and represent different areas fine.
- No, APCs cannot be placed in space.
- Placing an APC from where a wall used to be will prioritize the APC area to be the area that the wall was in. e.g.: https://cdn.discordapp.com/attachments/488850419301220352/892845810604187678/unknown.png
- This is a thing: https://cdn.discordapp.com/attachments/488850419301220352/892846805237243984/unknown.png
- APCs still abide by normal APC placement rules (valid area, needs an APC)
- This means it's now impossible to place two APCs such that two terminals will be on the same tile.
- Mentioned by someone, no, you can't place APCs using TK this way since it checks first to make sure you're 1 cardinal tile away (see /obj/item/wallframe/proc/try_build)
- No, wizard fireballs don't collide with APCs placed this way...
- **A result of this is that APCs are _technically_ placed on the floor instead, similar to Box's Central Hall APC**, and you can interact with them from a tile further but literally who cares (https://cdn.discordapp.com/attachments/658596233576841217/892849833524727828/unknown.png uhh)

## Changelog
:cl:
tweak: apc frame placement turf priority
/:cl: