### PR TITLE
Allows station pets to retain their color between shifts

### DIFF
--- a/code/modules/mob/living/carbon/monkey/punpun.dm
+++ b/code/modules/mob/living/carbon/monkey/punpun.dm
@@ -46,6 +46,7 @@
 	..()
 
 /mob/living/carbon/monkey/punpun/proc/Read_Memory()
+	var/saved_color
 	if(fexists("data/npc_saves/Punpun.sav")) //legacy compatability to convert old format to new
 		var/savefile/S = new /savefile("data/npc_saves/Punpun.sav")
 		S["ancestor_name"]	>> ancestor_name
@@ -62,6 +63,9 @@
 		ancestor_chain = json["ancestor_chain"]
 		relic_hat = json["relic_hat"]
 		relic_mask = json["relic_hat"]
+		saved_color = json["color"]
+	if(!isnull(saved_color))
+		add_atom_colour(json_decode(saved_color), FIXED_COLOUR_PRIORITY)
 
 /mob/living/carbon/monkey/punpun/proc/Write_Memory(dead, gibbed)
 	var/json_file = file("data/npc_saves/Punpun.json")
@@ -71,10 +75,12 @@
 		file_data["ancestor_chain"] = null
 		file_data["relic_hat"] = null
 		file_data["relic_mask"] = null
+		file_data["color"] = null
 	else
 		file_data["ancestor_name"] = ancestor_name ? ancestor_name : name
 		file_data["ancestor_chain"] = dead ? ancestor_chain + 1 : ancestor_chain
 		file_data["relic_hat"] = head ? head.type : null
 		file_data["relic_mask"] = wear_mask ? wear_mask.type : null
+		file_data["color"] = color ? json_encode(color) : null
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -136,6 +136,7 @@
 	..()
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Read_Memory()
+	var/saved_color
 	if(fexists("data/npc_saves/Runtime.sav")) //legacy compatability to convert old format to new
 		var/savefile/S = new /savefile("data/npc_saves/Runtime.sav")
 		S["family"] >> family
@@ -146,14 +147,21 @@
 			return
 		var/list/json = json_decode(file2text(json_file))
 		family = json["family"]
+		saved_color = json["color"]
 	if(isnull(family))
 		family = list()
+	if(!isnull(saved_color))
+		add_atom_colour(json_decode(saved_color), FIXED_COLOUR_PRIORITY)
 
 /mob/living/simple_animal/pet/cat/Runtime/proc/Write_Memory(dead)
 	var/json_file = file("data/npc_saves/Runtime.json")
 	var/list/file_data = list()
 	family = list()
 	if(!dead)
+		if(color)
+			file_data["color"] = json_encode(color)
+		else
+			file_data["color"] = null
 		for(var/mob/living/simple_animal/pet/cat/kitten/C in children)
 			if(istype(C,type) || C.stat || !C.z || !C.butcher_results) //That last one is a work around for hologram cats
 				continue
@@ -161,6 +169,8 @@
 				family[C.type] += 1
 			else
 				family[C.type] = 1
+	else
+		file_data["color"] = null
 	file_data["family"] = family
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -436,6 +436,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/proc/Read_Memory()
 	set waitfor = FALSE
+	var/saved_color
 	if(fexists("data/npc_saves/Ian.sav")) //legacy compatability to convert old format to new
 		var/savefile/S = new /savefile("data/npc_saves/Ian.sav")
 		S["age"] 		>> age
@@ -450,12 +451,15 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 		age = json["age"]
 		record_age = json["record_age"]
 		saved_head = json["saved_head"]
+		saved_color = json["color"]
 	if(isnull(age))
 		age = 0
 	if(isnull(record_age))
 		record_age = 1
 	if(saved_head)
 		place_on_head(new saved_head)
+	if(!isnull(saved_color))
+		add_atom_colour(json_decode(saved_color), FIXED_COLOUR_PRIORITY)
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/proc/Write_Memory(dead)
 	var/json_file = file("data/npc_saves/Ian.json")
@@ -470,10 +474,15 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 			file_data["saved_head"] = inventory_head.type
 		else
 			file_data["saved_head"] = null
+		if(color)
+			file_data["color"] = json_encode(color)
+		else
+			file_data["color"] = null
 	else
 		file_data["age"] = 0
 		file_data["record_age"] = record_age
 		file_data["saved_head"] = null
+		file_data["color"] = null
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
 

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -910,11 +910,13 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 		speak += pick("...[longest_survival].", "The things I've seen!", "I have lived many lives!", "What are you before me?")
 		desc += " Old as sin, and just as loud. Claimed to be [rounds_survived]."
 		speak_chance = 20 //His hubris has made him more annoying/easier to justify killing
-		add_atom_colour("#EEEE22", FIXED_COLOUR_PRIORITY)
+		if(!color)
+			add_atom_colour("#EEEE22", FIXED_COLOUR_PRIORITY)
 	else if(rounds_survived == longest_deathstreak)
 		speak += pick("What are you waiting for!", "Violence breeds violence!", "Blood! Blood!", "Strike me down if you dare!")
 		desc += " The squawks of [-rounds_survived] dead parrots ring out in your ears..."
-		add_atom_colour("#BB7777", FIXED_COLOUR_PRIORITY)
+		if(!color)
+			add_atom_colour("#BB7777", FIXED_COLOUR_PRIORITY)
 	else if(rounds_survived > 0)
 		speak += pick("...again?", "No, It was over!", "Let me out!", "It never ends!")
 		desc += " Over [rounds_survived] shifts without a \"terrible\" \"accident\"!"
@@ -947,6 +949,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 	..(gibbed)
 
 /mob/living/simple_animal/parrot/Poly/proc/Read_Memory()
+	var/saved_color
 	if(fexists("data/npc_saves/Poly.sav")) //legacy compatability to convert old format to new
 		var/savefile/S = new /savefile("data/npc_saves/Poly.sav")
 		S["phrases"] 			>> speech_buffer
@@ -963,8 +966,11 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 		rounds_survived = json["roundssurvived"]
 		longest_survival = json["longestsurvival"]
 		longest_deathstreak = json["longestdeathstreak"]
+		saved_color = json["color"]
 	if(!islist(speech_buffer))
 		speech_buffer = list()
+	if(!isnull(saved_color))
+		add_atom_colour(json_decode(saved_color), FIXED_COLOUR_PRIORITY)
 
 /mob/living/simple_animal/parrot/Poly/proc/Write_Memory(dead)
 	var/json_file = file("data/npc_saves/Poly.json")
@@ -978,6 +984,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 			file_data["longestdeathstreak"] = rounds_survived - 1
 		else
 			file_data["longestdeathstreak"] = longest_deathstreak
+		file_data["color"] = null
 	else
 		file_data["roundssurvived"] = rounds_survived + 1
 		if(rounds_survived + 1 > longest_survival)
@@ -985,6 +992,10 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 		else
 			file_data["longestsurvival"] = longest_survival
 		file_data["longestdeathstreak"] = longest_deathstreak
+		if(color)
+			file_data["color"] = json_encode(color)
+		else
+			file_data["color"] = null
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
 


### PR DESCRIPTION
## About The Pull Request
So today I learned there's ways for crewmembers to change the colors of station pets! This PR allows those color changes to be persistent, just like their age and accessories. This currently affects Ian, Poly, Runtime, and Punpun!

## Changelog
:cl: Bhijn & Myr
add: Station pets now retain their color between shifts!
/:cl:
