### PR TITLE
Acid overlay no longer lingers after done

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -52,12 +52,16 @@
 	return
 
 /**
-  * Properly removes the component from `parent` and cleans up references
-  * Setting `force` makes it not check for and remove the component from the parent
-  * Setting `silent` deletes the component without sending a `COMSIG_COMPONENT_REMOVING` signal
-  */
+ * Properly removes the component from `parent` and cleans up references
+ *
+ * Arguments:
+ * * force - makes it not check for and remove the component from the parent
+ * * silent - deletes the component without sending a [COMSIG_COMPONENT_REMOVING] signal
+ */
 /datum/component/Destroy(force=FALSE, silent=FALSE)
-	if(!force && parent)
+	if(!parent)
+		return ..()
+	if(!force)
 		_RemoveFromParent()
 	if(!silent)
 		SEND_SIGNAL(parent, COMSIG_COMPONENT_REMOVING, src)

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -38,9 +38,11 @@
 
 /datum/component/acid/Destroy()
 	STOP_PROCESSING(SSprocessing, src)
-	var/obj/O = parent
 	level = 0
-	O.update_overlays()
+	if(parent) // So, this is how you get runtimes fellas.
+		UnregisterSignal(parent, list(COMSIG_ATOM_UPDATE_OVERLAYS, COMSIG_ATOM_ATTACK_HAND)) // Don't worry about isitem checks, we don't need them.
+		var/atom/O = parent
+		O.update_icon(UPDATE_OVERLAYS)
 	return ..()
 
 /datum/component/acid/process()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -596,9 +596,13 @@
 	//SHOULD_CALL_PARENT(TRUE)
 	return SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_ICON_STATE)
 
-/// Updates the overlays of the atom
+/**
+ * Builds a list of overlays for the atom, this will not apply them.
+ * If you need to update overlays, use [update_icon(UPDATE_OVERLAYS)],
+ * This proc is intended to be overridden.
+ */
 /atom/proc/update_overlays()
-	//SHOULD_CALL_PARENT(TRUE)
+	SHOULD_CALL_PARENT(TRUE)
 	. = list()
 	SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_OVERLAYS, .)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Of course i would like for stuff to have acid overlays until the end of the round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Acid will disappear when not existant.
code: Updates component Destroy code, might result in less component related runtimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
