### PR TITLE
Fixes Linters

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -368,11 +368,15 @@
 		if(ishuman(hit_atom) && !caught && prob(throw_hit_chance) && thrownby)//if they are a carbon and they didn't catch it
 			baton_stun(hit_atom, thrownby, shoving = TRUE)
 		if(thrownby && !caught)
-			sleep(1)
-			if(!QDELETED(src))
-				throw_at(thrownby, throw_range+2, throw_speed, null, TRUE)
+			throw_back()
 	else
 		return ..()
+
+/obj/item/melee/baton/boomerang/proc/throw_back()
+	set waitfor = FALSE
+	sleep(1)
+	if(!QDELETED(src))
+		throw_at(thrownby, throw_range+2, throw_speed, null, TRUE)
 
 /obj/item/melee/baton/boomerang/update_icon()
 	if(turned_on)

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -734,6 +734,7 @@
 	delayed_release_smoke()
 
 /obj/item/reagent_containers/potion_container/proc/delayed_release_smoke()
+	set waitfor = FALSE
 	sleep(20)
 	var/datum/effect_system/smoke_spread/chem/s = new()
 	s.set_up(src.reagents, 3, get_turf(src))

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -731,9 +731,12 @@
 
 /obj/item/reagent_containers/potion_container/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	..()
+	delayed_release_smoke()
+
+/obj/item/reagent_containers/potion_container/proc/delayed_release_smoke()
 	sleep(20)
 	var/datum/effect_system/smoke_spread/chem/s = new()
-	s.set_up(src.reagents, 3, src.loc)
+	s.set_up(src.reagents, 3, get_turf(src))
 	s.start()
 	qdel(src)
 

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -92,6 +92,10 @@
 	icon_state = "capturedevice"
 
 /obj/item/capturedevice/attack(mob/living/M, mob/user)
+	try_catching(M, user)
+
+/obj/item/capturedevice/proc/try_catching(mob/living/M, mob/user)
+	set waitfor = FALSE
 	if(length(contents))
 		to_chat(user, "<span class='warning'>The device already has something inside.</span>")
 		return
@@ -116,7 +120,7 @@
 			to_chat(user, "<span class='warning'>This creature is too aggressive to capture.</span>")
 			return
 	to_chat(user, "<span class='notice'>You store [M] in the capture device.</span>")
-	store(M)
+	store(M, user)
 
 /obj/item/capturedevice/attack_self(mob/user)
 	if(contents.len)
@@ -125,7 +129,10 @@
 	else
 		to_chat(user, "<span class='warning'>The device is empty...</span>")
 
-/obj/item/capturedevice/proc/store(var/mob/living/M)
+/obj/item/capturedevice/proc/store(var/mob/living/M, mob/user)
+	if(length(contents))
+		to_chat(user, "<span class='warning'>The device already has something inside.</span>")
+		return
 	M.forceMove(src)
 
 /obj/item/capturedevice/proc/release()

--- a/strings/flavor_objectives/traitor/assistant.txt
+++ b/strings/flavor_objectives/traitor/assistant.txt
@@ -1,0 +1,1 @@
+There are no flavor objectives for this job so you got this one because it's needed for Github to stop screaming. If you get this because someone enabled flavor objectives without rechecking them, yell at coders.

--- a/strings/flavor_objectives/traitor/engineering.txt
+++ b/strings/flavor_objectives/traitor/engineering.txt
@@ -1,0 +1,1 @@
+There are no flavor objectives for this job so you got this one because it's needed for Github to stop screaming. If you get this because someone enabled flavor objectives without rechecking them, yell at coders.

--- a/strings/flavor_objectives/traitor/medical.txt
+++ b/strings/flavor_objectives/traitor/medical.txt
@@ -1,0 +1,1 @@
+There are no flavor objectives for this job so you got this one because it's needed for Github to stop screaming. If you get this because someone enabled flavor objectives without rechecking them, yell at coders.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Linters realized some should_not_sleep stuff was sleeping and started screaming. This fixes them.
Additionally, it also failed because some flavor objective .txts were empty, so I put a filler objective into each so it doesn't fail, aswell as flavor objectives not exactly currently being used.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Linters of PRs being able to not fail is kinda neat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Linters should no longer scream.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
