### PR TITLE
Making Omega Playable

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1282,13 +1282,13 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/engineering/gravity_generator)
@@ -1708,6 +1708,9 @@
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -6352,8 +6355,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/asteroid/nearstation)
 "ajY" = (
@@ -7612,15 +7615,18 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "alU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "alV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/chair,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "alW" = (
@@ -8134,6 +8140,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/item/clipboard,
 /obj/item/folder/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "amR" = (
@@ -8450,6 +8457,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "anv" = (
@@ -8460,6 +8470,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "anw" = (
@@ -8652,6 +8665,8 @@
 	pixel_x = -26
 	},
 /obj/item/rcl/pre_loaded,
+/obj/item/clothing/glasses/meson/gar,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "anL" = (
@@ -9033,6 +9048,9 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "aop" = (
@@ -9053,6 +9071,9 @@
 /obj/machinery/computer/security/telescreen/ce{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
@@ -9662,9 +9683,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -9672,6 +9690,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "app" = (
@@ -9690,9 +9711,6 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -9707,6 +9725,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 8;
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
@@ -9726,7 +9748,7 @@
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -9747,8 +9769,8 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -12490,9 +12512,6 @@
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "aty" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Oxygen to Pure"
@@ -13149,11 +13168,14 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "auv" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "auw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Port"
@@ -14576,11 +14598,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "awH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "awI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -14608,15 +14630,12 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "awL" = (
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "awM" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -14900,9 +14919,6 @@
 	lootcount = 3;
 	name = "3maintenance loot spawner"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -14926,17 +14942,13 @@
 /turf/open/floor/wood,
 /area/service/library)
 "axk" = (
-/obj/structure/girder,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "axl" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14952,9 +14964,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -15214,6 +15223,9 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/grimy,
 /area/commons/dorms)
 "axJ" = (
@@ -15238,6 +15250,9 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "axL" = (
@@ -15245,9 +15260,6 @@
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -15404,11 +15416,11 @@
 /turf/open/floor/plasteel/dark,
 /area/service/bar/atrium)
 "axU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "axV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/newscaster{
@@ -15425,9 +15437,12 @@
 /turf/closed/wall,
 /area/hallway/secondary/exit)
 "axX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall/rust,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "axY" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -15682,10 +15697,14 @@
 /area/commons/dorms)
 "ayA" = (
 /obj/structure/bed,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/bedsheet/blue,
+/obj/machinery/button/door{
+	id = "Dorm1";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/commons/dorms)
 "ayB" = (
@@ -15693,10 +15712,14 @@
 /area/commons/dorms)
 "ayC" = (
 /obj/structure/bed,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/bedsheet/red,
+/obj/machinery/button/door{
+	id = "Dorm2";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "ayD" = (
@@ -16339,12 +16362,13 @@
 /area/commons/dorms)
 "azD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Bar Back Room"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Dorm 1"
 	},
 /turf/open/floor/plasteel,
 /area/commons/dorms)
@@ -16704,10 +16728,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aAn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Engine"
 	},
-/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "aAo" = (
@@ -16717,6 +16741,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aAp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
@@ -16973,6 +17001,14 @@
 	dir = 4
 	},
 /obj/structure/bedsheetbin/color,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 1;
+	icon_state = "roomnum";
+	name = "Room Number 2";
+	pixel_x = -1;
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/white/corner,
 /area/commons/dorms)
 "aAK" = (
@@ -17704,6 +17740,14 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 8;
+	icon_state = "roomnum";
+	name = "Room Number 4";
+	pixel_x = -1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/commons/dorms)
@@ -18776,18 +18820,26 @@
 /area/commons/dorms)
 "aDH" = (
 /obj/structure/bed,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/bedsheet/brown,
+/obj/machinery/button/door{
+	id = "Dorm3";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aDI" = (
 /obj/structure/bed,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/item/bedsheet/black,
+/obj/machinery/button/door{
+	id = "Dorm4";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/commons/dorms)
 "aDJ" = (
@@ -19073,9 +19125,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aEg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/port/aft)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "aEh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -19561,6 +19619,9 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
 	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -19582,6 +19643,9 @@
 /obj/structure/dresser,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
 /area/commons/dorms)
@@ -19995,9 +20059,6 @@
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/areaeditor/blueprints,
-/obj/item/tank/jetpack/suit,
-/obj/item/clothing/shoes/magboots/advance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -21234,11 +21295,12 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Engine"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21246,11 +21308,11 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21273,12 +21335,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21289,9 +21353,6 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -21299,6 +21360,9 @@
 	c_tag = "Engineering Fore";
 	network = list("ss13","engine");
 	pixel_x = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21309,9 +21373,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21842,7 +21908,6 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -21885,9 +21950,11 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21897,9 +21964,8 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aIh" = (
@@ -21908,7 +21974,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21917,8 +21983,8 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Chamber"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -21926,13 +21992,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aIk" = (
@@ -21945,7 +22005,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -22491,7 +22551,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white/left,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -22598,6 +22657,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "aJo" = (
@@ -22621,8 +22681,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -22633,23 +22693,26 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Mix"
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aJr" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/item/wrench,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "aJs" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/delivery,
+/obj/machinery/meter/atmos,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "aJt" = (
@@ -23245,9 +23308,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -23257,6 +23317,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
@@ -23363,6 +23426,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "aKx" = (
@@ -23405,17 +23469,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aKz" = (
-/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "aKA" = (
@@ -23529,9 +23591,6 @@
 	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -23542,6 +23601,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24167,14 +24229,12 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/item/clothing/glasses/meson/engine,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "aLL" = (
@@ -24277,6 +24337,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aLX" = (
@@ -24291,6 +24354,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
 "aLZ" = (
@@ -24303,6 +24369,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/main)
@@ -24689,11 +24758,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aMD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/sign/poster/contraband/random,
-/turf/closed/wall,
-/area/maintenance/port/aft)
 "aME" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -25526,6 +25590,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aOe" = (
@@ -25701,6 +25766,8 @@
 	dir = 4
 	},
 /obj/machinery/shieldgen,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "aOu" = (
@@ -25867,6 +25934,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aOH" = (
@@ -25882,15 +25950,6 @@
 	},
 /turf/open/space/basic,
 /area/solars/port/aft)
-"aOI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "aOJ" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -25937,9 +25996,6 @@
 "aOL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aOM" = (
@@ -25947,9 +26003,6 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "aON" = (
@@ -25962,9 +26015,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
@@ -26034,11 +26084,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "aOS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "aOT" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
@@ -26516,10 +26571,6 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
@@ -26673,7 +26724,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -26700,9 +26751,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aPQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "aPR" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -26721,19 +26778,22 @@
 	},
 /area/maintenance/port/aft)
 "aPU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/closed/wall,
-/area/maintenance/port/aft)
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Dorm 2"
+	},
+/turf/open/floor/plasteel,
+/area/commons/dorms)
 "aPV" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -26746,9 +26806,6 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -26767,9 +26824,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway South-West";
 	dir = 1
@@ -26782,12 +26836,14 @@
 	},
 /area/hallway/primary/port/aft)
 "aPY" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9.2-EnteringEngi";
 	location = "9.1-Library"
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel{
@@ -27116,9 +27172,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "aQB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall,
 /area/maintenance/port/aft)
@@ -27170,11 +27223,18 @@
 /turf/open/floor/plating/asteroid,
 /area/command/heads_quarters/rd)
 "aQF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/closed/wall/rust,
-/area/maintenance/port/aft)
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	icon_state = "roomnum";
+	name = "Room Number 1";
+	pixel_x = -1;
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel,
+/area/commons/dorms)
 "aQG" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6
@@ -27240,8 +27300,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Loop to Freezer"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -27260,17 +27321,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aQN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -27279,9 +27334,6 @@
 	c_tag = "Engineering Aft";
 	network = list("ss13","engine");
 	pixel_x = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
 	},
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -27292,26 +27344,19 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aQQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aQR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -27416,9 +27461,20 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "aRe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 4;
+	icon_state = "roomnum";
+	name = "Room Number 3";
+	pixel_x = -1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/commons/dorms)
 "aRf" = (
 /turf/closed/wall,
 /area/medical/chemistry)
@@ -27694,21 +27750,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Gas to Cooling Loop"
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aRH" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
-"aRI" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -27717,12 +27762,22 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"aRI" = (
+/obj/structure/cable/white{
+	dir = 5;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "aRJ" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -27746,6 +27801,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/meter,
 /turf/open/floor/plasteel/dark,
 /area/engineering/main)
 "aRM" = (
@@ -27758,9 +27814,8 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "aRN" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Freezer to Gas"
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -27777,10 +27832,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "aRQ" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Gas to Cooling Loop"
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aRR" = (
@@ -27957,12 +28009,10 @@
 	dir = 8
 	},
 /obj/machinery/shieldgen,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "aSg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -28021,6 +28071,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "aSn" = (
@@ -28071,9 +28122,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aSr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -28300,9 +28348,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "aSQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -28345,11 +28390,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -28496,9 +28541,6 @@
 /turf/open/floor/plasteel/dark,
 /area/service/library)
 "aTj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -28902,6 +28944,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "aTW" = (
@@ -28987,6 +29032,9 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/white{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
@@ -29146,6 +29194,7 @@
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aUr" = (
@@ -29372,6 +29421,9 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "aUL" = (
@@ -29893,31 +29945,40 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "aVF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"aVG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"aVH" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"aVI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/door/airlock{
+	id_tag = "Dorm3";
+	name = "Dorm 3"
 	},
+/turf/open/floor/plasteel,
+/area/commons/dorms)
+"aVG" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port/aft)
+"aVH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm4";
+	name = "Room Four"
+	},
+/turf/open/floor/plasteel,
+/area/commons/dorms)
+"aVI" = (
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 9;
 	icon_state = "trimline"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aVJ" = (
@@ -30530,6 +30591,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aWJ" = (
@@ -30537,14 +30601,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -32815,9 +32879,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "bap" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
@@ -32831,6 +32892,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "baq" = (
@@ -33393,7 +33455,6 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -36306,9 +36367,6 @@
 /area/medical/medbay/zone3)
 "bfH" = (
 /obj/effect/landmark/start/virologist,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/medical/virology";
 	dir = 1;
@@ -36321,6 +36379,9 @@
 /obj/machinery/camera{
 	c_tag = "Virology";
 	network = list("ss13","medbay")
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
@@ -36414,6 +36475,9 @@
 	c_tag = "Virology Access";
 	dir = 1;
 	network = list("ss13","medbay")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -37470,16 +37534,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bhE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bhF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -37494,18 +37557,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bhH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -37514,20 +37571,15 @@
 /area/hallway/secondary/entry)
 "bhI" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bhJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bhK" = (
@@ -39034,6 +39086,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/engineering/main)
 "blo" = (
@@ -40002,8 +40055,8 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "bwW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/closed/wall/r_wall/rust,
 /area/tcommsat/server)
@@ -40023,9 +40076,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -40067,8 +40117,10 @@
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
 "bxu" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Gas to Cooling Loop"
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "bxv" = (
@@ -40676,6 +40728,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "die" = (
@@ -41052,6 +41105,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/mixing)
+"fey" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "fff" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -41101,6 +41163,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"fkE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "flE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -41111,6 +41189,7 @@
 /obj/structure/table/wood,
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/flashlight/lamp/green,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/carpet/green/airless,
 /area/service/lawoffice)
 "fnp" = (
@@ -41248,6 +41327,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/asteroid/nearstation)
+"fTp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/engineering/gravity_generator)
 "fWh" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
@@ -41272,6 +41355,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "gap" = (
@@ -41338,10 +41422,13 @@
 "glC" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
-"guM" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+"gre" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
+"guM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41709,6 +41796,9 @@
 /area/engineering/atmos)
 "hUL" = (
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "hVE" = (
@@ -41806,9 +41896,11 @@
 	},
 /area/maintenance/starboard/aft)
 "ixk" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -41822,10 +41914,8 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "iIj" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "iJz" = (
 /obj/structure/window/reinforced{
@@ -41835,21 +41925,21 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/entry)
 "iJY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "iKp" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/meter/atmos,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "iML" = (
@@ -41936,6 +42026,9 @@
 "iYt" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/lawyer,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/open/floor/carpet/green/airless,
 /area/service/lawoffice)
 "iZQ" = (
@@ -42021,6 +42114,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "jnK" = (
@@ -42087,6 +42181,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"jvx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
 "jwi" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -42140,9 +42241,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jCi" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -42154,6 +42252,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
@@ -42280,7 +42381,6 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
 "kdd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
@@ -42304,6 +42404,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"koL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engineering/main)
 "kpi" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice/catwalk,
@@ -42447,10 +42563,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "kTz" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "kUu" = (
@@ -42479,6 +42595,9 @@
 	pixel_y = 24
 	},
 /obj/effect/landmark/start/lawyer,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "loX" = (
@@ -42582,6 +42701,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
+"lFj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lFm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -42861,6 +42988,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"nhL" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/zone3)
 "nhU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -43048,6 +43192,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "orV" = (
@@ -43121,6 +43266,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "oGc" = (
@@ -43491,6 +43637,18 @@
 	icon_state = "wood-broken5"
 	},
 /area/asteroid/nearstation)
+"qaX" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "qcg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -43591,9 +43749,12 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qpG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall/rust,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/asteroid/nearstation)
 "qsc" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -43625,7 +43786,6 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qFj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -43703,15 +43863,16 @@
 	},
 /area/maintenance/starboard/aft)
 "qUW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "rae" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Air to Pure"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -43808,6 +43969,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "rVj" = (
@@ -44007,6 +44169,13 @@
 "swZ" = (
 /turf/closed/wall/r_wall/rust,
 /area/security/brig)
+"sxy" = (
+/obj/structure/girder,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sxC" = (
 /turf/closed/wall/r_wall/rust,
 /area/ai_monitored/turret_protected/ai)
@@ -45148,7 +45317,7 @@
 "sLL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "AI Core shutters";
+	id = "aicorewindow";
 	name = "AI core shutters"
 	},
 /turf/open/floor/plating,
@@ -46648,6 +46817,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "tin" = (
@@ -46975,20 +47145,12 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "uBJ" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/plating,
+/area/asteroid/nearstation)
 "uCY" = (
 /turf/open/pool,
 /area/maintenance/starboard/aft)
@@ -47075,8 +47237,8 @@
 /area/science/mixing)
 "uVJ" = (
 /obj/effect/decal/cleanable/oil,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
@@ -47425,6 +47587,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
+"wdK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Gas to Cooling Loop"
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "wkn" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/shovel/spade,
@@ -47481,9 +47651,9 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "wDb" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
 "wOe" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/research{
@@ -47514,6 +47684,11 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"wQj" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/plasteel/dark,
+/area/engineering/main)
 "wRY" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -47585,6 +47760,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "xiZ" = (
@@ -47661,11 +47837,6 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -47688,6 +47859,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower"
+	},
+/obj/effect/turf_decal/vg_decals/radiation,
 /turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "xAj" = (
@@ -47763,6 +47939,13 @@
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
+"xPL" = (
+/obj/structure/girder,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xTs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -75302,13 +75485,13 @@ jkl
 eew
 bgh
 qUW
-aqz
-aqz
-aGe
-sIu
-aGe
-aGe
-aGe
+qUW
+qUW
+wDb
+fTp
+wDb
+wDb
+gre
 sIu
 bwY
 abi
@@ -75552,17 +75735,17 @@ tdN
 oql
 oql
 ixk
-oql
+axk
 kTz
 iKp
 tgp
 dgV
 fYx
-aCG
-ajX
+iIj
 ajX
 qpG
-uBJ
+sIu
+aHe
 aIb
 aJh
 aKp
@@ -75809,7 +75992,7 @@ kCU
 rzq
 awI
 uVJ
-diG
+axU
 mTv
 guM
 oCy
@@ -75817,7 +76000,7 @@ orI
 xyo
 hNO
 aaW
-abu
+uBJ
 aGe
 aId
 aIc
@@ -76066,7 +76249,7 @@ mTT
 tgm
 vjN
 hUL
-diG
+axX
 rEx
 jCi
 anx
@@ -76074,7 +76257,7 @@ anx
 anx
 uok
 akM
-abu
+uBJ
 aGe
 aHg
 aId
@@ -76352,7 +76535,7 @@ buO
 sKn
 aMJ
 bak
-bat
+aLC
 aLC
 aLC
 aLC
@@ -76580,7 +76763,7 @@ fIN
 auq
 hqX
 wqL
-diG
+aAn
 yba
 eva
 aqA
@@ -76609,7 +76792,7 @@ sKj
 buR
 aMJ
 bal
-bau
+aLC
 bbf
 bbo
 aLC
@@ -76834,10 +77017,10 @@ tac
 xEQ
 bKQ
 fvd
-mae
+awH
 xeu
-wqL
-aAn
+awL
+fLr
 iJY
 uSs
 xIm
@@ -77094,8 +77277,8 @@ fvd
 mae
 mkF
 wqL
+diG
 aAp
-yba
 vVA
 anx
 anx
@@ -77351,8 +77534,8 @@ fFw
 auq
 hXn
 wqL
-iIj
-iJY
+diG
+aEg
 dFV
 aAh
 aBp
@@ -77362,7 +77545,7 @@ akS
 alI
 alI
 apq
-bwY
+jvx
 aJn
 aKw
 aLK
@@ -77609,7 +77792,7 @@ fEt
 mnD
 asx
 aty
-eaf
+aOS
 avx
 aAi
 axi
@@ -77629,13 +77812,13 @@ sJD
 aMN
 bxt
 bwW
-aMJ
-aMJ
-aMJ
-sJV
-aMJ
-aMJ
-sJV
+aMN
+aMN
+aMN
+sJD
+aMN
+aMN
+sJD
 bap
 bau
 bat
@@ -77865,8 +78048,8 @@ fFw
 auq
 qEl
 wqL
+diG
 aAp
-yba
 avy
 aAj
 blk
@@ -77892,7 +78075,7 @@ bvo
 aad
 bvo
 aad
-aKm
+aqo
 baq
 bbb
 aKm
@@ -78122,8 +78305,8 @@ qIp
 mae
 eOs
 wqL
+diG
 aAp
-yba
 fjs
 anx
 anx
@@ -78149,7 +78332,7 @@ aUQ
 aVK
 aUQ
 aXc
-aKm
+aqo
 aqo
 bbc
 aLv
@@ -78379,8 +78562,8 @@ jxc
 mae
 hqX
 wqL
-auv
-iJY
+diG
+aPQ
 kwF
 aAh
 aBr
@@ -78646,16 +78829,16 @@ uok
 aEr
 aFu
 aGi
-aHl
+qaX
 aIi
 aJs
-aKz
+wQj
 buW
 aMR
 aMX
 aMX
 sJG
-aQK
+fey
 aRI
 aSS
 aPL
@@ -79940,7 +80123,7 @@ aMW
 aMW
 aOD
 buW
-aQK
+aQM
 aRN
 aSX
 aPL
@@ -79952,13 +80135,13 @@ bvg
 aKm
 jlZ
 vDy
-aOI
+qFj
 qFj
 kdd
-aPQ
-aPQ
-aPQ
-aVF
+aSG
+aSG
+aVi
+aSG
 aKV
 aLn
 aRA
@@ -80209,13 +80392,13 @@ bvo
 aqo
 aKm
 bbj
-axU
+aKm
 aKm
 aMG
 aMG
 aUi
 aKm
-aVG
+aSG
 aKV
 aSe
 aSJ
@@ -80472,7 +80655,7 @@ aQV
 aSq
 aUk
 aUi
-aVG
+aSG
 aKV
 aTk
 aSK
@@ -80713,7 +80896,7 @@ aOF
 aPM
 aQS
 aRQ
-bxu
+wdK
 aUa
 aUU
 aUU
@@ -80986,8 +81169,8 @@ aRd
 aRc
 aUm
 aKm
-aVH
-aRe
+aSG
+aKV
 bfH
 aWL
 aZB
@@ -81224,21 +81407,21 @@ acB
 aEt
 aEt
 aqo
-awH
-axX
-aEg
-aEg
-axX
-axX
-aEg
-aEg
-axX
-aEg
-aEg
-aMD
+aqo
+aLs
+aqo
+aqo
+aLs
+aLs
+aqo
+aqo
+aLs
+aqo
+aqo
+aQB
 bbm
-aOS
-aPU
+aKm
+aKm
 aRj
 aSG
 aUo
@@ -81481,7 +81664,7 @@ aLY
 aNa
 aEt
 aqx
-awL
+aFM
 axY
 aEj
 aFM
@@ -81991,11 +82174,11 @@ aHh
 aIu
 aJD
 aKK
-aMa
+koL
 aNc
 aEt
 atE
-axk
+aMG
 aQW
 aRT
 aRU
@@ -82009,7 +82192,7 @@ aYw
 aZu
 aQW
 awB
-aQF
+aUi
 aRC
 aTb
 aUp
@@ -82266,11 +82449,11 @@ aYx
 aZv
 aQW
 aOV
-axU
+aKm
 aKm
 aTU
 aKm
-aMG
+sxy
 aVI
 aWw
 aXd
@@ -82527,7 +82710,7 @@ aQQ
 aRS
 aTV
 aUq
-aMG
+xPL
 aVJ
 aWx
 aXe
@@ -83023,7 +83206,7 @@ aMd
 aNg
 aEt
 awG
-axU
+aKm
 aQW
 aRX
 aTf
@@ -83037,9 +83220,9 @@ aLy
 aFM
 aFM
 aPP
-aQQ
+lFj
 aSm
-aSm
+fkE
 aUJ
 aKm
 aVR
@@ -84577,7 +84760,7 @@ aXl
 aSh
 aOg
 aGC
-aGC
+nhL
 aPA
 aJx
 aQD
@@ -85308,7 +85491,7 @@ akg
 ale
 alU
 amP
-aoC
+auv
 aoC
 sAc
 aqU
@@ -85580,7 +85763,7 @@ ayz
 azD
 aAH
 aBQ
-azD
+aVF
 aDG
 aEO
 sDl
@@ -85835,8 +86018,8 @@ awQ
 axI
 ayA
 awQ
-aAH
-aBQ
+aQF
+aRe
 awQ
 aDH
 aEP
@@ -86348,10 +86531,10 @@ apI
 awQ
 axJ
 ayB
-azD
+aPU
 aAH
 aBS
-azD
+aVH
 ayz
 aEQ
 sDl
@@ -97706,7 +97889,7 @@ aaa
 aaa
 aaa
 aaa
-wDb
+sdX
 aaa
 aaa
 aaa
@@ -97960,7 +98143,7 @@ aad
 aaa
 aaa
 aaa
-wDb
+sdX
 aaa
 sjr
 aaa
@@ -98472,7 +98655,7 @@ aaa
 aaa
 aaa
 aaa
-wDb
+sdX
 aaa
 aaa
 nqr


### PR DESCRIPTION
## About The Pull Request

-Adds freezers to pre-filter SM portion loop
-Adds pipe leading from atmos to SM
-Removes some wallpipes (added some too, cough cough)
-Moved med air alarm to not be behind glass
-Redid some of viro's pipes so it's not so weird
-Dorms have buttons now that work
-AI shutter button works (it's weird, but, whatever it works)
-Adds extra vent/scrubber in lawyer room so the other half can have air
-Moves air alarm outside of the turbine so it doesn't scream when it naturally vents
-Adds radiation lockers next to the turbine, along with a shower.

## Why It's Good For The Game

Fixes omega up so it should be good to add to map rotation.

## Changelog
:cl:
add: Adds pipes to the SM to make omega better
fix: Various omega fixes
/:cl: