### PR TITLE
Switches transfer vote to approval voting

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(autotransfer)
 	if(world.time < targettime)
 		return
 	if(maxvotes == NO_MAXVOTES_CAP || maxvotes > curvotes)
-		SSvote.initiate_vote("transfer","server")
+		SSvote.initiate_vote("transfer","server", votesystem=APPROVAL_VOTING)
 		targettime = targettime + voteinterval
 		curvotes++
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Switches the voting system for transfer votes from plurality to approval.

## Why It's Good For The Game

You might think this does *literally nothing*, since it's a two-option vote. But that's not the case: the raw amount of votes for "Continue playing" matters too. With this method, one could vote for *both* continue playing and initiate transfer, which is a distinct thing from not voting for either, since their vote would be counted for the minimum.

There are times I thought "well, I wouldn't mind it continuing, so I'll abstain unless 2 people vote continue, in which case I'll vote continue", but now you can just do both.

Approval also allows you to unvote completely, which is nice.

## Changelog
:cl:
tweak: Transfer vote is now approval instead of plurality
/:cl: