### PR TITLE
Rebalancing QCD matter a bit

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -27,6 +27,7 @@
 #define NOBLIUM_RESEARCH_AMOUNT				25
 #define BZ_RESEARCH_SCALE					4
 #define BZ_RESEARCH_MAX_AMOUNT				400
+#define QCD_RESEARCH_AMOUNT					2 // often made in absolutely massive quantities due to the simple nature of fusion
 #define MIASMA_RESEARCH_AMOUNT				6
 #define STIMULUM_RESEARCH_AMOUNT			50
 //Plasma fusion properties

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -73,6 +73,8 @@
 	TECHWEB_POINT_TYPE_GENERIC = "General Research"\
 	)
 
+#define LARGEST_BOMB				"bomb"
+
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
 #define BOMB_TARGET_SIZE			(world.system_type == MS_WINDOWS ? 240 : 50000) // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
 // Linux still has old trit fires, so

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -203,9 +203,13 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		point_gain = (BOMB_TARGET_POINTS * 2 * orig_light) / (orig_light + BOMB_TARGET_SIZE)
 
 	/*****The Point Capper*****/
-	if(point_gain > linked_techweb.largest_bomb_value)
-		var/old_tech_largest_bomb_value = linked_techweb.largest_bomb_value //held so we can pull old before we do math
-		linked_techweb.largest_bomb_value = point_gain
+
+	var/list/largest_values = linked_techweb.largest_values
+	if(!(LARGEST_BOMB in largest_values))
+		largest_values[LARGEST_BOMB] = 0
+	if(point_gain > largest_values[LARGEST_BOMB])
+		var/old_tech_largest_bomb_value = largest_values[LARGEST_BOMB] //held so we can pull old before we do math
+		linked_techweb.largest_values[LARGEST_BOMB] = point_gain
 		point_gain -= old_tech_largest_bomb_value
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		if(D)

--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -295,4 +295,4 @@
 	powermix = -1
 	transmit_modifier = -10
 	heat_penalty = -10
-	price = 10
+	price = 100 // it's kinda really hard to actually get it into a canister

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -759,7 +759,18 @@
 	var/initial_energy = air.thermal_energy()
 	for(var/g in air.get_gases())
 		air.set_moles(g, 0)
-	air.set_moles(GAS_QCD, initial_energy / (air.return_temperature() * GLOB.gas_data.specific_heats[GAS_QCD]))
+	var/amount = initial_energy / (air.return_temperature() * GLOB.gas_data.specific_heats[GAS_QCD])
+	air.set_moles(GAS_QCD, amount)
+	var/list/largest_values = SSresearch.science_tech.largest_values
+	if(!(GAS_QCD in largest_values))
+		largest_values[GAS_QCD] = 0
+	var/previous_largest = largest_values[GAS_QCD]
+	var/research_amount = amount * QCD_RESEARCH_AMOUNT
+	if(previous_largest < research_amount)
+		SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_amount)
+		largest_values[GAS_QCD] = research_amount
+	else
+		SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_amount / 100)
 
 /datum/gas_reaction/dehagedorn
 	priority = 50
@@ -781,11 +792,10 @@
 	var/list/gases = GLOB.gas_data.specific_heats.Copy()
 	gases -= GAS_QCD
 	gases -= GAS_TRITIUM // no refusing sorry
-	for(var/g in gases)
-		gases[g] = 10000 / gases[g]
+	gases -= GAS_HYPERNOB // makes it waaay too easy to stabilize it
 	while(energy_remaining > 0)
 		var/G = pick(gases)
 		air.adjust_moles(G, max(0.1, energy_remaining / (gases[G] * new_temp * 20)))
 		energy_remaining = initial_energy - air.thermal_energy()
-	air.adjust_heat(-energy_remaining)
+	air.set_temperature(initial_energy / air.heat_capacity())
 	return REACTING

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -17,7 +17,7 @@
 	var/list/obj/machinery/computer/rdconsole/consoles_accessing = list()
 	var/id = "generic"
 	var/list/research_logs = list()								//IC logs.
-	var/largest_bomb_value = 0
+	var/largest_values = list()
 	var/organization = "Third-Party"							//Organization name, used for display.
 	var/list/next_income = list()								//To be applied on the next passive techweb income
 	var/list/last_bitcoins = list()								//Current per-second production, used for display only.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now, there's a few weird issues with QCD matter:

1. It's not very rewarding to make, especially for how difficult it is. It's 10 credits per mole, but I couldn't get more than, like, 200 moles of it into a can in the first place.
2. When it's made, it tends to be in a situation where it'll cool back down quickly, at which point it'll make a bunch of random gases, including hyper-nob, which will prevent it from reforming. This is highly un-ideal, especially since it can make so much hyper-nob you'd rather sell that.
3. No research points for making it even though it's, essentially, the ultimate goal of fusion.
4. I did the condensation phase transition reaction while tired out of my gourd or something, because it made no sense at all and did the opposite of what I intended. This is fixed.|

For this, I also made the largest_bomb_value thing general, a list instead of a snowflake var.

## Why It's Good For The Game

It's a cool gas (I think) but it's lame right now.

## Changelog
:cl:
tweak: QCD matter can no longer decompose into hyper-noblium
balance: QCD matter is now worth 10x as much and makes 2 research pointer per mole
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
