### PR TITLE
Fixes siphoning vents to be labeled right

### DIFF
--- a/tgui/packages/tgui/interfaces/common/AtmosControls.js
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.js
@@ -37,7 +37,7 @@ export const Vent = (props, context) => {
         <LabeledList.Item label="Mode">
           <Button
             icon="sign-in-alt"
-            content={direction ? 'Pressurizing' : 'Scrubbing'}
+            content={direction ? 'Pressurizing' : 'Siphoning'}
             color={!direction && 'danger'}
             onClick={() => act('direction', {
               id_tag,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Scrubbing is removing a specific gas from the air, such as CO2. "Scrubbing" mode on vents removes all gases evenly. This is siphoning. Y'know. Like siphoning mode. On scrubbers.

## Why It's Good For The Game

Consistency is good.

## Changelog
:cl:
tweak: "Scrubbing" mode on siphoning vents renamed to "siphoning", as is good and proper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
