### PR TITLE
Antag roles will now respect your backup role preferences if none of the enabled roles are available

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -365,9 +365,14 @@ SUBSYSTEM_DEF(job)
 	JobDebug("DO, Handling unrejectable unassigned")
 	//Mop up people who can't leave.
 	for(var/mob/dead/new_player/player in unassigned) //Players that wanted to back out but couldn't because they're antags (can you feel the edge case?)
-		if(!GiveRandomJob(player))
-			if(!AssignRole(player, SSjob.overflow_role)) //If everything is already filled, make them an assistant
-				return FALSE //Living on the edge, the forced antagonist couldn't be assigned to overflow role (bans, client age) - just reroll
+		if(player.client.prefs.joblessrole == BERANDOMJOB) //Gives the player a random role if their preferences are set to it
+			if(!GiveRandomJob(player))
+				if(!AssignRole(player, SSjob.overflow_role)) //If everything is already filled, make them the overflow role
+					return FALSE //Living on the edge, the forced antagonist couldn't be assigned to overflow role (bans, client age) - just reroll
+		else //If the player prefers to return to lobby or be an assistant, give them assistant
+			if(!AssignRole(player, SSjob.overflow_role))
+				if(!GiveRandomJob(player)) //The forced antagonist couldn't be assigned to overflow role (bans, client age) - give a random role
+					return FALSE //Somehow the forced antagonist couldn't be assigned to the overflow role or the a random role - reroll
 
 	return validate_required_jobs(required_jobs)
 


### PR DESCRIPTION

## About The Pull Request

If you roll a station antagonist and only have sec/command/sillycon roles enabled, you will no longer be forced into a random role, as which role is assigned respects your preferences. (If you have get random job set, you get a random job, otherwise you just get assistant or the overflow role.)

## Why It's Good For The Game

Some players may only wish to play a small subset of specific roles. If you only have security, command, or silicon roles enabled you will be forced into a random job you may have no interest in playing or have any idea how to play when you role antag. This is annoying. Assistant is the ol' reliable in terms of roles, especially if you're antag, so giving people the option to only ever be forced into assistant is probably nice.

## Changelog
:cl: Tupinambis
tweak: Antag roles will now respect your backup role preferences if none of the enabled roles are available.
/:cl:
