### PR TITLE
Bumps up BOMB_TARGET_SIZE for new trit bombs

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -74,5 +74,5 @@
 	)
 
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
-#define BOMB_TARGET_SIZE			175 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
+#define BOMB_TARGET_SIZE			240 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
 #define BOMB_SUB_TARGET_EXPONENT	3 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Trit bombs are over 300 now, which is nice, because that means they're *significantly* better than plasma bombs. As such, I can bump up the target size to make plasma bombs even worse (though they're still worth it for the time they take).

## Why It's Good For The Game

Right now, trit bombs give ~70000 points and plasma bombs give something like 45000. This will change those to ~60000 and ~25000 respectively, I think? Might need more tweaking. We shall see. It's still probably too much, since it used to be 50000 max.

## Changelog
:cl:
balance: Nerfed toxins research output (still >50000 for trit bombs)
/:cl: