### PR TITLE
Nerfs* passive organ healing, plus some minor stuff

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -182,7 +182,7 @@
 
 ////organ defines
 #define STANDARD_ORGAN_THRESHOLD 	100
-#define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / (2 SECONDS)))
+#define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / (2 SECONDS))) / 3  //Base organ healing can be amped by a factor of up to x5 via satiety. This assumes it to be somewhat in the upper center of positive satiety as base.
 #define STANDARD_ORGAN_DECAY		(1/(15 MINUTES / (2 SECONDS)))		//designed to fail organs when left to decay for ~15 minutes. 2 SECOND is SSmobs tickrate.
 
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -157,6 +157,8 @@
 	if(organ_flags & ORGAN_SYNTHETIC_EMP) //Synthetic organ has been emped, is now failing.
 		applyOrganDamage(maxHealth * decay_factor)
 		return FALSE
+	if(organ_flags & ORGAN_SYNTHETIC)
+		return TRUE
 	if(!is_cold() && damage)
 		///Damage decrements by a percent of its maxhealth
 		var/healing_amount = -(maxHealth * healing_factor)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -156,12 +156,12 @@
 		return FALSE
 	if(organ_flags & ORGAN_SYNTHETIC_EMP) //Synthetic organ has been emped, is now failing.
 		applyOrganDamage(maxHealth * decay_factor)
-		return
+		return FALSE
 	if(!is_cold() && damage)
 		///Damage decrements by a percent of its maxhealth
 		var/healing_amount = -(maxHealth * healing_factor)
 		///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's satiety
-		healing_amount -= owner.satiety > 0 ? 4 * healing_factor * owner.satiety / MAX_SATIETY : 0
+		healing_amount -= owner.satiety > 0 ? 4 * (maxHealth * healing_factor) * (owner.satiety / MAX_SATIETY) : 0
 		if(healing_amount)
 			applyOrganDamage(healing_amount) //to FERMI_TWEAK
 	return TRUE

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -131,6 +131,13 @@
 	name = "ipc cell"
 	icon_state = "stomach-ipc"
 
+/obj/item/organ/stomach/ipc/on_life()
+	. = ..()
+	if(!.)
+		return
+	if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM) && owner.nutrition >= NUTRITION_LEVEL_FED)
+		owner.satiety += 5	//We don't need to cap the value as it's already automatically capped during nutrition level handling. Also effectively only +4 as you lose 1 per life tick. 300 seconds of sufficient charge to reach full satiety.
+
 /obj/item/organ/stomach/ipc/emp_act(severity)
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So basically, a big while ago Silicons buffed organ healing because "it would take more than 30 minutes to heal"
This assumed the base organ heal rate (aka % of organ damage that gets healed per life tick) is constant. In reality, organ healing can be up to x5 of its default depending on satiety (added by vitamins on process mainly, very quickly so)
This made it so you'd heal from 1 organ hp to full within 3 minutes if satiated... And here I was wondering why organ damage disappeared so quickly.
Given that medical has multiple ways to deal with damaged organs (chemicals, monkeys, organ printer, robotics organs after earlyish research), weakening the passive heal requiring nothing shouldn't be as big of a deal. Or, you could just grab a nice healthy snack to speed it up. (at full satiety, a completely messed up organ close to failure (1hp) will take 9 minutes to heal now. Base assumption is about half satiety or 15 minutes, as the default healing intends, slower at low satiety)

I also noticed two seperate things, the first being that cybernetic organs still healed despite the on_life comment saying they did not, so I fixed that (IPC / Synth organs are not technically "true" Cybernetic organs codewise, merely snowflaked, so that doesn't apply to them)
Additionally, while looking at the satiety stuff I realized Synthetics currently cannot gain satiety due to not processing food, so I moved it to their stomach slowly increasing their satiety provided they are sufficiently charged (5 minutes of sufficient charge to reach max satiety rn, could be tweaked). This only applies to Synthetics that have them, no cheating satiety as organic.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Organ damage that is not total failure being totally irrelevant is kinda bad. This should make it at least slightly more relevant and makes medbay's options slightly more viable to be used on organs that aren't fully rotten as opposed to now.

Cybernetic organs healing damage despite the comment on the proc saying they don't is a fix I'd say.

Synths being able to gain satiety may be useful given there's a bunch of things that hook into it they're still affected by.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Base organ healing rate reduced by 66% (It can still be increased to up to 500% of the base value via sufficient satiety)
fix: Cybernetic organs no longer passively heal damage despite the proc stating they didn't.
balance: Synthetics now gain satiety at sufficient charge (~5 minutes to max satiety from 0)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
