### PR TITLE
Climax with partner now counts mouth

### DIFF
--- a/code/modules/arousal/arousal.dm
+++ b/code/modules/arousal/arousal.dm
@@ -145,7 +145,7 @@
 			partners -= L
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
-			if(!C.exposed_genitals.len || !C.is_groin_exposed() || !C.is_chest_exposed() || !C.is_mouth_covered()) //Nothing through_clothing, no proper partner.
+			if(!C.exposed_genitals.len && !C.is_groin_exposed() && !C.is_chest_exposed() && C.is_mouth_covered()) //Nothing through_clothing, no proper partner.
 				partners -= C
 	//NOW the list should only contain correct partners
 	if(!partners.len)

--- a/code/modules/arousal/arousal.dm
+++ b/code/modules/arousal/arousal.dm
@@ -145,7 +145,7 @@
 			partners -= L
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
-			if(!C.exposed_genitals.len && !C.is_groin_exposed() && !C.is_chest_exposed()) //Nothing through_clothing, no proper partner.
+			if(!C.exposed_genitals.len || !C.is_groin_exposed() || !C.is_chest_exposed() || !C.is_mouth_covered()) //Nothing through_clothing, no proper partner.
 				partners -= C
 	//NOW the list should only contain correct partners
 	if(!partners.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows the climax with partner count people with their mouth exposed as a valid target. (I should note I can't test this on local but putnam said it will work.)
2/4 approving maintainers: 
https://discord.com/channels/161574200581029888/336748540690825216/955314725711921183 Lin
https://discord.com/channels/161574200581029888/336748540690825216/955479154277621780 Putnam
other two didn't respond over a 48+ hour period with two pings.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Uhhh... i don't think it is? But breastfeeding is hot af imo.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The receiving party of a climax with partner action can have their mouth exposed to count as a valid 'hole' 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
