### PR TITLE
Meta Atmos Layout

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -47284,6 +47284,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
+"dlw" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "dlA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -51574,13 +51581,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
-"faa" = (
-/obj/machinery/power/floodlight,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "faG" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52525,8 +52525,7 @@
 /area/science/circuit)
 "fFR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/engineering/atmos)
 "fFY" = (
 /obj/structure/cable,
@@ -55009,6 +55008,12 @@
 "hhA" = (
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
+"hhD" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "hhN" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -55428,6 +55433,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
+"hta" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "htx" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/extinguisher_cabinet{
@@ -61967,7 +61982,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -71537,16 +71554,6 @@
 	},
 /turf/open/space/basic,
 /area/solars/port/fore)
-"qnr" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "qnv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -81315,12 +81322,6 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
-"vXf" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "vXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -127702,7 +127703,7 @@ ooB
 ibJ
 ibJ
 ibJ
-qnr
+hta
 ibJ
 ibJ
 omb
@@ -127959,7 +127960,7 @@ eCZ
 mMn
 mMn
 mMn
-vXf
+hhD
 mMn
 mMn
 eWY
@@ -128216,7 +128217,7 @@ pcs
 mMn
 mMn
 mMn
-vXf
+hhD
 mMn
 mMn
 mMn
@@ -128473,7 +128474,7 @@ mMn
 mMn
 mMn
 mMn
-vXf
+hhD
 mMn
 mMn
 mMn
@@ -128730,7 +128731,7 @@ mMn
 mMn
 mMn
 mMn
-faa
+dlw
 mMn
 mMn
 mMn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24661,13 +24661,13 @@
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "bZD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Incinerator Access";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "32"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
@@ -25285,7 +25285,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "caZ" = (
 /obj/structure/cable/yellow{
@@ -25300,7 +25303,7 @@
 	c_tag = "Atmospherics - Incinerator";
 	name = "atmospherics camera"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cba" = (
 /obj/machinery/power/smes{
@@ -25310,7 +25313,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cbp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25905,7 +25908,7 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "ccU" = (
 /obj/structure/table/wood/poker,
@@ -47284,13 +47287,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/storage/tech)
-"dlw" = (
-/obj/machinery/power/floodlight,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "dlA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53101,6 +53097,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"fYL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "fZR" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/stripes/line{
@@ -55008,12 +55010,6 @@
 "hhA" = (
 /turf/open/floor/plasteel,
 /area/cargo/warehouse)
-"hhD" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "hhN" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -55433,16 +55429,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
-"hta" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "htx" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/extinguisher_cabinet{
@@ -60795,6 +60781,7 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kuk" = (
@@ -67758,6 +67745,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "olW" = (
@@ -68979,6 +68967,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "oWR" = (
@@ -77293,6 +77282,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solars/starboard/fore)
+"tzt" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "tAp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -77444,6 +77440,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/office)
+"tGd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "tGD" = (
 /obj/structure/closet/crate,
 /obj/structure/extinguisher_cabinet{
@@ -127703,7 +127709,7 @@ ooB
 ibJ
 ibJ
 ibJ
-hta
+tGd
 ibJ
 ibJ
 omb
@@ -127960,7 +127966,7 @@ eCZ
 mMn
 mMn
 mMn
-hhD
+fYL
 mMn
 mMn
 eWY
@@ -128217,7 +128223,7 @@ pcs
 mMn
 mMn
 mMn
-hhD
+fYL
 mMn
 mMn
 mMn
@@ -128474,7 +128480,7 @@ mMn
 mMn
 mMn
 mMn
-hhD
+fYL
 mMn
 mMn
 mMn
@@ -128731,7 +128737,7 @@ mMn
 mMn
 mMn
 mMn
-dlw
+tzt
 mMn
 mMn
 mMn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19429,6 +19429,10 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "bzi" = (
@@ -21199,10 +21203,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -44716,9 +44716,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "cVp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -44812,12 +44809,8 @@
 /turf/open/floor/carpet,
 /area/service/theater)
 "cWn" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Monitoring";
-	req_access_txt = "24"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -47801,24 +47794,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/aisat/exterior)
 "dtk" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "24"
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/suit_storage_unit/atmos,
+/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "dtl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49353,12 +49333,8 @@
 /area/maintenance/port)
 "dRb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Monitoring";
-	req_access_txt = "24"
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -50247,13 +50223,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
-"erz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
 "erD" = (
 /obj/machinery/reagentgrinder,
 /obj/structure/table/glass,
@@ -51605,6 +51574,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engineering/break_room)
+"faa" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "faG" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52060,7 +52036,9 @@
 	dir = 8
 	},
 /obj/machinery/pipedispenser/disposal,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "fpr" = (
@@ -52546,12 +52524,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "fFR" = (
-/obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Entrance"
-	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "fFY" = (
 /obj/structure/cable,
@@ -52799,7 +52774,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/light/small,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "fNh" = (
@@ -52807,6 +52787,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Entrance"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "fNk" = (
@@ -53158,9 +53141,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/pipedispenser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
@@ -53169,6 +53149,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -53738,7 +53721,7 @@
 	dir = 6
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -54301,14 +54284,20 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "gGc" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 26;
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "gGH" = (
 /obj/structure/cable/yellow{
@@ -54897,8 +54886,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "hdR" = (
 /obj/structure/chair/stool{
@@ -55730,6 +55722,12 @@
 /area/ai_monitored/aisat/exterior)
 "hAI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hAL" = (
@@ -56917,6 +56915,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "iiE" = (
@@ -57457,11 +57456,11 @@
 /turf/open/floor/plating,
 /area/service/chapel/main)
 "ixJ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "ixL" = (
@@ -60777,7 +60776,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/closed/wall,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kuk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -61962,12 +61965,11 @@
 /area/command/bridge)
 "kWW" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
+/obj/machinery/light/small,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kXd" = (
 /obj/machinery/power/terminal,
@@ -63117,14 +63119,13 @@
 /turf/open/floor/plasteel,
 /area/commons/locker)
 "lFH" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/atmos,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "lFQ" = (
 /obj/structure/chair/office/dark{
@@ -63624,10 +63625,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
+/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
 /area/engineering/atmos)
 "lUv" = (
 /obj/structure/noticeboard{
@@ -63765,10 +63765,7 @@
 /area/commons/fitness/recreation)
 "lXt" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -65447,6 +65444,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -67276,10 +67277,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
-/obj/machinery/pipedispenser/disposal/transit_tube,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
 	},
@@ -67737,6 +67734,12 @@
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -68249,9 +68252,6 @@
 /turf/open/floor/plasteel,
 /area/service/bar)
 "oBF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -68954,10 +68954,15 @@
 /turf/open/floor/plasteel,
 /area/commons/dorms)
 "oWF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring";
+	req_access_txt = "24"
 	},
-/turf/closed/wall,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/engineering/atmos)
 "oWR" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -71532,6 +71537,16 @@
 	},
 /turf/open/space/basic,
 /area/solars/port/fore)
+"qnr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "qnv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -72841,6 +72856,12 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "qXd" = (
@@ -73117,12 +73138,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Distribution Loop";
-	req_access_txt = "24"
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "rdv" = (
 /obj/effect/turf_decal/stripes/line,
@@ -77390,6 +77408,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "tFJ" = (
@@ -78818,8 +78839,11 @@
 /turf/open/floor/plasteel/dark,
 /area/cargo/office)
 "usM" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -79128,11 +79152,14 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "uED" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring";
+	req_access_txt = "24"
+	},
+/turf/open/floor/plasteel,
 /area/engineering/atmos)
 "uFM" = (
 /obj/machinery/power/emitter,
@@ -80575,6 +80602,12 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vzs" = (
@@ -81282,6 +81315,12 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
+"vXf" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "vXi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -82840,7 +82879,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "wKo" = (
 /obj/effect/turf_decal/stripes/line,
@@ -84685,9 +84725,8 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "xHm" = (
-/obj/machinery/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -126368,7 +126407,7 @@ qxd
 jJw
 usM
 lXt
-xHm
+lzQ
 tyC
 kLr
 kdi
@@ -126625,7 +126664,7 @@ odq
 ipm
 hAI
 oBF
-erz
+oBF
 jxI
 kLr
 qDJ
@@ -126881,9 +126920,9 @@ bvh
 qxd
 oNX
 vzb
-iix
-woN
-tyC
+mMn
+cWn
+xHm
 kLr
 iix
 sKv
@@ -127139,7 +127178,7 @@ qxd
 wtG
 qWR
 cVp
-woN
+gGc
 dtk
 lFH
 hdJ
@@ -127395,8 +127434,8 @@ iLe
 qxd
 oBX
 olw
-oWF
-cWn
+sKv
+sKv
 uKL
 ktV
 wKg
@@ -127653,7 +127692,7 @@ sKv
 oay
 fNf
 kWW
-gGc
+uKL
 grX
 hop
 ldI
@@ -127663,7 +127702,7 @@ ooB
 ibJ
 ibJ
 ibJ
-ibJ
+qnr
 ibJ
 ibJ
 omb
@@ -127910,7 +127949,7 @@ hZe
 mZD
 mSB
 dRb
-hAI
+oWF
 tFH
 tfk
 sfM
@@ -127920,7 +127959,7 @@ eCZ
 mMn
 mMn
 mMn
-mMn
+vXf
 mMn
 mMn
 eWY
@@ -128177,7 +128216,7 @@ pcs
 mMn
 mMn
 mMn
-mMn
+vXf
 mMn
 mMn
 mMn
@@ -128424,7 +128463,7 @@ uhB
 jiZ
 mHn
 mHn
-fGc
+mHn
 rdg
 fGc
 lHN
@@ -128434,7 +128473,7 @@ mMn
 mMn
 mMn
 mMn
-mMn
+vXf
 mMn
 mMn
 mMn
@@ -128691,7 +128730,7 @@ mMn
 mMn
 mMn
 mMn
-mMn
+faa
 mMn
 mMn
 mMn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Messes around with the layout of this area on Meta's atmospherics
Also gives them the "stripper pole light" as Box has (not shown in picture.)
![area](https://user-images.githubusercontent.com/6299921/147615267-496ae2eb-a71d-44d2-8eda-2c7bdd88c84c.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Something something Justin is a nerd.
Also reroutes some pipes and wires NOT to go through walls, which is good overall.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: (Meta) Floodlight to Atmospherics
tweak: (Meta) Atmospherics Entryway layout change
tweak: (Meta) Atmospherics Monitoring room layout tweak
tweak: (Meta) Atmospherics Supply Line room airlock location change
fix: (Meta) Incinerator Access airlock now has the correct access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
