### PR TITLE
Changes freezer/heater "efficiency" display on examine to something meaningful

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -61,7 +61,7 @@
 	. = ..()
 	. += "<span class='notice'>The thermostat is set to [target_temperature]K ([target_temperature-T0C]C).</span>"
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Effective heat capacity <b>[(heat_capacity] J/K</b>.</span>"
+		. += "<span class='notice'>The status display reads: Effective heat capacity <b>[heat_capacity] J/K</b>.</span>"
 		. += "<span class='notice'>Temperature range <b>[min_temperature]K - [max_temperature]K ([min_temperature-T0C]C - [max_temperature-T0C]C)</b>.</span>"
 
 /obj/machinery/atmospherics/components/unary/thermomachine/process_atmos()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -59,10 +59,10 @@
 
 /obj/machinery/atmospherics/components/unary/thermomachine/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>The thermostat is set to [target_temperature]K ([(T0C-target_temperature)*-1]C).</span>"
+	. += "<span class='notice'>The thermostat is set to [target_temperature]K ([target_temperature-T0C]C).</span>"
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Efficiency <b>[(heat_capacity/5000)*100]%</b>.</span>"
-		. += "<span class='notice'>Temperature range <b>[min_temperature]K - [max_temperature]K ([(T0C-min_temperature)*-1]C - [(T0C-max_temperature)*-1]C)</b>.</span>"
+		. += "<span class='notice'>The status display reads: Effective heat capacity <b>[(heat_capacity] J/K</b>.</span>"
+		. += "<span class='notice'>Temperature range <b>[min_temperature]K - [max_temperature]K ([min_temperature-T0C]C - [max_temperature-T0C]C)</b>.</span>"
 
 /obj/machinery/atmospherics/components/unary/thermomachine/process_atmos()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now it displays a meaningless "efficiency" % that there's no real way to understand. It's actually heat capacity divided by 50, or, in other words... the equivalent of 0.25 moles of plasma per cent. Uh. I don't even know. It's weird.

This changes it just to show heat capacity directly, since that's not something you have to calculate in your head for some reason.

I also fixed a bunch of `(a-b)*-1` instances. Like. Basic arithmetic. `(a-b)*-1 == (b-a)`. Seriously, what the hell. The worst part is that celsius is literally defined as `kelvins - 273.15`, but this was doing `(273.15 - kelvins) * -1`. What. What.

## Why It's Good For The Game

Stuff not using completely arbitrary, wacky parameters with no clear and obvious physical meaning... shouldn't. Do that.

## Changelog
:cl:
tweak: Freezers now show heat capacity instead of arbitrary "efficiency"
/:cl:
