### PR TITLE
Allow planets to have fuel-based atmospheres

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -347,6 +347,7 @@
 // / Breathing types. Lungs can access either by these or by a string, which will be considered a gas ID.
 #define BREATH_OXY		/datum/breathing_class/oxygen
 #define BREATH_PLASMA	/datum/breathing_class/plasma
+#define BREATH_METHANE	/datum/breathing_class/methane
 
 //Gremlins
 #define NPC_TAMPER_ACT_FORGET 1 //Don't try to tamper with this again

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -13,7 +13,7 @@
 	)
 	restricted_gases = list(
 		GAS_BZ=0.1,
-		GAS_METHYL_BROMIDE=0.1,
+		GAS_BROMINE=0.1
 	)
 	restricted_chance = 30
 
@@ -22,6 +22,23 @@
 
 	minimum_temp = 281
 	maximum_temp = 320
+
+/datum/atmosphere/lavaland/generate_gas_string()
+	if(prob(restricted_chance))
+		base_gases = list(
+			GAS_METHANE=5,
+			GAS_N2=10
+		)
+		normal_gases = list(
+			GAS_METHANE=5,
+			GAS_N2=5,
+		)
+		restricted_gases = list(
+			GAS_AMMONIA = 0.1,
+			GAS_METHYL_BROMIDE = 0.1,
+			GAS_HYDROGEN = 0.1
+		)
+	return ..()
 
 /datum/atmosphere/lavaland/check_for_sanity(datum/gas_mixture/mix)
 	var/datum/breathing_class/o2_class = GLOB.gas_data.breathing_classes[BREATH_OXY]
@@ -33,16 +50,16 @@
 	id = ICEMOON_DEFAULT_ATMOS
 
 	base_gases = list(
-		GAS_O2=5,
+		GAS_METHANE=5,
 		GAS_N2=10,
 	)
 	normal_gases = list(
-		GAS_O2=10,
-		GAS_N2=10,
-		GAS_CO2=10,
+		GAS_METHANE=5,
+		GAS_N2=10
 	)
 	restricted_gases = list(
 		GAS_METHYL_BROMIDE=0.1,
+		GAS_HYDROGEN=0.1
 	)
 	restricted_chance = 10
 
@@ -52,3 +69,18 @@
 	minimum_temp = 180
 	maximum_temp = 180
 
+/datum/atmosphere/icemoon/generate_gas_string()
+	if(prob(restricted_chance))
+		base_gases = list(
+			GAS_O2=5,
+			GAS_N2=10,
+		)
+		normal_gases = list(
+			GAS_O2=5,
+			GAS_N2=10,
+		)
+		restricted_gases = list(
+			GAS_BZ = 0.1,
+			GAS_METHYL_BROMIDE = 0.1,
+		)
+	return ..()

--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -41,10 +41,11 @@
 	return ..()
 
 /datum/atmosphere/lavaland/check_for_sanity(datum/gas_mixture/mix)
-	var/datum/breathing_class/o2_class = GLOB.gas_data.breathing_classes[BREATH_OXY]
-	while(o2_class.get_effective_pp(mix) < 10)
-		mix.adjust_moles(GAS_CO2, -0.5)
-		mix.adjust_moles(GAS_O2, 0.5)
+	if(mix.get_moles(GAS_METHANE) < 0.1)
+		var/datum/breathing_class/o2_class = GLOB.gas_data.breathing_classes[BREATH_OXY]
+		while(o2_class.get_effective_pp(mix) < 10)
+			mix.adjust_moles(GAS_CO2, -0.5)
+			mix.adjust_moles(GAS_O2, 0.5)
 
 /datum/atmosphere/icemoon
 	id = ICEMOON_DEFAULT_ATMOS

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -40,9 +40,16 @@
 	if(hotspot && istype(T) && T.air)
 		qdel(hotspot)
 		var/datum/gas_mixture/G = T.air
-		var/plas_amt = min(30,G.get_moles(GAS_PLASMA))  //Absorb some plasma
-		G.adjust_moles(GAS_PLASMA,-plas_amt)
-		absorbed_plasma += plas_amt
+		var/amt_removed = min(30,G.get_moles(GAS_PLASMA))  //Absorb some plasma
+		G.adjust_moles(GAS_PLASMA,-amt_removed)
+		absorbed_plasma += amt_removed
+		var/list/fire_gases = GLOB.gas_data.fire_temperatures.Copy()
+		for(var/gas in fire_gases - GAS_PLASMA)
+			if(amt_removed <= 0)
+				break
+			var/this_amount = min(30-amt_removed, G.get_moles(gas))
+			G.adjust_moles(gas, -this_amount)
+			amt_removed -= this_amount
 		if(G.return_temperature() > T20C)
 			G.set_temperature(max(G.return_temperature()/2,T20C))
 		T.air_update_turf()

--- a/code/modules/atmospherics/auxgm/breathing_classes.dm
+++ b/code/modules/atmospherics/auxgm/breathing_classes.dm
@@ -45,7 +45,7 @@
 /datum/breathing_class/methane
 	gases = list(
 		GAS_METHANE = 1,
-		GAS_METHYL_BROMIDE = -0.7
+		GAS_METHYL_BROMIDE = -0.7,
 		GAS_OXYGEN = -0.1,
 		GAS_PLUOXIUM = -0.8
 	)

--- a/code/modules/atmospherics/auxgm/breathing_classes.dm
+++ b/code/modules/atmospherics/auxgm/breathing_classes.dm
@@ -41,3 +41,18 @@
 	low_alert_datum = /atom/movable/screen/alert/not_enough_tox
 	high_alert_category = "too_much_tox"
 	high_alert_datum = /atom/movable/screen/alert/too_much_tox
+
+/datum/breathing_class/methane
+	gases = list(
+		GAS_METHANE = 1,
+		GAS_METHYL_BROMIDE = -0.7
+		GAS_OXYGEN = -0.1,
+		GAS_PLUOXIUM = -0.8
+	)
+	products = list(
+		GAS_METHYL_BROMIDE = 1
+	)
+	low_alert_category = "not_enough_ch4"
+	low_alert_datum = /atom/movable/screen/alert/not_enough_ch4
+	high_alert_category = "too_much_ch4"
+	high_alert_datum = /atom/movable/screen/alert/too_much_ch4

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -535,7 +535,7 @@
 			for(var/device_id in A.air_scrub_names)
 				send_signal(device_id, list(
 					"power" = 1,
-					"set_filters" = list(GAS_CO2, GAS_MIASMA, GAS_GROUP_CHEMICALS),
+					"set_filters" = list(GAS_CO2, GAS_METHANE, GAS_METHYL_BROMIDE, GAS_MIASMA, GAS_GROUP_CHEMICALS),
 					"scrubbing" = 1,
 					"widenet" = 0,
 				))

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -18,7 +18,7 @@
 	var/id_tag = null
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing
 
-	var/filter_types = list(GAS_CO2, GAS_MIASMA, GAS_GROUP_CHEMICALS)
+	var/filter_types = list(GAS_CO2, GAS_METHANE, GAS_METHYL_BROMIDE, GAS_MIASMA, GAS_GROUP_CHEMICALS)
 	var/list/clean_filter_types = null
 	var/volume_rate = 200
 	var/widenet = 0 //is this scrubber acting on the 3x3 area around it.

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -440,7 +440,7 @@
 			owner.adjust_bodytemperature(30*TEMPERATURE_DAMAGE_COEFFICIENT)
 		if(50 to INFINITY)
 			owner.adjust_bodytemperature(100*TEMPERATURE_DAMAGE_COEFFICIENT)
-	
+
 /obj/item/organ/lungs/ipc/ui_action_click(mob/user, actiontype)
 	if(!owner)
 		return
@@ -494,7 +494,7 @@
 	if(owner.blood_volume <= next_warn)
 		to_chat(owner, "[owner.blood_volume > BLOOD_VOLUME_BAD ? "<span class='notice'>" : "<span class='warning'>"]Coolant level passed threshold - now [round(owner.blood_volume / BLOOD_VOLUME_NORMAL * 100, 0.1)] percent.</span>")
 		next_warn -= (BLOOD_VOLUME_NORMAL * 0.1)
-			
+
 /obj/item/organ/lungs/plasmaman
 	name = "plasma filter"
 	desc = "A spongy rib-shaped mass for filtering plasma from the air."
@@ -574,6 +574,8 @@
 	// humans usually breathe 21 but require 16/17, so 80% - 1, which is more lenient but it's fine
 	#define SAFE_THRESHOLD_RATIO 0.8
 	var/datum/gas_mixture/breath = SSair.planetary[LAVALAND_DEFAULT_ATMOS] // y'all know
+	if(breath.get_moles(GAS_METHANE) > 0.1)
+		breathing_class = BREATH_METHANE
 	var/pressure = breath.return_pressure()
 	var/total_moles = breath.total_moles()
 	for(var/id in breath.get_gases())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Trust me, it's not as bad as it sounds. Right now, planets have oxidizer-based atmospheres, i.e. it's all oxygen. This allows them to also be methane based, instead. Ashwalkers will automatically have their lungs adjusted to fit this, of course.

It may be a good idea to give methane a graphic before I do this. Right now, it's an invisible odorless flammable gas, just like real life... but the thing is, in real life, *tritium* is also an invisible odorless flammable gas, so. Perhaps acceptable breaks from reality are in order.

Also, there's a few buffs to firefighting with this. Advanced firefighting foam now removes all flammable gases rather than just plasma (although plasma is prioritized) and scrubbers, by default, also scrub methane and methyl bromide (since they're both invisible and flammable).

## Why It's Good For The Game

I like funny atmosphere.

## Changelog
:cl:
add: Methane-based planetary atmospheres
tweak: Advanced fire extinguishers can now remove non-plasma flammable gases
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
