### PR TITLE
Makes railings climbable both ways (without issues. and in one single line!)

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -65,7 +65,7 @@
 /obj/structure/proc/do_climb(atom/movable/A)
 	if(climbable)
 		density = FALSE
-		. = step(A,get_dir(A,src.loc))
+		. = step(A, (A.loc == loc ? dir : get_dir(A,src.loc)))
 		density = TRUE
 
 /obj/structure/proc/climb_structure(mob/living/user)


### PR DESCRIPTION
## About The Pull Request
So! Turns out railings are only climbable one-way both here and on TG. A downstream attempted to rectify this on their own, and uh. [WELL....](https://www.reddit.com/r/SS13/comments/v5gcqa/splurt_spaghetti_code_enables_you_to_speedrun_the/)

This PR makes railings climbable both ways with only a single line of code. This single line of code allows railings to be climbed both ways in a way that respects collision detection and other movement checks!

## Changelog
:cl: Bhijn & Myr
tweak: Railings are now climbable both ways! This is accomplished by making climbing move you in the direction the structure's facing if you're on the same tile as it, instead of attempting to move you onto the structure's tile (and consequently failing because you're already there).
/:cl:
