### PR TITLE
optimises quirks

### DIFF
--- a/code/datums/traits/_quirk.dm
+++ b/code/datums/traits/_quirk.dm
@@ -14,6 +14,7 @@
 	/// should we immediately call on_spawn or add a timer to trigger
 	var/on_spawn_immediate = TRUE
 	var/mob/living/quirk_holder
+	var/processing_quirk = FALSE
 
 /datum/quirk/New(mob/living/quirk_mob, spawn_effects)
 	if(!quirk_mob || (human_only && !ishuman(quirk_mob)) || quirk_mob.has_quirk(type))
@@ -25,7 +26,8 @@
 	quirk_holder.roundstart_quirks += src
 	if(mob_trait)
 		ADD_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)
-	START_PROCESSING(SSquirks, src)
+	if(processing_quirk)
+		START_PROCESSING(SSquirks, src)
 	add()
 	if(spawn_effects)
 		if(on_spawn_immediate)
@@ -35,7 +37,8 @@
 		addtimer(CALLBACK(src, .proc/post_add), 30)
 
 /datum/quirk/Destroy()
-	STOP_PROCESSING(SSquirks, src)
+	if(processing_quirk)
+		STOP_PROCESSING(SSquirks, src)
 	remove()
 	if(quirk_holder)
 		to_chat(quirk_holder, lose_text)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -72,6 +72,7 @@
 	mob_trait = TRAIT_JOLLY
 	mood_quirk = TRUE
 	medical_record_text = "Patient demonstrates constant euthymia irregular for environment. It's a bit much, to be honest."
+	processing_quirk = TRUE
 
 /datum/quirk/jolly/on_process()
 	if(prob(0.05))

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -25,6 +25,7 @@
 	lose_text = "<span class='notice'>You no longer feel depressed.</span>" //if only it were that easy!
 	medical_record_text = "Patient has a severe mood disorder, causing them to experience acute episodes of depression."
 	mood_quirk = TRUE
+	processing_quirk = TRUE
 
 /datum/quirk/depression/on_process()
 	if(prob(0.05))
@@ -38,6 +39,7 @@
 	medical_record_text = "Patient demonstrates an unnatural attachment to a family heirloom."
 	var/obj/item/heirloom
 	var/where
+	processing_quirk = TRUE
 
 GLOBAL_LIST_EMPTY(family_heirlooms)
 
@@ -102,6 +104,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	gain_text = "<span class='danger'>You feel smooth.</span>"
 	lose_text = "<span class='notice'>You feel wrinkled again.</span>"
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
+	processing_quirk = TRUE
 
 /datum/quirk/brainproblems/on_process()
 	quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2)
@@ -128,6 +131,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
 	value = -1
 	medical_record_text = "Patient demonstrates a fear of the dark. (Seriously?)"
+	processing_quirk = TRUE
 
 /datum/quirk/nyctophobia/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -156,6 +160,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	gain_text = "<span class='danger'>Bright lights seem irritating.</span>"
 	lose_text = "<span class='notice'>Enlightening.</span>"
 	medical_record_text = "Despite my warnings, the patient refuses turn on the lights, only to end up rolling down a full flight of stairs and into the cellar."
+	processing_quirk = TRUE
 
 /datum/quirk/lightless/on_process()
 	var/turf/T = get_turf(quirk_holder)
@@ -236,6 +241,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	gain_text = "<span class='userdanger'>...</span>"
 	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"
 	medical_record_text = "Patient suffers from acute Reality Dissociation Syndrome and experiences vivid hallucinations."
+	processing_quirk = TRUE
 
 /datum/quirk/insanity/on_process()
 	if(quirk_holder.reagents.has_reagent(/datum/reagent/toxin/mindbreaker))
@@ -261,6 +267,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	lose_text = "<span class='notice'>You feel easier about talking again.</span>" //if only it were that easy!
 	medical_record_text = "Patient is usually anxious in social encounters and prefers to avoid them."
 	var/dumb_thing = TRUE
+	processing_quirk = TRUE
 
 /datum/quirk/social_anxiety/add()
 	RegisterSignal(quirk_holder, COMSIG_MOB_EYECONTACT, .proc/eye_contact)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -132,6 +132,7 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 	value = -1
 	medical_record_text = "Patient demonstrates a fear of the dark. (Seriously?)"
 
+/datum/quirk/nyctophobia/add()
 	RegisterSignal(quirk_holder, COMSIG_MOVABLE_MOVED, .proc/on_holder_moved)
 
 /datum/quirk/nyctophobia/remove()


### PR DESCRIPTION
## About The Pull Request
nyctophobia replaced with tg version
lightless replaced with a modified nyctophobia
quirks that don't require processing will no longer begin processing in the first place

behaviour change for nyctophobia: it's no longer 0.2 seconds of darkness to stop you running, but simply trying to run while in darkness (it's handled on_move instead of on_process!)

behaviour change for both: mood change will not occur until you move, compared to before where it would happen automatically, this should not have a large effect on gameplay

## Why It's Good For The Game
quirk subsystem will now go faster

## Changelog
:cl:
add: optimises quirks somewhat
tweak: nyctophobia will now stop run intent when you try to move in darkness with it on, compared to the old behaviour of automatically turning it off in darkness when it is on and you have been in darkness for >= 0.2 seconds
tweak: nyctophobia and lightless will both not update your mood until you move now, as part of the optimisations made by changing them to tg code
/:cl:
