### PR TITLE
Changing the range on Dynamic Days

### DIFF
--- a/code/modules/holiday/dynamic.dm
+++ b/code/modules/holiday/dynamic.dm
@@ -6,5 +6,4 @@
 	return lowertext(ddd) in days
 
 /datum/holiday/dynamic/celebrate()
-	GLOB.dynamic_forced_threat_level = rand(90, 100)
-	CONFIG_SET(string/force_gamemode, "dynamic") // prevents the round vote, which prevents extended
+	GLOB.dynamic_forced_threat_level = rand(50, 100)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
After some discussion among staff, we felt the small range of 90-100 was too chaotic for back-to-back rounds currently. This PR is meant to lower the bound so that there's a range of medium to high chaos, evenly distributed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A wider range of threat level should provide a healthier range of rounds while still showing off rarer modes and classic spessmen fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed the range of dynamic days to 50-100 instead of 90-100
del: Removed the forced dynamic, allowing the standard game mode vote.
/:cl: