### PR TITLE
fixes the ability to attach multiple tracking beacons to a single mech

### DIFF
--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -118,7 +118,7 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/M)
-	for(var/obj/item/I in M.equipment)
+	for(var/obj/item/I in M.contents)
 		if(istype(I, src))
 			to_chat(user, "<span class='warning'>[M] already has a tracking beacon!</span>")
 			return

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -118,7 +118,12 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_tracking/try_attach_part(mob/user, obj/vehicle/sealed/mecha/M)
-	if(!..())
+	for(var/obj/item/I in M.equipment)
+		if(istype(I, src))
+			to_chat(user, "<span class='warning'>[M] already has a tracking beacon!</span>")
+			return
+	. = ..()
+	if(!.)
 		return
 	M.trackers += src
 	M.diag_hud_set_mechtracking()


### PR DESCRIPTION
## About The Pull Request
This is an exploit that's apparently existed for years, but has gone largely unreported. The exploit in question allows you to completely nuke a mech with just a box of tracking beacons

## Changelog
:cl: Bhijn & Myr
fix: You can no longer attach multiple tracking beacons to a single mech, fixing an exploit where mechs can be nuked with minimal effort.
/:cl:
