### PR TITLE
Lingblood tweak - Increases the default value for ling ability loudness to 0.5

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -16,7 +16,7 @@
 	var/req_stat = CONSCIOUS // CONSCIOUS, UNCONSCIOUS or DEAD
 	var/always_keep = 0 // important for abilities like revive that screw you if you lose them.
 	var/ignores_fakedeath = FALSE // usable with the FAKEDEATH flag
-	var/loudness = 0 //Determines how much having this ability will affect changeling blood tests. At 4, the blood will react violently and turn to ash, creating a unique message in the process. At 10, the blood will explode when heated.
+	var/loudness = 0.5 //Determines how much having this ability will affect changeling blood tests. This is averaged with other purchased abilities. Above 1, the blood will react violently and turn to ash, creating a unique message in the process. Above 2, the blood will explode when heated.
 
 
 /obj/effect/proc_holder/changeling/proc/on_purchase(mob/user, is_respec)


### PR DESCRIPTION
## About The Pull Request
So it turns out lings are capable of being considered stealth by the loudness system despite having mostly loud, lethal abilities. Notably, a loadout of armblade, armor, shriek, and fleshmend, is capable of ending up with a combined loudness of 0.86 if the ling simply picks up 3 stealthy abilities. It's easy to guess how this might be a problem (it's a loadout that allows a ling to have a very aggressive playstyle on a whim, which by all means should result in the blood test getting tripped.)

So this PR increases the default loudness value for ling abilities to 0.5, which in turn increases the investment into stealth abilities required to avoid tripping the blood test. With the above loadout, one of those abilities has to be replaced in order to avoid tripping the blood test, as it instead ends up with a loudness of 1.07, just above the threshold for the blood test.

## Changelog
:cl: Bhijn & Myr
balance: Ling abilities now have a default loudness of 0.5. This change applies to every single ability that used to have 0 loudness.
/:cl:
