### PR TITLE
fixes parallax trying to make null objects

### DIFF
--- a/code/_rendering/parallax/types/space.dm
+++ b/code/_rendering/parallax/types/space.dm
@@ -17,7 +17,7 @@
 	P.pixel_x = planet_offset_x
 	P.pixel_y = planet_offset_y
 	. += P
-	if(random_layer)
+	if(ispath(random_layer, /atom/movable/screen/parallax_layer))
 		. += new random_layer
 	if(ispath(random_layer, /atom/movable/screen/parallax_layer/space/random/space_gas))
 		var/atom/movable/screen/parallax_layer/space/random/space_gas/SG = locate(random_layer) in objects


### PR DESCRIPTION
this
has a 30% chance of making the string "null"
not null null
thanks, byond :|

![image](https://user-images.githubusercontent.com/2003111/158435887-9a16624d-95c0-4385-af44-0855a473791e.png)
