### PR TITLE
Makes alcohol cause drunkenness properly again

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -573,9 +573,6 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	if(druggy)
 		adjust_drugginess(-1)
 
-	if(drunkenness)
-		drunkenness = max(drunkenness-1,0)
-
 	if(silent)
 		silent = max(silent-1, 0)
 
@@ -583,7 +580,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		handle_hallucinations()
 
 	if(drunkenness)
-		drunkenness = max(drunkenness - (drunkenness * 0.04), 0)
+		drunkenness *= 0.96
 		if(drunkenness >= 6)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "drunk", /datum/mood_event/drunk)
 			if(prob(25))
@@ -598,6 +595,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "drunk")
 			clear_alert("drunk")
 			sound_environment_override = SOUND_ENVIRONMENT_NONE
+			drunkenness = max(drunkenness - 0.2, 0)
 
 		if(mind && (mind.assigned_role == "Scientist" || mind.assigned_role == "Research Director"))
 			if(SSresearch.science_tech)


### PR DESCRIPTION
## About The Pull Request

#15203 for some reason made drunkenness go down by 1 every tick, which means that drunkenness is nearly impossible, since most drinks can't add that much per tick unless you drink a *lot* of it (for example, absinthe's drunkenness is net negative below 7 units).

This reverts that change, but also adjusts the math a little (`x-x*0.04 == x*.96`, which is less math to do) and adds an extra linear drop when below the standard drunkenness threshold (6) to make it so that drunkenness can ever reach 0 (it couldn't before the previous change, no matter how erroneous)

## Why It's Good For The Game

someone else will have to argue this for me

## Changelog
:cl:
fix: Alcohol works again
/:cl: