### PR TITLE
fixes slimes blood processing (see pr description)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -363,6 +363,3 @@
 #define MAPPING_HELPER_TRAIT "mapping-helper"
 /// Trait associated with mafia
 #define MAFIA_TRAIT "mafia"
-
-/// snowflake blood process (slimes)
-#define TRAIT_SNOWFLAKE_BLOOD_PROCESS "snowflake_blood_process"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -363,3 +363,6 @@
 #define MAPPING_HELPER_TRAIT "mapping-helper"
 /// Trait associated with mafia
 #define MAFIA_TRAIT "mafia"
+
+/// snowflake blood process (slimes)
+#define TRAIT_SNOWFLAKE_BLOOD_PROCESS "snowflake_blood_process"

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -38,6 +38,9 @@
 	if(HAS_TRAIT(src, TRAIT_NOMARROW)) //Bloodsuckers don't need to be here.
 		return
 
+	if(HAS_TRAIT(src, TRAIT_SNOWFLAKE_BLOOD_PROCESS)) //slimes regenerate blood in their own way and take damage from not having blood in their own way
+		return
+
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.
 		if(integrating_blood > 0)
 			var/blood_integrated = max(integrating_blood - 1, 0)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -39,7 +39,7 @@
 		return
 
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.
-		if(!HAS_TRAIT(src, TRAIT_SNOWFLAKE_BLOOD_PROCESS))
+		if(species.handle_blood()) // if this returns TRUE, then the species is not handling blood itself and we can control everything
 			if(integrating_blood > 0)
 				var/blood_integrated = max(integrating_blood - 1, 0)
 				var/blood_diff = integrating_blood - blood_integrated

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -39,7 +39,7 @@
 		return
 
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.
-		if(species.handle_blood()) // if this returns TRUE, then the species is not handling blood itself and we can control everything
+		if(dna.species.handle_blood()) // if this returns TRUE, then the species is not handling blood itself and we can control everything
 			if(integrating_blood > 0)
 				var/blood_integrated = max(integrating_blood - 1, 0)
 				var/blood_diff = integrating_blood - blood_integrated

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -38,60 +38,58 @@
 	if(HAS_TRAIT(src, TRAIT_NOMARROW)) //Bloodsuckers don't need to be here.
 		return
 
-	if(HAS_TRAIT(src, TRAIT_SNOWFLAKE_BLOOD_PROCESS)) //slimes regenerate blood in their own way and take damage from not having blood in their own way
-		return
-
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.
-		if(integrating_blood > 0)
-			var/blood_integrated = max(integrating_blood - 1, 0)
-			var/blood_diff = integrating_blood - blood_integrated
-			integrating_blood = blood_integrated
-			if(blood_volume < BLOOD_VOLUME_MAXIMUM)
-				blood_volume += blood_diff
-		if(blood_volume < BLOOD_VOLUME_NORMAL)
-			var/nutrition_ratio = 0
-			if(!HAS_TRAIT(src, TRAIT_NOHUNGER))
-				switch(nutrition)
-					if(0 to NUTRITION_LEVEL_STARVING)
-						nutrition_ratio = 0.2
-					if(NUTRITION_LEVEL_STARVING to NUTRITION_LEVEL_HUNGRY)
-						nutrition_ratio = 0.4
-					if(NUTRITION_LEVEL_HUNGRY to NUTRITION_LEVEL_FED)
-						nutrition_ratio = 0.6
-					if(NUTRITION_LEVEL_FED to NUTRITION_LEVEL_WELL_FED)
-						nutrition_ratio = 0.8
-					else
-						nutrition_ratio = 1
-				if(satiety > 80)
-					nutrition_ratio *= 1.25
-				adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR)
-				blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + 0.5 * nutrition_ratio)
+		if(!HAS_TRAIT(src, TRAIT_SNOWFLAKE_BLOOD_PROCESS)))
+			if(integrating_blood > 0)
+				var/blood_integrated = max(integrating_blood - 1, 0)
+				var/blood_diff = integrating_blood - blood_integrated
+				integrating_blood = blood_integrated
+				if(blood_volume < BLOOD_VOLUME_MAXIMUM)
+					blood_volume += blood_diff
+			if(blood_volume < BLOOD_VOLUME_NORMAL)
+				var/nutrition_ratio = 0
+				if(!HAS_TRAIT(src, TRAIT_NOHUNGER))
+					switch(nutrition)
+						if(0 to NUTRITION_LEVEL_STARVING)
+							nutrition_ratio = 0.2
+						if(NUTRITION_LEVEL_STARVING to NUTRITION_LEVEL_HUNGRY)
+							nutrition_ratio = 0.4
+						if(NUTRITION_LEVEL_HUNGRY to NUTRITION_LEVEL_FED)
+							nutrition_ratio = 0.6
+						if(NUTRITION_LEVEL_FED to NUTRITION_LEVEL_WELL_FED)
+							nutrition_ratio = 0.8
+						else
+							nutrition_ratio = 1
+					if(satiety > 80)
+						nutrition_ratio *= 1.25
+					adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR)
+					blood_volume = min(BLOOD_VOLUME_NORMAL, blood_volume + 0.5 * nutrition_ratio)
 
-		//Effects of bloodloss
-		if(!HAS_TRAIT(src, TRAIT_ROBOTIC_ORGANISM))	//Synths are immune to direct consequences of bloodloss, instead suffering penalties to heat exchange.
-			var/word = pick("dizzy","woozy","faint")
-			var/blood_effect_volume = blood_volume + integrating_blood
-			switch(blood_effect_volume)
-				if(BLOOD_VOLUME_MAXIMUM to BLOOD_VOLUME_EXCESS)
-					if(prob(10))
-						to_chat(src, "<span class='warning'>You feel terribly bloated.</span>")
-				if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
-					if(prob(5))
-						to_chat(src, "<span class='warning'>You feel [word].</span>")
-					adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.01, 1))
-				if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
-					adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
-					if(prob(5))
-						blur_eyes(6)
-						to_chat(src, "<span class='warning'>You feel very [word].</span>")
-				if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
-					adjustOxyLoss(5)
-					if(prob(15))
-						Unconscious(rand(20,60))
-						to_chat(src, "<span class='warning'>You feel extremely [word].</span>")
-				if(-INFINITY to BLOOD_VOLUME_SURVIVE)
-					if(!HAS_TRAIT(src, TRAIT_NODEATH))
-						death()
+			//Effects of bloodloss
+			if(!HAS_TRAIT(src, TRAIT_ROBOTIC_ORGANISM))	//Synths are immune to direct consequences of bloodloss, instead suffering penalties to heat exchange.
+				var/word = pick("dizzy","woozy","faint")
+				var/blood_effect_volume = blood_volume + integrating_blood
+				switch(blood_effect_volume)
+					if(BLOOD_VOLUME_MAXIMUM to BLOOD_VOLUME_EXCESS)
+						if(prob(10))
+							to_chat(src, "<span class='warning'>You feel terribly bloated.</span>")
+					if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
+						if(prob(5))
+							to_chat(src, "<span class='warning'>You feel [word].</span>")
+						adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.01, 1))
+					if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
+						adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
+						if(prob(5))
+							blur_eyes(6)
+							to_chat(src, "<span class='warning'>You feel very [word].</span>")
+					if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
+						adjustOxyLoss(5)
+						if(prob(15))
+							Unconscious(rand(20,60))
+							to_chat(src, "<span class='warning'>You feel extremely [word].</span>")
+					if(-INFINITY to BLOOD_VOLUME_SURVIVE)
+						if(!HAS_TRAIT(src, TRAIT_NODEATH))
+							death()
 
 		var/temp_bleed = 0
 		//Bleeding out

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -39,7 +39,7 @@
 		return
 
 	if(bodytemperature >= TCRYO && !(HAS_TRAIT(src, TRAIT_HUSK))) //cryosleep or husked people do not pump the blood.
-		if(!HAS_TRAIT(src, TRAIT_SNOWFLAKE_BLOOD_PROCESS)))
+		if(!HAS_TRAIT(src, TRAIT_SNOWFLAKE_BLOOD_PROCESS))
 			if(integrating_blood > 0)
 				var/blood_integrated = max(integrating_blood - 1, 0)
 				var/blood_diff = integrating_blood - blood_integrated

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -93,7 +93,7 @@
 		// don't allow toxinlover to push blood levels past BLOOD_VOLUME_MAXIMUM, but also don't set it back down to this if it's higher from something else
 		var/blood_cap = blood_volume > BLOOD_VOLUME_MAXIMUM ? blood_volume : BLOOD_VOLUME_MAXIMUM
 		if(amount > 0)
-			blood_volume blood_volume - min((3 * amount), blood_cap)	//5x was too much, this is punishing enough.
+			blood_volume = min((blood_volume - (3 * amount)), blood_cap)	//5x was too much, this is punishing enough.
 		else
 			blood_volume = min((blood_volume - amount), blood_cap)
 	return ..()

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -93,9 +93,9 @@
 		// don't allow toxinlover to push blood levels past BLOOD_VOLUME_MAXIMUM, but also don't set it back down to this if it's higher from something else
 		var/blood_cap = blood_volume > BLOOD_VOLUME_MAXIMUM ? blood_volume : BLOOD_VOLUME_MAXIMUM
 		if(amount > 0)
-			blood_volume blood_volume - min((3 * amount), blood_cap)		//5x was too much, this is punishing enough.
+			blood_volume blood_volume - min((3 * amount), blood_cap)	//5x was too much, this is punishing enough.
 		else
-			blood_volume = min(blood_volume - amount), blood_cap)
+			blood_volume = min((blood_volume - amount), blood_cap)
 	return ..()
 
 /mob/living/carbon/getStaminaLoss()

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -90,10 +90,12 @@
 /mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, toxins_type = TOX_DEFAULT)
 	if(!forced && HAS_TRAIT(src, TRAIT_TOXINLOVER) && toxins_type != TOX_SYSCORRUPT) //damage becomes healing and healing becomes damage
 		amount = -amount
+		// don't allow toxinlover to push blood levels past BLOOD_VOLUME_MAXIMUM, but also don't set it back down to this if it's higher from something else
+		var/blood_cap = blood_volume > BLOOD_VOLUME_MAXIMUM ? blood_volume : BLOOD_VOLUME_MAXIMUM
 		if(amount > 0)
-			blood_volume -= 3 * amount		//5x was too much, this is punishing enough.
+			blood_volume blood_volume - min((3 * amount), blood_cap)		//5x was too much, this is punishing enough.
 		else
-			blood_volume -= amount
+			blood_volume = min(blood_volume - amount), blood_cap)
 	return ..()
 
 /mob/living/carbon/getStaminaLoss()

--- a/code/modules/mob/living/carbon/human/innate_abilities/limb_regeneration.dm
+++ b/code/modules/mob/living/carbon/human/innate_abilities/limb_regeneration.dm
@@ -22,28 +22,24 @@
 					return FALSE
 		return 0
 
-/datum/action/innate/ability/limb_regrowth/Activate()
+/datum/action/innate/limb_regrowth/Activate()
 	var/mob/living/carbon/human/H = owner
 	var/list/limbs_to_heal = H.get_missing_limbs()
-	if(limbs_to_heal.len < 1)
-		to_chat(H, "<span class='notice'>You feel intact enough as it is.</span>")
+	if(!length(limbs_to_heal))
+		to_chat(H, span_notice("You feel intact enough as it is."))
 		return
-	to_chat(H, "<span class='notice'>You focus intently on your missing [limbs_to_heal.len >= 2 ? "limbs" : "limb"]...</span>")
-	var/mode = H.get_ability_property(INNATE_ABILITY_LIMB_REGROWTH, PROPERTY_LIMB_REGROWTH_USAGE_TYPE)
-	switch(mode)
-		if(REGROWTH_USES_BLOOD)
-			if(H.blood_volume >= 40*limbs_to_heal.len+(BLOOD_VOLUME_OKAY*H.blood_ratio))
-				H.regenerate_limbs()
-				H.blood_volume -= 40*limbs_to_heal.len
-				to_chat(H, "<span class='notice'>...and after a moment you finish reforming!</span>")
-				return
-			else if(H.blood_volume >= 40)//We can partially heal some limbs
-				while(H.blood_volume >= (BLOOD_VOLUME_OKAY*H.blood_ratio)+40)
-					var/healed_limb = pick(limbs_to_heal)
-					H.regenerate_limb(healed_limb)
-					limbs_to_heal -= healed_limb
-					H.blood_volume -= 40
-				to_chat(H, "<span class='warning'>...but there is not enough of you to fix everything! You must attain more mass to heal completely!</span>")
-				return
-			to_chat(H, "<span class='warning'>...but there is not enough of you to go around! You must attain more mass to heal!</span>")
-
+	to_chat(H, span_notice("You focus intently on your missing [length(limbs_to_heal) >= 2 ? "limbs" : "limb"]..."))
+	if(H.blood_volume >= 40*length(limbs_to_heal)+BLOOD_VOLUME_OKAY)
+		H.regenerate_limbs()
+		H.blood_volume -= 40*length(limbs_to_heal)
+		to_chat(H, span_notice("...and after a moment you finish reforming!"))
+		return
+	else if(H.blood_volume >= 40)//We can partially heal some limbs
+		while(H.blood_volume >= BLOOD_VOLUME_OKAY+40)
+			var/healed_limb = pick(limbs_to_heal)
+			H.regenerate_limb(healed_limb)
+			limbs_to_heal -= healed_limb
+			H.blood_volume -= 40
+		to_chat(H, span_warning("...but there is not enough of you to fix everything! You must attain more mass to heal completely!"))
+		return
+	to_chat(H, span_warning("...but there is not enough of you to go around! You must attain more mass to heal!"))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2453,6 +2453,13 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	return FALSE
 
 ////////////////
+//Blood Stuff///
+////////////////
+// true = handle blood normally, false = do not (and then handle blood in this proc instead please!!)
+/datum/species/proc/handle_blood()
+	return TRUE
+
+////////////////
 //Tail Wagging//
 ////////////////
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -55,9 +55,9 @@
 	//update blood color to body color
 	exotic_blood_color = "#" + H.dna.features["mcolor"]
 
-/datum/species/jelly/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
+/datum/species/jelly/handle_blood(mob/living/carbon/human/H, delta_time, times_fired)
 	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely
-		return
+		return TRUE // we dont handle blood when dead
 
 	if(H.blood_volume <= 0)
 		H.blood_volume += 2.5 * delta_time
@@ -79,6 +79,8 @@
 	var/datum/action/innate/ability/regrowth = H.ability_actions[INNATE_ABILITY_LIMB_REGROWTH]
 	if(regrowth)
 		regrowth.UpdateButtonIcon()
+
+	return FALSE // to let living/handle_blood know that the species is handling blood instead
 
 /datum/species/jelly/proc/Cannibalize_Body(mob/living/carbon/human/H)
 	var/list/limbs_to_consume = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG) - H.get_missing_limbs()

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -55,38 +55,44 @@
 	//update blood color to body color
 	exotic_blood_color = "#" + H.dna.features["mcolor"]
 
-/datum/species/jelly/spec_life(mob/living/carbon/human/H)
-	if(H.stat == DEAD || HAS_TRAIT(H, TRAIT_NOMARROW)) //can't farm slime jelly from a dead slime/jelly person indefinitely, and no regeneration for bloodsuckers
+/datum/species/jelly/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
+	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely
 		return
-	if(!H.blood_volume)
-		H.adjust_integration_blood(5)
-		H.adjustBruteLoss(5)
-		to_chat(H, "<span class='danger'>You feel empty!</span>")
 
-	if(H.blood_volume < (BLOOD_VOLUME_NORMAL * H.blood_ratio))
+	if(!H.blood_volume)
+		H.blood_volume += 2.5 * delta_time
+		H.adjustBruteLoss(2.5 * delta_time)
+		to_chat(H, span_danger("You feel empty!"))
+
+	if(H.blood_volume < BLOOD_VOLUME_NORMAL)
 		if(H.nutrition >= NUTRITION_LEVEL_STARVING)
-			H.adjust_integration_blood(3)
-			H.nutrition -= 2.5
-	if(H.blood_volume < (BLOOD_VOLUME_OKAY*H.blood_ratio))
-		if(prob(5))
-			to_chat(H, "<span class='danger'>You feel drained!</span>")
-	if(H.blood_volume < (BLOOD_VOLUME_BAD*H.blood_ratio))
+			H.blood_volume += 1.5 * delta_time
+			H.adjust_nutrition(-1.25 * delta_time)
+
+	if(H.blood_volume < BLOOD_VOLUME_OKAY)
+		if(DT_PROB(2.5, delta_time))
+			to_chat(H, span_danger("You feel drained!"))
+
+	if(H.blood_volume < BLOOD_VOLUME_BAD)
 		Cannibalize_Body(H)
-	..()
+
+	var/datum/action/innate/ability/regrowth = H.ability_actions[INNATE_ABILITY_LIMB_REGROWTH]
+	if(regrowth)
+		regrowth.UpdateButtonIcon()
 
 /datum/species/jelly/proc/Cannibalize_Body(mob/living/carbon/human/H)
 	var/list/limbs_to_consume = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG) - H.get_missing_limbs()
 	var/obj/item/bodypart/consumed_limb
-	if(!limbs_to_consume.len)
+	if(!length(limbs_to_consume))
 		H.losebreath++
 		return
 	if(H.get_num_legs(FALSE)) //Legs go before arms
 		limbs_to_consume -= list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
 	consumed_limb = H.get_bodypart(pick(limbs_to_consume))
 	consumed_limb.drop_limb()
-	to_chat(H, "<span class='userdanger'>Your [consumed_limb] is drawn back into your body, unable to maintain its shape!</span>")
+	to_chat(H, span_userdanger("Your [consumed_limb] is drawn back into your body, unable to maintain its shape!"))
 	qdel(consumed_limb)
-	H.adjust_integration_blood(20)
+	H.blood_volume += 20
 
 ////////////////////////////////////////////////////////SLIMEPEOPLE///////////////////////////////////////////////////////////////////
 
@@ -407,7 +413,7 @@
 	limbs_id = SPECIES_SLIME
 	default_color = "00FFFF"
 	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,HAS_FLESH)
-	inherent_traits = list(TRAIT_TOXINLOVER)
+	inherent_traits = list(TRAIT_TOXINLOVER, TRAIT_SNOWFLAKE_BLOOD_PROCESS)
 	mutant_bodyparts = list("mcolor" = "FFFFFF", "mcolor2" = "FFFFFF","mcolor3" = "FFFFFF", "mam_tail" = "None", "mam_ears" = "None", "mam_body_markings" = "Plain", "mam_snouts" = "None", "taur" = "None", "deco_wings" = "None", "legs" = "Plantigrade")
 	say_mod = "says"
 	hair_color = "mutcolor"

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -59,7 +59,7 @@
 	if(H.stat == DEAD) //can't farm slime jelly from a dead slime/jelly person indefinitely
 		return
 
-	if(!H.blood_volume)
+	if(H.blood_volume <= 0)
 		H.blood_volume += 2.5 * delta_time
 		H.adjustBruteLoss(2.5 * delta_time)
 		to_chat(H, span_danger("You feel empty!"))

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -415,7 +415,7 @@
 	limbs_id = SPECIES_SLIME
 	default_color = "00FFFF"
 	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,HAS_FLESH)
-	inherent_traits = list(TRAIT_TOXINLOVER, TRAIT_SNOWFLAKE_BLOOD_PROCESS)
+	inherent_traits = list(TRAIT_TOXINLOVER)
 	mutant_bodyparts = list("mcolor" = "FFFFFF", "mcolor2" = "FFFFFF","mcolor3" = "FFFFFF", "mam_tail" = "None", "mam_ears" = "None", "mam_body_markings" = "Plain", "mam_snouts" = "None", "taur" = "None", "deco_wings" = "None", "legs" = "Plantigrade")
 	say_mod = "says"
 	hair_color = "mutcolor"


### PR DESCRIPTION
## About The Pull Request
TESTMERGE THIS FIRST

it has been tested but it's best for a large species change like this to get some review on balance

currently handle_blood and spec_life for slimes runs at the same time
this means they are regenerating blood twice and taking damage penalties for blood twice
this means they die before even being able to cannibalize a limb and some parts of the code can't even be reached

this makes the following changes:
handle_blood is no longer used for slimes blood regeneration / low blood penalties, meaning they do not instantly die at 0 blood, nor do they regenerate blood from this proc, or take oxyloss from this proc
generic bleeding is still handled via this proc

spec_life continues to handle the regeneration of blood using nutrition for slimes, just using an updated tg version, slimes take brute when they have no blood and regain a small amount of blood (you can have negative blood from toxinlover it seems)

when below a certain amount of blood you will automatically consume limbs to gain 20 blood, (regeneration costs 40), losing your legs first, and upon having no more limbs to lose, you begin to lose oxygen (and thereby die)

----
right now 6u of charcoal or anti toxin can kill you via bloodloss, like you just outright die
with this: 15u of charcoal will crit you via toxin damage and you will then lose all your limbs over the course of about 30 seconds while in crit
12u of charcoal will crit you via toxin damage and you will lose both your legs, then gaining enough blood to be stable blood-wise, but still in crit

also they're regenerating far less blood passively than before, meaning drinking toxin is more important

also: you can no longer go past BLOOD_VOLUME_MAXIMUM from toxin as a slime (otherwise you'd just be able to have so much blood, charcoal/anti-toxin would do nothing to you)

## Why It's Good For The Game
makes slime blood work how it's supposed to work instead of having it be similarly handled in two places

the main change here is just no incredibly fast deaths from anti-toxins, instead it pulls it out to be a longer death that makes use of the limb cannibalism proc

## Changelog
:cl:
add: slimes no longer die from having no blood, properly consume limbs when at low blood, and suffer brute damage and oxygen loss for having no blood and no limbs left to consume respectably, they cannot go past BLOOD_VOLUME_MAXIMUM from consuming toxin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
