### PR TITLE
[TESTMERGE ONLY] comments out rd console normal mode's tooltips

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -720,9 +720,9 @@ Nothing else in the console has ID requirements.
 			l += "<BR><span class='linkOff bad'>[node.price_display(stored_research)]</span>"  // red - missing prereqs
 		if(ui_mode == RDCONSOLE_UI_MODE_NORMAL)
 			l += "[node.description]"
-			for(var/i in node.design_ids)
-				var/datum/design/D = SSresearch.techweb_design_by_id(i)
-				l += "<span data-tooltip='[D.name]' onclick='location=\"?src=[REF(src)];view_design=[i];back_screen=[screen]\"'>[D.icon_html(usr)]</span>[RDSCREEN_NOBREAK]"
+			//for(var/i in node.design_ids)
+				//var/datum/design/D = SSresearch.techweb_design_by_id(i)
+				//l += "<span data-tooltip='[D.name]' onclick='location=\"?src=[REF(src)];view_design=[i];back_screen=[screen]\"'>[D.icon_html(usr)]</span>[RDSCREEN_NOBREAK]"
 	l += "</div>[RDSCREEN_NOBREAK]"
 	return l
 


### PR DESCRIPTION
#15224 
Research consoles are apparently bugged when set to normal mode. Upon a quick glance at the code, I believe this might have something to do with the tooltips. As I'm currently tied up with other projects at the moment, and normal mode's tooltips are a fairly minor feature, I'm going to leave this testmerged until someone steps up to the plate of figuring out how to fix this

## Changelog
:cl:
del: Research console no longer displays tooltips in normal mode
/:cl:
