### PR TITLE
Ashwalker Welding Fuel 

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2050,6 +2050,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/lavaland/unpowered/ash_walkers)
 "Ig" = (


### PR DESCRIPTION
## About The Pull Request
Adds a welder fuel tank to the Ashwalker's hut for smithing.

## Why It's Good For The Game
The experimental welding tool breaks more often than not, and will not recharge fuel when used on a smelter. I'm too dumb to fix this bug so I just added a tank of fuel.

## Changelog
:cl:
add: Added a fuel tank to Ashwalker hut
/:cl: