### PR TITLE
Multiplicative blood

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -77,6 +77,7 @@
 	new_dna.species = new species.type
 	new_dna.species.say_mod = species.say_mod
 	new_dna.species.exotic_blood_color = species.exotic_blood_color //it can change from the default value
+	new_dna.species.exotic_blood_blend_mode = species.exotic_blood_blend_mode
 	new_dna.species.eye_type = species.eye_type
 	new_dna.species.limbs_id = species.limbs_id || species.id
 	new_dna.real_name = real_name

--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -10,7 +10,7 @@
 						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var
 
 // Helper similar to image()
-/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE, color = "#FFFFFF")
+/proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE, color = "#FFFFFF", blend_mode = BLEND_DEFAULT)
 	var/mutable_appearance/MA = new()
 	MA.icon = icon
 	MA.icon_state = icon_state
@@ -19,5 +19,6 @@
 	MA.alpha = alpha
 	MA.appearance_flags |= appearance_flags
 	MA.color = color
+	MA.blend_mode = blend_mode
 	return MA
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -702,7 +702,7 @@
 	var/blood_id = get_blood_id()
 	if(!(blood_id in GLOB.blood_reagent_types))
 		return
-	return list("color" = BLOOD_COLOR_HUMAN, "ANIMAL DNA" = "Y-")
+	return list("color" = BLOOD_COLOR_HUMAN, "blendmode" = BLEND_MULTIPLY, "ANIMAL DNA" = "Y-")
 
 /mob/living/carbon/get_blood_dna_list()
 	var/blood_id = get_blood_id()
@@ -711,14 +711,16 @@
 	var/list/blood_dna = list()
 	if(dna)
 		blood_dna["color"] = dna.species.exotic_blood_color //so when combined, the list grows with the number of colors
+		blood_dna["blendmode"] = dna.species.exotic_blood_blend_mode
 		blood_dna[dna.unique_enzymes] = dna.blood_type
 	else
 		blood_dna["color"] = BLOOD_COLOR_HUMAN
+		blood_dna["blendmode"] = BLEND_MULTIPLY
 		blood_dna["UNKNOWN DNA"] = "X*"
 	return blood_dna
 
 /mob/living/carbon/alien/get_blood_dna_list()
-	return list("color" = BLOOD_COLOR_XENO, "UNKNOWN DNA" = "X*")
+	return list("color" = BLOOD_COLOR_XENO, "blendmode" = BLEND_MULTIPLY, "UNKNOWN DNA" = "X*")
 
 //to add a mob's dna info into an object's blood_DNA list.
 /atom/proc/transfer_mob_blood_dna(mob/living/L)
@@ -737,6 +739,7 @@
 		var/old = blood_DNA["color"]
 		blood_DNA["color"] = BlendRGB(blood_DNA["color"], new_blood_dna["color"])
 		changed = old != blood_DNA["color"]
+	blood_DNA["blendmode"] = new_blood_dna["blendmode"]
 	if(blood_DNA.len == old_length)
 		return FALSE
 	return changed
@@ -756,6 +759,7 @@
 			blood_DNA["color"] = blood_dna["color"]
 		else
 			blood_DNA["color"] = BlendRGB(blood_DNA["color"], blood_dna["color"])
+		blood_DNA["blendmode"] = blood_dna["blendmode"]
 
 //to add blood from a mob onto something, and transfer their dna info
 /atom/proc/add_mob_blood(mob/living/M)
@@ -825,6 +829,11 @@
 
 /atom/proc/blood_DNA_to_color()
 	return (blood_DNA && blood_DNA["color"]) || BLOOD_COLOR_HUMAN
+
+/atom/proc/blood_DNA_to_blend()
+	if(blood_DNA && !isnull(blood_DNA["blendmode"]))
+		return blood_DNA["blendmode"]
+	return BLEND_MULTIPLY
 
 /atom/proc/clean_blood()
 	. = blood_DNA? TRUE : FALSE

--- a/code/game/objects/effects/decals/cleanable/gibs.dm
+++ b/code/game/objects/effects/decals/cleanable/gibs.dm
@@ -3,6 +3,7 @@
 	desc = "They look bloody and gruesome."
 	icon_state = "gibbl5"
 	layer = LOW_OBJ_LAYER
+	blend_mode = BLEND_DEFAULT
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
 	mergeable_decal = FALSE
 	bloodiness = 0				//This isn't supposed to be bloody.

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -3,6 +3,7 @@
 	desc = "It's gooey. Perhaps it's the chef's cooking?"
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "floor1"
+	blend_mode = BLEND_MULTIPLY
 	random_icon_states = list("floor1", "floor2", "floor3", "floor4", "floor5", "floor6", "floor7")
 	blood_state = BLOOD_STATE_BLOOD
 	bloodiness = BLOOD_AMOUNT_PER_DECAL
@@ -83,6 +84,7 @@
 	name = "blood"
 	icon = 'icons/effects/blood.dmi'
 	desc = "Your instincts say you shouldn't be following these."
+	blend_mode = BLEND_MULTIPLY
 	random_icon_states = null
 	beauty = -50
 	persistent = TRUE

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -34,16 +34,20 @@
 	. = ..()
 	if(!fixed_color)
 		add_atom_colour(blood_DNA_to_color(), FIXED_COLOUR_PRIORITY)
+		blend_mode = blood_DNA_to_blend()
 
 /obj/effect/decal/cleanable/blood/PersistenceSave(list/data)
 	. = ..()
 	data["color"] = color
+	data["blendmode"] = blend_mode
 
 /obj/effect/decal/cleanable/blood/PersistenceLoad(list/data)
 	. = ..()
 	if(data["color"])
 		fixed_color = TRUE
 		add_atom_colour(data["color"], FIXED_COLOUR_PRIORITY)
+	if(data["blendmode"])
+		blend_mode = data["blendmode"]
 	name = "dried blood"
 	desc = "Looks like it's been here a while. Eew"
 	bloodiness = 0
@@ -96,6 +100,7 @@
 	. = ..()
 	data["dir"] = dir
 	data["color"] = color
+	data["blendmode"] = blend_mode
 
 /obj/effect/decal/cleanable/trail_holder/PersistenceLoad(list/data)
 	. = ..()
@@ -104,11 +109,14 @@
 	if(data["color"])
 		fixed_color = TRUE
 		add_atom_colour(data["color"], FIXED_COLOUR_PRIORITY)
+	if(data["blendmode"])
+		blend_mode = data["blendmode"]
 
 /obj/effect/decal/cleanable/trail_holder/update_icon()
 	. = ..()
 	if(!fixed_color)
 		add_atom_colour(blood_DNA_to_color(), FIXED_COLOUR_PRIORITY)
+		blend_mode = blood_DNA_to_blend()
 
 /obj/effect/cleanable/trail_holder/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -32,7 +32,7 @@
 		if(damaged_clothes)
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedgloves")
 		if(blood_DNA)
-			. += mutable_appearance('icons/effects/blood.dmi', "bloodyhands", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+			. += mutable_appearance('icons/effects/blood.dmi', "bloodyhands", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 
 /obj/item/clothing/gloves/update_clothes_damaged_state()
 	..()

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -32,7 +32,7 @@
 		if(damaged_clothes)
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedgloves")
 		if(blood_DNA)
-			. += mutable_appearance('icons/effects/blood.dmi', "bloodyhands", color = blood_DNA_to_color())
+			. += mutable_appearance('icons/effects/blood.dmi', "bloodyhands", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 
 /obj/item/clothing/gloves/update_clothes_damaged_state()
 	..()

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -55,7 +55,7 @@
 		if(damaged_clothes)
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedhelmet")
 		if(blood_DNA)
-			. += mutable_appearance('icons/effects/blood.dmi', "helmetblood", color = blood_DNA_to_color())
+			. += mutable_appearance('icons/effects/blood.dmi', "helmetblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 
 /obj/item/clothing/head/update_clothes_damaged_state()
 	..()

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -55,7 +55,7 @@
 		if(damaged_clothes)
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedhelmet")
 		if(blood_DNA)
-			. += mutable_appearance('icons/effects/blood.dmi', "helmetblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+			. += mutable_appearance('icons/effects/blood.dmi', "helmetblood", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 
 /obj/item/clothing/head/update_clothes_damaged_state()
 	..()

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -36,7 +36,7 @@
 			if(damaged_clothes)
 				. += mutable_appearance('icons/effects/item_damage.dmi', "damagedmask")
 			if(blood_DNA)
-				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 
 /obj/item/clothing/mask/update_clothes_damaged_state()
 	..()

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -36,7 +36,7 @@
 			if(damaged_clothes)
 				. += mutable_appearance('icons/effects/item_damage.dmi', "damagedmask")
 			if(blood_DNA)
-				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color())
+				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 
 /obj/item/clothing/mask/update_clothes_damaged_state()
 	..()

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -13,7 +13,7 @@
 			if(damaged_clothes)
 				. += mutable_appearance('icons/effects/item_damage.dmi', "damagedmask")
 			if(blood_DNA)
-				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color())
+				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 
 /obj/item/clothing/neck/tie
 	name = "tie"

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -13,7 +13,7 @@
 			if(damaged_clothes)
 				. += mutable_appearance('icons/effects/item_damage.dmi', "damagedmask")
 			if(blood_DNA)
-				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+				. += mutable_appearance('icons/effects/blood.dmi', "maskblood", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 
 /obj/item/clothing/neck/tie
 	name = "tie"

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -19,6 +19,7 @@
 	var/last_bloodtype = ""	//used to track the last bloodtype to have graced these shoes; makes for better performing footprint shenanigans
 	var/last_blood_DNA = ""	//same as last one
 	var/last_blood_color = ""
+	var/last_blood_blend = null
 
 	///Whether these shoes have laces that can be tied/untied
 	var/can_be_tied = TRUE
@@ -68,6 +69,7 @@
 		last_bloodtype = blood_dna[blood_dna[blood_dna.len]]//trust me this works
 		last_blood_DNA = blood_dna[blood_dna.len]
 		last_blood_color = blood_dna["color"]
+		last_blood_blend = blood_dna["blendmode"]
 
 /obj/item/clothing/shoes/worn_overlays(isinhands = FALSE, icon_file, used_state, style_flags = NONE)
 	. = ..()
@@ -82,7 +84,7 @@
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedshoe")
 		if(bloody)
 			var/file2use = style_flags & STYLE_DIGITIGRADE ? 'icons/mob/clothing/feet_digi.dmi' : 'icons/effects/blood.dmi'
-			. += mutable_appearance(file2use, "shoeblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+			. += mutable_appearance(file2use, "shoeblood", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 
 /obj/item/clothing/shoes/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -82,7 +82,7 @@
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedshoe")
 		if(bloody)
 			var/file2use = style_flags & STYLE_DIGITIGRADE ? 'icons/mob/clothing/feet_digi.dmi' : 'icons/effects/blood.dmi'
-			. += mutable_appearance(file2use, "shoeblood", color = blood_DNA_to_color())
+			. += mutable_appearance(file2use, "shoeblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 
 /obj/item/clothing/shoes/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -20,7 +20,7 @@
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damaged[blood_overlay_type]")
 		if(blood_DNA)
 			var/file2use = (style_flags & STYLE_ALL_TAURIC) ? 'modular_citadel/icons/mob/64x32_effects.dmi' : 'icons/effects/blood.dmi'
-			. += mutable_appearance(file2use, "[blood_overlay_type]blood", color = blood_DNA_to_color())
+			. += mutable_appearance(file2use, "[blood_overlay_type]blood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 		var/mob/living/carbon/human/M = loc
 		if(ishuman(M) && M.w_uniform)
 			var/obj/item/clothing/under/U = M.w_uniform

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -20,7 +20,7 @@
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damaged[blood_overlay_type]")
 		if(blood_DNA)
 			var/file2use = (style_flags & STYLE_ALL_TAURIC) ? 'modular_citadel/icons/mob/64x32_effects.dmi' : 'icons/effects/blood.dmi'
-			. += mutable_appearance(file2use, "[blood_overlay_type]blood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+			. += mutable_appearance(file2use, "[blood_overlay_type]blood", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 		var/mob/living/carbon/human/M = loc
 		if(ishuman(M) && M.w_uniform)
 			var/obj/item/clothing/under/U = M.w_uniform

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -29,7 +29,7 @@
 	if(damaged_clothes)
 		. += mutable_appearance('icons/effects/item_damage.dmi', "damageduniform")
 	if(blood_DNA)
-		. += mutable_appearance('icons/effects/blood.dmi', "uniformblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+		. += mutable_appearance('icons/effects/blood.dmi', "uniformblood", color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 	if(accessory_overlay)
 		. += accessory_overlay
 

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -29,7 +29,7 @@
 	if(damaged_clothes)
 		. += mutable_appearance('icons/effects/item_damage.dmi', "damageduniform")
 	if(blood_DNA)
-		. += mutable_appearance('icons/effects/blood.dmi', "uniformblood", color = blood_DNA_to_color())
+		. += mutable_appearance('icons/effects/blood.dmi', "uniformblood", color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 	if(accessory_overlay)
 		. += accessory_overlay
 

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -193,6 +193,7 @@
 
 	blood_data["blood_DNA"] = dna.unique_enzymes
 	blood_data["bloodcolor"] = dna.species.exotic_blood_color
+	blood_data["bloodblend"] = dna.species.exotic_blood_blend_mode
 	if(disease_resistances && disease_resistances.len)
 		blood_data["resistances"] = disease_resistances.Copy()
 	var/list/temp_chem = list()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -85,6 +85,7 @@
 							FP.blood_DNA["color"] = S.last_blood_color
 						else
 							FP.blood_DNA["color"] = BlendRGB(FP.blood_DNA["color"], S.last_blood_color)
+						FP.blood_DNA["blendmode"] = S.last_blood_blend
 					FP.update_icon()
 					update_inv_shoes()
 				//End bloody footprints

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -65,6 +65,8 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	var/exotic_bloodtype = ""
 	/// Assume human as the default blood colour, override this default by species subtypes
 	var/exotic_blood_color = BLOOD_COLOR_HUMAN
+	/// Which blend mode should this species blood use?
+	var/exotic_blood_blend_mode = BLEND_MULTIPLY
 	///What the species drops when gibbed by a gibber machine.
 	var/meat = /obj/item/reagent_containers/food/snacks/meat/slab/human //What the species drops on gibbing
 	var/list/gib_types = list(/obj/effect/gibspawner/human, /obj/effect/gibspawner/human/bodypartless)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -17,6 +17,7 @@
 	exotic_blood = /datum/reagent/blood/jellyblood
 	exotic_bloodtype = "GEL"
 	exotic_blood_color = "BLOOD_COLOR_SLIME"
+	exotic_blood_blend_mode = BLEND_DEFAULT
 	damage_overlay_type = ""
 	liked_food = TOXIC | MEAT
 	disliked_food = null

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -209,7 +209,7 @@ There are several things that need to be remembered:
 			inv.update_icon()
 
 		if(!gloves && bloody_hands)
-			var/mutable_appearance/bloody_overlay = mutable_appearance('icons/effects/blood.dmi', "bloodyhands", -GLOVES_LAYER, color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
+			var/mutable_appearance/bloody_overlay = mutable_appearance('icons/effects/blood.dmi', "bloodyhands", -GLOVES_LAYER, color = blood_DNA_to_color(), blend_mode = blood_DNA_to_blend())
 			if(get_num_arms(FALSE) < 2)
 				if(has_left_hand(FALSE))
 					bloody_overlay.icon_state = "bloodyhands_left"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -209,7 +209,7 @@ There are several things that need to be remembered:
 			inv.update_icon()
 
 		if(!gloves && bloody_hands)
-			var/mutable_appearance/bloody_overlay = mutable_appearance('icons/effects/blood.dmi', "bloodyhands", -GLOVES_LAYER, color = blood_DNA_to_color())
+			var/mutable_appearance/bloody_overlay = mutable_appearance('icons/effects/blood.dmi', "bloodyhands", -GLOVES_LAYER, color = blood_DNA_to_color(), blend_mode = BLEND_MULTIPLY)
 			if(get_num_arms(FALSE) < 2)
 				if(has_left_hand(FALSE))
 					bloody_overlay.icon_state = "bloodyhands_left"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,5 +1,5 @@
 /datum/reagent/blood
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "blood_type"= null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "bloodblend" = BLEND_MULTIPLY, "blood_type"= null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
 	name = "Blood"
 	chemical_flags = REAGENT_ALL_PROCESS
 	value = REAGENT_VALUE_UNCOMMON // $$$ blood ""donations"" $$$
@@ -81,6 +81,7 @@
 			B.blood_DNA["color"] = data["bloodcolor"]
 		else
 			B.blood_DNA["color"] = BlendRGB(B.blood_DNA["color"], data["bloodcolor"])
+		B.blood_DNA["blendmode"] = data["bloodblend"]
 	if(B.reagents)
 		B.reagents.add_reagent(type, reac_volume)
 	B.update_icon()
@@ -148,7 +149,7 @@
 			. += D
 
 /datum/reagent/blood/synthetics
-	data = list("donor"=null,"viruses"=null,"blood_DNA"="REPLICATED", "bloodcolor" = BLOOD_COLOR_SYNTHETIC, "blood_type"="SY","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"="REPLICATED", "bloodcolor" = BLOOD_COLOR_SYNTHETIC, "bloodblend" = BLEND_MULTIPLY, "blood_type"="SY","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 	name = "Synthetic Blood"
 	description = "A synthetically produced imitation of blood."
 	taste_description = "oil"
@@ -156,7 +157,7 @@
 	value = REAGENT_VALUE_NONE
 
 /datum/reagent/blood/jellyblood
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_SLIME, "blood_type"="GEL","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_SLIME, "bloodblend" = BLEND_DEFAULT, "blood_type"="GEL","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 	name = "Slime Jelly Blood"
 	description = "A gooey semi-liquid produced from one of the deadliest lifeforms in existence. SO REAL."
 	color = BLOOD_COLOR_SLIME
@@ -165,7 +166,7 @@
 	pH = 4
 
 /datum/reagent/blood/tomato
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "blood_type"="SY","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "bloodblend" = BLEND_MULTIPLY, "blood_type"="SY","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 	name = "Tomato Blood"
 	description = "This highly resembles blood, but it doesnt actually function like it, resembling more ketchup, with a more blood-like consistency."
 	taste_description = "sap" //Like tree sap?
@@ -189,7 +190,7 @@
 	description = "You don't even want to think about what's in here."
 	taste_description = "gross iron"
 	shot_glass_icon_state = "shotglassred"
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "blood_type"= "O+","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "bloodblend" = BLEND_MULTIPLY, "blood_type"= "O+","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 	pH = 7.45
 
 /datum/reagent/liquidgibs/xeno
@@ -197,7 +198,7 @@
 	color = BLOOD_COLOR_XENO
 	taste_description = "blended heresy"
 	shot_glass_icon_state = "shotglassgreen"
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_XENO, "blood_type"="X*","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_XENO, "bloodblend" = BLEND_MULTIPLY, "blood_type"="X*","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 	pH = 2.5
 
 /datum/reagent/liquidgibs/slime
@@ -205,20 +206,20 @@
 	color = BLOOD_COLOR_SLIME
 	taste_description = "slime"
 	shot_glass_icon_state = "shotglassgreen"
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_SLIME, "blood_type"="GEL","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_SLIME, "bloodblend" = BLEND_DEFAULT, "blood_type"="GEL","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 	pH = 4
 
 /datum/reagent/liquidgibs/synth
 	name = "Synthetic sludge"
 	color = BLOOD_COLOR_SYNTHETIC
 	taste_description = "jellied plastic"
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_SYNTHETIC, "blood_type"="SY","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_SYNTHETIC, "bloodblend" = BLEND_MULTIPLY, "blood_type"="SY","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 
 /datum/reagent/liquidgibs/oil
 	name = "Hydraulic sludge"
 	color = BLOOD_COLOR_OIL
 	taste_description = "chunky burnt oil"
-	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_OIL, "blood_type"="HF","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
+	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_OIL, "bloodblend" = BLEND_MULTIPLY, "blood_type"="HF","resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null)
 	pH = 9.75
 
 /datum/reagent/vaccine

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -13,7 +13,7 @@
 /obj/item/reagent_containers/blood/Initialize(mapload)
 	. = ..()
 	if(blood_type != null)
-		reagents.add_reagent(/datum/reagent/blood, 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"bloodcolor"=bloodtype_to_color(blood_type), "blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
+		reagents.add_reagent(/datum/reagent/blood, 200, list("donor"=null,"viruses"=null,"blood_DNA"=null,"bloodcolor"=bloodtype_to_color(blood_type), "bloodblend" = BLEND_MULTIPLY, "blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
 		update_icon()
 
 /obj/item/reagent_containers/blood/on_reagent_change(changetype)


### PR DESCRIPTION
## About The Pull Request
So! This PR's hard to explain in words. This PR makes the vast majority of blood visuals use multiplicative blending rather than overlay blending. This results in blood looking significantly less cartoony, which in my opinion, matches much better with the rugged visual aesthetic of this codebase. There's a caveat, though: due to a BYOND bug, this causes blood to completely disappear from the right click menu, despite the blood objects still retaining their mouse opacity.
There's also the potential concern of brighter slimes looking weird with this, as brighter colors are significantly less visible due to how multiplicative blending works.

Without further ado, here's a before and after!

Before: (Features some slight artifacting from manually varediting after taking below screenshot)
![image](https://user-images.githubusercontent.com/6356337/170207448-98b60304-166a-4563-9686-964f2c4a97a4.png)

After: (Note: this is slightly out of date! Screenshot does not include multiplicative blood overlays, only multiplicative blood decals)
![image](https://user-images.githubusercontent.com/6356337/170207476-95f3e313-15a6-4e62-99e2-6396d2016a5f.png)


And here's an image of how the mob overlays look, in which the effect is immediately noticeable! (Note how the color of the uniform shines through significantly better than it does currently)
![image](https://user-images.githubusercontent.com/6356337/170207730-b96753f6-696d-416c-963f-3dc87b7a7526.png)


I would've applied multiplicative blending to item blood overlays, as well, but attempting to do so ends up breaking item animations, and my quick prodding reveals that it's incredibly easy to break item animations even further. As a result, item blood overlays are completely unaffected by this PR. I'm far too sober to rip apart item animation code as of writing.

## Changelog
:cl: Bhijn & Myr
tweak: All blood visuals, with the exception of item blood overlays, are now multiplicative!
/:cl:
