### PR TITLE
oil drum now recognises synthetic anthormorphs as synths

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/anthropomorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/anthropomorph.dm
@@ -48,3 +48,4 @@
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 
 	allowed_limb_ids = list("mammal","aquatic","avian", "human")
+	species_category = "robot"


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
fixes a bug

## Changelog
:cl:
fix: oil drum now recognises synthetic anthormorphs as synths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
