### PR TITLE
Fixes some lambda stuff

### DIFF
--- a/_maps/map_files/LambdaStation/dorms.dmm
+++ b/_maps/map_files/LambdaStation/dorms.dmm
@@ -365,13 +365,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aQ" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Control Room";
-	req_one_access_txt = "19; 61"
-	},
-/turf/open/floor/plating/airless,
-/area/tcommsat/chamber)
 "aR" = (
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
@@ -3201,6 +3194,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics/garden/monastery)
+"iA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/tcommsat/chamber)
 "iC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5602,6 +5601,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"ox" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "oy" = (
 /obj/structure/railing{
 	dir = 4;
@@ -7714,12 +7719,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/blue,
 /area/commons/vacant_room/office)
-"tS" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/airless,
-/area/tcommsat/chamber)
 "tT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14697,6 +14696,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"LG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "LH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37240,11 +37248,11 @@ lQ
 Yv
 Yv
 Yv
-dh
-Yv
-Yv
-aQ
-tS
+LG
+ox
+ox
+kF
+iA
 kF
 Gq
 LC

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -13476,24 +13476,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"ayl" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/storage/secure/briefcase{
-	pixel_x = -2
-	},
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/cartridge/detective,
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/hos";
-	dir = 1;
-	name = "Head of Security's Office APC";
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/command/heads_quarters/hos)
 "aym" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -14823,15 +14805,6 @@
 	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/command/heads_quarters/hos)
-"aAy" = (
-/obj/machinery/computer/prisoner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/hos)
 "aAz" = (
@@ -34520,13 +34493,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bpO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "bpP" = (
 /obj/structure/lattice/catwalk,
 /obj/item/wrench,
@@ -49053,18 +49019,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
-"cgv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/engineering/main";
-	dir = 1;
-	name = "Engine Room APC";
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/engineering/main)
 "cgw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -63058,6 +63012,37 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"cZR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
+"dbH" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/storage/secure/briefcase{
+	pixel_x = -2
+	},
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/cartridge/detective,
+/obj/machinery/power/apc{
+	areastring = "/area/command/heads_quarters/hos";
+	dir = 1;
+	name = "Head of Security's Office APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/heads_quarters/hos)
 "dcB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -64982,6 +64967,21 @@
 /obj/structure/stairs/south,
 /turf/open/floor/plasteel,
 /area/maintenance/department/cargo)
+"gci" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/engineering/main";
+	dir = 1;
+	name = "Engine Room APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
 "gcM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -66100,6 +66100,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"igd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/heads_quarters/hos)
 "igf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -117845,7 +117854,7 @@ axW
 awm
 axd
 axF
-ayl
+dbH
 azp
 aAr
 aBS
@@ -119645,7 +119654,7 @@ ayO
 aCD
 axF
 ays
-aAy
+igd
 aBz
 cAp
 cJw
@@ -120782,7 +120791,7 @@ lQs
 ceh
 ceP
 cXQ
-cgv
+gci
 chh
 cia
 cku
@@ -128946,7 +128955,7 @@ bnL
 bot
 boJ
 blZ
-bpO
+cZR
 bqG
 brm
 blZ
@@ -129202,7 +129211,7 @@ jqb
 bnL
 bot
 eec
-bpO
+cZR
 bip
 bqH
 brn


### PR DESCRIPTION


## About The Pull Request
Hos office gets their Security records console and their APC gets a wire node, Engineering PA room gets a wire node for its APC, and the comms relay for the second floor gets connected to the power grid since it dies nearly at shift start.

## Why It's Good For The Game
Fixing issues with maps is a good cause 

## Changelog
:cl:
add: Added two wire nodes under the engineering PA room Apc and under the HOS office APC
add: Added cables to connect the second floor relay to the power grid
del: Removed the generic broken computer from Hos Office
fix: Fixed Hos office not having the Security records console 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
