### PR TITLE
Block & Pellet wound pass

### DIFF
--- a/code/datums/elements/embed.dm
+++ b/code/datums/elements/embed.dm
@@ -168,11 +168,13 @@
   * If we hit a valid target (carbon or closed turf), we create the shrapnel_type object and immediately call tryEmbed() on it, targeting what we impacted. That will lead
   *	it to call tryForceEmbed() on its own embed element (it's out of our hands here, our projectile is done), where it will run through all the checks it needs to.
   */
-/datum/element/embed/proc/checkEmbedProjectile(obj/item/projectile/P, atom/movable/firer, atom/hit, angle, hit_zone)
+/datum/element/embed/proc/checkEmbedProjectile(obj/item/projectile/P, atom/movable/firer, atom/hit, angle, hit_zone, blocked)
 	if(!iscarbon(hit))
 		Detach(P)
 		return // we don't care
-
+	if(blocked >= 100)
+		Detach(P)	//fully blocked, no embedding for us.
+		return
 	var/obj/item/payload = new payload_type(get_turf(hit))
 	if(istype(payload, /obj/item/shrapnel/bullet))
 		payload.name = P.name

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -247,21 +247,27 @@
 	var/final_damage = damage
 
 	if(attack_type & ATTACK_TYPE_MELEE)
-		var/obj/hittingthing = object
-		if(hittingthing.damtype == BURN)
-			if((shield_flags & SHIELD_ENERGY_WEAK))
-				final_damage *= 2
-			else if((shield_flags & SHIELD_ENERGY_STRONG))
-				final_damage *= 0.5
+		if(istype(object, /obj))	//Assumption: non-object attackers are a meleeing mob. Therefore: Assuming physical attack in this case.
+			var/obj/hittingthing = object
+			if(hittingthing.damtype == BURN)
+				if((shield_flags & SHIELD_ENERGY_WEAK))
+					final_damage *= 2
+				else if((shield_flags & SHIELD_ENERGY_STRONG))
+					final_damage *= 0.5
 
-		if(hittingthing.damtype == BRUTE)
+			if(hittingthing.damtype == BRUTE)
+				if((shield_flags & SHIELD_KINETIC_WEAK))
+					final_damage *= 2
+				else if((shield_flags & SHIELD_KINETIC_STRONG))
+					final_damage *= 0.5
+
+			if(hittingthing.damtype == STAMINA || hittingthing.damtype == TOX || hittingthing.damtype == CLONE || hittingthing.damtype == BRAIN || hittingthing.damtype == OXY)
+				final_damage = 0
+		else
 			if((shield_flags & SHIELD_KINETIC_WEAK))
 				final_damage *= 2
 			else if((shield_flags & SHIELD_KINETIC_STRONG))
 				final_damage *= 0.5
-
-		if(hittingthing.damtype == STAMINA || hittingthing.damtype == TOX || hittingthing.damtype == CLONE || hittingthing.damtype == BRAIN || hittingthing.damtype == OXY)
-			final_damage = 0
 
 	if(attack_type & ATTACK_TYPE_PROJECTILE)
 		var/obj/item/projectile/shootingthing = object

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -215,7 +215,7 @@
 	if(isliving(target))
 		var/mob/living/L = target
 		hit_limb = L.check_limb_hit(def_zone)
-	SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle, hit_limb)
+	SEND_SIGNAL(src, COMSIG_PROJECTILE_SELF_ON_HIT, firer, target, Angle, hit_limb, blocked)
 	var/turf/target_loca = get_turf(target)
 
 	var/hitx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pellets before:
All their wound bonuses + damage gets added together and applied in one big hit
Now: Their damage gets added together, only the highest wound modifier gets added

Their damage for this previously also ignored block. This makes it care about it.

Additionally, embedding bullets now care about if they were fully blocked and do not embed if this is the case.

Also, shields now properly work against unarmed attacks instead of runtiming (these attacks count as KINETIC)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pellets wounds bypass shields and are really really strong in general. This makes them more in-line with normal bullets.
Embeds not embedding on full blocks seems good.
Shields working properly against unarmed / mob attacks seems good aswell.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Pellets now care about block woundwise
balance: Pellet wound-bonus no longer stacks for the final calculation
balance: Embeds no longer bypass full blocking.
fix: Shields now work properly against unarmed / mob attacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
