### PR TITLE
Fixes Table Air Alarm on Pubby and Redundant Fire Lock on Box

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5625,7 +5625,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -61634,7 +61633,6 @@
 /area/security/prison/upper)
 "qtw" = (
 /obj/machinery/door/airlock/external{
-	dir = 2;
 	name = "Port Docking Bay 4"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9274,11 +9274,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axI" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -85595,7 +85599,7 @@ avv
 xgz
 gZF
 ayL
-pFy
+axI
 aBd
 aCi
 aDo
@@ -86364,7 +86368,7 @@ ajM
 quY
 uFZ
 nDM
-axI
+axL
 axG
 aAh
 aBf


### PR DESCRIPTION
## About The Pull Request

Tin

## Why It's Good For The Game

it's nice to be able to interact with the air alarm freely, and two firelocks on the same tile is awful

## Changelog
:cl:
tweak: removed the extra firelock on box's courtroom sec side, moves the air alarm to be usable
/:cl: