### PR TITLE
Various Main Map Tweaks

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -14653,6 +14653,9 @@
 	pixel_x = 5;
 	pixel_y = 24
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/wood,
 /area/service/library)
 "aIs" = (
@@ -14666,6 +14669,9 @@
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#c1caff"
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -14696,6 +14702,9 @@
 	dir = 4
 	},
 /obj/structure/chair/sofa/left,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/service/library)
 "aIx" = (
@@ -14704,6 +14713,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -17411,11 +17423,17 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/wood,
 /area/service/library)
 "aQq" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -21366,6 +21384,9 @@
 "bav" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -59645,6 +59666,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nkh" = (
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/service/library)
 "nko" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -65921,6 +65948,28 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"wCu" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "permacells3";
+	name = "Privacy Shutters";
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/cells)
 "wCQ" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -66889,28 +66938,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison/upper)
-"ybo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "permacells3";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/cells)
 "ycd" = (
 /obj/structure/toilet/secret/low_loot{
 	dir = 4
@@ -88425,7 +88452,7 @@ giE
 rBK
 lJA
 fgy
-ybo
+wCu
 abc
 obs
 rBY
@@ -89707,7 +89734,7 @@ gZT
 hQw
 qCc
 kcR
-ybo
+wCu
 lJA
 weW
 xNV
@@ -109804,7 +109831,7 @@ qfD
 aRO
 aQp
 aRN
-aIt
+nkh
 aUB
 aFu
 aVN

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -8974,8 +8974,8 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "ast" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/structure/bed/double,
+/obj/item/bedsheet/random/double,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "asu" = (
@@ -52572,6 +52572,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"diT" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "permacells3";
+	name = "Privacy Shutters";
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/cells)
 "dkM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -59666,12 +59688,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nkh" = (
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/service/library)
 "nko" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -60634,6 +60650,12 @@
 	},
 /turf/closed/wall,
 /area/medical/medbay/central)
+"oTe" = (
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/service/library)
 "oTx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -65948,28 +65970,6 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"wCu" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "permacells3";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/cells)
 "wCQ" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -88452,7 +88452,7 @@ giE
 rBK
 lJA
 fgy
-wCu
+diT
 abc
 obs
 rBY
@@ -89734,7 +89734,7 @@ gZT
 hQw
 qCc
 kcR
-wCu
+diT
 lJA
 weW
 xNV
@@ -109831,7 +109831,7 @@ qfD
 aRO
 aQp
 aRN
-nkh
+oTe
 aUB
 aFu
 aVN

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -53954,11 +53954,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "permacells3";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/cells)
 "fhu" = (
@@ -61615,28 +61610,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"qsq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "permacells3";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/cells)
 "qto" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/shovel/spade,
@@ -66916,6 +66889,28 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison/upper)
+"ybo" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "permacells3";
+	name = "Privacy Shutters";
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/cells)
 "ycd" = (
 /obj/structure/toilet/secret/low_loot{
 	dir = 4
@@ -88430,7 +88425,7 @@ giE
 rBK
 lJA
 fgy
-rBK
+ybo
 abc
 obs
 rBY
@@ -89712,7 +89707,7 @@ gZT
 hQw
 qCc
 kcR
-qsq
+ybo
 lJA
 weW
 xNV

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57241,11 +57241,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "permacells3";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison/cells)
 "kdF" = (
@@ -61620,6 +61615,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"qsq" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "permacells3";
+	name = "Privacy Shutters";
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/cells)
 "qto" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/shovel/spade,
@@ -89695,7 +89712,7 @@ gZT
 hQw
 qCc
 kcR
-rBK
+qsq
 lJA
 weW
 xNV

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -23,7 +23,7 @@
 "aac" = (
 /obj/machinery/camera{
 	c_tag = "Bar";
-	dir = 8
+	dir = 9
 	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
@@ -54942,6 +54942,7 @@
 /area/security/brig)
 "gyy" = (
 /obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
 	name = "Isolation Cell";
 	req_access_txt = "2"
 	},

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -44586,6 +44586,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Incinerator";
+	name = "atmospherics camera"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cga" = (
@@ -52572,28 +52576,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"diT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
-	id = "permacells3";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison/cells)
 "dkM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -55698,6 +55680,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hIi" = (
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/service/library)
 "hIL" = (
 /obj/structure/sign/poster/contraband/space_up{
 	pixel_x = -32;
@@ -55854,6 +55842,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness)
+"hWm" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "permacells3";
+	name = "Privacy Shutters";
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison/cells)
 "hYd" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -60650,12 +60660,6 @@
 	},
 /turf/closed/wall,
 /area/medical/medbay/central)
-"oTe" = (
-/obj/structure/sign/painting/library{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/service/library)
 "oTx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -88452,7 +88456,7 @@ giE
 rBK
 lJA
 fgy
-diT
+hWm
 abc
 obs
 rBY
@@ -89734,7 +89738,7 @@ gZT
 hQw
 qCc
 kcR
-diT
+hWm
 lJA
 weW
 xNV
@@ -109831,7 +109835,7 @@ qfD
 aRO
 aQp
 aRN
-oTe
+hIi
 aUB
 aFu
 aVN

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -43290,6 +43290,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cWx" = (
@@ -75535,7 +75536,6 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -36417,8 +36417,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cEA" = (
-/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
-/turf/open/floor/engine/co2,
+/obj/effect/turf_decal/vg_decals/atmos/air,
+/turf/open/floor/engine/air,
 /area/engineering/atmos)
 "cFF" = (
 /turf/open/floor/engine{
@@ -81076,6 +81076,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "hEm" = (
@@ -92152,7 +92153,7 @@
 /turf/closed/wall,
 /area/commons/storage/primary)
 "lkg" = (
-/obj/machinery/atmospherics/miner/toxins,
+/obj/effect/turf_decal/vg_decals/atmos/plasma,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "lkF" = (
@@ -93712,7 +93713,7 @@
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "lNq" = (
-/obj/machinery/atmospherics/miner/nitrogen,
+/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "lNA" = (
@@ -95067,8 +95068,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "mmq" = (
-/obj/effect/turf_decal/vg_decals/atmos/nitrogen,
-/turf/open/floor/engine/n2,
+/obj/effect/turf_decal/vg_decals/atmos/mix,
+/turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "mmC" = (
 /obj/structure/cable/white{
@@ -95541,6 +95542,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "mwH" = (
@@ -98637,6 +98639,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "nzv" = (
@@ -100568,7 +100571,7 @@
 /turf/open/floor/plasteel/dark,
 /area/service/library)
 "ohX" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/effect/turf_decal/vg_decals/atmos/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "ohZ" = (
@@ -102605,7 +102608,7 @@
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
 "oTt" = (
-/obj/machinery/atmospherics/miner/n2o,
+/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "oTJ" = (
@@ -106021,7 +106024,6 @@
 	dir = 1;
 	name = "atmospherics camera"
 	},
-/obj/effect/turf_decal/vg_decals/atmos/mix,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "qbJ" = (
@@ -106069,10 +106071,6 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/engineering/atmos)
-"qcm" = (
-/obj/effect/turf_decal/vg_decals/atmos/plasma,
-/turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "qcW" = (
 /obj/machinery/firealarm{
@@ -108270,10 +108268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmospherics_engine)
-"qYy" = (
-/obj/effect/turf_decal/vg_decals/atmos/oxygen,
-/turf/open/floor/engine/o2,
-/area/engineering/atmos)
 "qYD" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
@@ -109954,10 +109948,6 @@
 	dir = 6
 	},
 /area/science/circuit)
-"rCx" = (
-/obj/effect/turf_decal/vg_decals/atmos/nitrous_oxide,
-/turf/open/floor/engine/n2o,
-/area/engineering/atmos)
 "rCK" = (
 /obj/machinery/button/door{
 	id = "teleporterhubshutters";
@@ -116140,10 +116130,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
-"tBF" = (
-/obj/effect/turf_decal/vg_decals/atmos/air,
-/turf/open/floor/engine/air,
-/area/engineering/atmos)
 "tBH" = (
 /obj/machinery/door/airlock/atmos/glass/critical{
 	heat_proof = 1;
@@ -117155,7 +117141,7 @@
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "tWb" = (
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/effect/turf_decal/vg_decals/atmos/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "tWi" = (
@@ -118594,6 +118580,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "uuL" = (
@@ -125328,6 +125315,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "wXR" = (
@@ -150110,18 +150098,18 @@ aSQ
 iio
 iMu
 ohX
-cEA
+hFW
 iio
 sEM
 lkg
-qcm
+kRS
 iio
 rUo
 oTt
-rCx
+lbI
 iio
 kcG
-kcG
+mmq
 qbG
 iio
 aad
@@ -157560,16 +157548,16 @@ aaa
 aad
 iio
 wTN
+cEA
 lEq
-tBF
 iio
 wjw
 tWb
-qYy
+sCm
 iio
 eFu
 lNq
-mmq
+skw
 iio
 aMN
 emZ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16790,13 +16790,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bmP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "bmQ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;25;46"
@@ -42568,6 +42561,10 @@
 	},
 /obj/structure/chair/stool,
 /obj/machinery/light/small,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cNq" = (
@@ -65562,6 +65559,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
+"mXg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "mXi" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -70406,6 +70410,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
+"pHM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "pHS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -84265,13 +84276,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"xxH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "xyp" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -125598,8 +125602,8 @@ ieJ
 nGn
 uoM
 lUn
-bmP
-xxH
+pHM
+mXg
 qxd
 qtO
 qtO

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40889,6 +40889,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
+/obj/item/cautery{
+	pixel_y = 15
+	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -54564,6 +54567,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
+"gQh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "gQq" = (
 /obj/structure/sink{
 	dir = 4;
@@ -65559,13 +65569,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
-"mXg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "mXi" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -70410,13 +70413,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/commons/cryopod)
-"pHM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "pHS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -82544,6 +82540,13 @@
 	dir = 5
 	},
 /area/service/kitchen)
+"wCt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "wCQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -125602,8 +125605,8 @@ ieJ
 nGn
 uoM
 lUn
-pHM
-mXg
+gQh
+wCt
 qxd
 qtO
 qtO

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -66161,6 +66161,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel/cafeteria,
 /area/commons/dorms)
 "nry" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28970,6 +28970,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"ckg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "ckh" = (
 /obj/machinery/light{
 	dir = 4
@@ -69641,6 +69648,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
+"pnD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "pnF" = (
 /obj/machinery/light{
 	dir = 4
@@ -125583,8 +125597,8 @@ ieJ
 nGn
 uoM
 lUn
-dlF
-uhB
+ckg
+pnD
 qxd
 qtO
 qtO

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16790,6 +16790,13 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bmP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "bmQ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;25;46"
@@ -28970,13 +28977,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"ckg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "ckh" = (
 /obj/machinery/light{
 	dir = 4
@@ -42567,6 +42567,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/chair/stool,
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "cNq" = (
@@ -69648,13 +69649,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/service/chapel/office)
-"pnD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "pnF" = (
 /obj/machinery/light{
 	dir = 4
@@ -84271,6 +84265,13 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"xxH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "xyp" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -125597,8 +125598,8 @@ ieJ
 nGn
 uoM
 lUn
-ckg
-pnD
+bmP
+xxH
 qxd
 qtO
 qtO

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25296,6 +25296,10 @@
 /obj/structure/sign/warning/deathsposal{
 	pixel_y = 32
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Incinerator";
+	name = "atmospherics camera"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cba" = (
@@ -56850,6 +56854,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/commons/fitness/recreation)
+"ify" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "ifM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -67123,13 +67134,6 @@
 	dir = 1
 	},
 /area/service/chapel/main)
-"nYV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "nZd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -125595,7 +125599,7 @@ nGn
 uoM
 lUn
 wFX
-nYV
+ify
 qxd
 qtO
 qtO

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -50834,7 +50834,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison/upper)
 "eFn" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
@@ -54567,13 +54566,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
-"gQh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "gQq" = (
 /obj/structure/sink{
 	dir = 4;
@@ -57710,9 +57702,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "iFl" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide{
-	valve_open = 1
-	},
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
@@ -63212,7 +63201,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "lIs" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
@@ -67135,6 +67123,13 @@
 	dir = 1
 	},
 /area/service/chapel/main)
+"nYV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "nZd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -69370,7 +69365,6 @@
 	},
 /area/command/heads_quarters/rd)
 "pgT" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
@@ -76263,7 +76257,6 @@
 /turf/closed/wall,
 /area/service/bar)
 "sTB" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
@@ -82540,13 +82533,6 @@
 	dir = 5
 	},
 /area/service/kitchen)
-"wCt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "wCQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82703,8 +82689,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "wFX" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "wGp" = (
 /obj/structure/cable/white{
@@ -125605,8 +125594,8 @@ ieJ
 nGn
 uoM
 lUn
-gQh
-wCt
+wFX
+nYV
 qxd
 qtO
 qtO
@@ -129480,7 +129469,7 @@ uKL
 aaf
 dYX
 htG
-wFX
+uLh
 rjT
 dPI
 aaf

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -50528,6 +50528,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/library/lounge)
 "cww" = (
@@ -50622,6 +50625,9 @@
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
 /obj/item/pen,
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/library/lounge)
 "cxb" = (
@@ -51484,6 +51490,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"cHB" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/library)
 "cHS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55590,6 +55602,9 @@
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/library/lounge)
 "jXA" = (
@@ -55809,6 +55824,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"kro" = (
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/library)
 "krU" = (
 /obj/structure/chair{
 	dir = 4
@@ -56464,6 +56485,12 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
+"lzT" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/service/library)
 "lAf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58032,6 +58059,9 @@
 "nYC" = (
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)
@@ -60341,6 +60371,9 @@
 "rSE" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library/lounge)
@@ -81160,11 +81193,11 @@ aht
 aht
 cjp
 cjp
-ckH
+lzT
 cyZ
 ckH
-ckH
-ckH
+kro
+kro
 ckH
 czI
 ckH
@@ -81425,7 +81458,7 @@ mXJ
 mXJ
 czM
 ckH
-ckH
+cHB
 cjp
 cjp
 cyU
@@ -83738,7 +83771,7 @@ ckH
 ckH
 rzm
 ckH
-ckH
+cHB
 cjp
 cjp
 cyU

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6971,7 +6971,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel/cafeteria,
 /area/commons/dorms)
 "ash" = (
@@ -48290,6 +48289,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/bedsheetbin/color,
 /turf/open/floor/plasteel/cafeteria,
 /area/commons/dorms)
 "coe" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes or tweaks things for the currently in rotation main maps.
Updating this as I go, will undraft when it's done.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Seemed like a good idea to get this done.
Most of these are parity issues, but some of them are actual fixes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: (Meta) Adds meters to the refill/scrubber station outside Engineering
add: (Meta) Adds a small light fixture to southeast solar access
add: (Meta) Places an intercom to southeast solar access
add: (Meta) Gives a cautery to Robotics
add: (Meta) Camera to Incinerator
add: (Meta) Linen bin to dorms
add: (Box) Camera to Incinerator
add: (Box) Painting mounts to Library
add: (Pubby) Painting mounts to Library
del: (Meta) Removes the example tanks from the Atmospherics gas chambers
tweak: (Box) Moves the Bar camera from out behind the soda dispenser
tweak: (Box) Gives dorm room 6 a double bed to start
tweak: (Pubby) Moves linen bin in washroom to a table
tweak: (Delta) Moves the plant in Medbay's Storage to not be in front of a vendor
tweak: (Delta) Moves the gas miners and labels inside the Atmoshperics gas chambers to the centers
fix: (Box) Made the upper Execution Chamber airlock unable to be used by the AI
fix: (Box) Moves prison cell 4 and 6's shutter button to the wall
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
