### PR TITLE
Synthetics can now hook up their power cord to cells instead of relying on moth-esque code

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -187,23 +187,6 @@
 /obj/item/stock_parts/cell/get_part_rating()
 	return rating * maxcharge
 
-// stuff so ipcs and synthlizards can eat power cells, taken from how moths can eat clothing
-/obj/item/reagent_containers/food/snacks/cell
-	name = "oops"
-	desc = "If you're reading this it means I messed up. This is related to ipcs/synths eating cells and I didn't know a better way to do it than making a new food object."
-	list_reagents = list(/datum/reagent/consumable/nutriment = 0.5)
-	tastes = list("electricity" = 1, "metal" = 1)
-
-/obj/item/stock_parts/cell/attack(mob/M, mob/user, def_zone)
-	if(user.a_intent != INTENT_HARM && isrobotic(M))
-		var/obj/item/reagent_containers/food/snacks/cell/cell_as_food = new
-		cell_as_food.name = name
-		if(cell_as_food.attack(M, user, def_zone))
-			take_damage(40, sound_effect=FALSE)
-		qdel(cell_as_food)
-	else
-		return ..()
-
 /* Cell variants*/
 /obj/item/stock_parts/cell/empty
 	start_charged = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. You can now connect your power cord implant to power cells, which will drain 2000 power for 20 nutrition per cycle. This is far less efficient or fast than recharging from APCs, but nonetheless a portable rechargable source of power.
This replaces being able to bite power cells for nutrition, which didn't work properly anyways.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Synthetics recharging from cells working properly seems good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Power cord implants can now also be connected to cells to recharge.
del: Synthetics can no longer bite power cells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
