### PR TITLE
Some gas balancing/rearranging (nitryl nerf)

### DIFF
--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -69,6 +69,19 @@
 	fire_products = FIRE_PRODUCT_PLASMA
 	enthalpy = FIRE_PLASMA_ENERGY_RELEASED // 3000000, 3 megajoules, 3000 kj
 
+/datum/gas/nitrous_oxide
+	id = GAS_NITROUS
+	specific_heat = 40
+	name = "Nitrous Oxide"
+	gas_overlay = "nitrous_oxide"
+	moles_visible = MOLES_GAS_VISIBLE * 2
+	flags = GAS_FLAG_DANGEROUS
+	fire_products = list(GAS_N2 = 1)
+	oxidation_rate = 0.5
+	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100
+	enthalpy = 81600
+	heat_resistance = 6
+
 /datum/gas/water_vapor
 	id = GAS_H2O
 	specific_heat = 40
@@ -82,18 +95,23 @@
 	powermix = 1
 	breath_reagent = /datum/reagent/water
 
-/datum/gas/nitrous_oxide
-	id = GAS_NITROUS
-	specific_heat = 40
-	name = "Nitrous Oxide"
-	gas_overlay = "nitrous_oxide"
-	moles_visible = MOLES_GAS_VISIBLE * 2
-	flags = GAS_FLAG_DANGEROUS
-	fire_products = list(GAS_N2 = 1)
-	oxidation_rate = 0.5
-	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100
-	enthalpy = 81600
-	heat_resistance = 6
+
+/datum/gas/pluoxium
+	id = GAS_PLUOXIUM
+	specific_heat = 80
+	name = "Pluoxium"
+	fusion_power = 10
+	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 25 // it is VERY stable
+	oxidation_rate = 8 // when it can oxidize, it can oxidize a LOT
+	enthalpy = -2000000 // but it reduces the heat output a great deal (plasma fires add 3000000 per mole)
+	powermix = -1
+	heat_penalty = -1
+	transmit_modifier = -5
+	heat_resistance = 3
+	price = 6
+
+/datum/gas/pluoxium/generate_TLV()
+	return new/datum/tlv(-1, -1, 5, 6)
 
 /datum/gas/tritium
 	id = GAS_TRITIUM
@@ -111,6 +129,7 @@
 	fire_burn_rate = 2
 	fire_radiation_released = 50 // arbitrary number, basically 60 moles of trit burning will just barely start to harm you
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50
+	price = 7
 
 /datum/gas/nitric_oxide
 	id = GAS_NITRIC
@@ -134,6 +153,7 @@
 	fire_products = list(GAS_N2 = 0.5)
 	enthalpy = 33200
 	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50
+	price = 3
 
 /datum/gas/hypernoblium
 	id = GAS_HYPERNOB
@@ -141,6 +161,7 @@
 	name = "Hyper-noblium"
 	gas_overlay = "freon"
 	moles_visible = MOLES_GAS_VISIBLE
+	price = 20
 
 /datum/gas/hydrogen
 	id = GAS_HYDROGEN
@@ -168,6 +189,7 @@
 	enthalpy = FIRE_CARBON_ENERGY_RELEASED // it is a mystery
 	transmit_modifier = -2
 	radioactivity_modifier = 5
+	price = 3
 
 /datum/gas/stimulum
 	id = GAS_STIMULUM
@@ -176,22 +198,7 @@
 	odor_strength = 10
 	name = "Stimulum"
 	fusion_power = 7
-
-/datum/gas/pluoxium
-	id = GAS_PLUOXIUM
-	specific_heat = 80
-	name = "Pluoxium"
-	fusion_power = 10
-	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 25 // it is VERY stable
-	oxidation_rate = 8 // when it can oxidize, it can oxidize a LOT
-	enthalpy = -2000000 // but it reduces the heat output a great deal (plasma fires add 3000000 per mole)
-	powermix = -1
-	heat_penalty = -1
-	transmit_modifier = -5
-	heat_resistance = 3
-
-/datum/gas/pluoxium/generate_TLV()
-	return new/datum/tlv(-1, -1, 5, 6)
+	price = 25
 
 /datum/gas/miasma
 	id = GAS_MIASMA
@@ -202,6 +209,7 @@
 	name = "Miasma"
 	gas_overlay = "miasma"
 	moles_visible = MOLES_GAS_VISIBLE * 60
+	price = 2
 
 /datum/gas/methane
 	id = GAS_METHANE
@@ -227,6 +235,7 @@
 	)
 	enthalpy = -74600
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST
+	price = 1
 
 /datum/gas/methyl_bromide
 	id = GAS_METHYL_BROMIDE
@@ -249,6 +258,7 @@
 	enthalpy = -35400
 	fire_burn_rate = 4 / 7 // oh no
 	fire_temperature = 808 // its autoignition; it apparently doesn't spark readily, so i don't put it lower
+	price = 2
 
 /datum/gas/bromine
 	id = GAS_BROMINE
@@ -285,3 +295,4 @@
 	powermix = -1
 	transmit_modifier = -10
 	heat_penalty = -10
+	price = 10

--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -161,7 +161,7 @@
 	name = "Hyper-noblium"
 	gas_overlay = "freon"
 	moles_visible = MOLES_GAS_VISIBLE
-	price = 20
+	price = 50
 
 /datum/gas/hydrogen
 	id = GAS_HYDROGEN

--- a/code/modules/atmospherics/gasmixtures/auxgm.dm
+++ b/code/modules/atmospherics/gasmixtures/auxgm.dm
@@ -43,6 +43,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(GAS_O2, GAS_N2, GAS_CO2, GA
 	var/list/TLVs = list()
 	var/list/odors = list()
 	var/list/odor_strengths = list()
+	var/list/prices = list()
 
 /datum/gas
 	var/id = ""
@@ -60,6 +61,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(GAS_O2, GAS_N2, GAS_CO2, GA
 	var/datum/reagent/breath_reagent = null // what breathing this adds to your reagents
 	var/datum/reagent/breath_reagent_dangerous = null // what breathing this adds to your reagents IF it's above a danger threshold
 	var/list/breath_alert_info = null // list for alerts that pop up when you have too much/not enough of something
+	var/price = 0 // How much this gas is worth when sold, per mole.
 	var/oxidation_temperature = null // temperature above which this gas is an oxidizer; null for none
 	var/oxidation_rate = 1 // how many moles of this can oxidize how many moles of material
 	var/fire_temperature = null // temperature above which gas may catch fire; null for none
@@ -135,6 +137,8 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(GAS_O2, GAS_N2, GAS_CO2, GA
 		if(gas.odor)
 			odor_strengths[g] = gas.odor_strength
 			odors[g] = gas.odor
+		if(gas.price)
+			prices[g] = gas.price
 		add_supermatter_properties(gas)
 		_auxtools_register_gas(gas)
 		if(done_initializing)

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -169,13 +169,9 @@
 /datum/export/large/gas_canister/get_cost(obj/O)
 	var/obj/machinery/portable_atmospherics/canister/C = O
 	var/worth = 10
-	worth += C.air_contents.get_moles(GAS_BZ)*3
-	worth += C.air_contents.get_moles(GAS_STIMULUM)*25
-	worth += C.air_contents.get_moles(GAS_HYPERNOB)*20
-	worth += C.air_contents.get_moles(GAS_MIASMA)*2
-	worth += C.air_contents.get_moles(GAS_TRITIUM)*7
-	worth += C.air_contents.get_moles(GAS_PLUOXIUM)*6
-	worth += C.air_contents.get_moles(GAS_NITRYL)*10
+	var/list/gas_prices = GLOB.gas_data.prices
+	for(var/gas in C.air_contents.get_gases())
+		worth += C.air_contents.get_moles(gas)*gas_prices[gas]
 	return worth
 
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -300,7 +300,7 @@
 				to_chat(H, "<span class='alert'>Your throat closes up!</span>")
 				H.silent = max(H.silent, 3)
 		else
-			H.adjustFireLoss(nitryl_pp/4)
+			H.adjustFireLoss(nitryl_pp/2)
 		gas_breathed = breath.get_moles(GAS_NITRYL)
 		if (gas_breathed > gas_stimulation_min)
 			H.reagents.add_reagent(/datum/reagent/nitryl,1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Un-hardcoded gas prices because I can never friggin' find them. They're part of the gas data structure now.
2. Nitryl (nitrogen dioxide) is now worth 30% as much because I made it way easier to make.
3. Nitryl now causes twice as much burn damage. This is mostly to counteract the fact that, again, it's easier to make: same reward, higher risk.
4. Methane and methyl bromide can now be sold (1 and 2 credits per mole, respectively).
5. Moved some gases around in the files so they're in an order more like their rarity. 
6. Since I nerfed hyper-nob production, multiplied its sell value by 2.5, to make it worth about as much to sell as tritium if you're focusing on it.
7. Quark matter can now be sold for 10 credits per mole. Good luck getting much into a canister.

## Why It's Good For The Game

I accidentally made nitryl too easy to make, mostly.

## Changelog
:cl:
balance: Nitryl is higher risk, can't be sold for as much
refactor: Gas prices are now part of the gas data structure
/:cl: