### PR TITLE
crusher gauntlets - resonator hitsound, sharpness to SHARP_NONE

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -245,6 +245,8 @@
 	those who wish to spit in the eyes of God. Sacrifices outright damage for \
 	a reliance on backstabs and the ability to give fauna concussions on a parry."
 	attack_verb = list("pummeled", "punched", "jabbed", "hammer-fisted", "uppercut", "slammed")
+	hitsound = 'sound/weapons/resonator_fire.ogg'
+	sharpness = SHARP_NONE // use your survival dagger or smth
 	icon_state = "crusher-hands"
 	item_state = "crusher0-fist"
 	unique_reskin = list("Gauntlets" = "crusher-hands",

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -245,7 +245,7 @@
 	those who wish to spit in the eyes of God. Sacrifices outright damage for \
 	a reliance on backstabs and the ability to give fauna concussions on a parry."
 	attack_verb = list("pummeled", "punched", "jabbed", "hammer-fisted", "uppercut", "slammed")
-	hitsound = 'sound/weapons/resonator_fire.ogg'
+	hitsound = 'sound/weapons/resonator_blast.ogg'
 	sharpness = SHARP_NONE // use your survival dagger or smth
 	icon_state = "crusher-hands"
 	item_state = "crusher0-fist"


### PR DESCRIPTION
## About The Pull Request
kinetic gauntlets have the resonator blast sound for a hitsound
in return they're no longer sharp
## Why It's Good For The Game
neat sound and no sharpness reflects their status as punchy hands
(also i guess this means you can literally break someone's legs by punching the shit out of them, which is neat)
## Changelog
:cl:
tweak: Proto-kinetic gauntlets, being gauntlets, are no longer sharp.
tweak: But now gauntlets do sound like resonators when you punch someone, which is neat.
/:cl: