### PR TITLE
Fixes trit/hydrogen fires to have right products

### DIFF
--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -129,6 +129,7 @@
 	heat_penalty = 10
 	transmit_modifier = 30
 	fire_products = list(GAS_H2O = 1)
+	enthalpy = 40000
 	fire_burn_rate = 2
 	fire_radiation_released = 50 // arbitrary number, basically 60 moles of trit burning will just barely start to harm you
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50

--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -113,7 +113,7 @@
 	powermix = 1
 	heat_penalty = 3
 	transmit_modifier = 10
-	fire_products = list(GAS_H2O = 2)
+	fire_products = list(GAS_H2O = 1)
 	fire_burn_rate = 2
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50
 
@@ -128,7 +128,7 @@
 	powermix = 1
 	heat_penalty = 10
 	transmit_modifier = 30
-	fire_products = list(GAS_H2O = 2)
+	fire_products = list(GAS_H2O = 1)
 	fire_burn_rate = 2
 	fire_radiation_released = 50 // arbitrary number, basically 60 moles of trit burning will just barely start to harm you
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now it's two moles of water per mole of hydrogen, which is... not right.

2H2 + 1O2 = 2H2O

As you can clearly see, that's 1 : 1. I think the 2 in the product confused me.

This makes trit fires _even less_ hot, which could be an issue for bombs, but to counteract this I just gave trit a bit of enthalpy of formation, which doesn't change how hot oxygen-rich plasma fires are (due to conservation of energy, which this system implements) but *does* change how hot trit *bombs* are.

## Why It's Good For The Game

I like conservation of energy. This sort of thing might be allowable as an oddity, but I'd prefer stuff be "realistic", since on balance it's all rather arbitrary.

## Changelog
:cl:
tweak: Trit/hydrogen fires now release 1 mole of H2O instead of 2
/:cl: