### PR TITLE
Adds a LOT more enthalpy to tritium

### DIFF
--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -129,7 +129,7 @@
 	heat_penalty = 10
 	transmit_modifier = 30
 	fire_products = list(GAS_H2O = 1)
-	enthalpy = 40000
+	enthalpy = 300000
 	fire_burn_rate = 2
 	fire_radiation_released = 50 // arbitrary number, basically 60 moles of trit burning will just barely start to harm you
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This changes tritium's enthalpy from 40,000 to 300,000. This makes trit fires about twice as hot. Unfortunately, due to conservation of energy, this doesn't change oxygen-rich plasma-oxy fires *at all* (all of the heat gain from trit burning is lost making the trit in the first place) but it'll buff trit bombs a lot.

## Why It's Good For The Game

Trit bombs are ~about as good as plasma bombs right now, which is bad. This makes tritium into more of a "heat storage" system, making it better for bombs.

## Changelog
:cl:
balance: Massively buffed trit fires (and nerfed trit-*generating* fires equally)
/:cl: