### PR TITLE
Fixes excited group process delay heuristic

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -405,7 +405,7 @@ SUBSYSTEM_DEF(air)
 		eq_cooldown += (1-delay_threshold) * (cost_equalize / total_thread_time) * 2
 		if(eq_cooldown > 0.5)
 			equalize_enabled = FALSE
-		excited_group_pressure_goal = max(0,excited_group_pressure_goal_target * (1 - delay_threshold))
+		excited_group_pressure_goal = max(0,excited_group_pressure_goal_target * delay_threshold)
 
 
 /datum/controller/subsystem/air/proc/process_turfs(resumed = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yeah, uh, I did a 1- once too many. Excited groups don't even work right now cause of this, whoops.

## Why It's Good For The Game

This sort of processing should be happening more to prevent atmos from being too slow (real time).

## Changelog
:cl:
fix: Atmos group processing heuristic no longer does opposite of intent
/:cl: