### PR TITLE
Makes supermatter take damage (and not heal) if too near to spaced turfs

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -469,15 +469,20 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			//((((some value between 0.5 and 1 * temp - ((273.15 + 40) * some values between 1 and 10)) * some number between 0.25 and knock your socks off / 150) * 0.25
 			//Heat and mols account for each other, a lot of hot mols are more damaging then a few
 			//Mols start to have a positive effect on damage after 350
+			var/spaced = 0
+			for(var/turf/open/space/T in range(2,src))
+				spaced++
 			damage = max(damage + (max(clamp(removed.total_moles() / 200, 0.5, 1) * removed.return_temperature() - ((T0C + HEAT_PENALTY_THRESHOLD)*dynamic_heat_resistance), 0) * mole_heat_penalty / 150 ) * DAMAGE_INCREASE_MULTIPLIER, 0)
 			//Power only starts affecting damage when it is above 5000
 			damage = max(damage + (max(power - POWER_PENALTY_THRESHOLD, 0)/500) * DAMAGE_INCREASE_MULTIPLIER, 0)
 			//Molar count only starts affecting damage when it is above 1800
 			damage = max(damage + (max(combined_gas - MOLE_PENALTY_THRESHOLD, 0)/80) * DAMAGE_INCREASE_MULTIPLIER, 0)
 
+			damage = max(damage + spaced * 0.1 * DAMAGE_INCREASE_MULTIPLIER, 0)
+
 			//There might be a way to integrate healing and hurting via heat
 			//healing damage
-			if(combined_gas < MOLE_PENALTY_THRESHOLD)
+			if(combined_gas < MOLE_PENALTY_THRESHOLD && !spaced)
 				//Only has a net positive effect when the temp is below 313.15, heals up to 2 damage. Psycologists increase this temp min by up to 45
 				damage = max(damage + (min(removed.return_temperature() - (T0C + HEAT_PENALTY_THRESHOLD), 0) / 150), 0)
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -470,7 +470,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			//Heat and mols account for each other, a lot of hot mols are more damaging then a few
 			//Mols start to have a positive effect on damage after 350
 			var/spaced = 0
-			for(var/turf/open/space/T in range(2,src))
+			for(var/turf/open/space/_space_turf in range(2,src))
 				spaced++
 			damage = max(damage + (max(clamp(removed.total_moles() / 200, 0.5, 1) * removed.return_temperature() - ((T0C + HEAT_PENALTY_THRESHOLD)*dynamic_heat_resistance), 0) * mole_heat_penalty / 150 ) * DAMAGE_INCREASE_MULTIPLIER, 0)
 			//Power only starts affecting damage when it is above 5000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yeah this was inevitable. Basically, for each space turf within 2 tiles of the supermatter, it takes a little bit of damage, and if there are *any*, it doesn't heal damage, ever. Could still allow panic repairs via spacing a turf, but won't allow setups based entirely around spacing a turf.

## Why It's Good For The Game

Engineers hate her! See how she used nothing but an RCD and 5 seconds to setup the supermatter with this one weird trick!

## Changelog
:cl:
balance: Supermatter now takes damage when near space tiles
/:cl: