### PR TITLE
Fix implosion compressor impossibility

### DIFF
--- a/code/modules/research/anomaly/explosive_compressor.dm
+++ b/code/modules/research/anomaly/explosive_compressor.dm
@@ -1,4 +1,4 @@
-#define MAX_RADIUS_REQUIRED 8000		//tritbomb
+#define MAX_RADIUS_REQUIRED 175		//tritbomb
 #define MIN_RADIUS_REQUIRED 20		//maxcap
 /**
   * # Explosive compressor machines


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I sorta forgot about this particular bomb mechanic so I didn't rebalance it when I rebalanced fires. The new maximum bomb size is around 175-200, so that's where this is. A nob bomb can get up to 1500 or so, I think, but that's neither here nor there; point is, this shouldn't be impossible.

As an aside, **if you notice these things, actually tell someone in a position to do something about it instead of silently complaining to your friends or whatever**, lord.

## Why It's Good For The Game

An entire feature shouldn't be swiftly made impossible by an oversight.

## Changelog
:cl:
balance: Implosion compressor now doesn't scale beyond bombs' ability to explode
/:cl: