### PR TITLE
redoes how pai emp silencing works

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -269,6 +269,10 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 
+/obj/item/radio/headset/silicon/pai/emp_act(severity)
+	. = ..()
+	return EMP_PROTECT_SELF
+
 /obj/item/radio/headset/silicon/ai
 	name = "\proper Integrated Subspace Transceiver "
 	keyslot2 = new /obj/item/encryptionkey/ai

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -1,5 +1,3 @@
-#define PAI_EMP_SILENCE_DURATION 3 MINUTES
-
 /mob/living/silicon/pai/blob_act(obj/structure/blob/B)
 	return FALSE
 
@@ -9,7 +7,7 @@
 		return
 	take_holo_damage(severity/2)
 	DefaultCombatKnockdown(severity*4)
-	silent = max(silent, (PAI_EMP_SILENCE_DURATION) / SSmobs.wait / severity)
+	short_radio()
 	if(holoform)
 		fold_in(force = TRUE)
 	emitter_next_use = world.time + emitter_emp_cd


### PR DESCRIPTION
It just shorts radio
Why?
Tracking 3 kinds of silencing is getting annoying and given our EMP code is literally blackjack and hookers right now I'd rather not play this game.

This should fix any remaining bugs regarding pAI emps.