### PR TITLE
More lung fixes

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -201,9 +201,9 @@
 			mole_adjustments[entry] = -required_moles
 			mole_adjustments[breath_results[entry]] = required_moles
 		if(required_pp < safe_min)
-			var/multiplier = 0
+			var/multiplier = handle_too_little_breath(H, required_pp, safe_min, required_moles)
 			if(required_moles > 0)
-				multiplier = handle_too_little_breath(H, required_pp, safe_min, required_moles) / required_moles
+				multiplier /= required_moles
 			for(var/adjustment in mole_adjustments)
 				mole_adjustments[adjustment] *= multiplier
 			if(alert_category)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -90,6 +90,11 @@
 		max = safe_breath_dam_max,
 		damage_type = safe_damage_type
 	)
+	if(ispath(breathing_class))
+		var/datum/breathing_class/class = GLOB.gas_data.breathing_classes[breathing_class]
+		for(var/g in class.gases)
+			if(class.gases[g] > 0)
+				gas_min -= g
 
 //TODO: lung health affects lung function
 /obj/item/organ/lungs/onDamage(damage_mod) //damage might be too low atm.
@@ -517,17 +522,20 @@
 	var/total_moles = breath.total_moles()
 	for(var/id in breath.get_gases())
 		var/this_pressure = PP(breath, id)
-		var/req_pressure = (this_pressure * SAFE_THRESHOLD_RATIO) - 1
-		if(req_pressure > 0)
-			gas_min[id] = req_pressure
+		if(id in gas_min)
+			var/req_pressure = (this_pressure * SAFE_THRESHOLD_RATIO) - 1
+			if(req_pressure > 0)
+				gas_min[id] = req_pressure
+			else
+				gas_min -= id // if there's not even enough of the gas to register, we shouldn't need it
 		if(id in gas_max)
 			gas_max[id] += this_pressure
-	var/bz = breath.get_moles(GAS_BZ)
+	var/bz = breath.get_moles(GAS_BZ) // snowflaked cause it's got special behavior, of course
 	if(bz)
 		BZ_trip_balls_min += bz
 		BZ_brain_damage_min += bz
 
-	gas_max[GAS_N2] = PP(breath, GAS_N2) + 5
+	gas_max[GAS_N2] = max(15, PP(breath, GAS_N2) + 3) // don't want ash lizards breathing on station; sometimes they might be able to, though
 	var/datum/breathing_class/class = GLOB.gas_data.breathing_classes[breathing_class]
 	var/o2_pp = class.get_effective_pp(breath)
 	safe_breath_min = min(3, 0.3 * o2_pp)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I wasn't sanity checking that the breathing class requirements and gas requirements wouldn't clash. I added a sanity check for this, so you can't be simultaneously getting not enough oxygen but plenty of oxygen (due to e.g. pluoxium). Fixes #15333.

I also had it only suffocate you when there is insufficient but not *literally 0* gas due to overzealously preventing a divide-by-zero. This is also fixed. Fixes #15332.

## Why It's Good For The Game

Ashwalkers have been experiencing a lot of issues. This fixes them.

## Changelog
:cl:
fix: Ashwalkers should no longer suffocate on lavaland (and hypothetical other future problems)
fix: A gas mix with 0 oxygen should now properly suffocate you (or 0 plasma, for ashwalkers)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
