### PR TITLE
Makes should_do_equalization actually work

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -396,12 +396,15 @@ SUBSYSTEM_DEF(air)
 	*/
 
 /datum/controller/subsystem/air/proc/run_delay_heuristics()
-	if(!equalize_enabled)
-		cost_equalize = 0
-		if(should_do_equalization)
-			eq_cooldown--
-			if(eq_cooldown <= 0)
-				equalize_enabled = TRUE
+	if(should_do_equalization)
+		if(!equalize_enabled)
+			cost_equalize = 0
+			if(should_do_equalization)
+				eq_cooldown--
+				if(eq_cooldown <= 0)
+					equalize_enabled = TRUE
+	else
+		equalize_enabled = FALSE
 	var/total_thread_time = cost_turfs + cost_equalize + cost_groups + cost_post_process
 	if(total_thread_time)
 		var/wait_ms = wait * 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We have a config option for equalization that isn't working right now because I messed up the coding thereof. This fixes it.

## Why It's Good For The Game

Our maps do *not* work with monster/katmos.

## Changelog
:cl:
fix: atmos equalization config now works properly
/:cl: