### PR TITLE
makes blunt wound damage to BIO_ONLY_FLESH convert at the same rate as slash wound damage to BIO_ONLY_BONE

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -251,7 +251,7 @@
 		if(BIO_JUST_FLESH)
 			if(wounding_type == WOUND_BLUNT)
 				wounding_type = WOUND_SLASH
-				wounding_dmg *= (easy_dismember ? 1 : 0.3)
+				wounding_dmg *= (easy_dismember ? 1 : 0.5)
 			if((mangled_state & BODYPART_MANGLED_FLESH) && try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus))
 				return
 		// standard humanoids


### PR DESCRIPTION
## About The Pull Request
if you stab a bone boy, they take 50% of the wound roll as BLUNT instead of SLASH (they are bone and cannot get flesh wounds)

if you punch a jelly boy, they take 30% of the wound roll as SLASH instead of BLUNT (they are flesh and cannot get bone wounds)

this makes it so instead of 30% of the slash being converted to blunt, it's 50% (the same as the bone boys)

the world's smallest slime nerf because these numbers should ideally be the same

## Why It's Good For The Game
i think these numbers should be the same, especially as the wound multiplier is already low and the 0.3 was initially just thrown out of nowhere because nothing actually had BIO_ONLY_FLESH to begin with so it was never actually thought about!

## Changelog
:cl:
tweak: blunt wound conversion rate on slimes is now equal to slash wound conversion rate on skeletons (tldr; slimes wound easier, at same rate as skeletons now)
/:cl:
