### PR TITLE
Fixes even more linter stuff

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -271,18 +271,7 @@
 		if(resin_cooldown)
 			to_chat(user, "<span class='warning'>Resin launcher is still recharging...</span>")
 			return
-		resin_cooldown = TRUE
-		R.remove_any(100)
-		var/obj/effect/resin_container/A = new (get_turf(src))
-		log_game("[key_name(user)] used Resin Launcher at [AREACOORD(user)].")
-		playsound(src,'sound/items/syringeproj.ogg',40,1)
-		for(var/a=0, a<5, a++)
-			step_towards(A, target)
-			sleep(2)
-		A.Smoke()
-		spawn(100)
-			if(src)
-				resin_cooldown = FALSE
+		launch_resin(target, user)
 		return
 	if(nozzle_mode == RESIN_FOAM)
 		if(!Adj|| !isturf(target))
@@ -300,6 +289,21 @@
 		else
 			to_chat(user, "<span class='warning'>Resin foam mix is still being synthesized...</span>")
 			return
+
+/obj/item/extinguisher/mini/nozzle/proc/launch_resin(atom/target, mob/user)
+	set waitfor = FALSE
+	resin_cooldown = TRUE
+	reagents.remove_any(100)
+	var/obj/effect/resin_container/A = new (get_turf(src))
+	log_game("[key_name(user)] used Resin Launcher at [AREACOORD(user)].")
+	playsound(src,'sound/items/syringeproj.ogg',40,1)
+	for(var/a=0, a<5, a++)
+		step_towards(A, target)
+		sleep(2)
+	A.Smoke()
+	spawn(100)
+		if(src)
+			resin_cooldown = FALSE
 
 /obj/effect/resin_container
 	name = "resin container"

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -660,40 +660,41 @@
 		return
 
 	if(istype(A, /obj/item))
-
-		var/list/cultists = list()
-		for(var/datum/mind/M in SSticker.mode.cult)
-			if(M.current && M.current.stat != DEAD)
-				cultists |= M.current
-		var/mob/living/cultist_to_receive = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in (cultists - user)
-		if(!Adjacent(user) || !src || QDELETED(src) || user.incapacitated())
-			return
-		if(!cultist_to_receive)
-			to_chat(user, "<span class='cult italic'>You require a destination!</span>")
-			log_game("Void torch failed - no target")
-			return
-		if(cultist_to_receive.stat == DEAD)
-			to_chat(user, "<span class='cult italic'>[cultist_to_receive] has died!</span>")
-			log_game("Void torch failed  - target died")
-			return
-		if(!iscultist(cultist_to_receive))
-			to_chat(user, "<span class='cult italic'>[cultist_to_receive] is not a follower of the Geometer!</span>")
-			log_game("Void torch failed - target was deconverted")
-			return
-		if(A in user.GetAllContents())
-			to_chat(user, "<span class='cult italic'>[A] must be on a surface in order to teleport it!</span>")
-			return
-		to_chat(user, "<span class='cult italic'>You ignite [A] with \the [src], turning it to ash, but through the torch's flames you see that [A] has reached [cultist_to_receive]!")
-		cultist_to_receive.put_in_hands(A)
-		charges--
-		to_chat(user, "\The [src] now has [charges] charge\s.")
-		if(charges == 0)
-			qdel(src)
+		transmit_item(A, user, proximity)
 
 	else
 		..()
 		to_chat(user, "<span class='warning'>\The [src] can only transport items!</span>")
 
+/obj/item/flashlight/flare/culttorch/proc/transmit_item(atom/movable/A, mob/user, proximity)
+	var/list/cultists = list()
+	for(var/datum/mind/M in SSticker.mode.cult)
+		if(M.current && M.current.stat != DEAD)
+			cultists |= M.current
+	var/mob/living/cultist_to_receive = input(user, "Who do you wish to call to [src]?", "Followers of the Geometer") as null|anything in (cultists - user)
+	if(!Adjacent(user) || !src || QDELETED(src) || user.incapacitated())
+		return
+	if(!cultist_to_receive)
+		to_chat(user, "<span class='cult italic'>You require a destination!</span>")
+		log_game("Void torch failed - no target")
+		return
+	if(cultist_to_receive.stat == DEAD)
+		to_chat(user, "<span class='cult italic'>[cultist_to_receive] has died!</span>")
+		log_game("Void torch failed  - target died")
+		return
+	if(!iscultist(cultist_to_receive))
+		to_chat(user, "<span class='cult italic'>[cultist_to_receive] is not a follower of the Geometer!</span>")
+		log_game("Void torch failed - target was deconverted")
+		return
+	if(A in user.GetAllContents())
+		to_chat(user, "<span class='cult italic'>[A] must be on a surface in order to teleport it!</span>")
+		return
+	to_chat(user, "<span class='cult italic'>You ignite [A] with \the [src], turning it to ash, but through the torch's flames you see that [A] has reached [cultist_to_receive]!")
+	cultist_to_receive.put_in_hands(A)
+	charges--
+	to_chat(user, "\The [src] now has [charges] charge\s.")
+	if(charges == 0)
+		qdel(src)
 
 /obj/item/cult_spear
 	name = "blood halberd"

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -667,6 +667,7 @@
 		to_chat(user, "<span class='warning'>\The [src] can only transport items!</span>")
 
 /obj/item/flashlight/flare/culttorch/proc/transmit_item(atom/movable/A, mob/user, proximity)
+	set waitfor = FALSE
 	var/list/cultists = list()
 	for(var/datum/mind/M in SSticker.mode.cult)
 		if(M.current && M.current.stat != DEAD)

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -60,83 +60,86 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 			return
 		if(A.anchored || (A.move_resist > max_force_fulton))
 			return
-		to_chat(user, "<span class='notice'>You start attaching the pack to [A]...</span>")
-		if(do_after(user,50,target=A))
-			to_chat(user, "<span class='notice'>You attach the pack to [A] and activate it.</span>")
-			if(loc == user && istype(user.back, /obj/item/storage/backpack))
-				var/obj/item/storage/backpack/B = user.back
-				SEND_SIGNAL(B, COMSIG_TRY_STORAGE_INSERT, src, user, FALSE, FALSE)
-			uses_left--
-			if(uses_left <= 0)
-				user.transferItemToLoc(src, A, TRUE)
-			var/mutable_appearance/balloon
-			var/mutable_appearance/balloon2
-			var/mutable_appearance/balloon3
-			if(isliving(A))
-				var/mob/living/M = A
-				M.DefaultCombatKnockdown(320) // Keep them from moving during the duration of the extraction
-				M.buckled = 0 // Unbuckle them to prevent anchoring problems
-			else
-				A.anchored = TRUE
-				A.density = FALSE
-			var/obj/effect/extraction_holder/holder_obj = new(A.loc)
-			holder_obj.appearance = A.appearance
-			A.forceMove(holder_obj)
-			balloon2 = mutable_appearance('icons/obj/fulton_balloon.dmi', "fulton_expand")
-			balloon2.pixel_y = 10
-			balloon2.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
-			holder_obj.add_overlay(balloon2)
-			sleep(4)
-			balloon = mutable_appearance('icons/obj/fulton_balloon.dmi', "fulton_balloon")
-			balloon.pixel_y = 10
-			balloon.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
-			holder_obj.cut_overlay(balloon2)
-			holder_obj.add_overlay(balloon)
-			playsound(holder_obj.loc, 'sound/items/fulext_deploy.wav', 50, 1, -3)
-			animate(holder_obj, pixel_z = 10, time = 20)
-			sleep(20)
-			animate(holder_obj, pixel_z = 15, time = 10)
-			sleep(10)
-			animate(holder_obj, pixel_z = 10, time = 10)
-			sleep(10)
-			animate(holder_obj, pixel_z = 15, time = 10)
-			sleep(10)
-			animate(holder_obj, pixel_z = 10, time = 10)
-			sleep(10)
-			playsound(holder_obj.loc, 'sound/items/fultext_launch.wav', 50, 1, -3)
-			animate(holder_obj, pixel_z = 1000, time = 30)
-			if(ishuman(A))
-				var/mob/living/carbon/human/L = A
-				L.SetUnconscious(0)
-				L.drowsyness = 0
-				L.SetSleeping(0)
-			sleep(30)
-			var/list/flooring_near_beacon = list()
-			for(var/turf/open/floor in orange(1, beacon))
-				flooring_near_beacon += floor
-			holder_obj.forceMove(pick(flooring_near_beacon))
-			animate(holder_obj, pixel_z = 10, time = 50)
-			sleep(50)
-			animate(holder_obj, pixel_z = 15, time = 10)
-			sleep(10)
-			animate(holder_obj, pixel_z = 10, time = 10)
-			sleep(10)
-			balloon3 = mutable_appearance('icons/obj/fulton_balloon.dmi', "fulton_retract")
-			balloon3.pixel_y = 10
-			balloon3.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
-			holder_obj.cut_overlay(balloon)
-			holder_obj.add_overlay(balloon3)
-			sleep(4)
-			holder_obj.cut_overlay(balloon3)
-			A.anchored = FALSE // An item has to be unanchored to be extracted in the first place.
-			A.density = initial(A.density)
-			animate(holder_obj, pixel_z = 0, time = 5)
-			sleep(5)
-			A.forceMove(holder_obj.loc)
-			qdel(holder_obj)
-			if(uses_left <= 0)
-				qdel(src)
+		attach_fulton(A, user, flag, params)
 
+/obj/item/extraction_pack/proc/attach_fulton(atom/movable/A, mob/living/carbon/human/user, flag, params)
+	set waitfor = FALSE
+	to_chat(user, "<span class='notice'>You start attaching the pack to [A]...</span>")
+	if(do_after(user,50,target=A))
+		to_chat(user, "<span class='notice'>You attach the pack to [A] and activate it.</span>")
+		if(loc == user && istype(user.back, /obj/item/storage/backpack))
+			var/obj/item/storage/backpack/B = user.back
+			SEND_SIGNAL(B, COMSIG_TRY_STORAGE_INSERT, src, user, FALSE, FALSE)
+		uses_left--
+		if(uses_left <= 0)
+			user.transferItemToLoc(src, A, TRUE)
+		var/mutable_appearance/balloon
+		var/mutable_appearance/balloon2
+		var/mutable_appearance/balloon3
+		if(isliving(A))
+			var/mob/living/M = A
+			M.DefaultCombatKnockdown(320) // Keep them from moving during the duration of the extraction
+			M.buckled = 0 // Unbuckle them to prevent anchoring problems
+		else
+			A.anchored = TRUE
+			A.density = FALSE
+		var/obj/effect/extraction_holder/holder_obj = new(A.loc)
+		holder_obj.appearance = A.appearance
+		A.forceMove(holder_obj)
+		balloon2 = mutable_appearance('icons/obj/fulton_balloon.dmi', "fulton_expand")
+		balloon2.pixel_y = 10
+		balloon2.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
+		holder_obj.add_overlay(balloon2)
+		sleep(4)
+		balloon = mutable_appearance('icons/obj/fulton_balloon.dmi', "fulton_balloon")
+		balloon.pixel_y = 10
+		balloon.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
+		holder_obj.cut_overlay(balloon2)
+		holder_obj.add_overlay(balloon)
+		playsound(holder_obj.loc, 'sound/items/fulext_deploy.wav', 50, 1, -3)
+		animate(holder_obj, pixel_z = 10, time = 20)
+		sleep(20)
+		animate(holder_obj, pixel_z = 15, time = 10)
+		sleep(10)
+		animate(holder_obj, pixel_z = 10, time = 10)
+		sleep(10)
+		animate(holder_obj, pixel_z = 15, time = 10)
+		sleep(10)
+		animate(holder_obj, pixel_z = 10, time = 10)
+		sleep(10)
+		playsound(holder_obj.loc, 'sound/items/fultext_launch.wav', 50, 1, -3)
+		animate(holder_obj, pixel_z = 1000, time = 30)
+		if(ishuman(A))
+			var/mob/living/carbon/human/L = A
+			L.SetUnconscious(0)
+			L.drowsyness = 0
+			L.SetSleeping(0)
+		sleep(30)
+		var/list/flooring_near_beacon = list()
+		for(var/turf/open/floor in orange(1, beacon))
+			flooring_near_beacon += floor
+		holder_obj.forceMove(pick(flooring_near_beacon))
+		animate(holder_obj, pixel_z = 10, time = 50)
+		sleep(50)
+		animate(holder_obj, pixel_z = 15, time = 10)
+		sleep(10)
+		animate(holder_obj, pixel_z = 10, time = 10)
+		sleep(10)
+		balloon3 = mutable_appearance('icons/obj/fulton_balloon.dmi', "fulton_retract")
+		balloon3.pixel_y = 10
+		balloon3.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
+		holder_obj.cut_overlay(balloon)
+		holder_obj.add_overlay(balloon3)
+		sleep(4)
+		holder_obj.cut_overlay(balloon3)
+		A.anchored = FALSE // An item has to be unanchored to be extracted in the first place.
+		A.density = initial(A.density)
+		animate(holder_obj, pixel_z = 0, time = 5)
+		sleep(5)
+		A.forceMove(holder_obj.loc)
+		qdel(holder_obj)
+		if(uses_left <= 0)
+			qdel(src)
 
 /obj/item/fulton_core
 	name = "extraction beacon signaller"

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -148,6 +148,10 @@
 /obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
 	. = ..()
 	//Changing name/description of items. Only works if they have the UNIQUE_RENAME object flag set
+	try_modify_object(O, user, proximity)
+
+/obj/item/pen/proc/try_modify_object(obj/O, mob/living/user, proximity)
+	set waitfor = FALSE
 	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
 		var/penchoice = input(user, "What would you like to edit?", "Rename, change description or reset both?") as null|anything in list("Rename","Change description","Reset")
 		if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -735,7 +735,10 @@
 	if(jb)
 		to_chat(user, "<span class='warning'>Your mind goes blank as you attempt to use the potion.</span>")
 		return
+	try_transfer_mind(SM, user)
 
+/obj/item/slimepotion/transference/proc/try_transfer_mind(mob/living/simple_animal/SM, mob/user)
+	set waitfor = FALSE
 	prompted = 1
 	if(alert("This will permanently transfer your consciousness to [SM]. Are you sure you want to do this?",,"Yes","No")=="No")
 		prompted = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After I resolved the sleeps in attack itself, now it complains about afterattack instead. Fantastic, could it please have done that initially too?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Linters make me scream but funny green checkmark is good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Linters should no longer complain about afterattack sleeps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
