### PR TITLE
Adds a minimum vote count to continue rounds

### DIFF
--- a/code/__DEFINES/vote.dm
+++ b/code/__DEFINES/vote.dm
@@ -5,6 +5,9 @@
 #define HIGHEST_MEDIAN_VOTING "HIGHEST_MEDIAN"
 #define INSTANT_RUNOFF_VOTING "IRV"
 
+#define VOTE_TRANSFER "Initiate Crew Transfer"
+#define VOTE_CONTINUE "Continue Playing"
+
 #define SHOW_RESULTS (1<<0)
 #define SHOW_VOTES (1<<1)
 #define SHOW_WINNER (1<<2)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -32,6 +32,8 @@ SUBSYSTEM_DEF(vote)
 
 	var/list/stored_modetier_results = list() // The aggregated tier list of the modes available in secret.
 
+	var/transfer_votes_done = 0
+
 /datum/controller/subsystem/vote/fire()	//called by master_controller
 	if(mode)
 		if(end_time < world.time)
@@ -248,8 +250,17 @@ SUBSYSTEM_DEF(vote)
 	if(vote_system == SCORE_VOTING)
 		calculate_scores(vote_title_text)
 	if(vote_system == HIGHEST_MEDIAN_VOTING)
-		calculate_highest_median(vote_title_text) // nothing uses this at the moment
-	var/list/winners = vote_system == INSTANT_RUNOFF_VOTING ? get_runoff_results() : get_result()
+		calculate_highest_median(vote_title_text)
+	var/list/winners = list()
+	if(mode == "transfer")
+		var/greater_amount_required = 2 + transfer_votes_done
+		text += "\nExtending requires [greater_amount_required] more votes to win."
+		if(choices[VOTE_TRANSFER] + greater_amount_required >= choices[VOTE_CONTINUE])
+			winners = list(VOTE_TRANSFER)
+		else
+			winners = list(VOTE_CONTINUE)
+	else
+		winners = vote_system == INSTANT_RUNOFF_VOTING ? get_runoff_results() : get_result()
 	var/was_roundtype_vote = mode == "roundtype" || mode == "dynamic"
 	if(winners.len > 0)
 		if(was_roundtype_vote)
@@ -305,7 +316,7 @@ SUBSYSTEM_DEF(vote)
 			if(vote_system == SCHULZE_VOTING)
 				admintext += "\nIt should be noted that this is not a raw tally of votes (impossible in ranked choice) but the score determined by the schulze method of voting, so the numbers will look weird!"
 			else if(vote_system == HIGHEST_MEDIAN_VOTING)
-				admintext += "\nIt should be noted that this is not a raw tally of votes but the number of runoffs done by majority judgement!"
+				admintext += "\nIt should be noted that this is not a raw tally of votes but rather the median score plus a tiebreaker!"
 			for(var/i=1,i<=choices.len,i++)
 				var/votes = choices[choices[i]]
 				admintext += "\n<b>[choices[i]]:</b> [votes]"
@@ -339,7 +350,7 @@ SUBSYSTEM_DEF(vote)
 				if(SSmapping.changemap(config.maplist[.]))
 					to_chat(world, "<span class='boldannounce'>The map vote has chosen [VM.map_name] for next round!</span>")
 			if("transfer") // austation begin -- Crew autotransfer vote
-				if(. == "Initiate Crew Transfer")
+				if(. == VOTE_TRANSFER)
 					SSshuttle.autoEnd()
 					var/obj/machinery/computer/communications/C = locate() in GLOB.machines
 					if(C)
@@ -446,7 +457,7 @@ SUBSYSTEM_DEF(vote)
 						continue
 					choices |= M
 			if("transfer") // austation begin -- Crew autotranfer vote
-				choices.Add("Initiate Crew Transfer","Continue Playing") // austation end
+				choices.Add(VOTE_TRANSFER,VOTE_CONTINUE) // austation end
 			if("roundtype") //CIT CHANGE - adds the roundstart secret/extended vote
 				choices.Add("dynamic", "extended")
 			if("custom")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -253,9 +253,9 @@ SUBSYSTEM_DEF(vote)
 		calculate_highest_median(vote_title_text)
 	var/list/winners = list()
 	if(mode == "transfer")
-		var/greater_amount_required = 2 + transfer_votes_done
-		text += "\nExtending requires [greater_amount_required] more votes to win."
-		if(choices[VOTE_TRANSFER] + greater_amount_required >= choices[VOTE_CONTINUE])
+		var/amount_required = 3 + transfer_votes_done
+		text += "\nExtending requires at least [amount_required] votes to win."
+		if(choices[VOTE_CONTINUE] < amount_required || choices[VOTE_TRANSFER] >= choices[VOTE_CONTINUE])
 			winners = list(VOTE_TRANSFER)
 		else
 			winners = list(VOTE_CONTINUE)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -254,6 +254,7 @@ SUBSYSTEM_DEF(vote)
 	var/list/winners = list()
 	if(mode == "transfer")
 		var/amount_required = 3 + transfer_votes_done
+		transfer_votes_done += 1
 		text += "\nExtending requires at least [amount_required] votes to win."
 		if(choices[VOTE_CONTINUE] < amount_required || choices[VOTE_TRANSFER] >= choices[VOTE_CONTINUE])
 			winners = list(VOTE_TRANSFER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Essentially, for the round to actually extend when "Continue playing" is voted on, at least 3+(number of extend votes) people need to have voted on it; any less and it'll call the shuttle anyway. Also, ties always call the shuttle, rather than being a coin flip.

## Why It's Good For The Game

Long rounds with few people on them *kill* the server, outright. People don't join until rounds are over and rounds can go so long that people who might want to play, like, go to bed or whatever. This is really bad, actually. Shorter average rounds means more people can actually play.

## Changelog
:cl:
add: Round continuation limitations based on population voting for continuation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
