### PR TITLE
Fixes Omegastation's airmix filter being flipped by default

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -16379,9 +16379,8 @@
 /area/hallway/secondary/exit)
 "aEg" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
-	dir = 4;
-	name = "air mixer"
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"


### PR DESCRIPTION
## About The Pull Request
PR's exactly what the title says on the tin


## Changelog
:cl: Bhijn & Myr
fix: Omegastation's airmix filter is no longer inverted! The oxygen:nitrogen levels of Omega later in the round should now be normal again.
/:cl:
