### PR TITLE
changes to how slimes and cold interact

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -24,6 +24,8 @@
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 0.5 // = 1/2x generic burn damage
+	cold_offset = -10 //take cold damage slightly earlier, can be negated by wearing things like wintercoats, space suits, etc
+
 	species_language_holder = /datum/language_holder/jelly
 
 	tail_type = "mam_tail"
@@ -413,8 +415,6 @@
 	coldmod = 3
 	heatmod = 1
 	burnmod = 1
-	cold_offset = -10 //take cold damage slightly earlier, can be negated by wearing things like wintercoats, space suits, etc
-
 	allowed_limb_ids = list(SPECIES_SLIME,SPECIES_STARGAZER,SPECIES_SLIME_LUMI)
 
 ///////////////////////////////////LUMINESCENTS//////////////////////////////////////////

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -21,6 +21,7 @@
 	liked_food = TOXIC | MEAT
 	disliked_food = null
 	toxic_food = ANTITOXIC
+
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 0.5 // = 1/2x generic burn damage

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -28,7 +28,7 @@
 
 	//take cold damage slightly earlier, can be negated by wearing things like wintercoats, space suits, etc
 	//this value is the same as the difference between the old tier 1 value for when slime lungs made slimes take damage in comparison to regular lungs
-	cold_offset = -25
+	cold_offset = 25
 
 	species_language_holder = /datum/language_holder/jelly
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -409,10 +409,11 @@
 	mutant_bodyparts = list("mcolor" = "FFFFFF", "mcolor2" = "FFFFFF","mcolor3" = "FFFFFF", "mam_tail" = "None", "mam_ears" = "None", "mam_body_markings" = "Plain", "mam_snouts" = "None", "taur" = "None", "deco_wings" = "None", "legs" = "Plantigrade")
 	say_mod = "says"
 	hair_color = "mutcolor"
-	hair_alpha = 160 //a notch brighter so it blends better.
+	hair_alpha = 160 //a notch brighter so it blends better. //ok but imagine we could change this for all species as a customization feature????
 	coldmod = 3
 	heatmod = 1
 	burnmod = 1
+	cold_offset = -10 //take cold damage slightly earlier, can be negated by wearing things like wintercoats, space suits, etc
 
 	allowed_limb_ids = list(SPECIES_SLIME,SPECIES_STARGAZER,SPECIES_SLIME_LUMI)
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -24,7 +24,10 @@
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 0.5 // = 1/2x generic burn damage
-	cold_offset = -10 //take cold damage slightly earlier, can be negated by wearing things like wintercoats, space suits, etc
+
+	//take cold damage slightly earlier, can be negated by wearing things like wintercoats, space suits, etc
+	//this value is the same as the difference between the old tier 1 value for when slime lungs made slimes take damage in comparison to regular lungs
+	cold_offset = -25
 
 	species_language_holder = /datum/language_holder/jelly
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -614,10 +614,6 @@
 	icon_state = "lungs-s"
 	desc = "A large organelle designed to store oxygen and other important gasses."
 
-	cold_level_1_threshold = 285 // Remember when slimes used to be succeptable to cold? Well....
-	cold_level_2_threshold = 260
-	cold_level_3_threshold = 230
-
 /obj/item/organ/lungs/ashwalker/populate_gas_info()
 	..()
 	gas_max -= GAS_PLASMA

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -618,8 +618,6 @@
 	cold_level_2_threshold = 260
 	cold_level_3_threshold = 230
 
-	maxHealth = 250
-
 /obj/item/organ/lungs/ashwalker/populate_gas_info()
 	..()
 	gas_max -= GAS_PLASMA


### PR DESCRIPTION
## About The Pull Request
stuff this pr does:
1. removes all snowflake behaviour of slime lungs (less hp and get hurt by cold 25K earlier)
2. makes slimes start taking cold damage 25K earlier in **body temperature**
2.1. you can reduce the weakness by wearing things like winter coats, as this is how bodytemp changes work

for reference your body takes damage when 50K below regular temperature
ice reduces it by 5K / sodas reduce it by 8K (you cant stack these to freeze yourself with how adjust_bodytemp works)
this means slimes will take damage when 25K below regular temperature instead

no you will not die from drinking soda

please testmerge this first to get feedback

## Why It's Good For The Game
slimes are weak to cold, not just cold air!
this changes their weakness to mechanically make more sense

## Changelog
:cl:
add: changes to how slimes and cold interact, no longer cold air, but cold bodytemp
/:cl:
