### PR TITLE
[S] properly patches up a freshly rediscovered aimbot exploit

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -101,14 +101,6 @@
 	..()
 
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
-	var/list/L = params2list(params)
-	if (L["middle"])
-		if (src_object && src_location != over_location)
-			middragtime = world.time
-			middragatom = src_object
-		else
-			middragtime = 0
-			middragatom = null
 	mouseParams = params
 	mouseLocation = over_location
 	mouseObject = over_object
@@ -121,9 +113,3 @@
 
 /obj/item/proc/onMouseDrag(src_object, over_object, src_location, over_location, params, mob)
 	return
-
-/client/MouseDrop(src_object, over_object, src_location, over_location, src_control, over_control, params)
-	if (middragatom == src_object)
-		middragtime = 0
-		middragatom = null
-	..()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -135,10 +135,6 @@
 	///Used in MouseDrag to preserve the last mouse-entered object.
 	var/mouseObject = null
 	var/mouseControlObject = null
-	//Middle-mouse-button click dragtime control for aimbot exploit detection.
-	var/middragtime = 0
-	//Middle-mouse-button clicked object control for aimbot exploit detection.
-	var/atom/middragatom
 
 	/// Messages currently seen by this client
 	var/list/seen_messages

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -867,10 +867,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		return
 	last_activity = world.time
 	last_click = world.time
-	var/ab = FALSE
 	var/list/L = params2list(params)
-	if (object && object == middragatom && L["left"])
-		ab = max(0, 5 SECONDS-(world.time-middragtime)*0.1)
+
+	if(L["drag"])
+		return
+
 	var/mcl = CONFIG_GET(number/minute_click_limit)
 	if (!holder && !ignore_spam && mcl)
 		var/minute = round(world.time, 600)
@@ -879,20 +880,14 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if (minute != clicklimiter[CURRENT_MINUTE])
 			clicklimiter[CURRENT_MINUTE] = minute
 			clicklimiter[MINUTE_COUNT] = 0
-		clicklimiter[MINUTE_COUNT] += 1+(ab)
+		clicklimiter[MINUTE_COUNT] += 1
 		if (clicklimiter[MINUTE_COUNT] > mcl)
 			var/msg = "Your previous click was ignored because you've done too many in a minute."
 			if (minute != clicklimiter[ADMINSWARNED_AT]) //only one admin message per-minute. (if they spam the admins can just boot/ban them)
 				clicklimiter[ADMINSWARNED_AT] = minute
 
 				msg += " Administrators have been informed."
-				if (ab)
-					log_game("[key_name(src)] is using the middle click aimbot exploit")
-					message_admins("[ADMIN_LOOKUPFLW(src)] [ADMIN_KICK(usr)] is using the middle click aimbot exploit</span>")
-					add_system_note("aimbot", "Is using the middle click aimbot exploit")
-					log_click(object, location, control, params, src, "lockout (spam - minute ab c [ab] s [middragtime])", TRUE)
-				else
-					log_click(object, location, control, params, src, "lockout (spam - minute)", TRUE)
+				log_click(object, location, control, params, src, "lockout (spam - minute)", TRUE)
 				log_game("[key_name(src)] Has hit the per-minute click limit of [mcl] clicks in a given game minute")
 				message_admins("[ADMIN_LOOKUPFLW(src)] [ADMIN_KICK(usr)] Has hit the per-minute click limit of [mcl] clicks in a given game minute")
 			to_chat(src, "<span class='danger'>[msg]</span>")
@@ -906,14 +901,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if (second != clicklimiter[CURRENT_SECOND])
 			clicklimiter[CURRENT_SECOND] = second
 			clicklimiter[SECOND_COUNT] = 0
-		clicklimiter[SECOND_COUNT] += 1+(!!ab)
+		clicklimiter[SECOND_COUNT] += 1//+(!!ab)
 		if (clicklimiter[SECOND_COUNT] > scl)
 			to_chat(src, "<span class='danger'>Your previous click was ignored because you've done too many in a second</span>")
 			return
-
-	if(ab) //Citadel edit, things with stuff.
-		log_click(object, location, control, params, src, "dropped (ab c [ab] s [middragtime])", TRUE)
-		return
 
 	if(prefs.log_clicks)
 		log_click(object, location, control, params, src, extra_info? "clicked ([extra_info])" : null)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -901,7 +901,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		if (second != clicklimiter[CURRENT_SECOND])
 			clicklimiter[CURRENT_SECOND] = second
 			clicklimiter[SECOND_COUNT] = 0
-		clicklimiter[SECOND_COUNT] += 1//+(!!ab)
+		clicklimiter[SECOND_COUNT] += 1
 		if (clicklimiter[SECOND_COUNT] > scl)
 			to_chat(src, "<span class='danger'>Your previous click was ignored because you've done too many in a second</span>")
 			return


### PR DESCRIPTION
No changelog since this is an exploit patch that doesn't affect good-faith players at all. The code that previously deterred this exploit is one that was particularly overengineered, and affects only a hyperspecific strain of the exploit.

This also removes a warning that's long since gone obsolete. The hyperspecific strain of the exploit that the warning notifies admins of, is one that's long since fallen into complete obscurity, and currently exists primarily to prank less-knowledgeable players into spamming admin logs. Aside from that, clicks are already logged more than well enough to manually investigate anomalous click patterns.

After some testing with higher movespeeds, this doesn't appear to have any impact on good-faith gameplay.