### PR TITLE
Makes TEG generate heat based on actual heat transfer (again)

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -63,7 +63,7 @@
 
 
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
-				var/efficiency =  LOGISTIC_FUNCTION(max_efficiency,0.0009,delta_temperature,10000)
+				var/efficiency = LOGISTIC_FUNCTION(max_efficiency,0.0009,delta_temperature,10000)
 
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -12,6 +12,8 @@
 	var/lastgenlev = -1
 	var/lastcirc = "00"
 
+	var/max_efficiency = 0.45
+
 
 /obj/machinery/power/generator/Initialize(mapload)
 	. = ..()
@@ -61,15 +63,12 @@
 
 
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
-				var/efficiency = 0.45
+				var/efficiency =  LOGISTIC_FUNCTION(max_efficiency,0.0009,delta_temperature,10000)
 
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 
-				var/heat = energy_transfer*(1-efficiency)
-				if(delta_temperature < 16800) // second point where derivative of below function = 1
-					lastgen += LOGISTIC_FUNCTION(500000,0.0009,delta_temperature,10000)
-				else
-					lastgen += delta_temperature + 482102 // value of above function at 16800, or very nearly so
+				lastgen += energy_transfer * efficiency
+				var/heat = energy_transfer * (1-efficiency)
 
 				hot_air.set_temperature(hot_air.return_temperature() - energy_transfer/hot_air_heat_capacity)
 				cold_air.set_temperature(cold_air.return_temperature() + heat/cold_air_heat_capacity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yeah, it was going based on raw delta-T. For some reason I couldn't think of a way to make it not do that without making 3x3s viable again, but I thought about it for 5 minutes just now and figured it out.

Instead of using a logistic function of temperature, it now generates power based on the actual, literal heat transferred from hot to cold... except the *efficiency* is now multiplied by the logistic function being used to keep it from operating at too low a temperature delta, so a 3x3 will have pitiful energy, not even breaking even (not even *close to* breaking even-- it's at 0.03% efficiency there).

## Why It's Good For The Game

TEG being more logical is good. Right now the optimal way of doing it is kinda stupid.

## Changelog
:cl:
tweak: TEG formula now takes heat capacity into account
/:cl: