### PR TITLE
Devastation level explosions no longer delete organs of gibbed humans

### DIFF
--- a/code/datums/components/field_of_vision.dm
+++ b/code/datums/components/field_of_vision.dm
@@ -327,7 +327,7 @@
 /atom/movable/fov_holder/has_gravity(turf/T)
 	return FALSE
 
-/atom/movable/fov_holder/ex_act(severity)
+/atom/movable/fov_holder/ex_act(severity, target, origin)
 	return FALSE
 
 /atom/movable/fov_holder/singularity_act()

--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -253,7 +253,7 @@ GLOBAL_LIST_EMPTY(explosions)
 		if(dist > EXPLODE_NONE)
 			T.explosion_level = max(T.explosion_level, dist)	//let the bigger one have it
 			T.explosion_id = id
-			T.ex_act(dist)
+			T.ex_act(dist, origin = src)
 			exploded_this_tick += T
 
 		//--- THROW ITEMS AROUND ---

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -610,12 +610,12 @@
 		user.buckle_message_cooldown = world.time + 50
 		to_chat(user, "<span class='warning'>You can't move while buckled to [src]!</span>")
 
-/atom/proc/contents_explosion(severity, target)
+/atom/proc/contents_explosion(severity, target, origin)
 	return //For handling the effects of explosions on contents that would not normally be effected
 
-/atom/proc/ex_act(severity, target, datum/explosion/E)
+/atom/proc/ex_act(severity, target, origin)
 	set waitfor = FALSE
-	contents_explosion(severity, target)
+	contents_explosion(severity, target, origin)
 	SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, target)
 
 /**

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -58,9 +58,9 @@
 		storedpda.forceMove(loc)
 		storedpda = null
 
-/obj/machinery/pdapainter/contents_explosion(severity, target)
+/obj/machinery/pdapainter/contents_explosion(severity, target, origin)
 	if(storedpda)
-		storedpda.ex_act(severity, target)
+		storedpda.ex_act(severity, target, origin)
 
 /obj/machinery/pdapainter/handle_atom_del(atom/A)
 	if(A == storedpda)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -405,9 +405,9 @@ Class Procs:
 		update_appearance()
 		return TRUE
 
-/obj/machinery/contents_explosion(severity, target)
+/obj/machinery/contents_explosion(severity, target, origin)
 	if(occupant)
-		occupant.ex_act(severity, target)
+		occupant.ex_act(severity, target, origin)
 
 /obj/machinery/handle_atom_del(atom/A)
 	if(A == occupant)

--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -55,9 +55,9 @@
 		storedpart.forceMove(loc)
 		storedpart = null
 
-/obj/machinery/aug_manipulator/contents_explosion(severity, target)
+/obj/machinery/aug_manipulator/contents_explosion(severity, target, origin)
 	if(storedpart)
-		storedpart.ex_act(severity, target)
+		storedpart.ex_act(severity, target, origin)
 
 /obj/machinery/aug_manipulator/handle_atom_del(atom/A)
 	if(A == storedpart)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -125,7 +125,7 @@
 					M.reset_perspective(null)
 					to_chat(M, "The screen bursts into static.")
 
-/obj/machinery/camera/ex_act(severity, target)
+/obj/machinery/camera/ex_act(severity, target, origin)
 	if(invuln)
 		return
 	..()

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -439,7 +439,7 @@
 			mob_occupant.copy_from_prefs_vr()
 			go_out()
 
-/obj/machinery/clonepod/ex_act(severity, target)
+/obj/machinery/clonepod/ex_act(severity, target, origin)
 	..()
 	if(!QDELETED(src))
 		go_out()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -158,11 +158,8 @@
 	name = "Circuit board (Cryogenic Oversight Console)"
 	build_path = "/obj/machinery/computer/cryopod"
 
-/obj/machinery/computer/cryopod/contents_explosion()
+/obj/machinery/computer/cryopod/contents_explosion(severity, target, origin)
 	return
-
-/obj/machinery/computer/cryopod/contents_explosion()
-	return			//don't blow everyone's shit up.
 
 /// The box
 /obj/item/storage/box/blue/cryostorage_items

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -407,7 +407,7 @@
 	if(!stat) //Opens only powered doors.
 		open() //Open everything!
 
-/obj/machinery/door/ex_act(severity, target)
+/obj/machinery/door/ex_act(severity, target, origin)
 	//if it blows up a wall it should blow up a door
 	..(severity ? max(1, severity - 1) : 0, target)
 

--- a/code/game/machinery/doors/passworddoor.dm
+++ b/code/game/machinery/doors/passworddoor.dm
@@ -69,7 +69,7 @@
 /obj/machinery/door/password/emp_act(severity)
 	return
 
-/obj/machinery/door/password/ex_act(severity, target)
+/obj/machinery/door/password/ex_act(severity, target, origin)
 	return
 
 /obj/machinery/door/password/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -68,7 +68,7 @@
 		return ..()
 
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.
-/obj/machinery/door/poddoor/ex_act(severity, target)
+/obj/machinery/door/poddoor/ex_act(severity, target, origin)
 	if(severity == 3)
 		return
 	..()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -270,7 +270,7 @@
 	var/range_light = 17
 	var/range_flame = 17
 
-/obj/item/bombcore/ex_act(severity, target) // Little boom can chain a big boom.
+/obj/item/bombcore/ex_act(severity, target, origin) // Little boom can chain a big boom.
 	detonate()
 
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -118,16 +118,16 @@
 		log_append_to_last("Armor saved, changing severity to [severity].")
 	. = ..()
 
-/obj/mecha/contents_explosion(severity, target)
+/obj/mecha/contents_explosion(severity, target, origin)
 	severity++
 	for(var/X in equipment)
 		var/obj/item/mecha_parts/mecha_equipment/ME = X
-		ME.ex_act(severity,target)
+		ME.ex_act(severity, target, origin)
 	for(var/Y in trackers)
 		var/obj/item/mecha_parts/mecha_tracking/MT = Y
-		MT.ex_act(severity, target)
+		MT.ex_act(severity, target, origin)
 	if(occupant)
-		occupant.ex_act(severity,target)
+		occupant.ex_act(severity, target, origin)
 
 /obj/mecha/handle_atom_del(atom/A)
 	if(A == occupant)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -111,7 +111,7 @@
 	mecha_log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).", color="red")
 	. = ..()
 
-/obj/mecha/ex_act(severity, target)
+/obj/mecha/ex_act(severity, target, origin)
 	mecha_log_message("Affected by explosion of severity: [severity].", color="red")
 	if(prob(deflect_chance))
 		severity++

--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -144,7 +144,7 @@
 	return
 
 
-/obj/mecha/working/ripley/contents_explosion(severity, target)
+/obj/mecha/working/ripley/contents_explosion(severity, target, origin)
 	for(var/X in cargo)
 		var/obj/O = X
 		if(prob(30/severity))

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -69,7 +69,7 @@
 /obj/effect/anomaly/proc/detonate()
 	return
 
-/obj/effect/anomaly/ex_act(severity, target)
+/obj/effect/anomaly/ex_act(severity, target, origin)
 	if(severity == 1)
 		qdel(src)
 

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -60,7 +60,7 @@
 	STOP_PROCESSING(SSfastprocess, src)
 	. = ..()
 
-/obj/effect/countdown/ex_act(severity, target) //immune to explosions
+/obj/effect/countdown/ex_act(severity, target, origin) //immune to explosions
 	return
 
 /obj/effect/countdown/syndicatebomb

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -77,10 +77,10 @@
 	else
 		return ..()
 
-/obj/effect/decal/cleanable/ex_act()
+/obj/effect/decal/cleanable/ex_act(severity, target, origin)
 	if(reagents)
 		for(var/datum/reagent/R in reagents.reagent_list)
-			R.on_ex_act()
+			R.on_ex_act(severity)
 	..()
 
 /obj/effect/decal/cleanable/fire_act(exposed_temperature, exposed_volume)

--- a/code/game/objects/effects/decals/cleanable/gibs.dm
+++ b/code/game/objects/effects/decals/cleanable/gibs.dm
@@ -36,7 +36,7 @@
 	. = ..()
 	return /obj/effect/decal/cleanable/blood/gibs/old
 
-/obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)
+/obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target, origin)
 	return
 
 /obj/effect/decal/cleanable/blood/gibs/Crossed(mob/living/L)

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -47,7 +47,7 @@
 	. = ..()
 	setDir(pick(GLOB.cardinals))
 
-/obj/effect/decal/cleanable/glass/ex_act()
+/obj/effect/decal/cleanable/glass/ex_act(severity, target, origin)
 	qdel(src)
 
 /obj/effect/decal/cleanable/glass/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -32,7 +32,7 @@
 		if (!step_to(src, get_step(src, direction), 0))
 			break
 
-/obj/effect/decal/cleanable/robot_debris/ex_act()
+/obj/effect/decal/cleanable/robot_debris/ex_act(severity, target, origin)
 	return
 
 /obj/effect/decal/cleanable/robot_debris/limb

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -17,7 +17,7 @@
 /obj/effect/decal/proc/NeverShouldHaveComeHere(turf/T)
 	return isclosedturf(T) || isgroundlessturf(T)
 
-/obj/effect/decal/ex_act(severity, target)
+/obj/effect/decal/ex_act(severity, target, origin)
 	qdel(src)
 
 /obj/effect/decal/fire_act(exposed_temperature, exposed_volume)

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -30,7 +30,7 @@
 /obj/effect/experience_pressure_difference()
 	return
 
-/obj/effect/ex_act(severity, target)
+/obj/effect/ex_act(severity, target, origin)
 	if(target == src)
 		qdel(src)
 	else
@@ -51,7 +51,7 @@
 /obj/effect/ConveyorMove()
 	return
 
-/obj/effect/abstract/ex_act(severity, target)
+/obj/effect/abstract/ex_act(severity, target, origin)
 	return
 
 /obj/effect/abstract/singularity_pull()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -11,7 +11,7 @@
 	return
 
 // Please stop bombing the Observer-Start landmark.
-/obj/effect/landmark/ex_act()
+/obj/effect/landmark/ex_act(severity, target, origin)
 	return
 
 /obj/effect/landmark/singularity_pull()

--- a/code/game/objects/effects/temporary_visuals/temporary_visual.dm
+++ b/code/game/objects/effects/temporary_visuals/temporary_visual.dm
@@ -25,7 +25,7 @@
 /obj/effect/temp_visual/singularity_pull()
 	return
 
-/obj/effect/temp_visual/ex_act()
+/obj/effect/temp_visual/ex_act(severity, target, origin)
 	return
 
 /obj/effect/temp_visual/dir_setting

--- a/code/game/objects/items/chrono_eraser.dm
+++ b/code/game/objects/items/chrono_eraser.dm
@@ -266,7 +266,7 @@
 /obj/effect/chrono_field/singularity_pull()
 	return
 
-/obj/effect/chrono_field/ex_act()
+/obj/effect/chrono_field/ex_act(severity, target, origin)
 	return
 
 /obj/effect/chrono_field/blob_act(obj/structure/blob/B)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -144,8 +144,8 @@
 /obj/effect/dummy/chameleon/attack_alien()
 	master.disrupt()
 
-/obj/effect/dummy/chameleon/ex_act(S, T)
-	contents_explosion(S, T)
+/obj/effect/dummy/chameleon/ex_act(severity, target, origin)
+	contents_explosion(severity, target, origin)
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/bullet_act()

--- a/code/game/objects/items/devices/doorCharge.dm
+++ b/code/game/objects/items/devices/doorCharge.dm
@@ -14,7 +14,7 @@
 	attack_verb = list("blown up", "exploded", "detonated")
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=30)
 
-/obj/item/doorCharge/ex_act(severity, target)
+/obj/item/doorCharge/ex_act(severity, target, origin)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			visible_message("<span class='warning'>[src] detonates!</span>")

--- a/code/game/objects/items/devices/portable_chem_mixer.dm
+++ b/code/game/objects/items/devices/portable_chem_mixer.dm
@@ -27,7 +27,7 @@
 	QDEL_NULL(beaker)
 	return ..()
 
-/obj/item/storage/portable_chem_mixer/ex_act(severity, target)
+/obj/item/storage/portable_chem_mixer/ex_act(severity, target, origin)
 	if(severity < 3)
 		..()
 

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -31,7 +31,7 @@
 		user.update_inv_hands()
 	loc.assume_air(air_contents)
 
-/obj/item/latexballon/ex_act(severity, target)
+/obj/item/latexballon/ex_act(severity, target, origin)
 	burst()
 	switch(severity)
 		if (1)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -557,7 +557,7 @@
 	..()
 	balanced = 0
 
-/obj/item/melee/supermatter_sword/ex_act(severity, target)
+/obj/item/melee/supermatter_sword/ex_act(severity, target, origin)
 	visible_message("<span class='danger'>The blast wave smacks into [src] and rapidly flashes to ash.</span>",\
 	"<span class='italics'>You hear a loud crack as you are washed with a wave of heat.</span>")
 	consume_everything()

--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -54,7 +54,7 @@
 /obj/machinery/door/keycard/emp_act(severity)
 	return
 
-/obj/machinery/door/keycard/ex_act(severity, target)
+/obj/machinery/door/keycard/ex_act(severity, target, origin)
 	return
 
 /obj/machinery/door/keycard/try_to_activate_door(mob/user)

--- a/code/game/objects/items/storage/_storage.dm
+++ b/code/game/objects/items/storage/_storage.dm
@@ -18,10 +18,10 @@
 /obj/item/storage/AllowDrop()
 	return TRUE
 
-/obj/item/storage/contents_explosion(severity, target)
+/obj/item/storage/contents_explosion(severity, target, origin)
 	var/in_storage = istype(loc, /obj/item/storage)? (max(0, severity - 1)) : (severity)
 	for(var/atom/A in contents)
-		A.ex_act(in_storage, target)
+		A.ex_act(in_storage, target, origin)
 		CHECK_TICK
 
 //Cyberboss says: "USE THIS TO FILL IT, NOT INITIALIZE OR NEW"

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -56,7 +56,7 @@
 			throwdamage = 0
 	take_damage(throwdamage, BRUTE, "melee", 1, get_dir(src, AM))
 
-/obj/ex_act(severity, target)
+/obj/ex_act(severity, target, origin)
 	if(resistance_flags & INDESTRUCTIBLE)
 		return
 	..() //contents explosion

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -554,9 +554,9 @@
 			if(!QDELETED(lockerelectronics))
 				lockerelectronics.accesses = req_access
 
-/obj/structure/closet/contents_explosion(severity, target)
+/obj/structure/closet/contents_explosion(severity, target, origin)
 	for(var/atom/A in contents)
-		A.ex_act(severity, target)
+		A.ex_act(severity, target, origin)
 		CHECK_TICK
 
 /obj/structure/closet/singularity_act()

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -21,7 +21,7 @@
 	if(.) //if we actually closed the locker
 		recursive_organ_check(src)
 
-/obj/structure/closet/secure_closet/freezer/ex_act()
+/obj/structure/closet/secure_closet/freezer/ex_act(severity, target, origin)
 	if(!jones)
 		jones = TRUE
 	else

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -32,9 +32,9 @@
 		stored_extinguisher = null
 	return ..()
 
-/obj/structure/extinguisher_cabinet/contents_explosion(severity, target)
+/obj/structure/extinguisher_cabinet/contents_explosion(severity, target, origin)
 	if(stored_extinguisher)
-		stored_extinguisher.ex_act(severity, target)
+		stored_extinguisher.ex_act(severity, target, origin)
 
 /obj/structure/extinguisher_cabinet/handle_atom_del(atom/A)
 	if(A == stored_extinguisher)

--- a/code/game/objects/structures/guncase.dm
+++ b/code/game/objects/structures/guncase.dm
@@ -91,9 +91,9 @@
 /obj/structure/guncase/handle_atom_del(atom/A)
 	update_icon()
 
-/obj/structure/guncase/contents_explosion(severity, target)
+/obj/structure/guncase/contents_explosion(severity, target, origin)
 	for(var/atom/A in contents)
-		A.ex_act(severity++, target)
+		A.ex_act(severity++, target, origin)
 		CHECK_TICK
 
 /obj/structure/guncase/shotgun

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -249,7 +249,7 @@
 	P.setAngle(rotation_angle)
 	return ..()
 
-/obj/structure/reflector/ex_act()
+/obj/structure/reflector/ex_act(severity, target, origin)
 	if(admin)
 		return
 	else

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -84,7 +84,7 @@ FLOOR SAFES
 /obj/structure/safe/blob_act(obj/structure/blob/B)
 	return
 
-/obj/structure/safe/ex_act(severity, target)
+/obj/structure/safe/ex_act(severity, target, origin)
 	if(((severity == 2 && target == src) || severity == 1) && explosion_count < BROKEN_THRESHOLD)
 		explosion_count++
 		switch(explosion_count)

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -50,7 +50,7 @@
 		empty_pod(location)
 	qdel(src)
 
-/obj/structure/transit_tube_pod/ex_act(severity, target)
+/obj/structure/transit_tube_pod/ex_act(severity, target, origin)
 	..()
 	if(!QDELETED(src))
 		empty_pod()

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -55,9 +55,9 @@
 	if(!QDELETED(src))
 		empty_pod()
 
-/obj/structure/transit_tube_pod/contents_explosion(severity, target)
+/obj/structure/transit_tube_pod/contents_explosion(severity, target, origin)
 	for(var/atom/movable/AM in contents)
-		AM.ex_act(severity, target)
+		AM.ex_act(severity, target, origin)
 
 /obj/structure/transit_tube_pod/singularity_pull(S, current_size)
 	..()

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -72,7 +72,7 @@
 	if(mapload && prob(66)) // 2/3 instead of 1/3 (default)
 		MakeDirty()
 
-/turf/open/floor/ex_act(severity, target)
+/turf/open/floor/ex_act(severity, target, origin)
 	var/shielded = is_shielded()
 	..()
 	if(severity != 1 && shielded && target != src)

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -195,7 +195,7 @@
 		return TRUE
 	return FALSE
 
-/turf/open/floor/plating/foam/ex_act()
+/turf/open/floor/plating/foam/ex_act(severity, target, origin)
 	..()
 	ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -89,7 +89,7 @@
 			for(var/obj/item/stack/ore/O in src)
 				SEND_SIGNAL(W, COMSIG_PARENT_ATTACKBY, O)
 
-/turf/open/floor/plating/asteroid/ex_act(severity, target)
+/turf/open/floor/plating/asteroid/ex_act(severity, target, origin)
 	. = SEND_SIGNAL(src, COMSIG_ATOM_EX_ACT, severity, target)
 	contents_explosion(severity, target)
 

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -120,7 +120,7 @@
 /turf/open/floor/plating/beach/try_replace_tile(obj/item/stack/tile/T, mob/user, params)
 	return
 
-/turf/open/floor/plating/beach/ex_act(severity, target)
+/turf/open/floor/plating/beach/ex_act(severity, target, origin)
 	contents_explosion(severity, target)
 
 /turf/open/floor/plating/beach/sand

--- a/code/game/turfs/simulated/floor/reinf_floor.dm
+++ b/code/game/turfs/simulated/floor/reinf_floor.dm
@@ -53,7 +53,7 @@
 	acidpwr = min(acidpwr, 50) //we reduce the power so reinf floor never get melted.
 	. = ..()
 
-/turf/open/floor/engine/ex_act(severity,target)
+/turf/open/floor/engine/ex_act(severity,target, origin)
 	var/shielded = is_shielded()
 	contents_explosion(severity, target)
 	if(severity != 1 && shielded && target != src)

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -18,8 +18,8 @@
 	clawfootstep = FOOTSTEP_LAVA
 	heavyfootstep = FOOTSTEP_LAVA
 
-/turf/open/lava/ex_act(severity, target)
-	contents_explosion(severity, target)
+/turf/open/lava/ex_act(severity, target, origin)
+	contents_explosion(severity, target, origin)
 
 /turf/open/lava/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)
 	return

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -171,7 +171,7 @@
 /turf/closed/mineral/acid_melt()
 	ScrapeAway()
 
-/turf/closed/mineral/ex_act(severity, target)
+/turf/closed/mineral/ex_act(severity, target, origin)
 	..()
 	switch(severity)
 		if(3)
@@ -661,7 +661,7 @@
 /turf/closed/mineral/strong/acid_melt()
 	return
 
-/turf/closed/mineral/strong/ex_act(severity, target)
+/turf/closed/mineral/strong/ex_act(severity, target, origin)
 	return
 
 #undef MINING_MESSAGE_COOLDOWN

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -272,12 +272,10 @@
 	icon_state = "map-overspace"
 	fixed_underlay = list("space"=1)
 
-/turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity)
+/turf/closed/wall/mineral/plastitanium/explosive/ex_act(severity, target, origin)
 	var/datum/explosion/acted_explosion = null
-	for(var/datum/explosion/E in GLOB.explosions)
-		if(E.explosion_id == explosion_id)
-			acted_explosion = E
-			break
+	if(istype(origin, /datum/explosion))
+		acted_explosion = origin
 	if(acted_explosion && istype(acted_explosion.explosion_source, /obj/item/bombcore))
 		var/obj/item/bombcore/large/bombcore = new(get_turf(src))
 		bombcore.detonate()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -80,7 +80,7 @@
 	if(girder_type)
 		new /obj/item/stack/sheet/metal(src)
 
-/turf/closed/wall/ex_act(severity, target)
+/turf/closed/wall/ex_act(severity, target, origin)
 	if(target == src)
 		dismantle_wall(1,1)
 		return

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -88,7 +88,7 @@
 		if(1)
 			//SN src = null
 			var/turf/NT = ScrapeAway()
-			NT.contents_explosion(severity, target)
+			NT.contents_explosion(severity, target, origin)
 			return
 		if(2)
 			if (prob(50))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -451,7 +451,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/is_shielded()
 
-/turf/contents_explosion(severity, target)
+/turf/contents_explosion(severity, target, origin)
 	var/affecting_level
 	if(severity == 1)
 		affecting_level = 1
@@ -469,7 +469,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 				var/atom/movable/AM = A
 				if(!AM.ex_check(explosion_id))
 					continue
-			A.ex_act(severity, target)
+			A.ex_act(severity, target, origin)
 			CHECK_TICK
 
 /turf/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1592,7 +1592,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	light_range = 2
 	duration = 9
 
-/obj/effect/temp_visual/target/ex_act()
+/obj/effect/temp_visual/target/ex_act(severity, target, origin)
 	return
 
 /obj/effect/temp_visual/target/Initialize(mapload, list/flame_hit)

--- a/code/modules/antagonists/blob/blob/blobs/core.dm
+++ b/code/modules/antagonists/blob/blob/blobs/core.dm
@@ -45,7 +45,7 @@
 	GLOB.poi_list -= src
 	return ..()
 
-/obj/structure/blob/core/ex_act(severity, target)
+/obj/structure/blob/core/ex_act(severity, target, origin)
 	var/damage = 50 - 10 * severity //remember, the core takes half brute damage, so this is 20/15/10 damage based on severity
 	take_damage(damage, BRUTE, "bomb", 0)
 

--- a/code/modules/antagonists/clockcult/clock_effects/clock_overlay.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_overlay.dm
@@ -8,7 +8,7 @@
 		linked.examine(user)
 	return ..()
 
-/obj/effect/clockwork/overlay/ex_act()
+/obj/effect/clockwork/overlay/ex_act(severity, target, origin)
 	return FALSE
 
 /obj/effect/clockwork/overlay/singularity_act()

--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -36,7 +36,7 @@
 		return TRUE
 	. = ..()
 
-/obj/effect/clockwork/sigil/ex_act(severity)
+/obj/effect/clockwork/sigil/ex_act(severity, target, origin)
 	visible_message("<span class='warning'>[src] scatters into thousands of particles.</span>")
 	qdel(src)
 
@@ -204,7 +204,7 @@
 	. = ..()
 	update_icon()
 
-/obj/effect/clockwork/sigil/transmission/ex_act(severity)
+/obj/effect/clockwork/sigil/transmission/ex_act(severity, target, origin)
 	if(severity == 3)
 		adjust_clockwork_power(500) //Light explosions charge the network!
 		visible_message("<span class='warning'>[src] flares a brilliant orange!</span>")

--- a/code/modules/antagonists/clockcult/clock_effects/servant_blocker.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/servant_blocker.dm
@@ -38,7 +38,7 @@
 /obj/effect/clockwork/servant_blocker/singularity_pull()
 	return
 
-/obj/effect/clockwork/servant_blocker/ex_act(severity, target)
+/obj/effect/clockwork/servant_blocker/ex_act(severity, target, origin)
 	return
 
 /obj/effect/clockwork/servant_blocker/safe_throw_at()

--- a/code/modules/antagonists/clockcult/clock_effects/spatial_gateway.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/spatial_gateway.dm
@@ -102,7 +102,7 @@
 		return TRUE
 	return ..()
 
-/obj/effect/clockwork/spatial_gateway/ex_act(severity)
+/obj/effect/clockwork/spatial_gateway/ex_act(severity, target, origin)
 	if(severity == 1 && uses)
 		uses = 0
 		visible_message("<span class='warning'>[src] is disrupted!</span>")
@@ -251,7 +251,7 @@
 	name = "stable gateway"
 	is_stable = TRUE
 
-/obj/effect/clockwork/spatial_gateway/stable/ex_act(severity)
+/obj/effect/clockwork/spatial_gateway/stable/ex_act(severity, target, origin)
 	if(severity == 1)
 		start_shutdown() //Yes, you can chain devastation-level explosions to delay a gateway shutdown, if you somehow manage to do it without breaking the obelisk. Is it worth it? Probably not.
 		return TRUE

--- a/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
@@ -214,5 +214,5 @@
 	sleep(3) //so the animation completes properly
 	qdel(src)
 
-/obj/effect/clockwork/judicial_marker/ex_act(severity)
+/obj/effect/clockwork/judicial_marker/ex_act(severity, target, origin)
 	return

--- a/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ark_of_the_clockwork_justicar.dm
@@ -197,7 +197,7 @@
 		glow = new /obj/effect/clockwork/overlay/gateway_glow(get_turf(src))
 		glow.linked = src
 
-/obj/structure/destructible/clockwork/massive/celestial_gateway/ex_act(severity)
+/obj/structure/destructible/clockwork/massive/celestial_gateway/ex_act(severity, target, origin)
 	var/damage = max((obj_integrity * 0.7) / severity, 100) //requires multiple bombs to take down
 	take_damage(damage, BRUTE, "bomb", 0)
 

--- a/code/modules/antagonists/devil/true_devil/_true_devil.dm
+++ b/code/modules/antagonists/devil/true_devil/_true_devil.dm
@@ -179,7 +179,7 @@
 /mob/living/carbon/true_devil/is_literate()
 	return 1
 
-/mob/living/carbon/true_devil/ex_act(severity, ex_target)
+/mob/living/carbon/true_devil/ex_act(severity, target, origin)
 	if(!ascended)
 		var/b_loss
 		switch (severity)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -174,7 +174,7 @@
 
 //Immunities
 
-/mob/living/simple_animal/revenant/ex_act(severity, target)
+/mob/living/simple_animal/revenant/ex_act(severity, target, origin)
 	return 1 //Immune to the effects of explosions.
 
 /mob/living/simple_animal/revenant/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -249,7 +249,7 @@
 	released and fully healed, because in the end it's just a jape, \
 	sibling!</B>"
 
-/mob/living/simple_animal/slaughter/laughter/ex_act(severity)
+/mob/living/simple_animal/slaughter/laughter/ex_act(severity, target, origin)
 	switch(severity)
 		if(1)
 			death()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -72,10 +72,10 @@
 	QDEL_NULL(beaker)
 	return ..()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/contents_explosion(severity, target)
+/obj/machinery/atmospherics/components/unary/cryo_cell/contents_explosion(severity, target, origin)
 	..()
 	if(beaker)
-		beaker.ex_act(severity, target)
+		beaker.ex_act(severity, target, origin)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/handle_atom_del(atom/A)
 	..()

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -149,5 +149,5 @@ GLOBAL_VAR_INIT(sc_safecode5, "[rand(0,9)]")
 	if(prob(25))
 		mezzer()
 
-/obj/singularity/narsie/mini/ex_act()
+/obj/singularity/narsie/mini/ex_act(severity, target, origin)
 	return

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -190,7 +190,7 @@
 /obj/structure/closet/supplypod/ex_act(severity, target, origin) //Explosions dont do SHIT TO US! This is because supplypods create explosions when they land.
 	return
 
-/obj/structure/closet/supplypod/contents_explosion() //Supplypods also protect their contents from the harmful effects of fucking exploding.
+/obj/structure/closet/supplypod/contents_explosion(severity, target, origin) //Supplypods also protect their contents from the harmful effects of fucking exploding.
 	return
 
 /obj/structure/closet/supplypod/toggle(mob/living/user)

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -187,7 +187,7 @@
 	else
 		..()
 
-/obj/structure/closet/supplypod/ex_act() //Explosions dont do SHIT TO US! This is because supplypods create explosions when they land.
+/obj/structure/closet/supplypod/ex_act(severity, target, origin) //Explosions dont do SHIT TO US! This is because supplypods create explosions when they land.
 	return
 
 /obj/structure/closet/supplypod/contents_explosion() //Supplypods also protect their contents from the harmful effects of fucking exploding.

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -99,7 +99,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	walk(src,0)
 	walk_towards(src, destination, 1)
 
-/obj/effect/immovablerod/ex_act(severity, target)
+/obj/effect/immovablerod/ex_act(severity, target, origin)
 	return 0
 
 /obj/effect/immovablerod/singularity_act()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -507,7 +507,7 @@
 			if(master)
 				master.spawn_spacevine_piece(stepturf, src)
 
-/obj/structure/spacevine/ex_act(severity, target)
+/obj/structure/spacevine/ex_act(severity, target, origin)
 	if(istype(target, type)) //if its agressive spread vine dont do anything
 		return
 	var/i

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -203,7 +203,7 @@
 		return
 	emergency_shutdown()
 
-/obj/machinery/computer/holodeck/ex_act(severity, target)
+/obj/machinery/computer/holodeck/ex_act(severity, target, origin)
 	emergency_shutdown()
 	return ..()
 

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -27,10 +27,10 @@
 	QDEL_NULL(beaker)
 	return ..()
 
-/obj/machinery/biogenerator/contents_explosion(severity, target)
+/obj/machinery/biogenerator/contents_explosion(severity, target, origin)
 	..()
 	if(beaker)
-		beaker.ex_act(severity, target)
+		beaker.ex_act(severity, target, origin)
 
 /obj/machinery/biogenerator/handle_atom_del(atom/A)
 	..()

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -173,7 +173,7 @@
 		var/mob/M = loc
 		M.dropItemToGround(src)
 
-/obj/item/reagent_containers/food/snacks/grown/firelemon/ex_act(severity)
+/obj/item/reagent_containers/food/snacks/grown/firelemon/ex_act(severity, target, origin)
 	qdel(src) //Ensuring that it's deleted by its own explosion
 
 /obj/item/reagent_containers/food/snacks/grown/firelemon/proc/prime(mob/living/lanced_by)

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -224,7 +224,7 @@
 	if(!QDELETED(src))
 		qdel(src)
 
-/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/ex_act(severity)
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/ex_act(severity, target, origin)
 	qdel(src) //Ensuring that it's deleted by its own explosion. Also prevents mass chain reaction with piles of cherry bombs
 
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime(mob/living/lanced_by)
@@ -500,7 +500,7 @@
 	log_game("Coconut bomb detonation at [AREACOORD(T)], location [loc]")
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/grown/coconut/ex_act(severity)
+/obj/item/reagent_containers/food/snacks/grown/coconut/ex_act(severity, target, origin)
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/grown/coconut/deconstruct(disassembled = TRUE)

--- a/code/modules/lighting/emissive_blocker.dm
+++ b/code/modules/lighting/emissive_blocker.dm
@@ -26,7 +26,7 @@
 	color = GLOB.em_block_color
 
 
-/atom/movable/emissive_blocker/ex_act(severity)
+/atom/movable/emissive_blocker/ex_act(severity, target, origin)
 	return FALSE
 
 /atom/movable/emissive_blocker/singularity_act()

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -124,7 +124,7 @@
 
 // Variety of overrides so the overlays don't get affected by weird things.
 
-/atom/movable/lighting_object/ex_act(severity)
+/atom/movable/lighting_object/ex_act(severity, target, origin)
 	return 0
 
 /atom/movable/lighting_object/singularity_act()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -484,7 +484,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
 
-/obj/effect/warp_cube/ex_act(severity, target)
+/obj/effect/warp_cube/ex_act(severity, target, origin)
 	return
 
 //Meat Hook
@@ -607,7 +607,7 @@
 /obj/effect/immortality_talisman/attackby()
 	return
 
-/obj/effect/immortality_talisman/ex_act()
+/obj/effect/immortality_talisman/ex_act(severity, target, origin)
 	return
 
 /obj/effect/immortality_talisman/singularity_pull()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -346,7 +346,7 @@
 				to_chat(usr, "<span class='warning'>Required access not found.</span>")
 			return TRUE
 
-/obj/machinery/mineral/ore_redemption/ex_act(severity, target)
+/obj/machinery/mineral/ore_redemption/ex_act(severity, target, origin)
 	do_sparks(5, TRUE, src)
 	..()
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -270,7 +270,7 @@
 	SSblackbox.record_feedback("tally", "crusher_voucher_redeemed", 1, selection)
 	qdel(voucher)
 
-/obj/machinery/mineral/equipment_vendor/ex_act(severity, target)
+/obj/machinery/mineral/equipment_vendor/ex_act(severity, target, origin)
 	do_sparks(5, TRUE, src)
 	if(prob(50 / severity) && severity < 3)
 		qdel(src)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	C.forcesay("*scream")
 	qdel(src)
 
-/obj/item/stack/ore/glass/ex_act(severity, target)
+/obj/item/stack/ore/glass/ex_act(severity, target, origin)
 	if (severity == EXPLODE_NONE)
 		return
 	qdel(src)
@@ -314,7 +314,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	GibtoniteReaction(P.firer)
 	. = ..()
 
-/obj/item/gibtonite/ex_act()
+/obj/item/gibtonite/ex_act(severity, target, origin)
 	GibtoniteReaction(null, 1)
 
 /obj/item/gibtonite/proc/GibtoniteReaction(mob/user, triggered_by = 0)
@@ -356,7 +356,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	pixel_x = initial(pixel_x) + rand(0, 16) - 8
 	pixel_y = initial(pixel_y) + rand(0, 8) - 8
 
-/obj/item/stack/ore/ex_act(severity, target)
+/obj/item/stack/ore/ex_act(severity, target, origin)
 	if (!severity || severity >= 2)
 		return
 	qdel(src)

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -11,7 +11,7 @@
 /obj/effect/dummy/phased_mob/slaughter/relaymove(mob/user, direction)
 	forceMove(get_step(src,direction))
 
-/obj/effect/dummy/phased_mob/slaughter/ex_act()
+/obj/effect/dummy/phased_mob/slaughter/ex_act(severity, target, origin)
 	return
 
 /obj/effect/dummy/phased_mob/slaughter/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -43,7 +43,7 @@
 /mob/living/brain/update_mobility()
 	return ((mobility_flags = (container?.in_contents_of(/obj/mecha)? MOBILITY_FLAGS_DEFAULT : NONE)))
 
-/mob/living/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.
+/mob/living/brain/ex_act(severity, target, origin) //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.
 	return
 
 /mob/living/brain/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -319,7 +319,10 @@
 					var/atom/A = I
 					if(!QDELETED(A))
 						A.ex_act(severity)
-				gib()
+				if(istype(origin, /datum/explosion))
+					gib(was_explosion = origin)
+				else
+					gib()
 				return
 			else
 				brute_loss = 500

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -28,7 +28,7 @@
 				if(2)
 					SSshuttle.requestEvac(src,"ALERT: Energy surge detected in AI core! Station integrity may be compromised! Initiati--%m091#ar-BZZT")
 
-/mob/living/silicon/ai/ex_act(severity, target)
+/mob/living/silicon/ai/ex_act(severity, target, origin)
 	switch(severity)
 		if(1)
 			gib()

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -13,7 +13,7 @@
 	emitter_next_use = world.time + emitter_emp_cd
 	//Need more effects that aren't instadeath or permanent law corruption.
 
-/mob/living/silicon/pai/ex_act(severity, target)
+/mob/living/silicon/pai/ex_act(severity, target, origin)
 	take_holo_damage(severity * 50)
 	switch(severity)
 		if(1)	//RIP

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -184,7 +184,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		gib()
 	return TRUE
 
-/mob/living/silicon/robot/ex_act(severity, target)
+/mob/living/silicon/robot/ex_act(severity, target, origin)
 	switch(severity)
 		if(1)
 			gib()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -78,7 +78,7 @@
 	GLOB.silicon_mobs -= src
 	return ..()
 
-/mob/living/silicon/contents_explosion(severity, target)
+/mob/living/silicon/contents_explosion(severity, target, origin)
 	return
 
 /mob/living/silicon/proc/cancelAlarm()

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -138,7 +138,7 @@
 		add_overlay(load)
 	return
 
-/mob/living/simple_animal/bot/mulebot/ex_act(severity)
+/mob/living/simple_animal/bot/mulebot/ex_act(severity, target, origin)
 	unload(0)
 	switch(severity)
 		if(1)

--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -60,5 +60,5 @@
 		else
 			visible_message("<span class='notice'>[src] avoids getting crushed.</span>")
 
-/mob/living/simple_animal/cockroach/ex_act() //Explosions are a terrible way to handle a cockroach.
+/mob/living/simple_animal/cockroach/ex_act(severity, target, origin) //Explosions are a terrible way to handle a cockroach.
 	return

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -273,10 +273,13 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 				summoner.adjustCloneLoss(amount * 0.5) //dying hosts take 50% bonus damage as cloneloss
 		update_health_hud()
 
-/mob/living/simple_animal/hostile/guardian/ex_act(severity, target)
+/mob/living/simple_animal/hostile/guardian/ex_act(severity, target, origin)
 	switch(severity)
 		if(1)
-			gib()
+			if(istype(origin, /datum/explosion))
+				gib(was_explosion = origin)
+			else
+				gib()
 			return
 		if(2)
 			adjustBruteLoss(60)
@@ -286,10 +289,10 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 /mob/living/simple_animal/hostile/guardian/wave_ex_act(power, datum/wave_explosion/explosion, dir)
 	adjustBruteLoss(EXPLOSION_POWER_STANDARD_SCALE_MOB_DAMAGE(power, explosion.mob_damage_mod * 0.33))
 
-/mob/living/simple_animal/hostile/guardian/gib()
+/mob/living/simple_animal/hostile/guardian/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
 	if(summoner)
 		to_chat(summoner, "<span class='danger'><B>Your [src] was blown up!</span></B>")
-		summoner.gib()
+		summoner.gib(was_explosion = was_explosion)
 	ghostize()
 	qdel(src)
 

--- a/code/modules/mob/living/simple_animal/guardian/types/protector.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/protector.dm
@@ -11,7 +11,7 @@
 	toggle_button_type = /atom/movable/screen/guardian/ToggleMode
 	var/toggle = FALSE
 
-/mob/living/simple_animal/hostile/guardian/protector/ex_act(severity)
+/mob/living/simple_animal/hostile/guardian/protector/ex_act(severity, target, origin)
 	if(severity == 1)
 		adjustBruteLoss(400) //if in protector mode, will do 20 damage and not actually necessarily kill the summoner
 	else

--- a/code/modules/mob/living/simple_animal/hostile/banana_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/banana_spider.dm
@@ -87,7 +87,7 @@
 			else
 				visible_message("<span class='notice'>[src] avoids getting crushed.</span>")
 
-/mob/living/simple_animal/banana_spider/ex_act()
+/mob/living/simple_animal/banana_spider/ex_act(severity, target, origin)
 	return
 
 /mob/living/simple_animal/banana_spider/start_pulling()

--- a/code/modules/mob/living/simple_animal/hostile/bread.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bread.dm
@@ -62,7 +62,7 @@
 	user.transfer_ckey(src, FALSE)
 	density = TRUE
 
-/mob/living/simple_animal/hostile/bread/ex_act()
+/mob/living/simple_animal/hostile/bread/ex_act(severity, target, origin)
 	return
 
 /mob/living/simple_animal/hostile/bread/start_pulling()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -132,7 +132,7 @@ Difficulty: Medium
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/ex_act(severity, target)
+/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner/ex_act(severity, target, origin)
 	if(dash())
 		return
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -154,7 +154,7 @@ Difficulty: Hard
 		return 0
 	return ..()
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/ex_act(severity, target)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/ex_act(severity, target, origin)
 	if(severity >= EXPLODE_LIGHT)
 		return
 	severity = EXPLODE_LIGHT // puny mortals

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -421,7 +421,7 @@ Difficulty: Very Hard
 	if(ismob(AM))
 		ActivationReaction(AM, ACTIVATE_MOB_BUMP)
 
-/obj/machinery/anomalous_crystal/ex_act()
+/obj/machinery/anomalous_crystal/ex_act(severity, target, origin)
 	ActivationReaction(null, ACTIVATE_BOMB)
 
 /obj/machinery/anomalous_crystal/honk //Strips and equips you as a clown. I apologize for nothing
@@ -740,7 +740,7 @@ Difficulty: Very Hard
 /obj/structure/closet/stasis/emp_act()
 	return
 
-/obj/structure/closet/stasis/ex_act()
+/obj/structure/closet/stasis/ex_act(severity, target, origin)
 	return
 
 /obj/structure/closet/stasis/handle_lock_addition()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -147,7 +147,7 @@ Difficulty: Extremely Hard
 	if(isturf(target) || isobj(target))
 		target.ex_act(EXPLODE_HEAVY)
 
-/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner/ex_act(severity, target)
+/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner/ex_act(severity, target, origin)
 	adjustBruteLoss(30 * severity - 120)
 	visible_message("<span class='danger'>[src] absorbs the explosion!</span>", "<span class='userdanger'>You absorb the explosion!</span>")
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -79,7 +79,7 @@ Difficulty: Medium
 	. = ..()
 	internal = new/obj/item/gps/internal/dragon(src)
 
-/mob/living/simple_animal/hostile/megafauna/dragon/ex_act(severity, target)
+/mob/living/simple_animal/hostile/megafauna/dragon/ex_act(severity, target, origin)
 	if(severity == 3)
 		return
 	..()
@@ -387,7 +387,7 @@ Difficulty: Medium
 	light_range = 2
 	duration = 13
 
-/obj/effect/temp_visual/lava_warning/ex_act()
+/obj/effect/temp_visual/lava_warning/ex_act(severity, target, origin)
 	return
 
 /obj/effect/temp_visual/lava_warning/Initialize(mapload, var/reset_time = 10)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -674,7 +674,7 @@ Difficulty: Normal
 	layer = LOW_OBJ_LAYER
 	anchored = TRUE
 
-/obj/effect/hierophant/ex_act()
+/obj/effect/hierophant/ex_act(severity, target, origin)
 	return
 
 /obj/effect/hierophant/attackby(obj/item/I, mob/user, params)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -138,7 +138,7 @@
 		adjustBruteLoss(-L.maxHealth/2)
 	L.gib()
 
-/mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)
+/mob/living/simple_animal/hostile/megafauna/ex_act(severity, target, origin)
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
 			adjustBruteLoss(250)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -50,7 +50,7 @@
 		if(isliving(target) && !target.Adjacent(targets_from) && ranged_cooldown <= world.time)//No more being shot at point blank or spammed with RNG beams
 			OpenFire(target)
 
-/mob/living/simple_animal/hostile/asteroid/basilisk/ex_act(severity, target)
+/mob/living/simple_animal/hostile/asteroid/basilisk/ex_act(severity, target, origin)
 	switch(severity)
 		if(1)
 			gib()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -307,7 +307,7 @@
 	if((bodytemperature < minbodytemp) || (bodytemperature > maxbodytemp))
 		adjustHealth(unsuitable_atmos_damage)
 
-/mob/living/simple_animal/gib()
+/mob/living/simple_animal/gib(no_brain, no_organs, no_bodyparts, datum/explosion/was_explosion)
 	if(butcher_results)
 		var/atom/Tsec = drop_location()
 		for(var/path in butcher_results)

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -124,9 +124,9 @@
 
 // Stronger explosions cause serious damage to internal components
 // Minor explosions are mostly mitigitated by casing.
-/obj/machinery/modular_computer/ex_act(severity)
+/obj/machinery/modular_computer/ex_act(severity, target, origin)
 	if(cpu)
-		cpu.ex_act(severity)
+		cpu.ex_act(severity, target, origin)
 		// switch(severity)
 		// 	if(EXPLODE_DEVASTATE)
 		// 		SSexplosions.high_mov_atom += cpu

--- a/code/modules/power/antimatter/containment_jar.dm
+++ b/code/modules/power/antimatter/containment_jar.dm
@@ -15,7 +15,7 @@
 	var/stability = 100//TODO: add all the stability things to this so its not very safe if you keep hitting in on things
 
 
-/obj/item/am_containment/ex_act(severity, target)
+/obj/item/am_containment/ex_act(severity, target, origin)
 	switch(severity)
 		if(1)
 			explosion(get_turf(src), 1, 2, 3, 5)//Should likely be larger but this works fine for now I guess

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -114,7 +114,7 @@
 	check_stability()
 	return
 
-/obj/machinery/power/am_control_unit/ex_act(severity, target)
+/obj/machinery/power/am_control_unit/ex_act(severity, target, origin)
 	stability -= (80 - (severity * 20))
 	check_stability()
 	return

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -94,7 +94,7 @@
 /obj/machinery/am_shielding/emp_act()//Immune due to not really much in the way of electronics.
 	return
 
-/obj/machinery/am_shielding/ex_act(severity, target)
+/obj/machinery/am_shielding/ex_act(severity, target, origin)
 	stability -= (80 - (severity * 20))
 	check_stability()
 	return

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -142,7 +142,7 @@
 	if(charge < 0)
 		charge = 0
 
-/obj/item/stock_parts/cell/ex_act(severity, target)
+/obj/item/stock_parts/cell/ex_act(severity, target, origin)
 	..()
 	if(!QDELETED(src))
 		switch(severity)

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 /obj/machinery/gravity_generator/safe_throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = MOVE_FORCE_STRONG, gentle = FALSE)
 	return FALSE
 
-/obj/machinery/gravity_generator/ex_act(severity, target)
+/obj/machinery/gravity_generator/ex_act(severity, target, origin)
 	if(severity >= EXPLODE_DEVASTATE) // Very sturdy.
 		set_broken()
 

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -115,7 +115,7 @@
 /obj/machinery/power/rtg/abductor/blob_act(obj/structure/blob/B)
 	overload()
 
-/obj/machinery/power/rtg/abductor/ex_act()
+/obj/machinery/power/rtg/abductor/ex_act(severity, target, origin)
 	if(going_kaboom)
 		qdel(src)
 	else

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -42,7 +42,7 @@
 /obj/machinery/field/containment/blob_act(obj/structure/blob/B)
 	return FALSE
 
-/obj/machinery/field/containment/ex_act(severity, target)
+/obj/machinery/field/containment/ex_act(severity, target, origin)
 	return FALSE
 
 /obj/machinery/field/containment/attack_animal(mob/living/simple_animal/M)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -143,7 +143,7 @@
 		A.narsie_act()
 
 
-/obj/singularity/narsie/ex_act() //No throwing bombs at her either.
+/obj/singularity/narsie/ex_act(severity, target, origin) //No throwing bombs at her either.
 	return
 
 

--- a/code/modules/power/singularity/particle_accelerator/particle.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle.dm
@@ -49,7 +49,7 @@
 		toxmob(A)
 
 
-/obj/effect/accelerated_particle/ex_act(severity, target)
+/obj/effect/accelerated_particle/ex_act(severity, target, origin)
 	qdel(src)
 
 /obj/effect/accelerated_particle/singularity_pull()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -97,7 +97,7 @@
 		return
 	return ..()
 
-/obj/singularity/ex_act(severity, target)
+/obj/singularity/ex_act(severity, target, origin)
 	switch(severity)
 		if(1)
 			if(current_size <= STAGE_TWO)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -894,7 +894,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	CALCULATE_ADJACENT_TURFS(T)
 
 //Do not blow up our internal radio
-/obj/machinery/power/supermatter_crystal/contents_explosion(severity, target)
+/obj/machinery/power/supermatter_crystal/contents_explosion(severity, target, origin)
 	return
 
 /obj/machinery/power/supermatter_crystal/engine

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -39,7 +39,7 @@
 	if(!is_miniball)
 		set_light(10, 7, "#EEEEFF")
 
-/obj/singularity/energy_ball/ex_act(severity, target)
+/obj/singularity/energy_ball/ex_act(severity, target, origin)
 	return
 
 /obj/singularity/energy_ball/consume(severity, target)

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -156,5 +156,5 @@
 	mediumr = max(mediumr - 1, 0)
 	lightr = max(lightr - 1, 0)
 
-/obj/item/projectile/blastwave/ex_act()
+/obj/item/projectile/blastwave/ex_act(severity, target, origin)
 	return

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -165,7 +165,7 @@
 	obj_flags |= EMAGGED
 	return TRUE
 
-/obj/machinery/chem_dispenser/ex_act(severity, target)
+/obj/machinery/chem_dispenser/ex_act(severity, target, origin)
 	if(severity < 3)
 		..()
 

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -169,10 +169,10 @@
 	if(severity < 3)
 		..()
 
-/obj/machinery/chem_dispenser/contents_explosion(severity, target)
+/obj/machinery/chem_dispenser/contents_explosion(severity, target, origin)
 	..()
 	if(beaker)
-		beaker.ex_act(severity, target)
+		beaker.ex_act(severity, target, origin)
 
 /obj/machinery/chem_dispenser/Exited(atom/movable/A, atom/newloc)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -50,12 +50,12 @@
 	if(severity < 3)
 		..()
 
-/obj/machinery/chem_master/contents_explosion(severity, target)
+/obj/machinery/chem_master/contents_explosion(severity, target, origin)
 	..()
 	if(beaker)
-		beaker.ex_act(severity, target)
+		beaker.ex_act(severity, target, origin)
 	if(bottle)
-		bottle.ex_act(severity, target)
+		bottle.ex_act(severity, target, origin)
 
 /obj/machinery/chem_master/Exited(atom/movable/A, atom/newloc)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -46,7 +46,7 @@
 	for(var/obj/item/reagent_containers/glass/beaker/B in component_parts)
 		reagents.maximum_volume += B.reagents.maximum_volume
 
-/obj/machinery/chem_master/ex_act(severity, target)
+/obj/machinery/chem_master/ex_act(severity, target, origin)
 	if(severity < 3)
 		..()
 

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -43,9 +43,9 @@
 	drop_all_items()
 	return ..()
 
-/obj/machinery/reagentgrinder/contents_explosion(severity, target)
+/obj/machinery/reagentgrinder/contents_explosion(severity, target, origin)
 	if(beaker)
-		beaker.ex_act(severity, target)
+		beaker.ex_act(severity, target, origin)
 
 /obj/machinery/reagentgrinder/RefreshParts()
 	speed = 1

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -88,10 +88,10 @@
 		return 0
 	return 1
 
-/obj/item/reagent_containers/ex_act()
+/obj/item/reagent_containers/ex_act(severity, target, origin)
 	if(reagents)
 		for(var/datum/reagent/R in reagents.reagent_list)
-			R.on_ex_act()
+			R.on_ex_act(severity)
 	if(!QDELETED(src))
 		..()
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -151,7 +151,7 @@
 /obj/structure/reagent_dispensers/fueltank/blob_act(obj/structure/blob/B)
 	boom()
 
-/obj/structure/reagent_dispensers/fueltank/ex_act()
+/obj/structure/reagent_dispensers/fueltank/ex_act(severity, target, origin)
 	boom()
 
 /obj/structure/reagent_dispensers/fueltank/fire_act(exposed_temperature, exposed_volume)

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -130,5 +130,5 @@
 /obj/structure/disposalholder/AllowDrop()
 	return TRUE
 
-/obj/structure/disposalholder/ex_act(severity, target)
+/obj/structure/disposalholder/ex_act(severity, target, origin)
 	return

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -132,10 +132,10 @@
 
 
 // pipe affected by explosion
-/obj/structure/disposalpipe/contents_explosion(severity, target)
+/obj/structure/disposalpipe/contents_explosion(severity, target, origin)
 	var/obj/structure/disposalholder/H = locate() in src
 	if(H)
-		H.contents_explosion(severity, target)
+		H.contents_explosion(severity, target, origin)
 
 
 /obj/structure/disposalpipe/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -18,9 +18,9 @@
 		AM.forceMove(T)
 	return ..()
 
-/obj/structure/bigDelivery/contents_explosion(severity, target)
+/obj/structure/bigDelivery/contents_explosion(severity, target, origin)
 	for(var/atom/movable/AM in contents)
-		AM.ex_act()
+		AM.ex_act(severity, target, origin)
 
 /obj/structure/bigDelivery/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/destTagger))
@@ -82,9 +82,9 @@
 	var/giftwrapped = 0
 	var/sortTag = 0
 
-/obj/item/smallDelivery/contents_explosion(severity, target)
+/obj/item/smallDelivery/contents_explosion(severity, target, origin)
 	for(var/atom/movable/AM in contents)
-		AM.ex_act()
+		AM.ex_act(severity, target, origin)
 
 /obj/item/smallDelivery/attack_self(mob/user)
 	user.temporarilyRemoveItemFromInventory(src, TRUE)

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -44,7 +44,7 @@
 /obj/machinery/power/emitter/energycannon/magical/attackby(obj/item/W, mob/user, params)
 	return
 
-/obj/machinery/power/emitter/energycannon/magical/ex_act(severity)
+/obj/machinery/power/emitter/energycannon/magical/ex_act(severity, target, origin)
 	return
 
 /obj/machinery/power/emitter/energycannon/magical/emag_act(mob/user)

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -105,7 +105,7 @@
 
 	forceMove(newLoc)
 
-/obj/effect/dummy/phased_mob/spell_jaunt/ex_act(blah)
+/obj/effect/dummy/phased_mob/spell_jaunt/ex_act(severity, target, origin)
 	return
 
 /obj/effect/dummy/phased_mob/spell_jaunt/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -87,7 +87,7 @@
 		qdel(src)
 	check_light_level()
 
-/obj/effect/dummy/phased_mob/shadow/ex_act()
+/obj/effect/dummy/phased_mob/shadow/ex_act(severity, target, origin)
 	return
 
 /obj/effect/dummy/phased_mob/shadow/wave_ex_act(power, datum/wave_explosion/explosion, dir)

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -226,7 +226,7 @@
 	invisibility = INVISIBILITY_ABSTRACT
 	var/obj/machinery/parent
 
-/obj/structure/filler/ex_act()
+/obj/structure/filler/ex_act(severity, target, origin)
 	return
 
 /obj/machinery/computer/bsa_control


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Some measures against this were implemented a whiile ago, but didn't actually work or cover all cases. This aims to actually do this and make deva explosions, whilst body destroying, not a full permakill.

~~Note, this will absolutely fail CI for now. Gonna fix that once it tells me what it wants because I'm too lazy to find all the overrides myself.~~
Overrides of ex_act() / contents_explosion() adjusted to the current state.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Devastation explosion gibbing finally working as it was supposed to after however much time good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Devastation level explosions no longer delete your organs after gibbing you.
code: Adjusted all overrides of ex_act() and contents_explosion() to take account of current args for them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
