### PR TITLE
Revert "Bump pillow from 8.3.2 to 9.0.0 in /tools"

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 pygit2==1.0.1
 bidict==0.13.1
-Pillow==9.0.0
+Pillow==8.3.2
 
 # changelogs
 PyYaml==5.4


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#15468

target python version is `3.6.8`, `9.0.0` is only for python `3.7` and above