### PR TITLE
GAS_OXYGEN should be GAS_O2

### DIFF
--- a/code/modules/atmospherics/auxgm/breathing_classes.dm
+++ b/code/modules/atmospherics/auxgm/breathing_classes.dm
@@ -46,7 +46,7 @@
 	gases = list(
 		GAS_METHANE = 1,
 		GAS_METHYL_BROMIDE = -0.7,
-		GAS_OXYGEN = -0.1,
+		GAS_O2 = -0.1,
 		GAS_PLUOXIUM = -0.8
 	)
 	products = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title, made a typo

## Why It's Good For The Game

Nothing uses this breathing class but downstreams do I think so this should be fixed up here

## Changelog
:cl:
fix: GAS_OXYGEN -> GAS_O2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
