### PR TITLE
Fixes a bug in admin vote deobfuscation

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -320,11 +320,11 @@ SUBSYSTEM_DEF(vote)
 				admintext += "\nIt should be noted that this is not a raw tally of votes but rather the median score plus a tiebreaker!"
 			for(var/i=1,i<=choices.len,i++)
 				var/votes = choices[choices[i]]
-				admintext += "\n<b>[choices[i]]:</b> [votes]"
+				admintext += "\n<b>[choices[i]]:</b> [votes ? votes : "0"]" //This is raw data, but the raw data is null by default. If ya don't compensate for it, then it'll look weird!
 		else
 			for(var/i=1,i<=scores.len,i++)
 				var/score = scores[scores[i]]
-				admintext += "\n<b>[scores[i]]:</b> [score]"
+				admintext += "\n<b>[scores[i]]:</b> [score ? score : "0"]"
 		message_admins(admintext)
 	return .
 


### PR DESCRIPTION
## About The Pull Request
This PR makes it so that, when admins are shown the deobfuscated results of a vote, options that were simply never voted for are now properly displayed as 0, rather than completely blank. The display bases itself off raw data, but the raw data is null by default!

## Changelog
:cl: Bhijn & Myr
fix: Admin vote deobfuscation now properly displays votes as 0 if they were simply never voted for.
/:cl:
