### PR TITLE
Fix recycler runtime

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -123,7 +123,7 @@
 				living_detected = living_detected || AM
 			nom += AM
 		else if(isliving(AM))
-			living_detected = living_detected || TRUE
+			living_detected = living_detected || AM
 			crunchy_nom += AM
 	var/not_eaten = to_eat.len - nom.len - crunchy_nom.len
 	if(living_detected) // First, check if we have any living beings detected.

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -120,10 +120,10 @@
 			var/obj/item/bodypart/head/as_head = AM
 			var/obj/item/mmi/as_mmi = AM
 			if(istype(AM, /obj/item/organ/brain) || (istype(as_head) && as_head.brain) || (istype(as_mmi) && as_mmi.brain) || istype(AM, /obj/item/dullahan_relay))
-				living_detected = living_detected || AM
+				living_detected = living_detected ? living_detected : AM
 			nom += AM
 		else if(isliving(AM))
-			living_detected = living_detected || AM
+			living_detected = living_detected ? living_detected : AM
 			crunchy_nom += AM
 	var/not_eaten = to_eat.len - nom.len - crunchy_nom.len
 	if(living_detected) // First, check if we have any living beings detected.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There's a runtime because someone was very confused about byond's types, and Lua, and some other stuff

## Why It's Good For The Game

Runtimes are bad

## Changelog
:cl:
fix: recycler now emergency stops properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
