### PR TITLE
Another lavaland breathing fix

### DIFF
--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -16,6 +16,9 @@
 /datum/atmosphere/New()
 	generate_gas_string()
 
+/datum/atmosphere/proc/check_for_sanity(datum/gas_mixture/mix)
+	return
+
 /datum/atmosphere/proc/generate_gas_string()
 	var/list/spicy_gas = restricted_gases.Copy()
 	var/target_pressure = rand(minimum_pressure, maximum_pressure)
@@ -51,6 +54,8 @@
 		var/moles_to_remove = (1 - target_pressure / gasmix.return_pressure()) * gasmix.total_moles()
 		gasmix.adjust_moles(gastype, -moles_to_remove)
 	gasmix.set_moles(gastype, FLOOR(gasmix.get_moles(gastype), 0.1))
+
+	check_for_sanity(gasmix)
 
 	// Now finally lets make that string
 	var/list/gas_string_builder = list()

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -23,6 +23,13 @@
 	minimum_temp = 270
 	maximum_temp = 320
 
+/datum/atmosphere/lavaland/check_for_sanity(datum/gas_mixture/mix)
+	var/datum/breathing_class/o2_class = GLOB.gas_data.breathing_classes[BREATH_OXY]
+	var/initial_co2_quantity = mix.get_moles(GAS_CO2)
+	while(o2_class.get_effective_pp(mix) < 10)
+		mix.adjust_moles(GAS_CO2, -0.5)
+		mix.adjust_moles(GAS_O2, 0.5)
+
 /datum/atmosphere/icemoon
 	id = ICEMOON_DEFAULT_ATMOS
 

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -25,7 +25,6 @@
 
 /datum/atmosphere/lavaland/check_for_sanity(datum/gas_mixture/mix)
 	var/datum/breathing_class/o2_class = GLOB.gas_data.breathing_classes[BREATH_OXY]
-	var/initial_co2_quantity = mix.get_moles(GAS_CO2)
 	while(o2_class.get_effective_pp(mix) < 10)
 		mix.adjust_moles(GAS_CO2, -0.5)
 		mix.adjust_moles(GAS_O2, 0.5)

--- a/code/modules/atmospherics/auxgm/breathing_classes.dm
+++ b/code/modules/atmospherics/auxgm/breathing_classes.dm
@@ -14,6 +14,12 @@
 	var/high_alert_category = "too_much_oxy"
 	var/high_alert_datum =  /atom/movable/screen/alert/too_much_oxy
 
+/datum/breathing_class/proc/get_effective_pp(datum/gas_mixture/breath)
+	var/mol = 0
+	for(var/gas in gases)
+		mol += breath.get_moles(gas) * gases[gas]
+	return (mol/breath.total_moles()) * breath.return_pressure()
+
 /datum/breathing_class/oxygen
 	gases = list(
 		GAS_O2 = 1,

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -528,7 +528,8 @@
 		BZ_brain_damage_min += bz
 
 	gas_max[GAS_N2] = PP(breath, GAS_N2) + 5
-	var/o2_pp = PP(breath, GAS_O2)
+	var/datum/breathing_class/class = GLOB.gas_data.breathing_classes[breathing_class]
+	var/o2_pp = class.get_effective_pp(breath)
 	safe_breath_min = 0.3 * o2_pp
 	safe_breath_max = 1.3 * o2_pp
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot that if `CO2 * 0.7 > O2` then the air will never be breathable by ashwalkers (or any oxygen-breathing species) under any circumstances, since I made CO2 a proper asphyxiant. This makes lavaland's air never asphyxiating via a sanity check.

## Why It's Good For The Game

Again, lavaland should never be unbreathable to ashwalkers.

## Changelog
:cl:
fix: Ashwalkers can always breathe on lavaland
/:cl: