### PR TITLE
literally also just makes it so IPCs can have winges

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -9,7 +9,7 @@
 	species_traits = list(MUTCOLORS,NOEYES,NOTRANSSTING,HAS_FLESH,HAS_BONE,HAIR,ROBOTIC_LIMBS)
 	hair_alpha = 210
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
-	mutant_bodyparts = list("ipc_screen" = "Blank", "ipc_antenna" = "None")
+	mutant_bodyparts = list("ipc_screen" = "Blank", "deco_wings" = "None", "ipc_antenna" = "None")
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc
 	gib_types = list(/obj/effect/gibspawner/ipc, /obj/effect/gibspawner/ipc/bodypartless)
 


### PR DESCRIPTION
## About The Pull Request

gives IPCs wings just like https://github.com/Citadel-Station-13/Citadel-Station-13/pull/15444

## Why It's Good For The Game

i want my ultrakill wings. we have robotic wings but we can't use them on robots??? seems cringe to me

## Changelog
:cl:
add: Humanity is... Ok. Blood is fuel. IPCs have wings.
/:cl: