### PR TITLE
Makes stasis beds *slightly* less hated

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -30330,7 +30330,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "bwD" = (
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bwE" = (

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -58323,7 +58323,9 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/west,
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2)
 "ctZ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -47560,7 +47560,9 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "deD" = (

--- a/_maps/map_files/FestiveBall/FestiveStation.dmm
+++ b/_maps/map_files/FestiveBall/FestiveStation.dmm
@@ -29801,7 +29801,7 @@
 /area/medical/surgery)
 "byn" = (
 /obj/effect/decal/festive/christmas_ivy_string,
-/obj/machinery/stasis,
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel/white/side,
 /area/medical/exam_room)
 "byo" = (
@@ -29882,7 +29882,7 @@
 /turf/open/floor/plasteel/white/side,
 /area/medical/exam_room)
 "byy" = (
-/obj/machinery/stasis,
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel/white/side,
 /area/medical/exam_room)
 "byz" = (
@@ -33048,7 +33048,9 @@
 	},
 /area/medical/genetics/cloning)
 "bEC" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22447,7 +22447,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "aLj" = (
@@ -84643,6 +84645,17 @@
 	icon_state = "wood-broken6"
 	},
 /area/commons/vacant_room/office)
+"fuh" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/central)
 "fyr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/mineral/random/labormineral,
@@ -104569,7 +104582,7 @@ aRd
 aOR
 abl
 aSW
-aLi
+fuh
 aLi
 aOW
 aWp

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -38157,7 +38157,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bDr" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -81042,7 +81042,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/treatment_center)
 "vMm" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -26817,7 +26817,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -28165,7 +28167,9 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -32745,7 +32745,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/treatment_center)
 "bzQ" = (
@@ -33969,7 +33971,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/treatment_center)
 "bCl" = (

--- a/_maps/map_files/Snaxi/Snaxi.dmm
+++ b/_maps/map_files/Snaxi/Snaxi.dmm
@@ -20523,7 +20523,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fVm" = (
@@ -46269,7 +46271,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wuC" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1120,7 +1120,9 @@
 /obj/structure/window{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -11919,7 +11921,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/stasis,
+/obj/machinery/sleeper{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "BI" = (
@@ -16441,7 +16445,9 @@
 /turf/open/floor/holofloor/wood,
 /area/holodeck/rec_center/wrestlingarena)
 "Lh" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "Li" = (
@@ -17325,6 +17331,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"Pa" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/evac)
 "Pg" = (
 /obj/machinery/light{
 	dir = 1
@@ -46058,7 +46070,7 @@ KH
 KY
 Lb
 KV
-Lh
+Pa
 Lb
 Li
 Li

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -1,10 +1,12 @@
 #define STASIS_TOGGLE_COOLDOWN 50
 /obj/machinery/stasis
-	name = "Lifeform Stasis Unit"
+	name = "lifeform stasis unit"
 	desc = "A not so comfortable looking bed with some nozzles at the top and bottom. It will keep someone in stasis."
 	icon = 'icons/obj/machines/stasis.dmi'
 	icon_state = "stasis"
+	base_icon_state = "stasis"
 	density = FALSE
+	// obj_flags = NO_BUILD
 	can_buckle = TRUE
 	buckle_lying = 90
 	circuit = /obj/item/circuitboard/machine/stasis
@@ -14,14 +16,13 @@
 	payment_department = ACCOUNT_MED
 	var/stasis_enabled = TRUE
 	var/last_stasis_sound = FALSE
-	var/stasis_can_toggle = 0
+	COOLDOWN_DECLARE(stasis_can_toggle)
 	var/mattress_state = "stasis_on"
 	var/obj/effect/overlay/vis/mattress_on
 
 /obj/machinery/stasis/examine(mob/user)
-	..()
-	var/turn_on_or_off = stasis_enabled ? "turn off" : "turn on"
-	to_chat(user, "<span class='notice'>Alt-click to [turn_on_or_off] the machine.</span>")
+	. = ..()
+	. += span_notice("Alt-click to [stasis_enabled ? "turn off" : "turn on"] the machine.")
 
 /obj/machinery/stasis/proc/play_power_sound()
 	var/_running = stasis_running()
@@ -34,61 +35,67 @@
 		last_stasis_sound = _running
 
 /obj/machinery/stasis/AltClick(mob/user)
-	if(world.time >= stasis_can_toggle && user.canUseTopic(src))
+	. = ..()
+	if(!can_interact(user))
+		return
+	if(COOLDOWN_FINISHED(src, stasis_can_toggle) && user.canUseTopic(src, !issilicon(user)))
 		stasis_enabled = !stasis_enabled
-		stasis_can_toggle = world.time + STASIS_TOGGLE_COOLDOWN
+		COOLDOWN_START(src, stasis_can_toggle, STASIS_TOGGLE_COOLDOWN)
 		playsound(src, 'sound/machines/click.ogg', 60, TRUE)
+		user.visible_message(span_notice("\The [src] [stasis_enabled ? "powers on" : "shuts down"]."), \
+					span_notice("You [stasis_enabled ? "power on" : "shut down"] \the [src]."), \
+					span_hear("You hear a nearby machine [stasis_enabled ? "power on" : "shut down"]."))
 		play_power_sound()
-		update_icon()
+		update_appearance()
 
-/obj/machinery/stasis/Exited(atom/movable/AM, atom/newloc)
-	if(AM == occupant)
-		var/mob/living/L = AM
+/obj/machinery/stasis/Exited(atom/movable/gone, atom/newloc)
+	if(gone == occupant)
+		var/mob/living/L = gone
 		if(IS_IN_STASIS(L))
 			thaw_them(L)
-	. = ..()
+	return ..()
 
 /obj/machinery/stasis/proc/stasis_running()
 	return stasis_enabled && is_operational()
 
-/obj/machinery/stasis/update_icon()
-	. = ..()
-	var/_running = stasis_running()
-	var/list/overlays_to_remove = managed_vis_overlays
-
-	if(mattress_state)
-		if(!mattress_on || !managed_vis_overlays)
-			mattress_on = SSvis_overlays.add_vis_overlay(src, icon, mattress_state, layer, plane, dir, alpha = 0, unique = TRUE)
-
-		if(mattress_on.alpha ? !_running : _running) //check the inverse of _running compared to truthy alpha, to see if they differ
-			var/new_alpha = _running ? 255 : 0
-			var/easing_direction = _running ? EASE_OUT : EASE_IN
-			animate(mattress_on, alpha = new_alpha, time = 50, easing = CUBIC_EASING|easing_direction)
-
-		overlays_to_remove = managed_vis_overlays - mattress_on
-
-	SSvis_overlays.remove_vis_overlay(src, overlays_to_remove)
-
-	if(occupant)
-		SSvis_overlays.add_vis_overlay(src, 'icons/obj/machines/stasis.dmi', "tubes", LYING_MOB_LAYER + 0.1, plane, dir) //using vis_overlays instead of normal overlays for mouse_opacity here
-
+/obj/machinery/stasis/update_icon_state()
 	if(stat & BROKEN)
-		icon_state = "stasis_broken"
-		return
+		icon_state = "[base_icon_state]_broken"
+		return ..()
 	if(panel_open || stat & MAINT)
-		icon_state = "stasis_maintenance"
+		icon_state = "[base_icon_state]_maintenance"
+		return ..()
+	icon_state = base_icon_state
+	return ..()
+
+/obj/machinery/stasis/update_overlays()
+	. = ..()
+	if(!mattress_state)
 		return
-	icon_state = "stasis"
+	var/_running = stasis_running()
+	if(!mattress_on)
+		mattress_on = SSvis_overlays.add_vis_overlay(src, icon, mattress_state, BELOW_OBJ_LAYER, plane, dir, alpha = 0, unique = TRUE)
+	else
+		vis_contents += mattress_on
+		if(managed_vis_overlays)
+			managed_vis_overlays += mattress_on
+		else
+			managed_vis_overlays = list(mattress_on)
+
+	if(mattress_on.alpha ? !_running : _running) //check the inverse of _running compared to truthy alpha, to see if they differ
+		var/new_alpha = _running ? 255 : 0
+		var/easing_direction = _running ? EASE_OUT : EASE_IN
+		animate(mattress_on, alpha = new_alpha, time = 50, easing = CUBIC_EASING|easing_direction)
 
 /obj/machinery/stasis/obj_break(damage_flag)
 	. = ..()
-	play_power_sound()
-	update_icon()
+	if(.)
+		play_power_sound()
 
 /obj/machinery/stasis/power_change()
 	. = ..()
-	play_power_sound()
-	update_icon()
+	if(.)
+		play_power_sound()
 
 /obj/machinery/stasis/proc/chill_out(mob/living/target)
 	if(target != occupant)
@@ -96,12 +103,13 @@
 	var/freq = rand(24750, 26550)
 	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 2, frequency = freq)
 	target.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
-
+	// ADD_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
 	target.ExtinguishMob()
 	use_power = ACTIVE_POWER_USE
 
 /obj/machinery/stasis/proc/thaw_them(mob/living/target)
 	target.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
+	// REMOVE_TRAIT(target, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
 	if(target == occupant)
 		use_power = IDLE_POWER_USE
 
@@ -111,16 +119,16 @@
 	occupant = L
 	if(stasis_running() && check_nap_violations())
 		chill_out(L)
-	update_icon()
+	update_appearance()
 
 /obj/machinery/stasis/post_unbuckle_mob(mob/living/L)
 	thaw_them(L)
 	if(L == occupant)
 		occupant = null
-	update_icon()
+	update_appearance()
 
 /obj/machinery/stasis/process()
-	if( !( occupant && isliving(occupant) && check_nap_violations() ) )
+	if(!(occupant && isliving(occupant) && check_nap_violations()))
 		use_power = IDLE_POWER_USE
 		return
 	var/mob/living/L_occupant = occupant
@@ -131,12 +139,15 @@
 		thaw_them(L_occupant)
 
 /obj/machinery/stasis/screwdriver_act(mob/living/user, obj/item/I)
-	. = default_deconstruction_screwdriver(user, "stasis_maintenance", "stasis", I)
-	update_icon()
+	. = ..()
+	. |= default_deconstruction_screwdriver(user, "[base_icon_state]_maintenance", "[base_icon_state]", I)
+	update_appearance()
 
 /obj/machinery/stasis/crowbar_act(mob/living/user, obj/item/I)
-	return default_deconstruction_crowbar(I)
+	. = ..()
+	return default_deconstruction_crowbar(I) || .
 
 /obj/machinery/stasis/nap_violation(mob/violator)
 	unbuckle_mob(violator, TRUE)
+
 #undef STASIS_TOGGLE_COOLDOWN

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -920,14 +920,14 @@
 		/obj/item/stock_parts/cell = 1)
 	needs_anchored = FALSE
 
-// /obj/item/circuitboard/machine/stasis
-// 	name = "\improper Lifeform Stasis Unit (Machine Board)"
-// 	icon_state = "medical"
-// 	build_path = /obj/machinery/stasis
-// 	req_components = list(
-// 		/obj/item/stack/cable_coil = 3,
-// 		/obj/item/stock_parts/manipulator = 1,
-// 		/obj/item/stock_parts/capacitor = 1)
+/obj/item/circuitboard/machine/stasis
+	name = "\improper Lifeform Stasis Unit (Machine Board)"
+	icon_state = "medical"
+	build_path = /obj/machinery/stasis
+	req_components = list(
+		/obj/item/stack/cable_coil = 3,
+		/obj/item/stock_parts/manipulator = 1,
+		/obj/item/stock_parts/capacitor = 1)
 
 /obj/item/circuitboard/machine/medipen_refiller
 	name = "Medipen Refiller (Machine Board)"
@@ -1482,11 +1482,3 @@
 	icon_state = "engineering"
 	build_path = /obj/machinery/research/explosive_compressor
 	req_components = list(/obj/item/stock_parts/matter_bin = 3)
-
-/obj/item/circuitboard/machine/stasis
-	name = "Lifeform Stasis Unit (Machine Board)"
-	build_path = /obj/machinery/stasis
-	req_components = list(
-		/obj/item/stack/cable_coil = 3,
-		/obj/item/stock_parts/manipulator = 1,
-		/obj/item/stock_parts/capacitor = 1)

--- a/code/modules/research/designs/machine_desings/machine_designs_engi.dm
+++ b/code/modules/research/designs/machine_desings/machine_designs_engi.dm
@@ -105,6 +105,14 @@
 	category = list ("Engineering Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
+/datum/design/board/stasis
+	name = "Machine Design (Lifeform Stasis Unit)"
+	desc = "The circuit board for a stasis unit."
+	id = "stasis"
+	build_path = /obj/item/circuitboard/machine/stasis
+	category = list("Medical Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
 /datum/design/board/spaceship_navigation_beacon
 	name = "Machine Design (Bluespace Navigation Gigabeacon)"
 	desc = "The circuit board for a Bluespace Navigation Gigabeacon."

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -13,7 +13,7 @@
 	display_name = "Cryostasis Technology"
 	description = "Smart freezing of objects to preserve them!"
 	prereq_ids = list("adv_engi", "biotech")
-	design_ids = list("splitbeaker", "noreactsyringe", "cryotube", "cryo_Grenade")
+	design_ids = list("splitbeaker", "noreactsyringe", "cryotube", "cryo_Grenade", "stasis")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
 /datum/techweb_node/adv_defibrillator_tec


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title and check changelogs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The stasis beds can now be researched alongside being built.
balance: Maps are now half stasis beds and half sleepers... only in medbay.
fix: The stasis bed's examine now works.
refactor: Generally updates stasis bed's code and adds cooldown defines (i learnt how to use them)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
