### PR TITLE
Minimap Refresh - higher detail, JS fixes, pixel-perfect scaling, and more!

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -212,6 +212,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
 	// airlock_wires = /datum/wires/airlock/maint
 	sound_environment = SOUND_AREA_TUNNEL_ENCLOSED
+	minimap_color = "#454545"
 
 //Maintenance - Departmental
 
@@ -435,6 +436,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/hallway
 	nightshift_public_area = NIGHTSHIFT_AREA_PUBLIC
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	minimap_color = "#aaaaaa"
 
 /area/hallway/primary
 	name = "Primary Hallway"
@@ -490,6 +492,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/hallway/secondary/exit
 	name = "Escape Shuttle Hallway"
 	icon_state = "escape"
+	minimap_color = "#baa0a0"
 
 /area/hallway/secondary/exit/departure_lounge
 	name = "Departure Lounge"
@@ -498,6 +501,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/hallway/secondary/entry
 	name = "Arrival Shuttle Hallway"
 	icon_state = "entry"
+	minimap_color = "#a0a0ba"
 
 /area/hallway/secondary/service
 	name = "Service Hallway"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -124,6 +124,10 @@
 	/// Color on minimaps, if it's null (which is default) it makes one at random.
 	var/minimap_color
 
+	var/minimap_color2 // if this isn't null, then this will show as a checkerboard pattern mixed in with the above. works even if the above is null (for better or worse)
+
+	var/minimap_show_walls = TRUE
+
 /**
   * These two vars allow for multiple unique areas to be linked to a master area
   * and share some functionalities such as APC powernet nodes, fire alarms etc, without sacrificing

--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -9,6 +9,9 @@
 	ambientsounds = RUINS
 	sound_environment = SOUND_ENVIRONMENT_STONEROOM
 	var/valid_territory = FALSE // hey so what if we did not allow things like cult summons to appear on ruins
+	minimap_color = "#775940"
+	minimap_color2 = "#6b5d48"
+	minimap_show_walls = FALSE
 
 
 /area/ruin/unpowered

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -7,6 +7,8 @@
 	var/obj_flags = CAN_BE_HIT
 	var/set_obj_flags // ONLY FOR MAPPING: Sets flags from a string list, handled in Initialize. Usage: set_obj_flags = "EMAGGED;!CAN_BE_HIT" to set EMAGGED and clear CAN_BE_HIT.
 
+	var/minimap_override_color // allows this obj to set its own color on the minimap
+
 	var/damtype = BRUTE
 	var/force = 0
 

--- a/code/modules/mapping/minimaps.dm
+++ b/code/modules/mapping/minimaps.dm
@@ -47,21 +47,43 @@
 
 		var/meta_color = area_to_color[A]
 		if(!meta_color)
-			meta_color = rgb(rand(0, 255), rand(0, 255), rand(0, 255)) // technically conflicts could happen but it's like very unlikely and it's not that big of a deal if one happens
+			var/meta_x = LAZYLEN(area_to_color) + 1
+			var/meta_y = (((meta_x + 1) - ((meta_x + 1) % 255)) / 255)
+			var/meta_z = (((meta_y + 1) - ((meta_y + 1) % 255)) / 255)
+			meta_color = rgb(meta_x % 255, meta_y % 255, meta_z % 255) //This supports exactly 16,581,374 areas with no conflicts whatsoever before it just gives up
 			area_to_color[A] = meta_color
 			color_area_names[meta_color] = A.name
 		meta_icon.DrawBox(meta_color, img_x, img_y)
 
-		if(istype(T, /turf/closed/wall))
+		if(A.minimap_show_walls && istype(T, /turf/closed/wall))
 			map_icon.DrawBox("#000000", img_x, img_y)
 
 		else if(!istype(A, /area/space))
-			var/color = A.minimap_color || "#FF00FF"
-			if(locate(/obj/machinery/power/solar) in T)
-				color = "#02026a"
+			var/color = (A.minimap_color2 ? (((img_x + img_y) % 2) ? A.minimap_color2 : A.minimap_color ) : A.minimap_color) || "#FF00FF"
+			if(A.minimap_show_walls)
+				var/overridden
+				for(var/obj/structure/O in T)
+					if(O.minimap_override_color)
+						color = O.minimap_override_color
+						overridden = TRUE
+						break
+					else if(O.density && O.anchored)
+						color = BlendRGB(color, "#000000", 0.5)
+						overridden = TRUE
+						break
 
-			if((locate(/obj/effect/spawner/structure/window) in T) || (locate(/obj/structure/grille) in T))
-				color = BlendRGB(color, "#000000", 0.5)
+				//In an ideal world, we'd be able to get away with just doing for(var/obj/O in T) up there, and calling it a day. However. HOWEVER!
+				//Doing that causes the code to also loop through items. and that uh. Kinda bloats minimap gen time. A LOT. We're talking straight-up doubling the time it takes to gen.
+				//So instead we take our ctrl+c. We copy the above code. And we ctrl+v. It's awful. We hate it. But it works. It's faster. Funny mapgen go vroom
+				if(!overridden)
+					for(var/obj/machinery/O in T)
+						if(O.minimap_override_color)
+							color = O.minimap_override_color
+							break
+						else if(O.density && O.anchored)
+							color = BlendRGB(color, "#000000", 0.25)
+							break
+
 			map_icon.DrawBox(color, img_x, img_y)
 
 	map_icon.Crop(crop_x1, crop_y1, crop_x2, crop_y2)
@@ -102,22 +124,48 @@
 
 	var/list/datas = list()
 	var/list/info = list()
-
-	for(var/i in 1 to length(minimaps))// OLD: for(var/i in 1 to length(minimaps))
+	var/buttonfield = ""
+	var/totalmaps = length(minimaps)
+	for(var/i in 1 to totalmaps)// OLD: for(var/i in 1 to length(minimaps))
 		var/datum/minimap/M = minimaps[i]
 		var/map_name = "minimap-[M.id].png"
 		var/meta_name = "minimap-[M.id]-meta.png"
 		M.send(user)
 		info += {"
-			<div class="block">
+			<div class="block" id='layer-[i]' [i == 1 ? "" : "style='display:none'"]>
+				[totalmaps > 1 ? "<h3>Layer [i]</h3>" : ""]
 				<div> <!-- The div is in here to fit it both in the block div -->
 					<img id='map-[i]' src='[SSassets.transport.get_asset_url(map_name)]' />
 					<img id='map-[i]-meta' src='[SSassets.transport.get_asset_url(meta_name)]' style='display: none' />
 				</div>
-				<div class="statusDisplay" id='label-[i]'></div>
+				[totalmaps <= 1 ? "<div class='statusDisplay' id='label-[i]'> </div>" : ""]
 			</div>
 		"}
 		datas += json_encode(M.color_area_names);
+		buttonfield += "<a onclick='switchmap(\"layer-[i]\")'>Layer [i]</a> "
+
+	if(totalmaps > 1)
+		info += "<div class='block'><div class='statusDisplay'>[buttonfield]</div></div>"
+
+	//This is a hacky workaround; the status display is extremely buggy when multiple z-levels are present. We couldn't figure out how to fix this after 7 hours of banging our head against the wall
+	//We're coder
+	var/mousemove_bit = {"
+				canvas.onmousemove = function(e){
+					var rect = canvas.getBoundingClientRect();
+					var x = Math.floor(e.offsetX * img.width / rect.width);
+					var y = Math.floor(e.offsetY * img.height / rect.height);
+
+					var color_idx = x * 4 + (y * 4 * imagedata.width);
+					var color = "#" + hexify(imagedata.data\[color_idx]) + hexify(imagedata.data\[color_idx+1]) + hexify(imagedata.data\[color_idx+2]);
+
+					label.textContent = data\[color];
+					canvas.title = data\[color];
+				}
+				canvas.onmouseout = function(e){
+					label.textContent = " ";
+					canvas.title = "";
+				}
+	"}
 
 	info = info.Join()
 	//this is bad. Too bad!
@@ -132,6 +180,14 @@
 				num = "0" + num;
 			}
 			return num;
+		}
+		function switchmap(mapid) {
+			var targetblock = document.getElementById(mapid);
+			for(var i = 0; i < [length(minimaps)]; i++) {
+				var currentblock = document.getElementById("layer-" + (i + 1));
+				currentblock.style.display = 'none';
+			}
+			targetblock.style.display = '';
 		}
 		window.onload = function() {
 			if(!window.HTMLCanvasElement) {
@@ -150,6 +206,7 @@
 				var canvas = document.createElement("canvas");
 				canvas.width = img.width * 2;
 				canvas.height = img.height * 2;
+				canvas.id = "canvas-" + (i+1);
 
 				var ctx = canvas.getContext('2d');
 				ctx.msImageSmoothingEnabled = false;
@@ -158,31 +215,23 @@
 				ctx = document.createElement("canvas").getContext('2d');
 				ctx.canvas.width = img.width;
 				ctx.canvas.height = img.height;
+				ctx.id = "ctx-" + (i+1);
 				ctx.drawImage(document.getElementById("map-" + (i+1) + "-meta"), 0, 0);
 
 				var imagedata = ctx.getImageData(0, 0, img.width, img.height);
 
-				canvas.onmousemove = function(e){
-					var rect = canvas.getBoundingClientRect();
-					var x = Math.floor(e.offsetX * img.width / rect.width);
-					var y = Math.floor(e.offsetY * img.height / rect.height);
-
-					var color_idx = x * 4 + (y * 4 * imagedata.width);
-					var color = "#" + hexify(imagedata.data\[color_idx]) + hexify(imagedata.data\[color_idx+1]) + hexify(imagedata.data\[color_idx+2]);
-					var label = document.getElementById("label-" + (i+1)); //label-String(n)
-
-					label.textContent = data\[color];
-					canvas.title = data\[color];
-				}
-				canvas.onmouseout = function(e){
-					canvas.title = "";
-				}
+				var label = document.getElementById("label-" + (i+1)); //label-String(n);
+				[totalmaps <= 1 ? mousemove_bit : ""]
 			}
 		}
 	</script>
 	<style>
 		img, canvas {
-			width: 100%;
+			max-width: 100%;
+			width: auto;
+			margin: auto;
+			display: flex;
+			justify-content: center;
 			background-color: white;
 		}
 	</style>

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -5,6 +5,7 @@
 	desc = "A solar panel. Generates electricity when in contact with sunlight."
 	icon = 'goon/icons/obj/power.dmi'
 	icon_state = "sp_base"
+	minimap_override_color = "#02026a"
 	density = TRUE
 	use_power = NO_POWER_USE
 	idle_power_usage = 0


### PR DESCRIPTION
## About The Pull Request
This PR focuses specifically on the station minimap (available in the OOC tab!). This improves it in a variety of ways! It now scales pixel-perfectly (it was kinda blurry and inconsistent before), the JS no longer errors when you mouse over it, the map now outlines more than just windows and grilles, it now features (somewhat limited) support for multi-z, ruins are now somewhat obfuscated, and some areas have been given nicer colors!

Or to put it in simpler terms, here's a before and after:

BEFORE:
![image](https://user-images.githubusercontent.com/6356337/172032844-4978bf45-f27b-4bde-9e2a-f8356222544d.png)


AFTER:
![image](https://user-images.githubusercontent.com/6356337/172032851-9f8afe94-8bff-44f9-8cb7-a3cc88b6a8c9.png)


To elaborate a little further on the multi-z support: I was unable to get the status display and tooltips fully working when multiple images are present. It took 7 hours of me banging my head against the wall until I eventually just gave up, and made the status display simply not be present if the minimap is multiz.

## Changelog
:cl: Bhijn & Myr
add: The station minimap now features higher detail! Instead of just windows and grilles being outlined, all dense+anchored structures and machinery are shown on the minimap.
add: The station minimap now supports obfuscating entire areas, via the minimap_show_walls var.
add: The station minimap now supports defining two area colors, allowing for a checkerboard pattern!
tweak: Hallways and maint have been given white and gray colors, respectively, for ease of readability.
tweak: Ruins are now obfuscated on the minimap, and have been given a subtle, yet distinct, color pattern!
fix: The station minimap no longer errors when you mouse over it
add: The station minimap now supports multiz! (However, due to bugginess, multiz minimaps won't display area tooltips.)
tweak: The station minimap now features pixel-perfect scaling.
code: The station minimap can now support managing data for up to 16,581,374 areas without any conflicts at all! Before, BYOND's psuedorandom RNG meant that it was somewhat common for areas to collide with each others' data.
/:cl:
