### PR TITLE
Makes regal rat require not being dead to use abilities

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -90,7 +90,7 @@
 
 /datum/action/cooldown/coffer/Trigger()
 	. = ..()
-	if(!.)
+	if(!. || owner.stat != CONSCIOUS)
 		return
 	var/turf/T = get_turf(owner)
 	var/loot = rand(1,100)
@@ -135,7 +135,7 @@
 
 /datum/action/cooldown/riot/Trigger()
 	. = ..()
-	if(!.)
+	if(!. || owner.stat != CONSCIOUS)
 		return
 	var/cap = CONFIG_GET(number/ratcap)
 	var/something_from_nothing = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

this is clearly not intentional.

## Changelog
:cl:
fix: Regal rat can no longer keep spawning stuff while dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
