### PR TITLE
Advanced mutation toxin nerf; new cure, removes instant subspecies transformation

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -217,8 +217,8 @@
 
 /datum/disease/transformation/slime
 	name = "Advanced Mutation Transformation"
-	cure_text = "frost oil"
-	cures = list(/datum/reagent/consumable/frostoil)
+	cure_text = "Frost Oil or Mutadone."
+	cures = list(/datum/reagent/consumable/frostoil, /datum/reagent/medicine/mutadone)
 	cure_chance = 80
 	agent = "Advanced Mutation Toxin"
 	desc = "This highly concentrated extract converts anything into more of itself."
@@ -233,16 +233,11 @@
 
 /datum/disease/transformation/slime/stage_act()
 	..()
-	switch(stage)
-		if(1)
-			if(ishuman(affected_mob) && affected_mob.dna)
-				if(affected_mob.dna.species.id == SPECIES_SLIME_LUMI || affected_mob.dna.species.id == SPECIES_STARGAZER || affected_mob.dna.species.id == SPECIES_SLIME_LUMI)
-					stage = 5
-		if(3)
-			if(ishuman(affected_mob))
-				var/mob/living/carbon/human/human = affected_mob
-				if(human.dna.species.id != SPECIES_SLIME_LUMI && affected_mob.dna.species.id != SPECIES_STARGAZER && affected_mob.dna.species.id != SPECIES_SLIME_LUMI)
-					human.set_species(/datum/species/jelly/slime)
+	if(stage == 3)
+		if(ishuman(affected_mob))
+			var/mob/living/carbon/human/human = affected_mob
+			if(!isjellyperson(human))
+				human.set_species(/datum/species/jelly/slime)
 
 /datum/disease/transformation/corgi
 	name = "The Barkening"

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -230,6 +230,7 @@
 	stage4	= list("<span class='danger'>You are turning into a slime.</span>")
 	stage5	= list("<span class='danger'>You have become a slime.</span>")
 	new_form = /mob/living/simple_animal/slime/random
+	needs_all_cures = FALSE
 
 /datum/disease/transformation/slime/stage_act()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This does the two things to the "Advanced Mutation Transformation" 'disease':

- Adds another possible cure besides Frost Oil: Mutadone.
- Removes the "instant transform if you are a non-roundstart slime" thing.

## Why It's Good For The Game

Turning someone into a slime is a **very** powerful trump card that xenobiology has access to. Chances are, if you've been following the meta I've been going for whenever I do xenobio, you might likely be aiming for black slimes anyways. Slimes, compared to whatever powerful antagonist that someone might use this against like changelings or heretics are effectively crippled, fails their objectives (usually) either way, and will just die forever when they get the funny water likely soon afterwards.

This is why I've added an alternate cure that's more accessible than frost oil. One that should pretty much be available roundstart if you know to rush the genetics pill bottle, which most maps should have.

The second change I imagine would be more controversial, but let me explain:
While this would effectively fuck up a rampaging xenobiologist who happened to be a subspecies of some kind, the xenobiologist can also pretty much use that disease's "stage(1) - set subspecies to stage = 5 instantly" to their advantage. A piercing syringe can hold 10 units, which is more than enough for another reagent that would turn people into these various slime subspecies to begin with; "slime mutation toxin", available from green slimes, an evolution step before blacks. This means someone could load their syringes with
- 4 units of slime mutation toxin or more
- 1 unit of advanced mutation toxin or more

And that can accelerate someone's transformation to be faster dramatically, assuming they haven't reached past stage 1 yet, and assuming the slime mutation toxin randomizes to anything but roundstart slimes. Sometimes RNG can result in that, and it's pretty likely it will.
If you were a roundstart slime, this also increases your chances to be insta-transformed much worse due to the effects where merely a decimal of the slime mutation toxin has a chance to turn you into a subspecies.

This change will result in a still powerful reagent, but it can't be abused/exploited to be instantaneous or quick.

Some of you probably know that I tested this on an antagonist that was stealing from my xenobio stash in-round yesterday. I'm judging it to be deserving of this nerf as a result.

## Changelog
:cl:
balance: Xenobiology's Advanced Mutation Toxin has another cure now, which is Mutadone. In addition, it no longer instantly transforms slime subspecies upon contraction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
