### PR TITLE
vareditable clip reloading delay for shotguns

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -25,7 +25,8 @@
 		playsound(user, 'sound/weapons/shotguninsert.ogg', 60, 1)
 		A.update_icon()
 		update_icon()
-		user.SetNextAction(clip_delay)
+		if(istype(A, /obj/item/ammo_box))
+			user.SetNextAction(clip_delay)
 
 /obj/item/gun/ballistic/shotgun/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..() //changed argument value

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -11,6 +11,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
 	casing_ejector = FALSE
 	var/recentpump = 0 // to prevent spammage
+	var/clip_delay = CLICK_CD_MELEE
 	weapon_weight = WEAPON_HEAVY
 	sawn_item_state = "sawnshotgun"
 
@@ -24,7 +25,7 @@
 		playsound(user, 'sound/weapons/shotguninsert.ogg', 60, 1)
 		A.update_icon()
 		update_icon()
-		user.SetNextAction(CLICK_CD_MELEE)
+		user.SetNextAction(clip_delay)
 
 /obj/item/gun/ballistic/shotgun/process_chamber(mob/living/user, empty_chamber = 0)
 	return ..() //changed argument value


### PR DESCRIPTION
## About The Pull Request
- theoretically only makes the additional click delay for reloading shotgun-types apply when using an ammo box and not a casing
- adds a variable to determine the clickdelay incurred when reloading via clip, which i'd really only use for the lever-actions and that's about it
## Why It's Good For The Game
clickdelay for clips only: if you're gonna wear a bandolier or something then i don't think you need to get kicked in the knee for reloading shells individually
variable clickdelay for clips: see lever-actions (soon (tm))
## Changelog
:cl:
tweak: Shotguns only incur additional clickdelay penalties on reloading when using a shell clip.
/:cl:
