### PR TITLE
Fixes fireman carry dropping the carried target if passing over a prone individual

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -222,6 +222,8 @@
 /// forces us to not render our overlays
 #define TRAIT_HUMAN_NO_RENDER			"human_no_render"
 #define TRAIT_TRASHCAN					"trashcan"
+///Used for fireman carry to have mobe not be dropped when passing by a prone individual.
+#define TRAIT_BEING_CARRIED "being_carried"	
 
 // mobility flag traits
 // IN THE FUTURE, IT WOULD BE NICE TO DO SOMETHING SIMILAR TO https://github.com/tgstation/tgstation/pull/48923/files (ofcourse not nearly the same because I have my.. thoughts on it)

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -219,6 +219,7 @@
 	if(!fireman_carrying)
 		M.Daze(25)
 	REMOVE_TRAIT(M, TRAIT_MOBILITY_NOUSE, src)
+	REMOVE_TRAIT(M, TRAIT_BEING_CARRIED, src)
 	return ..()
 
 /datum/component/riding/human/vehicle_mob_buckle(datum/source, mob/living/M, force = FALSE)
@@ -228,6 +229,7 @@
 		H.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/human_carry, TRUE, fireman_carrying? FIREMAN_CARRY_SLOWDOWN : PIGGYBACK_CARRY_SLOWDOWN)
 	if(fireman_carrying)
 		ADD_TRAIT(M, TRAIT_MOBILITY_NOUSE, src)
+	ADD_TRAIT(M, TRAIT_BEING_CARRIED, src)
 
 /datum/component/riding/human/proc/on_host_unarmed_melee(atom/target)
 	var/mob/living/carbon/human/H = parent

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -36,6 +36,8 @@
 	if(ismob(mover))
 		if(mover in buckled_mobs)
 			return TRUE
+		if(HAS_TRAIT(mover, TRAIT_BEING_CARRIED))
+			return TRUE	//We're being carried and our carrier managed to pass, ergo, let us pass aswell.
 	var/mob/living/L = mover		//typecast first, check isliving and only check this if living using short circuit
 	if(isliving(L) && lying && L.lying)		//if we're both lying down and aren't already being thrown/shipped around, don't pass
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Another funky bug introduced by making crawling under people take time, though by a different means.
This makes carrying someone add a trait to them that allows them to pass by mobs, as they'll only attempt the movement if the carrier already succeeded.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fireman carry no longer drops the carried person if passing over a prone individual.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
