### PR TITLE
makes brain trauma event respect canSpawnEvent conditions such as min players

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -5,6 +5,7 @@
 	min_players = 5
 
 /datum/round_event_control/brain_trauma/canSpawnEvent(var/players_amt, var/gamemode)
+	if(!..()) return FALSE
 	var/list/enemy_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
 	for (var/mob/M in GLOB.alive_mob_list)
 		if(M.stat != DEAD && (M.mind?.assigned_role in enemy_roles))


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
fix

## Changelog
:cl:
fix: makes brain trauma event respect canSpawnEvent conditions such as min players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
