### PR TITLE
Pool doesn't freeze people to death when its set to cool anymore.

### DIFF
--- a/code/modules/pool/pool_controller.dm
+++ b/code/modules/pool/pool_controller.dm
@@ -238,7 +238,7 @@
 				M.adjust_bodytemperature(20,0,360) //Heats up mobs till the thermometer shows up
 			//Normal temp does nothing, because it's just room temperature water.
 			if(POOL_COOL)
-				M.adjust_bodytemperature(-20,260.16) //Cools mobs till the thermometer shows up
+				M.adjust_bodytemperature(-20,261) //Cools mobs till the thermometer shows up
 			if(POOL_FRIGID) //Freezing
 				M.adjust_bodytemperature(-60) //cool mob at -35k per cycle, less would not affect the mob enough.
 				if(M.bodytemperature <= 50 && !M.stat)

--- a/code/modules/pool/pool_controller.dm
+++ b/code/modules/pool/pool_controller.dm
@@ -238,7 +238,7 @@
 				M.adjust_bodytemperature(20,0,360) //Heats up mobs till the thermometer shows up
 			//Normal temp does nothing, because it's just room temperature water.
 			if(POOL_COOL)
-				M.adjust_bodytemperature(-20,250) //Cools mobs till the thermometer shows up
+				M.adjust_bodytemperature(-20,261) //Cools mobs till the thermometer shows up
 			if(POOL_FRIGID) //Freezing
 				M.adjust_bodytemperature(-60) //cool mob at -35k per cycle, less would not affect the mob enough.
 				if(M.bodytemperature <= 50 && !M.stat)

--- a/code/modules/pool/pool_controller.dm
+++ b/code/modules/pool/pool_controller.dm
@@ -238,7 +238,7 @@
 				M.adjust_bodytemperature(20,0,360) //Heats up mobs till the thermometer shows up
 			//Normal temp does nothing, because it's just room temperature water.
 			if(POOL_COOL)
-				M.adjust_bodytemperature(-20,261) //Cools mobs till the thermometer shows up
+				M.adjust_bodytemperature(-20,260.16) //Cools mobs till the thermometer shows up
 			if(POOL_FRIGID) //Freezing
 				M.adjust_bodytemperature(-60) //cool mob at -35k per cycle, less would not affect the mob enough.
 				if(M.bodytemperature <= 50 && !M.stat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Raises pool 'cool' tempature to be 1 kelv above the cold damage limit so cold blooded people won't you know, die.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A non hacked setting should not be harmful to any crewmember.
These temps are going to need a pass if someone ever adds hypo/hyperthermia however.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Setting the pool tempature to cool doesnt start giving you freezerburn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
