### PR TITLE
Weekly high-chaos dynamic days

### DIFF
--- a/code/controllers/configuration/entries/dynamic.dm
+++ b/code/controllers/configuration/entries/dynamic.dm
@@ -94,6 +94,10 @@
 	config_entry_value = 10
 	min_val = 0
 
+/datum/config_entry/keyed_list/dynamic_mode_days
+	key_mode = KEY_MODE_TEXT
+	value_mode = VALUE_MODE_FLAG
+
 /datum/config_entry/keyed_list/storyteller_weight
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM

--- a/code/modules/holiday/dynamic.dm
+++ b/code/modules/holiday/dynamic.dm
@@ -1,0 +1,10 @@
+/datum/holiday/dynamic
+	name = "Dynamic Day"
+
+/datum/holiday/dynamic/shouldCelebrate(dd, mm, yy, ww, ddd)
+	var/list/days = CONFIG_GET(keyed_list/dynamic_mode_days)
+	return ddd in days
+
+/datum/holiday/dynamic/celebrate()
+	GLOB.dynamic_forced_threat_level = rand(90, 100)
+	CONFIG_SET(string/force_gamemode, "dynamic") // prevents the round vote, which prevents extended

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2252,6 +2252,7 @@
 #include "code\modules\food_and_drinks\recipes\tablecraft\recipes_spaghetti.dm"
 #include "code\modules\games\cas.dm"
 #include "code\modules\games\unum.dm"
+#include "code\modules\holiday\dynamic.dm"
 #include "code\modules\holiday\easter.dm"
 #include "code\modules\holiday\holidays.dm"
 #include "code\modules\holiday\halloween\bartholomew.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Weekdays can be configured to be high-chaos; on those days, all rounds will start with a high amount of chaos, extended will not be votable.

A config will need to be added to make this operable. For example:

DYNAMIC_MODE_DAYS Sat
DYNAMIC_MODE_DAYS Fri

[Exact strings are here](https://github.com/Citadel-Station-13/Citadel-Station-13/blob/eae147f6a3474f224a45ea0592918fcc3d9688fa/code/__DEFINES/time.dm#L34).

## Why It's Good For The Game

Weekly events are fun. Even if people only show up for the dynamic days, it's still good.

## Changelog
:cl:
add: Configurable weekly high-chaos days
/:cl: