### PR TITLE
Makes science points show actual change in last minute instead of just passive gen

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -349,9 +349,9 @@ SUBSYSTEM_DEF(research)
 		if(!length(last_bitcoins))
 			last_bitcoins = science_tech.research_points
 		for(var/i in last_bitcoins)
-			var/old_weighted = last_bitcoins[i] * (1 MINUTE - income_time_difference)
+			var/old_weighted = last_bitcoins[i] * (1 MINUTES - income_time_difference)
 			var/new_weighted = science_tech.research_points[i] * income_time_difference
-			last_bitcoins[i] = round((old_weighted + new_weighted) / (1 MINUTE))
+			last_bitcoins[i] = round((old_weighted + new_weighted) / (1 MINUTES))
 	last_income = world.time
 
 /datum/controller/subsystem/research/proc/calculate_server_coefficient()	//Diminishing returns.

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -346,12 +346,12 @@ SUBSYSTEM_DEF(research)
 		for(var/i in bitcoins)
 			bitcoins[i] *= income_time_difference / 10
 		science_tech.add_point_list(bitcoins)
-		if(!length(last_bitcoins))
-			last_bitcoins = science_tech.research_points
-		for(var/i in last_bitcoins)
-			var/old_weighted = last_bitcoins[i] * (1 MINUTES - income_time_difference)
+		if(!length(science_tech.last_bitcoins))
+			science_tech.last_bitcoins = science_tech.research_points
+		for(var/i in science_tech.last_bitcoins)
+			var/old_weighted = science_tech.last_bitcoins[i] * (1 MINUTES - income_time_difference)
 			var/new_weighted = science_tech.research_points[i] * income_time_difference
-			last_bitcoins[i] = round((old_weighted + new_weighted) / (1 MINUTES))
+			science_tech.last_bitcoins[i] = round((old_weighted + new_weighted) / (1 MINUTES))
 	last_income = world.time
 
 /datum/controller/subsystem/research/proc/calculate_server_coefficient()	//Diminishing returns.

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -351,7 +351,7 @@ SUBSYSTEM_DEF(research)
 		for(var/i in last_bitcoins)
 			var/old_weighted = last_bitcoins[i] * (1 MINUTE - income_time_difference)
 			var/new_weighted = science_tech.research_points[i] * income_time_difference
-			last_bitcoins[i] = (old_weighted + new_weighted) / (1 MINUTE)
+			last_bitcoins[i] = round((old_weighted + new_weighted) / (1 MINUTE))
 	last_income = world.time
 
 /datum/controller/subsystem/research/proc/calculate_server_coefficient()	//Diminishing returns.

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -343,10 +343,15 @@ SUBSYSTEM_DEF(research)
 				break			//Just need one to work.
 	if (!isnull(last_income))
 		var/income_time_difference = world.time - last_income
-		science_tech.last_bitcoins = bitcoins  // Doesn't take tick drift into account
 		for(var/i in bitcoins)
 			bitcoins[i] *= income_time_difference / 10
 		science_tech.add_point_list(bitcoins)
+		if(!length(last_bitcoins))
+			last_bitcoins = science_tech.research_points
+		for(var/i in last_bitcoins)
+			var/old_weighted = last_bitcoins[i] * (1 MINUTE - income_time_difference)
+			var/new_weighted = science_tech.research_points[i] * income_time_difference
+			last_bitcoins[i] = (old_weighted + new_weighted) / (1 MINUTE)
 	last_income = world.time
 
 /datum/controller/subsystem/research/proc/calculate_server_coefficient()	//Diminishing returns.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Per minute change now accounts for toxins bombs, gas generation, crossbreed deconstruction and so on.

## Why It's Good For The Game

It's always 2100/min right now. Like, literally always. It can't be changed, we don't have multiple research servers enabled. This makes the display meaningful.

## Changelog
:cl:
tweak: Sciences points/minute display now shows actual points/minute instead of just passive
/:cl:
