### PR TITLE
Omega-ning (Gravgen, Xenobio)

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5389,7 +5389,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "ajY" = (
@@ -5935,6 +5937,9 @@
 /obj/item/chair,
 /obj/item/stack/ore/silver,
 /obj/item/stack/ore/iron,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "akN" = (
@@ -5948,6 +5953,8 @@
 	dir = 4
 	},
 /obj/structure/lattice,
+/obj/item/broken_bottle,
+/obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
 "akP" = (
@@ -6356,6 +6363,9 @@
 	network = list("ss13","engine")
 	},
 /mob/living/simple_animal/parrot/Poly,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/ce)
 "alF" = (
@@ -7275,9 +7285,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "anw" = (
@@ -17486,7 +17494,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/engineering/main)
 "aGi" = (
 /obj/structure/sign/warning/securearea,
@@ -17518,7 +17526,7 @@
 	name = "Power Monitoring";
 	req_access_txt = "32"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/engineering/main)
 "aGl" = (
 /obj/machinery/door/firedoor,
@@ -17562,7 +17570,7 @@
 	name = "Engineering Access";
 	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/engineering/main)
 "aGo" = (
 /obj/structure/sign/warning/fire,
@@ -18063,15 +18071,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics)
-"aHg" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
-	dir = 6;
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plasteel/dark,
-/area/engineering/gravity_generator)
 "aHh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -18631,19 +18630,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aIb" = (
-/obj/structure/sign/warning/radiation{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/engineering/gravity_generator)
 "aIc" = (
 /turf/open/floor/circuit/green,
 /area/engineering/gravity_generator)
 "aId" = (
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "aIe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -19217,16 +19209,13 @@
 	},
 /area/medical/genetics)
 "aJh" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "aJi" = (
 /obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "aJj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -19897,10 +19886,6 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
 "aKp" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -19910,7 +19895,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "aKr" = (
 /obj/machinery/power/solar{
@@ -20007,7 +19992,9 @@
 	name = "Engineering Access";
 	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/engineering/gravity_generator)
 "aKy" = (
 /obj/structure/cable/white{
@@ -20110,7 +20097,9 @@
 	name = "Engineering Access";
 	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/engineering/main)
 "aKI" = (
 /obj/structure/cable/white{
@@ -20604,7 +20593,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "aLF" = (
 /obj/structure/table/reinforced,
@@ -21194,7 +21183,7 @@
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side,
 /area/tcommsat/server)
 "aMM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31944,7 +31933,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -32250,21 +32238,18 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bhS" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
 	},
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
+/turf/open/floor/plasteel,
+/area/engineering/atmos)
 "bhX" = (
 /obj/machinery/pool/filter{
 	pixel_y = 16
@@ -32981,7 +32966,7 @@
 	name = "Xenobiology Kill Room";
 	req_access_txt = "47"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/telecomms,
 /area/science/xenobiology)
 "bjw" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden,
@@ -34575,6 +34560,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -34697,8 +34685,12 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "cpn" = (
-/turf/closed/wall,
-/area/space/station_ruins)
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room";
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plasteel/dark,
+/area/engineering/gravity_generator)
 "csX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -34747,6 +34739,40 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"cLX" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno5";
+	name = "Creature Cell #5"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "cRz" = (
 /obj/machinery/button/door{
 	id = "supplybridge";
@@ -35415,7 +35441,7 @@
 /area/asteroid/nearstation)
 "fTp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall/rust,
+/turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "fWh" = (
 /turf/open/floor/wood{
@@ -35525,7 +35551,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/sign/warning/radiation{
+	pixel_x = -32
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "guM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -35805,8 +35838,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hIF" = (
-/turf/closed/wall,
-/area/space)
+/turf/open/floor/plasteel,
+/area/engineering/gravity_generator)
 "hNO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -36087,10 +36120,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "iVy" = (
@@ -36331,10 +36360,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -36682,6 +36707,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"lbA" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "lcW" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
@@ -37034,6 +37066,17 @@
 "mQi" = (
 /turf/closed/wall/rust,
 /area/maintenance/starboard/central)
+"mRi" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mTv" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -37202,6 +37245,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/turf_decal/caution,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "nIf" = (
@@ -37607,11 +37651,8 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "psq" = (
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
+/area/engineering/gravity_generator)
 "puc" = (
 /obj/structure/bed,
 /turf/open/floor/wood,
@@ -37802,12 +37843,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "qdY" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/turf/open/floor/plasteel,
+/area/engineering/gravity_generator)
 "qeO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -37857,13 +37898,13 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qpG" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/extinguisher/mini,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/engineering/atmos)
+/area/science/xenobiology)
 "qsc" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -38038,6 +38079,12 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/starboard/aft)
+"rpu" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "rwH" = (
 /turf/closed/wall/mineral/titanium,
 /area/asteroid/nearstation)
@@ -38052,33 +38099,17 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "rCw" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno4";
-	name = "Creature Cell #4"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "rEx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -40819,13 +40850,36 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "uBJ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno4";
+	name = "Creature Cell #4"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/broken_bottle,
-/obj/item/pickaxe,
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "uBW" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -41026,8 +41080,15 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vsf" = (
-/obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "vsL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41276,8 +41337,8 @@
 /area/command/bridge)
 "wiJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/engineering/atmos)
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
 "wkn" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/shovel/spade,
@@ -41353,7 +41414,10 @@
 /area/service/bar/atrium)
 "wDb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
+/obj/structure/sign/warning/radiation{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "wOe" = (
 /obj/machinery/door/firedoor/heavy,
@@ -41632,13 +41696,14 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "xKp" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
-/area/engineering/main)
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "xMv" = (
 /obj/structure/lattice,
 /obj/structure/fluff/broken_flooring{
@@ -41651,9 +41716,6 @@
 /turf/closed/wall,
 /area/command/gateway)
 "xPz" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
@@ -41750,36 +41812,17 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "yeE" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno5";
-	name = "Creature Cell #5"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "yeO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41811,6 +41854,7 @@
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
 "yhg" = (
+/obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -66119,7 +66163,7 @@ aaa
 aaa
 aaa
 aaa
-cpn
+jFP
 jFP
 jFP
 jFP
@@ -66376,7 +66420,7 @@ aaa
 aaa
 aaa
 aaa
-hIF
+aaa
 aaa
 jFP
 jFP
@@ -66633,7 +66677,7 @@ aaa
 aaa
 aaa
 aaa
-hIF
+aaa
 aaa
 jFP
 jFP
@@ -66890,7 +66934,7 @@ aaa
 aaa
 aaa
 aaa
-hIF
+aaa
 aaa
 aaa
 aaa
@@ -68429,7 +68473,7 @@ dMl
 uhz
 gNH
 kas
-aad
+kas
 aad
 aad
 aad
@@ -68685,8 +68729,8 @@ gSv
 xtL
 uhz
 nHD
+bhS
 kas
-aad
 aad
 aad
 aad
@@ -68942,13 +68986,13 @@ kiw
 nUk
 ezP
 xPz
-kas
-aad
-aad
-aad
-aad
-aad
-aad
+aGe
+aGe
+aGe
+aGe
+aGe
+aGe
+aGe
 bxd
 aad
 aad
@@ -69202,8 +69246,8 @@ twh
 wiJ
 wDb
 fTp
-wDb
-wDb
+qdY
+fTp
 gre
 sIu
 bwY
@@ -69456,10 +69500,10 @@ dgV
 fYx
 iIj
 ajX
-qpG
-sIu
+aGe
+cpn
 aHe
-aIb
+aId
 aJh
 aKp
 aLD
@@ -69713,8 +69757,8 @@ orI
 xyo
 hNO
 bOy
-uBJ
 aGe
+hIF
 aId
 aIc
 aJi
@@ -69970,9 +70014,9 @@ anx
 anx
 uok
 akM
-qdY
 aGe
-aHg
+psq
+aJh
 aId
 aHe
 pbT
@@ -70226,8 +70270,8 @@ xIm
 rVj
 aAg
 akN
-alI
 anu
+alI
 aGe
 aGe
 sIu
@@ -71783,7 +71827,7 @@ aPI
 bwV
 aRF
 aSP
-xKp
+aEt
 yhg
 aad
 bvo
@@ -85686,7 +85730,7 @@ bgZ
 bhM
 ibv
 bgm
-bgZ
+bhg
 bhM
 sKZ
 aad
@@ -86962,13 +87006,13 @@ baa
 aZl
 dfP
 bfP
-bgo
+qpG
 rCw
-bhN
+vsf
 ibv
-bgo
+lbA
 yeE
-bhN
+mRi
 nTi
 biZ
 bjs
@@ -87219,13 +87263,13 @@ bem
 beO
 sOV
 bfP
-bgm
-bgm
-bhS
+bgo
+uBJ
+bhN
 ibv
-bgm
-bgm
-bhS
+bgo
+cLX
+bhN
 ibv
 bja
 bjt
@@ -87476,13 +87520,13 @@ ben
 beP
 bfn
 bfP
-vsf
-bhg
 bgm
+bgm
+xKp
 ibv
-psq
-bgZ
 bgm
+bgm
+xKp
 xFw
 bjb
 bju
@@ -87737,8 +87781,8 @@ bgm
 bhg
 bgm
 ibv
-bgm
-bhg
+rpu
+bgZ
 bgm
 bfP
 bjc

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -34582,6 +34582,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"bTd" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "bVs" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating,
@@ -34739,40 +34745,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"cLX" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno5";
-	name = "Creature Cell #5"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "cRz" = (
 /obj/machinery/button/door{
 	id = "supplybridge";
@@ -35226,6 +35198,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/mixing)
+"fds" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "fey" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36456,6 +36442,40 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"jRV" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno5";
+	name = "Creature Cell #5"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "jXc" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -36707,13 +36727,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"lbA" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "lcW" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
@@ -37066,17 +37079,6 @@
 "mQi" = (
 /turf/closed/wall/rust,
 /area/maintenance/starboard/central)
-"mRi" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "mTv" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -37478,6 +37480,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oWO" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "oXj" = (
 /obj/structure/toilet{
 	dir = 8
@@ -38079,12 +38091,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/starboard/aft)
-"rpu" = (
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "rwH" = (
 /turf/closed/wall/mineral/titanium,
 /area/asteroid/nearstation)
@@ -41087,6 +41093,9 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -87010,9 +87019,9 @@ qpG
 rCw
 vsf
 ibv
-lbA
+oWO
 yeE
-mRi
+fds
 nTi
 biZ
 bjs
@@ -87268,7 +87277,7 @@ uBJ
 bhN
 ibv
 bgo
-cLX
+jRV
 bhN
 ibv
 bja
@@ -87781,7 +87790,7 @@ bgm
 bhg
 bgm
 ibv
-rpu
+bTd
 bgZ
 bgm
 bfP

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -13907,7 +13907,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -24663,16 +24663,6 @@
 /area/science/lab)
 "aTI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "aTJ" = (
@@ -34582,12 +34572,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"bTd" = (
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "bVs" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating,
@@ -34799,6 +34783,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"cYf" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "dai" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -35198,20 +35192,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/mixing)
-"fds" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "fey" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36442,40 +36422,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"jRV" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno5";
-	name = "Creature Cell #5"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "jXc" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -36579,6 +36525,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kqC" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "kqH" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -36956,6 +36908,20 @@
 "meo" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/mixing)
+"mfw" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mgs" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 1
@@ -37480,16 +37446,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oWO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "oXj" = (
 /obj/structure/toilet{
 	dir = 8
@@ -38094,6 +38050,40 @@
 "rwH" = (
 /turf/closed/wall/mineral/titanium,
 /area/asteroid/nearstation)
+"ryU" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno5";
+	name = "Creature Cell #5"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "rzn" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -87019,9 +87009,9 @@ qpG
 rCw
 vsf
 ibv
-oWO
+cYf
 yeE
-fds
+mfw
 nTi
 biZ
 bjs
@@ -87277,7 +87267,7 @@ uBJ
 bhN
 ibv
 bgo
-jRV
+ryU
 bhN
 ibv
 bja
@@ -87790,7 +87780,7 @@ bgm
 bhg
 bgm
 ibv
-bTd
+kqC
 bgZ
 bgm
 bfP

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -7272,11 +7272,17 @@
 /turf/open/floor/plating,
 /area/cargo/miningdock)
 "anu" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/ce)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/engineering/atmos)
 "anv" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -9664,7 +9670,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/engineering/atmos)
 "arB" = (
 /obj/effect/turf_decal/tile/red{
@@ -10252,10 +10258,10 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	dir = 1
+	dir = 4
 	},
 /area/engineering/atmos)
 "asx" = (
@@ -10321,10 +10327,10 @@
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	dir = 1
+	dir = 4
 	},
 /area/engineering/atmos)
 "asD" = (
@@ -10342,20 +10348,20 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	dir = 1
+	dir = 4
 	},
 /area/engineering/atmos)
 "asG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	dir = 1
+	dir = 4
 	},
 /area/engineering/atmos)
 "asH" = (
@@ -10956,10 +10962,10 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "atJ" = (
 /turf/open/floor/wood,
@@ -11486,10 +11492,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "auC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12027,10 +12033,10 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "avH" = (
 /obj/structure/table/wood,
@@ -12584,10 +12590,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "awL" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -12845,10 +12851,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "axq" = (
 /obj/machinery/light{
@@ -12863,9 +12868,11 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "axr" = (
 /obj/structure/cable/white{
@@ -12875,9 +12882,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "axs" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -12889,9 +12898,12 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
 "axt" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -13857,10 +13869,10 @@
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	dir = 1
+	dir = 4
 	},
 /area/engineering/atmos)
 "azn" = (
@@ -29743,9 +29755,12 @@
 	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/checker,
 /area/engineering/atmos)
 "bdw" = (
 /obj/machinery/holopad,
@@ -32231,14 +32246,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bhS" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
-	},
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
 /area/engineering/atmos)
 "bhX" = (
 /obj/machinery/pool/filter{
@@ -33634,6 +33648,15 @@
 	dir = 8
 	},
 /area/hallway/secondary/exit)
+"bnS" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "boD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -34675,12 +34698,11 @@
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "cpn" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
-	network = list("ss13","engine")
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engineering/gravity_generator)
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/ce)
 "csX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -34719,6 +34741,40 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"cCv" = (
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno5";
+	name = "Creature Cell #5"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/science/xenobiology)
 "cGA" = (
 /obj/machinery/pool/controller,
 /turf/open/floor/wood,
@@ -34783,16 +34839,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"cYf" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dai" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -34951,6 +34997,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"dZL" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "eaf" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/cable{
@@ -35510,6 +35566,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"gkP" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "glC" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
@@ -35549,6 +35619,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"gBW" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
 "gGq" = (
 /obj/machinery/mass_driver{
 	dir = 4;
@@ -35804,8 +35880,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hIF" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/engineering/gravity_generator)
+/area/engineering/atmos)
 "hNO" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
@@ -36525,12 +36608,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"kqC" = (
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "kqH" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -36908,20 +36985,6 @@
 "meo" = (
 /turf/closed/wall/r_wall/rust,
 /area/science/mixing)
-"mfw" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "mgs" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 1
@@ -37619,6 +37682,10 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "psq" = (
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room";
+	network = list("ss13","engine")
+	},
 /turf/open/floor/plasteel/dark,
 /area/engineering/gravity_generator)
 "puc" = (
@@ -37811,10 +37878,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "qdY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engineering/gravity_generator)
 "qeO" = (
@@ -37866,13 +37929,8 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "qpG" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/extinguisher/mini,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/science/xenobiology)
+/turf/open/floor/plasteel/dark,
+/area/engineering/gravity_generator)
 "qsc" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -38050,40 +38108,6 @@
 "rwH" = (
 /turf/closed/wall/mineral/titanium,
 /area/asteroid/nearstation)
-"ryU" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno5";
-	name = "Creature Cell #5"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/science/xenobiology)
 "rzn" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -40846,36 +40870,12 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "uBJ" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno4";
-	name = "Creature Cell #4"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/science/xenobiology)
+/turf/open/floor/plasteel,
+/area/engineering/gravity_generator)
 "uBW" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -41076,18 +41076,12 @@
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
 "vsf" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/extinguisher/mini,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "vsL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -41217,6 +41211,20 @@
 "vMb" = (
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
+"vMG" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "vPH" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/power/tracker,
@@ -41695,13 +41703,35 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "xKp" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/door/window/brigdoor{
+	dir = 4;
+	name = "Creature Pen";
+	req_access_txt = "47"
 	},
-/obj/structure/disposaloutlet{
+/obj/machinery/door/poddoor/preopen{
+	id = "xeno4";
+	name = "Creature Cell #4"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/science/xenobiology)
 "xMv" = (
 /obj/structure/lattice,
@@ -68728,7 +68758,7 @@ gSv
 xtL
 uhz
 nHD
-bhS
+hIF
 kas
 aad
 aad
@@ -69245,7 +69275,7 @@ twh
 wiJ
 wDb
 fTp
-qdY
+uBJ
 fTp
 gre
 sIu
@@ -69500,7 +69530,7 @@ fYx
 iIj
 ajX
 aGe
-cpn
+psq
 aHe
 aId
 aJh
@@ -69757,7 +69787,7 @@ xyo
 hNO
 bOy
 aGe
-hIF
+qdY
 aId
 aIc
 aJi
@@ -70014,7 +70044,7 @@ anx
 uok
 akM
 aGe
-psq
+qpG
 aJh
 aId
 aHe
@@ -70269,7 +70299,7 @@ xIm
 rVj
 aAg
 akN
-anu
+cpn
 alI
 aGe
 aGe
@@ -71799,7 +71829,7 @@ vMb
 srR
 tac
 arr
-bKQ
+anu
 fFw
 auq
 qEl
@@ -72056,7 +72086,7 @@ gap
 fnp
 aqA
 viy
-bKQ
+anu
 qIp
 mae
 eOs
@@ -73084,7 +73114,7 @@ aor
 apv
 aqA
 arw
-oiL
+bhS
 jxc
 mae
 hqX
@@ -87005,13 +87035,13 @@ baa
 aZl
 dfP
 bfP
-qpG
-rCw
 vsf
+rCw
+vMG
 ibv
-cYf
+dZL
 yeE
-mfw
+gkP
 nTi
 biZ
 bjs
@@ -87263,11 +87293,11 @@ beO
 sOV
 bfP
 bgo
-uBJ
+xKp
 bhN
 ibv
 bgo
-ryU
+cCv
 bhN
 ibv
 bja
@@ -87521,11 +87551,11 @@ bfn
 bfP
 bgm
 bgm
-xKp
+bnS
 ibv
 bgm
 bgm
-xKp
+bnS
 xFw
 bjb
 bju
@@ -87780,7 +87810,7 @@ bgm
 bhg
 bgm
 ibv
-kqC
+gBW
 bgZ
 bgm
 bfP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so you can walk around the Gravity Generator room and also shrinks two of Xenobio's pens to make room for the chutes they were missing.
Also removes the airlock to the Supermatter Cooling Loop because there already exists an entry to it below.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Interior Design Is My Passion
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: [Omega] Engineering Supermatter shortcut airlock to Cooling Loop
tweak: [Omega] Gravity Generator walkable area
fix: [Omega] Two Xenobiology pens now have chutes
fix: [Omega] Makes a t-junction pipe in Atmospherics not visible above the floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
