### PR TITLE
Removes a redundant variable declaration

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -223,7 +223,6 @@
 		var/alert_type = null
 		if(ispath(breathing_class))
 			breathing_class = breathing_classes[breathing_class]
-			var/list/gases = breathing_class.gases
 			alert_category = breathing_class.high_alert_category
 			alert_type = breathing_class.high_alert_datum
 			danger_reagent = breathing_class.danger_reagent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I unironically thought I fixed this weeks ago. I am unaccountably annoyed at its continued existence. How has nobody else fixed this. Et cetera.

## Why It's Good For The Game

It's an unused var that the compiler warns you about every time you compile the game.

## Changelog
:cl:
/:cl: