### PR TITLE
Adds a config flag for if station renames require admin approval (and enables it)

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -347,3 +347,5 @@
 	default = FALSE
 
 /datum/config_entry/flag/dynamic_config_enabled
+
+/datum/config_entry/flag/station_name_needs_approval

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2038,6 +2038,12 @@
 		var/obj/item/station_charter/charter = locate(href_list["reject_custom_name"])
 		if(istype(charter))
 			charter.reject_proposed(usr)
+	else if(href_list["approve_custom_name"])
+		if(!check_rights(R_ADMIN))
+			return
+		var/obj/item/station_charter/charter = locate(href_list["approve_custom_name"])
+		if(istype(charter))
+			charter.allow_pass(usr)
 	else if(href_list["jumpto"])
 		if(!isobserver(usr) && !check_rights(R_ADMIN))
 			return

--- a/config/entries/general.txt
+++ b/config/entries/general.txt
@@ -503,3 +503,6 @@ PAI_CUSTOM_HOLOFORMS
 
 ## Enables monstermos/"equalization" step in atmos.
 # ATMOS_EQUALIZATION_ENABLED
+
+## Do station renames from the station charter require admin approval to pass, as opposed to autoapproving if not denied.
+STATION_NAME_NEEDS_APPROVAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right now, station names from the station charter simply autoapprove unless denied by an admin. This makes it that, when this flag is enabled, it will instead autodeny *unless* an admin hits the approve button.
This is probably a good idea in wake of recent events which are making byond hub server appearances slightly more volatile and I'd rather not invoke Lummox's wrath.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Considering whats going on with hub-related stuff right now, I believe we should take additional precautions against getting outselves a visit from Lummox because someone chose a wacky name and no admin saw it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Station names now require admin approval instead of autoaccepting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
