### PR TITLE
RLD Rebalance - Reagen Skill Issue Edition

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -679,8 +679,8 @@ RLD
 	icon_state = "rld"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	matter = 200
-	max_matter = 200
+	matter = 350
+	max_matter = 350
 	sheetmultiplier = 5
 	var/mode = LIGHT_MODE
 	actions_types = list(/datum/action/item_action/pick_color)
@@ -691,8 +691,8 @@ RLD
 	var/floorcost = 15
 	var/deconcost = 15
 
-	var/walldelay = 20
-	var/floordelay = 15
+	var/walldelay = 50
+	var/floordelay = 35
 	var/decondelay = 10
 
 	var/color_choice = null
@@ -821,8 +821,8 @@ RLD
 /obj/item/construction/rld/mini
 	name = "mini-rapid-light-device (MRLD)"
 	desc = "A device used to rapidly provide lighting sources to an area. Reload with metal, plasteel, glass or compressed matter cartridges."
-	matter = 100
-	max_matter = 100
+	matter = 150
+	max_matter = 150
 
 /obj/item/rcd_upgrade
 	name = "RCD advanced design disk"

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -688,12 +688,11 @@ RLD
 	has_ammobar = TRUE
 
 	var/wallcost = 20
-	var/floorcost = 25
-	var/launchcost = 10
-	var/deconcost = 20
+	var/floorcost = 15
+	var/deconcost = 15
 
-	var/walldelay = 10
-	var/floordelay = 10
+	var/walldelay = 20
+	var/floordelay = 15
 	var/decondelay = 10
 
 	var/color_choice = null
@@ -721,9 +720,6 @@ RLD
 			mode = LIGHT_MODE
 			to_chat(user, "<span class='notice'>You change RLD's mode to 'Permanent Light Construction'.</span>")
 		if(LIGHT_MODE)
-			mode = GLOW_MODE
-			to_chat(user, "<span class='notice'>You change RLD's mode to 'Light Launcher'.</span>")
-		if(GLOW_MODE)
 			mode = REMOVE_MODE
 			to_chat(user, "<span class='notice'>You change RLD's mode to 'Deconstruct'.</span>")
 
@@ -820,19 +816,6 @@ RLD
 						FL.color = color_choice
 						FL.light_color = FL.color
 						return TRUE
-				return FALSE
-
-		if(GLOW_MODE)
-			if(useResource(launchcost, user))
-				activate()
-				to_chat(user, "<span class='notice'>You fire a glowstick!</span>")
-				var/obj/item/flashlight/glowstick/G  = new /obj/item/flashlight/glowstick(start)
-				G.color = color_choice
-				G.light_color = G.color
-				G.throw_at(A, 9, 3, user)
-				G.on = TRUE
-				G.update_brightness()
-				return TRUE
 			return FALSE
 
 /obj/item/construction/rld/mini

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -687,6 +687,7 @@ RLD
 	ammo_sections = 5
 	has_ammobar = TRUE
 
+	var/delay_mod = 1.2
 	var/wallcost = 20
 	var/floorcost = 15
 	var/deconcost = 15

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -687,7 +687,6 @@ RLD
 	ammo_sections = 5
 	has_ammobar = TRUE
 
-	delay_mod = 1.2
 	var/wallcost = 20
 	var/floorcost = 15
 	var/deconcost = 15

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -687,12 +687,12 @@ RLD
 	ammo_sections = 5
 	has_ammobar = TRUE
 
-	var/delay_mod = 1.2
+	delay_mod = 1.2
 	var/wallcost = 20
 	var/floorcost = 15
 	var/deconcost = 15
 
-	var/walldelay = 50
+	var/walldelay = 35
 	var/floordelay = 35
 	var/decondelay = 10
 

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -183,18 +183,6 @@
 /////////////////////////////// Janitor //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-/datum/supply_pack/service/advlighting
-	name = "Advanced Lighting crate"
-	desc = "Thanks to advanced lighting tech we here at the Lamp Factory have be able to produce more lamps and lamp items! This crate has three lamps, a box of lights and a state of the art rapid-light-device!"
-	cost = 2750
-	contains = list(/obj/item/construction/rld,
-					/obj/item/flashlight/lamp,
-					/obj/item/flashlight/lamp,
-					/obj/item/flashlight/lamp/green,
-					/obj/item/storage/box/lights/mixed)
-	crate_name = "advanced lighting crate"
-	crate_type = /obj/structure/closet/crate/secure
-
 /datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights" //Subgrouping this with Advanced Lighting Crate, they're both lighting related.
 	desc = "May the light of Aether shine upon this station! Or at least, the light of forty two light tubes and twenty one light bulbs as well as a light replacer."

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -844,6 +844,6 @@
 	icon_state = "floor"
 	brightness = 3
 	nightshift_brightness = 2
-	layer = 4.25
+	layer = BELOW_MOB_LAYER
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -842,8 +842,8 @@
 	icon = 'icons/obj/lighting.dmi'
 	base_state = "floor"		// base description and icon_state
 	icon_state = "floor"
-	brightness = 5
-	nightshift_brightness = 4
-	layer = 2.5
+	brightness = 3
+	nightshift_brightness = 2
+	layer = 4.25
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Several nerfs, buffs, and anything in between that relates to the RLD:

1. Advanced lighting crate is removed from cargo. It no served purpose whatsoever, it had no reason to exist at all, and there's nothing advanced about it at all aside from the fact it had a rapid lighting device in it. This means the only way one could reasonably obtain an RLD is through BEPIS, which was where it came from to begin with.
2. Floor light brightness changed from 5 to 3. Layering changed from 2.5 to 3.7. Meaning, it cannot really be hidden beneath mobs nor block them. 
3. Max matter increased to 350 from 200. 
4. **Light launcher (aka glowstick spammer) removed from the RLD. **

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shrug. 
I guess if a tool with a different purpose entirely is only being used to counter a midround antagonist, it should probably just get some adjustments or something? It had no business existing as an item that could be obtained through cargo. The light launcher _really_ didn't have a reason to exist besides the original creator on TG adding it for the hell of it. Floor lights were also a bit of a concern for me, given how there is not much investment into placing them beyond simply clicking an open turf and waiting a short amount of time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: RLD wall-light construction delay increased to 35 from 10.
tweak: RLD floor light construction delay increased to 35 from 10. 
tweak: Floor light brightness decreased from 5 to 3. A little under the brightness of a light bulb.
tweak: Floor lights are now always above items and structures I guess. Layer is now 3.7 (BENEATH_MOB_LAYER) from 2.5. If you need a more explicit understanding; they are no longer beneath tables.
balance: Light launcher removed from rapid lighting device. 
balance: RLD max matter increased to 350 from 200.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
