### PR TITLE
Bot refresh - Makes bot output channels configurable, makes the bot capable of pinging the reboot role

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -258,15 +258,24 @@
 
 	send2adminchat("Server", "A round of [mode.name] just ended[mode_result == "undefined" ? "." : " with a [mode_result]."] Survival rate: [survival_rate]")
 
-	if(LAZYLEN(GLOB.round_end_notifiees))
-		world.TgsTargetedChatBroadcast("[GLOB.round_end_notifiees.Join(", ")] the round has ended.", FALSE)
-
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		send_news_report()
 
 	//tell the nice people on discord what went on before the salt cannon happens.
-	world.TgsTargetedChatBroadcast("The current round has ended. Please standby for your shift interlude Nanotrasen News Network's report!", FALSE)
-	world.TgsTargetedChatBroadcast(send_news_report(), FALSE)
+	if(CONFIG_GET(string/chat_roundend_notice_tag))
+		var/broadcastmessage = ""
+
+		if(LAZYLEN(GLOB.round_end_notifiees))
+			broadcastmessage += "[GLOB.round_end_notifiees.Join(", ")], "
+
+
+		broadcastmessage += "[((broadcastmessage == "") ? "the" : "The")] current round has ended. Please standby for your shift interlude Nanotrasen News Network's report!\n"
+		broadcastmessage += "```\n[send_news_report()]\n```"
+
+		if(CONFIG_GET(string/chat_reboot_role))
+			broadcastmessage += "\n\n<@&[CONFIG_GET(string/chat_reboot_role)]>, the server will reboot shortly!"
+
+		send2chat(broadcastmessage, CONFIG_GET(string/chat_roundend_notice_tag))
 
 	CHECK_TICK
 

--- a/code/controllers/configuration/entries/bot.dm
+++ b/code/controllers/configuration/entries/bot.dm
@@ -1,0 +1,14 @@
+/datum/config_entry/flag/irc_announce_new_game
+	deprecated_by = /datum/config_entry/string/chat_announce_new_game
+
+/datum/config_entry/flag/irc_announce_new_game/DeprecationUpdate(value)
+	return ""	//default broadcast
+
+/datum/config_entry/string/chat_announce_new_game
+	config_entry_value = null
+
+/datum/config_entry/string/chat_reboot_role
+
+/datum/config_entry/string/chat_roundend_notice_tag
+
+/datum/config_entry/string/chat_squawk_tag

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -39,16 +39,6 @@
 
 /datum/config_entry/flag/show_irc_name
 
-/datum/config_entry/flag/irc_announce_new_game
-	deprecated_by = /datum/config_entry/string/chat_announce_new_game
-
-/datum/config_entry/flag/irc_announce_new_game/DeprecationUpdate(value)
-	return ""	//default broadcast
-
-/datum/config_entry/string/chat_announce_new_game
-
-	config_entry_value = null
-
 /datum/config_entry/string/default_view
 	config_entry_value = "15x15"
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -612,7 +612,7 @@ SUBSYSTEM_DEF(ticker)
 		var/list/ded = SSblackbox.first_death
 		if(ded.len)
 			var/last_words = ded["last_words"] ? " Their last words were: \"[ded["last_words"]]\"" : ""
-			news_message += "\nNT Sanctioned Psykers picked up faint traces of someone near the station, allegedly having had died. Their name was: [ded["name"]], [ded["role"]], at [ded["area"]].[last_words]"
+			news_message += "\nNT Sanctioned Psykers picked up faint traces of someone near the station, allegedly having had died.\nTheir name was: [ded["name"]], [ded["role"]], at [ded["area"]].[last_words]"
 		else
 			news_message += "\nNT Sanctioned Psykers proudly confirm reports that nobody died this shift!"
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -925,8 +925,8 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 
 /mob/living/simple_animal/parrot/Poly/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	. = ..()
-	if(. && !client && prob(1) && prob(1)) //Only the one true bird may speak across dimensions.
-		world.TgsTargetedChatBroadcast("A stray squawk is heard... \"[message]\"", FALSE)
+	if(. && !client && prob(1) && prob(1) && CONFIG_GET(string/chat_squawk_tag)) //Only the one true bird may speak across dimensions.
+		send2chat("A stray squawk is heard... \"[message]\"", CONFIG_GET(string/chat_squawk_tag))
 
 /mob/living/simple_animal/parrot/Poly/BiologicalLife(seconds, times_fired)
 	if(!(. = ..()))

--- a/config/config.txt
+++ b/config/config.txt
@@ -15,6 +15,7 @@
 $include entries/admin.txt
 $include entries/alert.txt
 $include entries/antag_rep.txt
+$include entries/bot.txt
 $include entries/comms.txt
 $include entries/connections.txt
 $include entries/dbconfig.txt

--- a/config/entries/bot.txt
+++ b/config/entries/bot.txt
@@ -1,0 +1,17 @@
+## Chat Announce Options
+## Various messages to be sent to game chats
+## Uncommenting these will enable them, by default they will be broadcast to Game chat channels on TGS3 or non-admin channels on TGS4
+## If using TGS4, the string option can be set as a chat channel tag to limit the message to channels of that tag type (case-sensitive)
+## i.e. CHAT_ANNOUNCE_NEW_GAME chat_channel_tag
+
+## Announcements for when a new round begins.
+#CHAT_ANNOUNCE_NEW_GAME
+
+## Announcements for when the round ends, pending server reboot.
+#CHAT_ROUNDEND_NOTICE_TAG
+
+## For where should the one true bird speak?
+#CHAT_SQUAWK_TAG
+
+## Role ID that, when present, will be pinged every round end.
+#CHAT_REBOOT_ROLE

--- a/config/entries/general.txt
+++ b/config/entries/general.txt
@@ -31,15 +31,6 @@ ALLOW_HOLIDAYS
 ## Uncomment to show the names of the admin sending a pm from IRC instead of showing as a stealthmin.
 #SHOW_IRC_NAME
 
-## Chat Announce Options
-## Various messages to be sent to game chats
-## Uncommenting these will enable them, by default they will be broadcast to Game chat channels on TGS3 or non-admin channels on TGS4
-## If using TGS4, the string option can be set as a chat channel tag to limit the message to channels of that tag type (case-sensitive)
-## i.e. CHAT_ANNOUNCE_NEW_GAME chat_channel_tag
-
-## Send a message with the station name starting a new game
-#CHAT_ANNOUNCE_NEW_GAME
-
 ##Default screen resolution, in tiles.
 ##	By default, this is 15x15, which gets simplified to 7 by BYOND, as it is a 1:1 screen ratio.
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -320,6 +320,7 @@
 #include "code\controllers\configuration\entries\admin.dm"
 #include "code\controllers\configuration\entries\alert.dm"
 #include "code\controllers\configuration\entries\antag_rep.dm"
+#include "code\controllers\configuration\entries\bot.dm"
 #include "code\controllers\configuration\entries\comms.dm"
 #include "code\controllers\configuration\entries\connections.dm"
 #include "code\controllers\configuration\entries\dbconfig.dm"


### PR DESCRIPTION
## About The Pull Request
This PR is fairly straight-forward; it makes it possible to configure the bot's output channels via TGS4's tags, and adds config options to allow the bot to ping a role whenever the round ends.

This also cleans up the round-end message a little bit, as seen below! No other functionality is modified.
![image](https://user-images.githubusercontent.com/6356337/169387210-34243318-b50b-4d91-aaed-35f9e112feb5.png)


## Changelog
:cl: Bhijn & Myr
add: The TGS bot is now capable of pinging the reboot role! Rejoice!
tweak: The TGS bot's automated output can now be configured to define which channels certain messages are output to.
/:cl:
