### PR TITLE
Fixes audio panning sounding weird by adding 1 to the Y value in playsoundlocal

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -173,7 +173,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 		var/dz = turf_source.y - T.y // Hearing from infront/behind
 		S.z = dz * distance_multiplier
 		var/dy = (turf_source.z - T.z) * 5 * distance_multiplier // Hearing from  above / below, multiplied by 5 because we assume height is further along coords.
-		S.y = dy
+		S.y = dy + 1
 
 		S.falloff = isnull(max_distance)? FALLOFF_SOUNDS : max_distance //use max_distance, else just use 1 as we are a direct sound so falloff isnt relevant.
 


### PR DESCRIPTION
## About The Pull Request
This PR does exactly as it says on the tin. Prior to Immersionaudio, playsoundlocal had a +1 for sounds being played, such that audio sounds like it's a little bit ahead of you. For surround-sound users (hi! that'd be me), this single +1 makes audio sound a lot more natural, as it matches up fairly closely with what's actually going on on-screen. This also affects those who don't use surround sound, in that stereo panning gradually grows the further away something is from the center of the screen. However, after Immersionaudio, this +1 was removed, making the panning sound legitimately awful, as something right next to your character suddenly plays only on one stereo channel, which can contribute to listening fatigue among other issues.

## Why It's Good For The Game
See above

## Changelog
:cl: Bhijn
tweak: Sounds now have a default Y value of 1, making audio panning sound significantly less weird with only one single line changed.
/:cl:
