### PR TITLE
Makes auxmos do fires on Linux

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -74,5 +74,6 @@
 	)
 
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
-#define BOMB_TARGET_SIZE			175 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
+#define BOMB_TARGET_SIZE			(world.system_type == MS_WINDOWS ? 240 : 50000) // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
+// Linux still has old trit fires, so
 #define BOMB_SUB_TARGET_EXPONENT	3 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.

--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -60,6 +60,10 @@
 	fire_products = "plasma_fire"
 	enthalpy = FIRE_PLASMA_ENERGY_RELEASED // 3000000, 3 megajoules, 3000 kj
 
+/datum/gas/plasma/New()
+	if(world.system_type == UNIX)
+		fire_temperature = null
+
 /datum/gas/water_vapor
 	id = GAS_H2O
 	specific_heat = 40
@@ -133,6 +137,10 @@
 	fire_burn_rate = 2
 	fire_radiation_released = 50 // arbitrary number, basically 60 moles of trit burning will just barely start to harm you
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50
+
+/datum/gas/tritium/New()
+	if(world.system_type == UNIX)
+		fire_temperature = null
 
 /datum/gas/bz
 	id = GAS_BZ

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -5,10 +5,9 @@
 
 	for(var/r in subtypesof(/datum/gas_reaction))
 		var/datum/gas_reaction/reaction = r
-		if(initial(reaction.exclude))
-			continue
 		reaction = new r
-		. += reaction
+		if(!reaction.exclude)
+			. += reaction
 	sortTim(., /proc/cmp_gas_reaction)
 
 /proc/cmp_gas_reaction(datum/gas_reaction/a, datum/gas_reaction/b) // compares lists of reactions by the maximum priority contained within the list
@@ -119,6 +118,7 @@
 	id = "tritfire"
 
 /datum/gas_reaction/tritfire/init_reqs()
+	exclude = world.system_type == MS_WINDOWS // temporary stopgap until generic fires work on linux
 	min_requirements = list(
 		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST,
 		GAS_TRITIUM = MINIMUM_MOLE_COUNT,
@@ -200,6 +200,7 @@
 	id = "plasmafire"
 
 /datum/gas_reaction/plasmafire/init_reqs()
+	exclude = world.system_type == MS_WINDOWS // temporary stopgap until generic fires work on linux
 	min_requirements = list(
 		"TEMP" = FIRE_MINIMUM_TEMPERATURE_TO_EXIST,
 		GAS_PLASMA = MINIMUM_MOLE_COUNT,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. This changes no behavior in-game, while we're running on Windows. This is mostly temporary stopgap measures until I can actually fix generic fires on Linux; I have no idea what might be going wrong with them.

## Why It's Good For The Game

We have downstreams on Linux and this is annoying to them.

## Changelog
:cl:
fix: Fires are back on Linux
tweak: Linux-only: plasma and trit fires work as before
/:cl: