### PR TITLE
Xenohybrids like gross food and are above junkfood

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/xeno.dm
+++ b/code/modules/mob/living/carbon/human/species_types/xeno.dm
@@ -14,5 +14,6 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/xeno
 	exotic_bloodtype = "X*"
 	damage_overlay_type = "xeno"
-	liked_food = MEAT
+	disliked_food = JUNKFOOD
+	liked_food = GROSS | MEAT
 	species_category = SPECIES_CATEGORY_ALIEN


### PR DESCRIPTION
## About The Pull Request

Lets xenos enjoy gross food, and dislike junkfood.

## Why It's Good For The Game

The fact xenos couldn't eat rats and such made no sense, so this fixes that. I don't know where every food fits in so if I missed something let me know. The junk food is mostly balancing that I think fits the species.

## Changelog
:cl: Tupinambis
balance: Xenohybrids now like gross food, dislike junk food.
/:cl:
