### PR TITLE
You've heard of "no cops at pride". Now get ready for... 

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -379,6 +379,8 @@
 
 	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(world.time - SSticker.round_start_time)]</B>"
 	parts += "[FOURSPACES]Station Integrity: <B>[mode.station_was_nuked ? "<span class='redtext'>Destroyed</span>" : "[popcount["station_integrity"]]%"]</B>"
+	if(mode.station_was_nuked && SSevents.holidays && SSevents.holidays[PRIDE_MONTH])
+		parts += "[FOURSPACES]Gender revealed: <B>[pick(500; "Male", 500; "Female", "Bigender", "Agender", "Demiboy", "Demigirl", "Genderfluid", "Pangender", "Xenogender", 50; "What", 50; "Oh no.", 50; "Excuse me?")]</B>"
 	var/total_players = GLOB.joined_player_list.len
 	if(total_players)
 		parts+= "[FOURSPACES]Total Population: <B>[total_players]</B>"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -380,7 +380,7 @@
 	parts += "[FOURSPACES]Shift Duration: <B>[DisplayTimeText(world.time - SSticker.round_start_time)]</B>"
 	parts += "[FOURSPACES]Station Integrity: <B>[mode.station_was_nuked ? "<span class='redtext'>Destroyed</span>" : "[popcount["station_integrity"]]%"]</B>"
 	if(mode.station_was_nuked && SSevents.holidays && SSevents.holidays[PRIDE_MONTH])
-		parts += "[FOURSPACES]Gender revealed: <B>[pick(500; "Male", 500; "Female", "Bigender", "Agender", "Demiboy", "Demigirl", "Genderfluid", "Pangender", "Xenogender", 50; "What", 50; "Oh no.", 50; "Excuse me?")]</B>"
+		parts += "[FOURSPACES]Gender revealed: <B>[pick(500; "Male", 500; "Female", "Bigender", "Agender", "Demiboy", "Demigirl", "Genderfluid", "Pangender", "Xenogender", "Clown", 50; "What", 50; "Oh no.", 50; "Excuse me?")]</B>"
 	var/total_players = GLOB.joined_player_list.len
 	if(total_players)
 		parts+= "[FOURSPACES]Total Population: <B>[total_players]</B>"

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -66,8 +66,20 @@
 	icon_state = "nuclearbomb_base"
 	anchored = TRUE //stops it being moved
 
+/obj/machinery/nuclearbomb/selfdestruct/Initialize(mapload)
+	. = ..()
+	if(SSevents.holidays && SSevents.holidays[PRIDE_MONTH] && prob(10))
+		name = "station-wide gender-reveal terminal"
+		desc = "For when the whole sector deserves to know a gender. But of whom? Don't ask."
+
 /obj/machinery/nuclearbomb/syndicate
 	//ui_style = "syndicate" // actually the nuke op bomb is a stole nt bomb
+
+/obj/machinery/nuclearbomb/syndicate/Initialize(mapload)
+	. = ..()
+	if(SSevents.holidays && SSevents.holidays[PRIDE_MONTH] && prob(50))
+		name = "tactical gender-reveal device"
+		desc = "\"But who's gender is it revealing?\" you ponder. Don't worry. That comes later."
 
 /obj/machinery/nuclearbomb/syndicate/get_cinematic_type(off_station)
 	var/datum/game_mode/nuclear/NM = SSticker.mode

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -79,7 +79,7 @@
 	. = ..()
 	if(SSevents.holidays && SSevents.holidays[PRIDE_MONTH] && prob(50))
 		name = "tactical gender-reveal device"
-		desc = "\"But who's gender is it revealing?\" you ponder. Don't worry. That comes later."
+		desc = "\"But whose gender is it revealing?\" you ponder. Don't worry. That comes later."
 
 /obj/machinery/nuclearbomb/syndicate/get_cinematic_type(off_station)
 	var/datum/game_mode/nuclear/NM = SSticker.mode


### PR DESCRIPTION
**Nukeops at pride.**

## About The Pull Request
This PR is mostly just a shitpost. This makes it so that, during pride month, self-destruct terminals and the syndicate nuke both have a chance of changing their flavortext to be gender-reveal devices. Additionally, when the station's nuked during pride month, an additional "Gender revealed:" field is included in the round-end report, containing a wide assortment of genders and confusion.

## Changelog
:cl: Bhijn & Myr
add: During pride month, station nukes are significantly more efficient at revealing genders.
/:cl:
