### PR TITLE
Thins up the loot piles

### DIFF
--- a/code/game/objects/structures/loot_pile.dm
+++ b/code/game/objects/structures/loot_pile.dm
@@ -9,6 +9,7 @@
 	icon_state = "randompile"
 	density = FALSE
 	anchored = TRUE
+	max_integrity = 100
 	var/loot_amount = 5
 	var/delete_on_depletion = FALSE
 	var/can_use_hands = TRUE


### PR DESCRIPTION
## About The Pull Request

Reduces the loot pile to the strength to that of a table, enough that you gotta work for it, but not really that much.

## Why It's Good For The Game

It defaults to 300, and that seems a bit much to crunch your way through if you need to.

## Changelog
:cl:
balance: Reduces the HP from loot piles to 100, from 300.
/:cl:
