### PR TITLE
Fixes power alerts not to work precisely incorrectly

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -319,38 +319,38 @@ GLOBAL_LIST_EMPTY(teleportlocs)
  *
  * Sends to all ai players, alert consoles, drones and alarm monitor programs in the world
  */
-/area/proc/poweralert(state, obj/source)
+/area/proc/poweralert(set_alarm, obj/source)
 	if (area_flags & NO_ALERTS)
 		return
-	if (state != poweralm)
-		poweralm = state
+	if (set_alarm != poweralm)
+		poweralm = set_alarm
 		if(istype(source))	//Only report power alarms on the z-level where the source is located.
 			for (var/item in GLOB.silicon_mobs)
 				var/mob/living/silicon/aiPlayer = item
-				if (state == 1)
-					aiPlayer.cancelAlarm("Power", src, source)
-				else
+				if (set_alarm)
 					aiPlayer.triggerAlarm("Power", src, cameras, source)
+				else
+					aiPlayer.cancelAlarm("Power", src, source)
 
 			for (var/item in GLOB.alert_consoles)
 				var/obj/machinery/computer/station_alert/a = item
-				if(state == 1)
-					a.cancelAlarm("Power", src, source)
-				else
+				if (set_alarm)
 					a.triggerAlarm("Power", src, cameras, source)
+				else
+					a.cancelAlarm("Power", src, source)
 
 			for (var/item in GLOB.drones_list)
 				var/mob/living/simple_animal/drone/D = item
-				if(state == 1)
-					D.cancelAlarm("Power", src, source)
-				else
+				if (set_alarm)
 					D.triggerAlarm("Power", src, cameras, source)
+				else
+					D.cancelAlarm("Power", src, source)
 			for(var/item in GLOB.alarmdisplay)
 				var/datum/computer_file/program/alarm_monitor/p = item
-				if(state == 1)
-					p.cancelAlarm("Power", src, source)
-				else
+				if (set_alarm)
 					p.triggerAlarm("Power", src, cameras, source)
+				else
+					p.cancelAlarm("Power", src, source)
 
 /area/proc/atmosalert(danger_level, obj/source)
 	if (area_flags & NO_ALERTS)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -300,7 +300,7 @@
 	area.power_equip = FALSE
 	area.power_environ = FALSE
 	area.power_change()
-	area.poweralert(FALSE, src)
+	area.poweralert(TRUE, src)
 	if(occupier)
 		malfvacate(1)
 	qdel(wires)
@@ -1444,8 +1444,6 @@
 			lighting = autoset(lighting, AUTOSET_ON)
 			environ = autoset(environ, AUTOSET_ON)
 			area.poweralert(FALSE, src)
-			if(cell.percent() > 75)
-				area.poweralert(FALSE, src)
 
 		// now trickle-charge the cell
 		if(chargemode && charging == APC_CHARGING && operating)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As of right now, the APC code assumes sending poweralert(TRUE) will turn on the alarms. The poweralert code assumes the precise opposite.

The only reason every single APC in the entire world doesn't immediately get its alarm set on the consoles is because there's a check to make sure it only complains if the power alert *changes*.

## Why It's Good For The Game

It's good that things don't work the exact opposite of how they're supposed to.

## Changelog
:cl:
fix: Power alerts now work
/:cl: