### PR TITLE
Mech movement power use debug pass

### DIFF
--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -9,12 +9,13 @@
 	deflect_chance = 5
 	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 15, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 100)
 	max_temperature = 25000
-	leg_overload_coeff = 80
+	leg_overload_coeff = 300
+	overload_step_energy_drain_min = 300
 	force = 25
 	wreckage = /obj/structure/mecha_wreckage/gygax
 	internal_damage_threshold = 35
 	max_equip = 3
-	step_energy_drain = 3
+	normal_step_energy_drain = 3
 
 /obj/vehicle/sealed/mecha/combat/gygax/dark
 	desc = "A lightweight exosuit, painted in a dark scheme. This model appears to have some modifications."
@@ -24,7 +25,8 @@
 	deflect_chance = 20
 	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, BIO = 0, RAD =20, FIRE = 100, ACID = 100)
 	max_temperature = 35000
-	leg_overload_coeff = 70
+	leg_overload_coeff = 100
+	overload_step_energy_drain_min = 100
 	force = 30
 	operation_req_access = list(ACCESS_SYNDICATE)
 	internals_req_access = list(ACCESS_SYNDICATE)

--- a/code/modules/vehicles/mecha/combat/medigax.dm
+++ b/code/modules/vehicles/mecha/combat/medigax.dm
@@ -11,7 +11,7 @@
 	max_temperature = 25000
 	wreckage = /obj/structure/mecha_wreckage/odysseus
 	internal_damage_threshold = 35
-	step_energy_drain = 6
+	normal_step_energy_drain = 6
 	infra_luminosity = 6
 	internals_req_access = list(ACCESS_ROBOTICS, ACCESS_MEDICAL)
 

--- a/code/modules/vehicles/mecha/combat/phazon.dm
+++ b/code/modules/vehicles/mecha/combat/phazon.dm
@@ -4,7 +4,7 @@
 	icon_state = "phazon"
 	movedelay = 2
 	dir_in = 2 //Facing South.
-	step_energy_drain = 3
+	normal_step_energy_drain = 3
 	max_integrity = 200
 	deflect_chance = 30
 	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 30, BIO = 0, RAD = 50, FIRE = 100, ACID = 100)

--- a/code/modules/vehicles/mecha/combat/reticence.dm
+++ b/code/modules/vehicles/mecha/combat/reticence.dm
@@ -14,7 +14,7 @@
 	mecha_flags =  CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS
 	internal_damage_threshold = 25
 	max_equip = 2
-	step_energy_drain = 3
+	normal_step_energy_drain = 3
 	color = "#87878715"
 	stepsound = null
 	turnsound = null

--- a/code/modules/vehicles/mecha/medical/odysseus.dm
+++ b/code/modules/vehicles/mecha/medical/odysseus.dm
@@ -9,7 +9,7 @@
 	wreckage = /obj/structure/mecha_wreckage/odysseus
 	internal_damage_threshold = 35
 	deflect_chance = 15
-	step_energy_drain = 6
+	normal_step_energy_drain = 6
 	internals_req_access = list(ACCESS_ROBOTICS, ACCESS_MEDICAL)
 
 /obj/vehicle/sealed/mecha/medical/odysseus/moved_inside(mob/living/carbon/human/H)

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -96,7 +96,7 @@
 	movedelay = 4
 	lights_power = 7
 	wreckage = /obj/structure/mecha_wreckage/ripley/deathripley
-	step_energy_drain = 0
+	normal_step_energy_drain = 0
 	enclosed = TRUE
 	enter_delay = 40
 	silicon_icon_state = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After the /tg/ mech port, it looks like a few things have been broken for a while.
Firstly, mechs didn't actually use any power when moving, as it only checked for if you had enough to move, but didn't actually consume it.
Secondly, the mining only check is no longer incorrectly inverted, although still unused.
Thirdly, actuator overload's accidental buff during this port has been reverted to pre-port-levels, although it did not use any power at all at the moment thanks to the nonexistant power use call.
All mechs with different to usual power drains also had it set to modify step use power and not normal step use power and immediately got overwritten by that, so those values are now in the correct place.
And, last but no least, adjusts part impact on power cost to not just nullify any changes to movement power drain, instead going by a percentage of the base value (and not reaching zero at even tier four)
Part energy costs modifiers are now:
3x T1
1x T2
0.6x T3
0.4x T4


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mechs currently are very broken in the power use department which has been made obvious "thanks to" people exploiting it. This resolves some of the problems.
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Mechs now use power when moving.
fix: The check for mining-only mechs is no longer inverted to only allow non-mining z levels.
fix: Reverted an accidental buff from the /tg/ mech code port and its adjustment to citadel's mech state.
fix: Mechs with different base movement power cost now actually have it apply instead of immediately being overwritten.
tweak: Adjusted part impact on movement power use to make more sense.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
