### PR TITLE
Supernova rad storm tweaks

### DIFF
--- a/code/modules/events/supernova.dm
+++ b/code/modules/events/supernova.dm
@@ -58,7 +58,7 @@
 		supernova.power_mod = min(supernova.power_mod*1.2, power)
 	if(activeFor > endWhen-10)
 		supernova.power_mod /= 4
-	if(prob(round(supernova.power_mod)) && prob(3) && storm_count < 5 && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
+	if(prob(round(supernova.power_mod)) && prob(5-storm_count) && !SSweather.get_weather_by_type(/datum/weather/rad_storm))
 		SSweather.run_weather(/datum/weather/rad_storm/supernova)
 		storm_count++
 
@@ -73,6 +73,6 @@
 	weather_duration_lower = 50
 	weather_duration_upper = 100
 	telegraph_duration = 200
-	radiation_intensity = 1000
+	radiation_intensity = 500
 	weather_sound = null
 	telegraph_message = "<span class='userdanger'>The air begins to grow very warm!</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Supernova rad storms now do flatly half as much radiation. Gorillas every time was a bit weird, and getting over 1100 rads per rad storm is icky.
2. Rad storms are now more likely to happen *at least once* and less likely to happen *all 5 times*. Basically, before it would have a flat 3% chance per tick on top of the power% chance, now it's a (5-storm_count)% chance, i.e. 5% chance per tick for first storm, 4% chance etc.

## Why It's Good For The Game

Supernovae are literally nothing a bit too often and overwhelming disasters a bit too often too.

## Changelog
:cl:
balance: Made supernova rad storms less strong, slightly more common (but less spammy)
/:cl: