### PR TITLE
Fixes / nerfs stabilized orange extract temp adjustments and tweaks its effects on Synthetics

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -81,6 +81,7 @@
 #define SYNTH_ACTIVE_COOLING_MIN_ADJUSTMENT 5				//What is the minimum amount of temp you move towards the target point, even if it would be less with default calculations?
 #define SYNTH_INTEGRATION_COOLANT_PENALTY 0.4				//Integrating coolant is multiplied with this for calculation of impact on passive cooling.
 #define SYNTH_INTEGRATION_COOLANT_CAP 0.25					//Integrating coolant is capped at counting as current_blood * this number. This is so you can't just run on salglu or whatever.
+#define SYNTH_COLD_OFFSET -125								//How much colder temps Synths can tolerate. Used in their species.
 
 #define BODYTEMP_NORMAL						310.15			//The natural temperature for a body
 #define BODYTEMP_AUTORECOVERY_DIVISOR		11		//This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.

--- a/code/modules/mob/living/carbon/human/species_types/anthropomorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/anthropomorph.dm
@@ -32,7 +32,7 @@
 
 	coldmod = 0.5
 	heatmod = 1.2
-	cold_offset = -125	//Can handle pretty cold environments, but it's still a slightly bad idea if you enter a room thats full of near-absolute-zero gas
+	cold_offset = SYNTH_COLD_OFFSET	//Can handle pretty cold environments, but it's still a slightly bad idea if you enter a room thats full of near-absolute-zero gas
 	blacklisted_quirks = list(/datum/quirk/coldblooded)
 	balance_point_values = TRUE
 

--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -15,7 +15,7 @@
 
 	coldmod = 0.5
 	heatmod = 1.2
-	cold_offset = -125	//Can handle pretty cold environments, but it's still a slightly bad idea if you enter a room thats full of near-absolute-zero gas
+	cold_offset = SYNTH_COLD_OFFSET	//Can handle pretty cold environments, but it's still a slightly bad idea if you enter a room thats full of near-absolute-zero gas
 	blacklisted_quirks = list(/datum/quirk/coldblooded)
 	balance_point_values = TRUE
 

--- a/code/modules/mob/living/carbon/human/species_types/synthliz.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synthliz.dm
@@ -12,7 +12,7 @@
 
 	coldmod = 0.5
 	heatmod = 1.2
-	cold_offset = -125	//Can handle pretty cold environments, but it's still a slightly bad idea if you enter a room thats full of near-absolute-zero gas
+	cold_offset = SYNTH_COLD_OFFSET	//Can handle pretty cold environments, but it's still a slightly bad idea if you enter a room thats full of near-absolute-zero gas
 	blacklisted_quirks = list(/datum/quirk/coldblooded)
 	balance_point_values = TRUE
 

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -495,7 +495,11 @@
 
 /datum/status_effect/stabilized/orange/tick()
 	var/body_temperature_difference = BODYTEMP_NORMAL - owner.bodytemperature
-	owner.adjust_bodytemperature(min(5,body_temperature_difference))
+	var/cooling_cap = -5
+	if(HAS_TRAIT(owner, TRAIT_ROBOTIC_ORGANISM))
+		cooling_cap *= 0.5									//Only cools by half as much (which is 5 per life tick since this ticks twice as much as life) so it isn't true spaceproofness..
+		body_temperature_difference += SYNTH_COLD_OFFSET	//.. But also cools towards a cold temp, provided there is nothing that counters it.
+	owner.adjust_bodytemperature(clamp(body_temperature_difference, cooling_cap, 5))
 	return ..()
 
 /datum/status_effect/stabilized/purple


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, stabilized orange extracts heat by a maximum of 5 degrees towards normal.. but cool by as much as the difference is as it is only checked one way.
Firstly, this PR also caps the downwards temp adjustment to -5 degrees.

However, they also allow Synthetics to spacewalk because status effects fire twice per life tick which would perfectly equalized space heatup. As having Synths spacewalk with exclusively an orange extract is somewhat unwanted, it has a halved cooling effect on them, which is 2.5 per status tick / 5 per life tick. This nonetheless halves space overheat speed, allowing for longer traversal.
Additionally, as this'd make the extract just in general weaker for Synths than for others, for Synthetics it now cools them towards a pretty low temp within their tolerance (about -100°C) instead of the standard bodytemp, provided their environment allows for such, which should be a funky quirk that may be useful in some situations and less so in others.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Orange extract somewhat broken in general, and Synth spacewalking simply via a stabilized orange bad-ish too. These changes should reduce both while still leaving the extract with some potential.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Stabilized orange extracts can only cool by -5 degrees per tick base instead of by as much as the difference is.
balance: Stabilized orange extracts only have halved cooling effects on Synthetics (2.5 per status tick / 5 per life), but also cool them towards ~-100°C instead of base bodytemp.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
