### PR TITLE
Boxstation - fixes the incinerator's sensors simply not working

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -47569,7 +47569,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/air_sensor{
+/obj/machinery/air_sensor/atmos/incinerator_tank{
 	pixel_x = -32;
 	pixel_y = -32
 	},


### PR DESCRIPTION
## About The Pull Request
This one's extremely straight-forward. The incinerator on Boxstation simply didn't function due to a lack of id_tag definition. This fixes that by making it use the proper air_sensor subtype!

## Changelog
:cl: Bhijn & Myr
fix: Boxstation's incinerator sensor now properly reports to atmos's machinery again
/:cl:
