### PR TITLE
Fully restores the functionality of audiovisual redirection

### DIFF
--- a/code/datums/components/virtual_reality.dm
+++ b/code/datums/components/virtual_reality.dm
@@ -84,9 +84,9 @@
 	if(VR)
 		VR.level_below = src
 		level_above = VR
-	M.transfer_ckey(vr_M, FALSE)
 	mastermind = M.mind
 	mastermind.current.audiovisual_redirect = parent
+	M.transfer_ckey(vr_M, FALSE)
 	RegisterSignal(mastermind, COMSIG_PRE_MIND_TRANSFER, .proc/switch_player)
 	RegisterSignal(M, list(COMSIG_MOB_DEATH, COMSIG_PARENT_QDELETING), .proc/game_over)
 	RegisterSignal(M, COMSIG_MOB_PRE_PLAYER_CHANGE, .proc/player_hijacked)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -110,7 +110,11 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 */
 
 /mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff_exponent = SOUND_FALLOFF_EXPONENT, channel = 0, pressure_affected = TRUE, sound/S, max_distance,
-	falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = SOUND_DEFAULT_DISTANCE_MULTIPLIER, envwet = -10000, envdry = 0)
+	falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE, distance_multiplier = SOUND_DEFAULT_DISTANCE_MULTIPLIER, envwet = -10000, envdry = 0, virtual_hearer)
+	if(audiovisual_redirect)
+		virtual_hearer = get_turf(src)
+		audiovisual_redirect.playsound_local(turf_source, soundin, vol, vary, frequency, falloff_exponent, channel, pressure_affected, S, max_distance, falloff_distance, distance_multiplier, max(0, envwet), -10000, virtual_hearer)
+		//No return here, as we want to deliberately support the possibility of shenanigans in which mobs with clients can have active AV redirects to completely different players
 	if(!client)
 		return
 
@@ -134,7 +138,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 			S.frequency = get_rand_frequency()
 
 	if(isturf(turf_source))
-		var/turf/T = get_turf(src)
+		var/turf/T = virtual_hearer || get_turf(src)
 
 		//sound volume falloff with distance
 		var/distance = get_dist(T, turf_source)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -238,7 +238,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode, atom/movable/source)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args) //parent calls can't overwrite the current proc args.
-	if(!client)
+	if(!client && !audiovisual_redirect)
 		return
 	var/deaf_message
 	var/deaf_type

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -138,7 +138,7 @@
 		return
 	hearers -= ignored_mobs
 
-	if(target_message && target && istype(target) && target.client)
+	if(target_message && target && istype(target) && (target.client || target.audiovisual_redirect))
 		hearers -= target
 		if(omni)
 			target.show_message(target_message)
@@ -155,7 +155,7 @@
 	if(self_message)
 		hearers -= src
 	for(var/mob/M in hearers)
-		if(!M.client)
+		if(!M.client && !M.audiovisual_redirect)
 			continue
 		if(omni)
 			M.show_message(message)


### PR DESCRIPTION
## About The Pull Request
This PR does as it says on the tin! In laymen's terms, this makes it so that VR sleepers will now properly redirect your actual mob's audio and text to your client again, exactly as they used to. This feature was broken a few years back due to VR sleeper components, and broken further by robustaudio.

This PR will allow you to hear and see everything your actual mob is seeing and hearing while you're in a VR sleeper, albeit muffled, exactly as I originally implemented over 3 years ago (though it's been brought up to modern expectations)

## Changelog
:cl: Bhijn & Myr
fix: Audiovisual redirection now works exactly as it used to. In laymen's terms, this means folks in VR sleepers are aware of the world around them again!
/:cl:
