### PR TITLE
Makes oxygen, plasma more dangerous as setup gases; nerfs spacing supermatter

### DIFF
--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -4,8 +4,7 @@
 	name = "Oxygen"
 	oxidation_temperature = T0C - 100 // it checks max of this and fire temperature, so rarely will things spontaneously combust
 	powermix = 1
-	heat_penalty = 1
-	transmit_modifier = 1.5
+	transmit_modifier = 3
 
 /datum/gas/nitrogen
 	id = GAS_N2
@@ -51,8 +50,8 @@
 	gas_overlay = "plasma"
 	moles_visible = MOLES_GAS_VISIBLE
 	flags = GAS_FLAG_DANGEROUS
-	heat_penalty = 15
-	transmit_modifier = 4
+	heat_penalty = 30
+	transmit_modifier = 3
 	powermix = 1
 	// no fire info cause it has its own bespoke reaction for trit generation reasons
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -405,7 +405,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	if(!removed || !removed.total_moles() || isspaceturf(T)) //we're in space or there is no gas to process
 		if(takes_damage)
-			damage += max((power / 1000) * DAMAGE_INCREASE_MULTIPLIER, 0.1) // always does at least some damage
+			damage += max((power / 400) * DAMAGE_INCREASE_MULTIPLIER, 0.1) // always does at least some damage
 		combined_gas = max(0, combined_gas - 0.5)		// Slowly wear off.
 		for(var/gasID in gas_comp)
 			gas_comp[gasID] = max(0, gas_comp[gasID] - 0.05)		//slowly ramp down


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Plasma now causes twice as much heat output as it used to, and has slightly less power increase; oxygen no longer increases heat output, but makes a lot more power.

Also multiplied the damage caused by spacing the supermatter by 2.5.

## Why It's Good For The Game

Supermatter's in a dumb place right now. This should make plasma/oxy setups less good, make them cascade into death less often, and make spacing the supermatter not quite so effective.

## Changelog
:cl:
balance: Plasma/oxy now worse as supermatter setup gases
balance: Supermatter now takes 2.5x as much damage when the turf it's on is spaced
/:cl: