### PR TITLE
Gateway Power Issues

### DIFF
--- a/_maps/RandomZLevels/away_mission/SnowCabin.dmm
+++ b/_maps/RandomZLevels/away_mission/SnowCabin.dmm
@@ -99,7 +99,9 @@
 /obj/machinery/door/airlock/command{
 	name = "Manager's Office"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "as" = (
@@ -134,7 +136,9 @@
 /area/awaymission/cabin)
 "aw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "ax" = (
@@ -185,11 +189,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/awaymission/cabin)
 "aD" = (
-/obj/machinery/power/smes/magical{
-	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. It seems to be powered just fine without our intervention.";
-	name = "nanotrasen power storage unit"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/smes{
+	charge = 1.5e+006;
+	input_level = 30000;
+	inputting = 0;
+	output_level = 7000
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "aE" = (
@@ -207,7 +216,12 @@
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "aG" = (
@@ -255,7 +269,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -281,15 +297,6 @@
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "aQ" = (
-/obj/structure{
-	anchored = 1;
-	density = 1;
-	desc = "Generates power from lava!";
-	dir = 1;
-	icon = 'icons/obj/atmospherics/pipes/simple.dmi';
-	icon_state = "compressor";
-	name = "geothermal generator"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -366,7 +373,9 @@
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "bb" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "bc" = (
@@ -431,7 +440,9 @@
 	id_tag = "snowdorm5";
 	name = "Cabin 5"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "bn" = (
@@ -463,7 +474,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "bt" = (
@@ -492,7 +505,9 @@
 "by" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/cabin)
 "bz" = (
@@ -611,7 +626,9 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Garage"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "bW" = (
@@ -739,7 +756,9 @@
 /obj/structure/sign/poster/official/soft_cap_pop_art{
 	pixel_y = 32
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "cu" = (
@@ -838,14 +857,18 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "cM" = (
 /obj/machinery/door/airlock/wood{
 	name = "Gateway"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "cN" = (
@@ -859,12 +882,16 @@
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "cP" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/cabin)
 "cQ" = (
 /obj/effect/landmark/awaystart,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "cR" = (
@@ -898,7 +925,9 @@
 /area/awaymission/cabin)
 "cW" = (
 /obj/item/shovel,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -957,7 +986,9 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "df" = (
@@ -1040,20 +1071,19 @@
 /area/awaymission/cabin)
 "du" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/awaymission/cabin)
 "dv" = (
-/obj/structure{
-	anchored = 1;
-	density = 1;
-	desc = "Generates power from lava!";
-	icon = 'icons/obj/atmospherics/pipes/simple.dmi';
-	icon_state = "turbine";
-	name = "geothermal generator"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/rtg,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -1269,7 +1299,9 @@
 /turf/open/floor/wood/cold,
 /area/awaymission/cabin/snowforest)
 "eg" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "eh" = (
@@ -1279,7 +1311,9 @@
 "ei" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "ej" = (
@@ -1350,7 +1384,9 @@
 /area/awaymission/cabin/snowforest)
 "et" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "eu" = (
@@ -2724,11 +2760,15 @@
 /obj/structure/sign/poster/official/fruit_bowl{
 	pixel_y = 32
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "hi" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/awaymission/cabin)
 "hj" = (
@@ -2736,7 +2776,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "hk" = (
@@ -2781,7 +2823,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/generic,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "hs" = (
@@ -2789,14 +2833,18 @@
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_x = 32
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "ht" = (
 /obj/structure/window{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "hu" = (
@@ -2841,28 +2889,36 @@
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "hz" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/awaymission/cabin)
 "hA" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/freezer,
 /area/awaymission/cabin)
 "hB" = (
 /obj/machinery/door/airlock{
 	name = "Backstage"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "hC" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet,
 /area/awaymission/cabin)
 "hD" = (
@@ -2874,7 +2930,9 @@
 /obj/machinery/door/airlock{
 	name = "Kitchen"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "hF" = (
@@ -2889,7 +2947,9 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "hH" = (
@@ -3124,7 +3184,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "io" = (
@@ -3321,7 +3383,9 @@
 	id_tag = "snowdorm1";
 	name = "Cabin 1"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "iW" = (
@@ -3329,7 +3393,9 @@
 	id_tag = "snowdorm2";
 	name = "Cabin 2"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "iX" = (
@@ -3337,7 +3403,9 @@
 	id_tag = "snowdorm3";
 	name = "Cabin 3"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "iY" = (
@@ -3345,7 +3413,9 @@
 	id_tag = "snowdorm4";
 	name = "Cabin 4"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "iZ" = (
@@ -3518,7 +3588,9 @@
 	},
 /obj/item/reagent_containers/glass/bottle/cryoxadone,
 /obj/item/reagent_containers/glass/bottle/cryoxadone,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
 /area/awaymission/cabin)
 "jr" = (
@@ -3649,7 +3721,9 @@
 	name = "Generator Room"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "jD" = (
@@ -5450,7 +5524,9 @@
 /turf/open/floor/wood,
 /area/awaymission/cabin)
 "nR" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "nS" = (
@@ -5477,13 +5553,152 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
+/area/awaymission/cabin)
+"nY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/awaymission/cabin)
+"rn" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/awaymission/cabin)
+"rV" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/wood,
+/area/awaymission/cabin)
+"sn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/awaymission/cabin)
+"uk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/awaymission/cabin)
+"uD" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/awaymission/cabin)
+"ww" = (
+/obj/effect/landmark/awaystart,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet,
+/area/awaymission/cabin)
+"wx" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/awaymission/cabin)
+"zF" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/awaymission/cabin)
+"BB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/awaymission/cabin)
+"Co" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/awaymission/cabin)
+"DU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/awaymission/cabin)
+"Fj" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/awaymission/cabin)
+"FH" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/wood,
+/area/awaymission/cabin)
+"Hb" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/carpet,
+/area/awaymission/cabin)
+"He" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/awaymission/cabin)
+"IG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/awaymission/cabin)
+"JZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/awaymission/cabin)
+"KS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/awaymission/cabin)
+"MB" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
 /area/awaymission/cabin)
 "MS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
-/obj/effect/mapping_helpers/network_builder/power_cable/yellow/auto,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "TZ" = (
@@ -5495,6 +5710,37 @@
 /obj/item/clothing/shoes/winterboots/ice_boots,
 /turf/open/floor/plating/ice/smooth,
 /area/awaymission/cabin/caves)
+"UL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/awaymission/cabin)
+"WD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/awaymission/cabin)
+"WX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/awaymission/cabin)
+"WY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/wood,
+/area/awaymission/cabin)
 
 (1,1,1) = {"
 ab
@@ -25696,21 +25942,21 @@ iZ
 aN
 jl
 bb
-bb
-bb
+JZ
+JZ
 eg
 bm
-eg
+Fj
 nS
 an
-eg
+rV
 eg
 eg
 eg
 eg
 eg
 hB
-eg
+Fj
 aq
 an
 cT
@@ -25957,7 +26203,7 @@ az
 az
 aq
 an
-eg
+He
 bh
 an
 cA
@@ -25967,7 +26213,7 @@ an
 an
 hx
 an
-eg
+He
 aq
 an
 cU
@@ -26214,7 +26460,7 @@ az
 az
 aq
 an
-eg
+He
 aq
 an
 aq
@@ -26224,7 +26470,7 @@ aq
 aq
 aq
 an
-eg
+He
 aq
 an
 cV
@@ -26481,11 +26727,11 @@ aq
 aq
 bh
 an
-eg
+He
 bh
 an
 aL
-nR
+BB
 aL
 ed
 an
@@ -26728,17 +26974,17 @@ an
 an
 aR
 an
-eg
+He
 aq
 an
 aq
 aq
-eg
+FH
 aq
 aq
 aq
 an
-eg
+He
 aq
 an
 cU
@@ -26985,21 +27231,21 @@ aH
 an
 an
 an
-eg
+He
 aq
 an
 cz
 aq
-eg
+He
 aq
 aq
 bh
 an
-eg
+He
 aq
 an
 ed
-nR
+BB
 aL
 kE
 an
@@ -27242,7 +27488,7 @@ an
 an
 aS
 hg
-eg
+He
 bh
 an
 nT
@@ -27252,11 +27498,11 @@ bo
 bo
 cB
 an
-eg
+WD
 eg
 bV
-aw
-aw
+sn
+DU
 gM
 an
 an
@@ -27499,17 +27745,17 @@ aH
 an
 an
 an
-eg
+He
 aq
 an
 aO
 aO
 hC
-hC
-hC
-bb
-bb
-eg
+MB
+MB
+JZ
+JZ
+WY
 aq
 an
 eb
@@ -27756,7 +28002,7 @@ an
 an
 aT
 an
-eg
+He
 aq
 an
 az
@@ -27766,7 +28012,7 @@ az
 aq
 aq
 cO
-eg
+He
 bh
 an
 an
@@ -28270,7 +28516,7 @@ az
 az
 aq
 an
-eg
+He
 aq
 an
 aP
@@ -28280,7 +28526,7 @@ nB
 hd
 az
 aO
-eg
+He
 aq
 aq
 an
@@ -28527,7 +28773,7 @@ az
 az
 aq
 an
-eg
+He
 bh
 an
 bq
@@ -28537,7 +28783,7 @@ hc
 hd
 az
 az
-eg
+He
 aq
 aq
 aN
@@ -28780,11 +29026,11 @@ ja
 bp
 jm
 bb
-bb
-bb
+JZ
+JZ
 eg
 iY
-eg
+WY
 aq
 an
 bt
@@ -28794,7 +29040,7 @@ jx
 hd
 az
 cO
-eg
+He
 aq
 aq
 iR
@@ -29041,7 +29287,7 @@ aI
 aA
 jj
 an
-eg
+He
 aq
 an
 cN
@@ -29308,7 +29554,7 @@ az
 aq
 aq
 aO
-eg
+He
 aq
 aq
 an
@@ -29555,17 +29801,17 @@ ju
 au
 ji
 an
-eg
+He
 aq
 an
 de
-de
-de
-de
-de
-bb
-bb
-eg
+uD
+uD
+uD
+uD
+JZ
+JZ
+WY
 bh
 an
 an
@@ -29808,11 +30054,11 @@ jb
 aN
 jn
 bb
-bb
-bb
+JZ
+JZ
 eg
 iX
-eg
+WY
 bh
 an
 hb
@@ -29822,7 +30068,7 @@ eu
 cK
 cD
 an
-eg
+He
 aq
 aq
 an
@@ -30069,7 +30315,7 @@ az
 az
 aq
 an
-eg
+He
 aq
 an
 hn
@@ -30079,7 +30325,7 @@ aq
 aq
 aq
 an
-eg
+He
 aq
 aq
 aN
@@ -30326,7 +30572,7 @@ az
 az
 aq
 an
-eg
+He
 aq
 an
 bv
@@ -30336,7 +30582,7 @@ aq
 ap
 aq
 an
-eg
+He
 aq
 aq
 iU
@@ -30593,7 +30839,7 @@ bu
 an
 eo
 an
-eg
+He
 aq
 aq
 bp
@@ -30840,7 +31086,7 @@ an
 an
 aU
 an
-eg
+He
 aq
 an
 bw
@@ -30848,9 +31094,9 @@ bO
 bO
 bO
 bO
-hz
+Co
 hE
-eg
+WY
 aq
 aq
 an
@@ -31097,7 +31343,7 @@ aH
 an
 an
 an
-eg
+He
 aq
 an
 bx
@@ -31105,9 +31351,9 @@ bO
 cJ
 cF
 cJ
-hz
+nY
 an
-eg
+He
 bh
 an
 an
@@ -31354,7 +31600,7 @@ an
 an
 hf
 hy
-eg
+He
 aq
 an
 by
@@ -31362,9 +31608,9 @@ hz
 hz
 hz
 hz
-hz
+rn
 an
-eg
+He
 aq
 aq
 an
@@ -31611,7 +31857,7 @@ aH
 an
 an
 an
-eg
+He
 bh
 an
 bz
@@ -31619,9 +31865,9 @@ bO
 bW
 ck
 cj
-hz
+nY
 an
-eg
+He
 aq
 aq
 aN
@@ -31868,7 +32114,7 @@ an
 an
 aW
 an
-eg
+He
 aq
 an
 an
@@ -31878,7 +32124,7 @@ an
 an
 hA
 an
-eg
+He
 aq
 aq
 iS
@@ -32133,9 +32379,9 @@ bB
 bX
 cl
 cl
-hi
+uk
 an
-eg
+He
 aq
 aq
 bp
@@ -32382,15 +32628,15 @@ az
 az
 aq
 an
-eg
+He
 aq
 an
 hi
-hi
-hi
-hi
-hi
-hi
+UL
+UL
+UL
+UL
+wx
 an
 hh
 aq
@@ -32639,7 +32885,7 @@ az
 az
 aq
 an
-eg
+He
 aq
 an
 bC
@@ -32649,7 +32895,7 @@ is
 dt
 cG
 an
-eg
+He
 bh
 an
 an
@@ -32892,11 +33138,11 @@ jc
 bp
 jo
 bb
-bb
-bb
+JZ
+JZ
 eg
 iW
-eg
+WY
 aq
 an
 an
@@ -32906,7 +33152,7 @@ an
 an
 an
 an
-eg
+He
 aq
 aq
 an
@@ -33153,7 +33399,7 @@ aI
 aA
 jg
 an
-eg
+He
 aq
 an
 aJ
@@ -33163,7 +33409,7 @@ cv
 hq
 cv
 an
-eg
+He
 aq
 aq
 aN
@@ -33420,7 +33666,7 @@ bE
 bE
 lz
 an
-eg
+He
 aq
 aq
 iT
@@ -33667,7 +33913,7 @@ jw
 au
 jh
 an
-eg
+He
 aq
 an
 bD
@@ -33677,7 +33923,7 @@ cI
 hD
 bE
 nM
-eg
+He
 aq
 aq
 bp
@@ -33920,21 +34166,21 @@ jd
 aN
 jp
 bb
-bb
-bb
+JZ
+JZ
 eg
 iV
-eg
+WY
 aq
 an
 cP
-cP
-cP
-cP
+IG
+IG
+IG
 jq
-cP
-cP
-eg
+IG
+IG
+WY
 aq
 aq
 an
@@ -34181,7 +34427,7 @@ az
 az
 aq
 an
-eg
+He
 aq
 an
 bF
@@ -34191,7 +34437,7 @@ ho
 bE
 lz
 an
-eg
+He
 aq
 an
 an
@@ -34438,7 +34684,7 @@ az
 az
 aq
 an
-eg
+He
 nS
 an
 bF
@@ -34448,7 +34694,7 @@ hp
 js
 hp
 an
-eg
+He
 aq
 an
 dB
@@ -34705,7 +34951,7 @@ an
 an
 an
 an
-eg
+He
 bh
 an
 dB
@@ -34952,7 +35198,7 @@ an
 an
 aU
 an
-eg
+WD
 eg
 nV
 ei
@@ -34962,7 +35208,7 @@ hr
 hs
 et
 nV
-eg
+zF
 aq
 an
 dB
@@ -35466,7 +35712,7 @@ an
 an
 aX
 bf
-bb
+KS
 an
 bj
 bH
@@ -35476,7 +35722,7 @@ aq
 aq
 aq
 io
-bb
+KS
 az
 an
 dB
@@ -35719,11 +35965,11 @@ ax
 an
 aF
 cL
-aw
+sn
 jC
-bb
-bb
-bb
+JZ
+JZ
+Hb
 an
 bk
 bJ
@@ -35987,10 +36233,10 @@ an
 an
 aq
 cp
+rV
 eg
 eg
-eg
-cQ
+ww
 hI
 an
 dB
@@ -36230,8 +36476,8 @@ ac
 ac
 dB
 ax
-ed
-aw
+WX
+DU
 ed
 hv
 an

--- a/_maps/RandomZLevels/away_mission/jungleresort.dmm
+++ b/_maps/RandomZLevels/away_mission/jungleresort.dmm
@@ -2040,7 +2040,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/power/rtg,
 /turf/open/floor/plating,
 /area/awaymission/jungleresort)
 "CA" = (
@@ -3720,7 +3720,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/power/port_gen/pacman/super,
+/obj/machinery/power/rtg,
 /turf/open/floor/plating,
 /area/awaymission/jungleresort)
 "Yb" = (

--- a/_maps/RandomZLevels/away_mission/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/away_mission/undergroundoutpost45.dmm
@@ -815,16 +815,16 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 351.9
+	initial_temperature = 351.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "bX" = (
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 351.9
+	initial_temperature = 351.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "bY" = (
@@ -2263,8 +2263,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "eK" = (
@@ -2634,8 +2634,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/central)
 "fo" = (
@@ -2870,8 +2870,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/central)
 "fK" = (
@@ -3049,8 +3049,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "gg" = (
@@ -3197,8 +3197,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gC" = (
@@ -3411,8 +3411,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/research)
 "he" = (
@@ -3422,8 +3422,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hf" = (
@@ -3454,8 +3454,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hi" = (
@@ -4789,8 +4789,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jM" = (
@@ -4823,8 +4823,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/research)
 "jR" = (
@@ -6606,8 +6606,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mJ" = (
@@ -8072,12 +8072,10 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman{
-	name = "P.A.C.M.A.N.-type portable generator"
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/rtg,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -8086,9 +8084,6 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman/super{
-	name = "S.U.P.E.R.P.A.C.M.A.N.-type portable generator"
-	},
 /obj/item/wrench,
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -8096,6 +8091,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/rtg,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -8104,12 +8100,10 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/power/port_gen/pacman{
-	name = "P.A.C.M.A.N.-type portable generator"
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/rtg,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -8356,8 +8350,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "pv" = (
@@ -8367,8 +8361,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "pw" = (
@@ -8379,8 +8373,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "px" = (
@@ -8670,8 +8664,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "qb" = (
@@ -8902,8 +8896,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "qA" = (
@@ -8913,8 +8907,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "qB" = (
@@ -8924,8 +8918,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "qC" = (
@@ -11106,8 +11100,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "uc" = (
@@ -11752,8 +11746,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "vm" = (
@@ -11978,8 +11972,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/research)
 "vI" = (
@@ -12264,8 +12258,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "wk" = (
@@ -13483,8 +13477,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "yh" = (
@@ -13492,8 +13486,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yi" = (
@@ -13501,8 +13495,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yj" = (
@@ -13512,8 +13506,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yk" = (
@@ -13522,8 +13516,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yl" = (
@@ -13533,8 +13527,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "ym" = (
@@ -13543,8 +13537,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yn" = (
@@ -13552,8 +13546,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yo" = (
@@ -13562,8 +13556,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yp" = (
@@ -13572,8 +13566,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yq" = (
@@ -13581,8 +13575,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yr" = (
@@ -13590,8 +13584,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yt" = (
@@ -13600,8 +13594,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yu" = (
@@ -13610,8 +13604,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yw" = (
@@ -13620,8 +13614,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yz" = (
@@ -13629,8 +13623,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yA" = (
@@ -13639,8 +13633,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yB" = (
@@ -13648,8 +13642,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yC" = (
@@ -13658,8 +13652,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yD" = (
@@ -13669,8 +13663,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "yH" = (
@@ -13680,8 +13674,8 @@
 /turf/open/floor/plating/asteroid{
 	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
-	name = "Cave Floor";
-	initial_temperature = 363.9
+	initial_temperature = 363.9;
+	name = "Cave Floor"
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "KE" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the wiring in the Snow Cabin gateway, as well as giving Snow Cabin, Jungle Resort, and Plasma Outpost RTGs instead of PACMEN, due to the fact that they lose power unless someone goes in and sets it up early.
Xenomorph Hive is not affected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It'd be nice to have content that doesn't disable itself over time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Snow Cabin turbine
tweak: Snow Cabin, Jungle Resort, and Plasma Outpost gateways now use RTGs for power generation
balance: Snow Cabin SMES unit is now non-magical
fix: Snow Cabin gateway wiring now connected properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
