### PR TITLE
Hey what if cold blooded people didn't get a permanent too-hot alert if their body is the same temperature as the air around them 

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2195,7 +2195,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/cold, 1)
 			if(-20 to 0) //This is the sweet spot where air is considered normal
 				H.clear_alert("tempfeel")
-			if(0 to 15) //When the air around you matches your body's temperature, you'll start to feel warm.
+			if(1 to 15) //When the air around you matches your body's temperature, you'll start to feel warm.
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/hot, 1)
 			if(15 to 30)
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/hot, 2)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2193,7 +2193,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/cold, 2)
 			if(-35 to -20)
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/cold, 1)
-			if(-20 to 0.9) //This is the sweet spot where air is considered normal
+			if(-20 to 1) //This is the sweet spot where air is considered normal
 				H.clear_alert("tempfeel")
 			if(1 to 15) //When the air around you matches your body's temperature, you'll start to feel warm.
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/hot, 1)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2193,7 +2193,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/cold, 2)
 			if(-35 to -20)
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/cold, 1)
-			if(-20 to 0) //This is the sweet spot where air is considered normal
+			if(-20 to 0.9) //This is the sweet spot where air is considered normal
 				H.clear_alert("tempfeel")
 			if(1 to 15) //When the air around you matches your body's temperature, you'll start to feel warm.
 				H.throw_alert("tempfeel", /atom/movable/screen/alert/hot, 1)

--- a/code/modules/pool/pool_controller.dm
+++ b/code/modules/pool/pool_controller.dm
@@ -235,10 +235,10 @@
 			if(POOL_SCALDING) //Scalding
 				M.adjust_bodytemperature(50,0,500)
 			if(POOL_WARM) //Warm
-				M.adjust_bodytemperature(20,0,360) //Heats up mobs till the thermometer shows up
+				M.adjust_bodytemperature(20,0,323.15) //Heats up mobs till the thermometer shows up
 			//Normal temp does nothing, because it's just room temperature water.
 			if(POOL_COOL)
-				M.adjust_bodytemperature(-20,250) //Cools mobs till the thermometer shows up
+				M.adjust_bodytemperature(-20,274.15) //Cools mobs till the thermometer shows up
 			if(POOL_FRIGID) //Freezing
 				M.adjust_bodytemperature(-60) //cool mob at -35k per cycle, less would not affect the mob enough.
 				if(M.bodytemperature <= 50 && !M.stat)

--- a/code/modules/pool/pool_controller.dm
+++ b/code/modules/pool/pool_controller.dm
@@ -235,10 +235,10 @@
 			if(POOL_SCALDING) //Scalding
 				M.adjust_bodytemperature(50,0,500)
 			if(POOL_WARM) //Warm
-				M.adjust_bodytemperature(20,0,323.15) //Heats up mobs till the thermometer shows up
+				M.adjust_bodytemperature(20,0,360) //Heats up mobs till the thermometer shows up
 			//Normal temp does nothing, because it's just room temperature water.
 			if(POOL_COOL)
-				M.adjust_bodytemperature(-20,274.15) //Cools mobs till the thermometer shows up
+				M.adjust_bodytemperature(-20,250) //Cools mobs till the thermometer shows up
 			if(POOL_FRIGID) //Freezing
 				M.adjust_bodytemperature(-60) //cool mob at -35k per cycle, less would not affect the mob enough.
 				if(M.bodytemperature <= 50 && !M.stat)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/1371992/145140007-0a31fdde-aa3e-4e01-b85c-a2ba2825a150.png)
Fixes this nonsense, in particular it happens a cold blooded person's body tempature dips below the air temp and then equalizes again. 1C of leeway should be fine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
aaaaaaaaaaaaaaaaaaaaaaa I just want to play with the cold blooded trait and not constantly have the temp alert on my screen.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cold blooded critters won't worry too much about the air around them being too hot even though their body temperature is the same as it. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
