### PR TITLE
Buffs regen core healing for robots on lavaland, nerfs regen cores when not on lavaland

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -578,8 +578,12 @@
 /datum/status_effect/regenerative_core/on_apply()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "regenerative_core")
-
-	if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))	//Robots can heal from cores, but only get 1/5th of the healing. They can use this to get past the damage threshhold however, and then regularely heal from there.
+	var/turf/T = get_turf(owner)
+	if(T && is_mining_level(T.z))
+		if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))	//Robots can heal from cores, though they ""only"" heal 20 brute + burn damage each instead of 25
+			heal_amount *= 0.8
+	else
+		duration = 10 SECONDS
 		heal_amount *= 0.2
 	owner.adjustBruteLoss(-heal_amount, only_organic = FALSE)
 	if(!AmBloodsucker(owner))	//use your coffin you lazy bastard


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Regen cores used on Synthetics while on lavaland (or well, the mining z level, usually lavaland) now heal 80% of their base healing instead of 20%. 20 healing (of brute and burn) which ignores thresholds is pretty significant.
Regen cores used on anyone not on lavaland now have a .2 multiplier to healing and only apply ten seconds of slowdown reduction to strongly discourage farming them for onstation combat.

This is an alternate PR to #15469 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cores used on Synthetics were somewhat weakish, but granting them the full heal previously would have been rather problematic given it is effectively better nanogel effect-wise. Now, they should be more viable for Synthetics on lavaland, while on-station use is discouraged except in specific situations (injured sprinting for a short time, needing a little bit of healing more, simillar)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Regenerative cores when used on Synthetics on lavaland now heal for 20 brute + burn instead of 5
balance: Regenerative cores when used now on lavaland now only heal 5 brute + burn, regardless of whom they are used on. Additionally, their damage slowdown negation is reduced to ten seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
