### PR TITLE
removes mood buffs from vore/orgasms.

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -186,6 +186,10 @@
 	description = "<span class='nicegreen'>That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this.</span>\n"
 	mood_change = 4
 	timeout = 4 MINUTES
+	
+/datum/mood_event/cleared_stomach
+	description = "<span class='nicegreen'>Feels nice to get that out of the way!</span>\n"
+	mood_change = 3
 
 /datum/mood_event/high_five
 	description = "<span class='nicegreen'>I love getting high fives!</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -157,7 +157,7 @@
 /datum/mood_event/area
 	description = "" //Fill this out in the area
 	mood_change = 0
-//Power gamer stuff below
+
 /datum/mood_event/drankblood
 	description = "<span class='nicegreen'>I have fed greedly from that which nourishes me.</span>\n"
 	mood_change = 10
@@ -167,21 +167,6 @@
 	description = "<span class='nicegreen'>I slept in a coffin during the day. I feel whole again.</span>\n"
 	mood_change = 8
 	timeout = 1200
-
-//Cursed stuff below.
-
-/datum/mood_event/orgasm
-	description = "<span class='userlove'>I came!</span>\n" //funny meme haha
-	mood_change = 3
-	timeout = 100 SECONDS
-
-/datum/mood_event/fedpred
-	description = "<span class='nicegreen'>I've devoured someone!</span>\n"
-	mood_change = 3
-
-/datum/mood_event/fedprey
-	description = "<span class='nicegreen'>It feels quite cozy in here.</span>\n"
-	mood_change = 3
 
 /datum/mood_event/hope_lavaland
 	description = "<span class='nicegreen'>What a peculiar emblem.  It makes me feel hopeful for my future.</span>\n"
@@ -201,10 +186,6 @@
 	description = "<span class='nicegreen'>That work of art was so great it made me believe in the goodness of humanity. Says a lot in a place like this.</span>\n"
 	mood_change = 4
 	timeout = 4 MINUTES
-
-/datum/mood_event/cleared_stomach
-	description = "<span class='nicegreen'>Feels nice to get that out of the way!</span>\n"
-	mood_change = 3
 
 /datum/mood_event/high_five
 	description = "<span class='nicegreen'>I love getting high fives!</span>\n"

--- a/code/modules/arousal/arousal.dm
+++ b/code/modules/arousal/arousal.dm
@@ -105,7 +105,6 @@
 	else //knots and other non-spilling orgasms
 		to_chat(src,"<span class='userlove'>You climax with [L], your [G.name] spilling nothing.</span>")
 		to_chat(L,"<span class='userlove'>[src] climaxes with you, [p_their()] [G.name] spilling nothing!</span>")
-	SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 	do_climax(fluid_source, spillage ? loc : L, G, spillage)
 
 /mob/living/carbon/human/proc/mob_fill_container(obj/item/organ/genital/G, obj/item/reagent_containers/container, mb_time = 30) //For beaker-filling, beware the bartender

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2635,7 +2635,6 @@
 			M.visible_message("<span class='warning'>[M] throws up a hairball! Disgusting!</span>", ignored_mobs=M)
 			new /obj/item/toy/plush/hairball(get_turf(M))
 			to_chat(M, "<span class='notice'>Aaaah that's better!</span>")
-			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "cleared_stomach", /datum/mood_event/cleared_stomach, name)
 			M.reagents.del_reagent(/datum/reagent/hairball)
 			return
 	..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2635,6 +2635,7 @@
 			M.visible_message("<span class='warning'>[M] throws up a hairball! Disgusting!</span>", ignored_mobs=M)
 			new /obj/item/toy/plush/hairball(get_turf(M))
 			to_chat(M, "<span class='notice'>Aaaah that's better!</span>")
+			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "cleared_stomach", /datum/mood_event/cleared_stomach, name)
 			M.reagents.del_reagent(/datum/reagent/hairball)
 			return
 	..()

--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -221,7 +221,6 @@
 		var/atom/movable/AM = thing
 		if(isliving(AM))
 			var/mob/living/L = AM
-			var/mob/living/OW = owner
 			if(L.vore_flags & ABSORBED && !include_absorbed)
 				continue
 			L.vore_flags &= ~ABSORBED

--- a/code/modules/vore/eating/belly_obj.dm
+++ b/code/modules/vore/eating/belly_obj.dm
@@ -226,10 +226,6 @@
 				continue
 			L.vore_flags &= ~ABSORBED
 			L.stop_sound_channel(CHANNEL_PREYLOOP)
-			SEND_SIGNAL(OW, COMSIG_CLEAR_MOOD_EVENT, "fedpred", /datum/mood_event/fedpred)
-			SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "fedprey", /datum/mood_event/fedprey)
-			SEND_SIGNAL(OW, COMSIG_ADD_MOOD_EVENT, "emptypred", /datum/mood_event/emptypred)
-			SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "emptyprey", /datum/mood_event/emptyprey)
 		count += release_specific_contents(AM, silent = TRUE)
 
 	//Clean up our own business
@@ -273,10 +269,7 @@
 		var/mob/living/OW = owner
 		if(ML.client)
 			ML.stop_sound_channel(CHANNEL_PREYLOOP) //Stop the internal loop, it'll restart if the isbelly check on next tick anyway
-		SEND_SIGNAL(OW, COMSIG_CLEAR_MOOD_EVENT, "fedpred", /datum/mood_event/fedpred)
-		SEND_SIGNAL(ML, COMSIG_CLEAR_MOOD_EVENT, "fedprey", /datum/mood_event/fedprey)
-		SEND_SIGNAL(OW, COMSIG_ADD_MOOD_EVENT, "emptypred", /datum/mood_event/emptypred)
-		SEND_SIGNAL(ML, COMSIG_ADD_MOOD_EVENT, "emptyprey", /datum/mood_event/emptyprey)
+
 
 		if((ML.vore_flags & ABSORBED))
 			ML.vore_flags &= ~(ABSORBED)
@@ -322,12 +315,7 @@
 	if (prey.buckled)
 		prey.buckled.unbuckle_mob(prey,TRUE)
 
-	if(!isbelly(prey.loc))
-		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "fedpred", /datum/mood_event/fedpred)
-		SEND_SIGNAL(prey, COMSIG_ADD_MOOD_EVENT, "fedprey", /datum/mood_event/fedprey)
-	else
-		SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "emptypred", /datum/mood_event/emptypred)
-		SEND_SIGNAL(prey, COMSIG_CLEAR_MOOD_EVENT, "emptyprey", /datum/mood_event/emptyprey)
+
 
 	prey.forceMove(src)
 

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -234,7 +234,6 @@
 		message_admins("[src] used OOC escape to escape from [B.owner]'s belly.")
 		log_consent("[src] used OOC escape to escape from [B.owner]'s belly.")
 		src.stop_sound_channel(CHANNEL_PREYLOOP)
-		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "fedprey", /datum/mood_event/fedprey)
 		for(var/mob/living/simple_animal/SA in range(10))
 			SA.prey_excludes[src] = world.time
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes mood buffs from vore/orgasms
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
having erp mechanics that can be used to enhance your mood (which impacts move and action speed) is bad and abusable. This change keeps erp and gaming separated as it should be.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Orgasms and vore no longer enhance your mood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
