### PR TITLE
optimises genital/tail organs by returning when calling on_life

### DIFF
--- a/code/modules/arousal/genitals.dm
+++ b/code/modules/arousal/genitals.dm
@@ -33,6 +33,9 @@
 	linked_organ = null
 	. = ..()
 
+/obj/item/organ/genital/on_life()
+	return
+
 /obj/item/organ/genital/proc/set_aroused_state(new_state,cause = "manual toggle")
 	if(!(genital_flags & GENITAL_CAN_AROUSE))
 		return FALSE

--- a/code/modules/arousal/organs/butt.dm
+++ b/code/modules/arousal/organs/butt.dm
@@ -15,12 +15,6 @@
 	var/prev_size //former size value, to allow update_size() to early return should be there no significant changes.
 	layer_index = BUTT_LAYER_INDEX
 
-/obj/item/organ/genital/butt/on_life()
-	if(QDELETED(src))
-		return
-	if(!owner)
-		return
-
 /obj/item/organ/genital/butt/modify_size(modifier, min = -INFINITY, max = BUTT_SIZE_MAX)
 	var/new_value = clamp(size_cached + modifier, min, max)
 	if(new_value == size_cached)

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -13,6 +13,9 @@
 		owner.dna.species.stop_wagging_tail(owner)
 	return ..()
 
+/obj/item/organ/tail/on_life()
+	return
+
 /obj/item/organ/tail/cat
 	name = "cat tail"
 	desc = "A severed cat tail. Who's wagging now?"


### PR DESCRIPTION
## About The Pull Request
title

no this does not change the effect or availability of genitals or tails, it has no in-game effects it is just an optimisation
on_life code is used for decay and passive organ function
genitals and tails have no decay behaviour or anything that relies on the on_life proc

## Why It's Good For The Game
optimisation

## Changelog
:cl:
tweak: optimises genital/tail organs by returning when calling on_life
/:cl:
