### PR TITLE
makes a new proc for adjusting blood volume, ties it into toxinlover handling

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -45,7 +45,9 @@
 				adjustStaminaLoss(damage_amount, forced = forced)
 	return TRUE
 
-
+// adjust blood value
+/mob/living/carbon/proc/adjustBloodVolume(amount)
+	blood_volume = max(0,  blood_volume - amount)
 
 //These procs fetch a cumulative total damage from all bodyparts
 /mob/living/carbon/getBruteLoss()
@@ -89,11 +91,10 @@
 //God save me from spaghettifying this - Syscorrupt damage is not affected by toxlovers.
 /mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, toxins_type = TOX_DEFAULT)
 	if(!forced && HAS_TRAIT(src, TRAIT_TOXINLOVER) && toxins_type != TOX_SYSCORRUPT) //damage becomes healing and healing becomes damage
-		amount = -amount
 		if(amount > 0)
-			blood_volume -= 3 * amount		//5x was too much, this is punishing enough.
+			adjustBloodVolume(3 * amount)		//5x was too much, this is punishing enough.
 		else
-			blood_volume -= amount
+			adjustBloodVolume(amount)
 	return ..()
 
 /mob/living/carbon/getStaminaLoss()


### PR DESCRIPTION
## About The Pull Request
title

no i'm not applying this to every direct bloodvolume change in the code

## Why It's Good For The Game
anti-toxin should not be able to give you negative blood

## Changelog
:cl:
fix: anti-toxin can no longer give you negative blood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
