### PR TITLE
Makes reinforced plasma glass windows buildable

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -719,7 +719,6 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 	icon = 'icons/obj/smooth_structures/rplasma_window.dmi'
 	icon_state = "rplasmawindow"
 	dir = FULLTILE_WINDOW_DIR
-	state = PRWINDOW_SECURE
 	max_integrity = 1000
 	fulltile = TRUE
 	flags_1 = PREVENT_CLICK_UNDER_1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

a useless line made them be built in a fully built but also unanchored state, which is a bugged, uninteractable state. this removes that line, because Initialize **handles this anyway**

## Why It's Good For The Game

because features should work

## Changelog
:cl:
fix: reinforced plasma glass windows are buildable
/:cl: