### PR TITLE
Stimpack transfer buff

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -168,7 +168,8 @@
 	icon_state = "syndipen"
 	item_state = "syndipen"
 	volume = 50
-	amount_per_transfer_from_this = 50
+	amount_per_transfer_from_this = 10
+	possible_transfer_amounts = list(5,10,25,50)
 	list_reagents = list(/datum/reagent/medicine/stimulants = 50)
 
 /obj/item/reagent_containers/hypospray/medipen/stimulants/baseball

--- a/code/modules/uplink/uplink_items/uplink_devices.dm
+++ b/code/modules/uplink/uplink_items/uplink_devices.dm
@@ -211,7 +211,7 @@
 
 /datum/uplink_item/device_tools/stimpack
 	name = "Stimpack"
-	desc = "Stimpacks, the tool of many great heroes. Makes you nearly immune to non-lethal weaponry for about \
+	desc = "Stimpacks, the tool of many great heroes. Makes you nearly immune to non-lethal weaponry for up to \
 			5 minutes after injection."
 	item = /obj/item/reagent_containers/hypospray/medipen/stimulants
 	cost = 5

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -544,18 +544,6 @@
 				<li class="balance">triple fire breath for the lava swoop only happens below half health now</li>
 				<li class="bugfix">The arena attack not making safespots when you fight it in a mech</li>
 			</ul>
-
-			<h2 class="date">21 April 2021</h2>
-			<h3 class="author">necromanceranne updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="balance">Stun batons (not police batons/telebatons) no longer knockdown on leftclick.</li>
-				<li class="balance">Stun batons apply a knockdown and tase effect on right click, but once every few seconds (they still don't disarm). They are vulnerable to a shove disarm briefly, however. Standard batons have a cooldown of 5 seconds. Stun prods have a cooldown of 7 seconds.</li>
-				<li class="balance">Taser resistance prevents the knockdown, so any chem that grants this (like adrenals) protects you from this knockdown.</li>
-				<li class="balance">Stun batons apply a stagger when they hit someone, preventing sprinting for a few seconds.</li>
-				<li class="balance">Stun batons respect melee armor for their stamina damage, but their cells, based on max charge, grant armor penetration. For every 1000 charge, they gain 1 armor pen. (Roundstart batons have 15 pen, just fyi)</li>
-				<li class="balance">Shoves can disarm you of any item, not just guns.</li>
-				<li class="bugfix">Removes a duplicate trait definition for TRAIT_NICE_SHOT.</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -487,6 +487,36 @@
 			<h3 class="author">timothyteakettle updated:</h3>
 			<ul class="changes bgimages16">
 				<li class="bugfix">fixes losing your additional language upon changing species</li>
+			<h2 class="date">22 February 2021</h2>
+			<h3 class="author">Putnam3145 updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">(Hexa)crocin</li>
+				<li class="rscadd">(Hexa)camphor</li>
+				<li class="rscadd">Nymphomaniac quirk</li>
+				<li class="admin">All climaxes and arousals are now logged, as well as genital exposure.</li>
+			</ul>
+			<h3 class="author">SandPoot updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Cyborg tablets and it's special app for self-management.</li>
+				<li class="bugfix">In the case of a doomsday device being created outside of an AI it will delete itself.</li>
+				<li class="imageadd">Some sprites for it have been added and the borg's hud light toggles been changed to only on-off (made by yours truly)</li>
+				<li class="refactor">A lot of borg code was changed</li>
+				<li class="refactor">Tools no longer use istype checks and actually check for their behavior.</li>
+			</ul>
+			<h3 class="author">Vynzill updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">cursed rice hat that's hard to find and obtain, along with a couple other hats</li>
+				<li class="rscadd">a replacement toy gun for donksoft lmg</li>
+				<li class="rscadd">gorillas to the jungle gateway, friendly, even when attacked.</li>
+				<li class="bugfix">couple mapping errors I noticed, most importantly a missing window in the chapel.</li>
+				<li class="balance">shotgun and donksoft lmg removed, captain coat nerfed armor values.</li>
+				<li class="balance">leaper healthpool from 450 to 550 hopefully making it more of a struggle, and gives it a name.</li>
+				<li class="tweak">leaper pit is more wider. The hidden room south is now more obvious to find</li>
+			</ul>
+			<h3 class="author">dzahlus updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">Added pain emote to getting wounded</li>
+				<li class="soundadd">added a new pain emote sounds</li>
 			</ul>
 		</div>
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -517,6 +517,44 @@
 			<ul class="changes bgimages16">
 				<li class="rscadd">Added pain emote to getting wounded</li>
 				<li class="soundadd">added a new pain emote sounds</li>
+			<h2 class="date">22 April 2021</h2>
+			<h3 class="author">Whoneedspacee updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="rscadd">new arena attack where ash drake summons lava around you</li>
+				<li class="rscdel">removed old swooping above you, instead flies above you instantly</li>
+				<li class="balance">ash drake now spawns temporary lava pools instead of meteors falling down</li>
+				<li class="balance">ash drake takes twice as long to swoop down now that he instantly goes above you</li>
+				<li class="balance">ash drake now moves twice as fast</li>
+				<li class="balance">increases the odds of lava spawns in the lava pool attack</li>
+				<li class="balance">increases fire line damage and decreases lava attacks direct damage tweak: ash drake fire now shoots in the direction of the target tweak: changes times of certain animations tweak: changes sounds of meteor falling to lava creation</li>
+				<li class="bugfix">a bug where ash drakes attacks did not damage mechs</li>
+				<li class="imageadd">changes meteor icon to lava creation animation from lava staff</li>
+				<li class="rscadd">Mass fire attack, sends fire out from the ash drake in all directions</li>
+				<li class="rscadd">Adds an enraged attack for ash drake, heals him as well as making him glow and go faster, spawning massive amounts of fire in all directions</li>
+				<li class="rscdel">Removes the old triple swoop with lava pools attack tweak: Lava pools can now spawn with the normal fire breath attack sometimes tweak: Lava pools now have changed delays for lesser amounts so they don't all just place around one area tweak: Increases default swoop delay</li>
+				<li class="balance">Teleporting out of the lava arena now has some actual consequences by enraging the ash drake</li>
+				<li class="bugfix">Makes lava arena a bit less laggy by not recalculating range_turfs every time</li>
+				<li class="bugfix">Fixes the arena attack selecting inaccessible tiles as the safe tile though this will not change the turfs to basalt temporarily to prevent moving through indestructible walls</li>
+				<li class="bugfix">Fire lines would not spawn if their range would place their final turf location outside of the map</li>
+				<li class="bugfix">The arena attack will no longer destroy indestructible open turfs</li>
+				<li class="balance">ash drake fire does less damage now</li>
+				<li class="balance">ash drake takes longer to swoop down now</li>
+				<li class="balance">tiles take longer to fully convert into lava now, slowing down the arena attack as well</li>
+				<li class="balance">fire breath now moves slower</li>
+				<li class="balance">triple fire breath for the lava swoop only happens below half health now</li>
+				<li class="bugfix">The arena attack not making safespots when you fight it in a mech</li>
+			</ul>
+
+			<h2 class="date">21 April 2021</h2>
+			<h3 class="author">necromanceranne updated:</h3>
+			<ul class="changes bgimages16">
+				<li class="balance">Stun batons (not police batons/telebatons) no longer knockdown on leftclick.</li>
+				<li class="balance">Stun batons apply a knockdown and tase effect on right click, but once every few seconds (they still don't disarm). They are vulnerable to a shove disarm briefly, however. Standard batons have a cooldown of 5 seconds. Stun prods have a cooldown of 7 seconds.</li>
+				<li class="balance">Taser resistance prevents the knockdown, so any chem that grants this (like adrenals) protects you from this knockdown.</li>
+				<li class="balance">Stun batons apply a stagger when they hit someone, preventing sprinting for a few seconds.</li>
+				<li class="balance">Stun batons respect melee armor for their stamina damage, but their cells, based on max charge, grant armor penetration. For every 1000 charge, they gain 1 armor pen. (Roundstart batons have 15 pen, just fyi)</li>
+				<li class="balance">Shoves can disarm you of any item, not just guns.</li>
+				<li class="bugfix">Removes a duplicate trait definition for TRAIT_NICE_SHOT.</li>
 			</ul>
 		</div>
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Syndie stimpack has been buffed to allow different transfer amounts (5, 10, 25, or 50) through in-hand use or right-click context menu, instead of the usual 50u injection. The stimpack from the homerun syndie bundle has not been changed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lets syndicate agents use stimpacks without having to go on an aggressive rampage for 5 minutes straight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Syndie Stimpack now has possible transfer amounts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
