### PR TITLE
Change BOMB_TARGET_SIZE to match new trit fire

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -74,5 +74,5 @@
 	)
 
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
-#define BOMB_TARGET_SIZE			200 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
+#define BOMB_TARGET_SIZE			175 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
 #define BOMB_SUB_TARGET_EXPONENT	2 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -75,4 +75,4 @@
 
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
 #define BOMB_TARGET_SIZE			175 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
-#define BOMB_SUB_TARGET_EXPONENT	2 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.
+#define BOMB_SUB_TARGET_EXPONENT	3 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Trit fires were nerfed when I made them generate less water vapor. This made it nigh-impossible to get to 50,000 points naturally. This brings it back to the previous balance.

## Why It's Good For The Game

Accidentally nerfing toxins is bad.

## Changelog
:cl:
balance: Now slightly easier to get 50,000 points with toxins (50,000 point baseline changed from 200 light range to 175)
/:cl: