### PR TITLE
Puts public library paintings in Omegastation's library instead of generic empty ones

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -23914,7 +23914,7 @@
 	c_tag = "Library 2";
 	dir = 4
 	},
-/obj/structure/sign/painting{
+/obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark/side{
@@ -23925,6 +23925,9 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
+/obj/structure/sign/painting/library{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)
 "aRV" = (
@@ -23994,6 +23997,9 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark/side{
@@ -24955,6 +24961,9 @@
 /area/maintenance/port/aft)
 "aUj" = (
 /obj/machinery/photocopier,
+/obj/structure/sign/painting/library{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
 	},
@@ -26434,7 +26443,7 @@
 /turf/closed/wall,
 /area/service/library)
 "aXg" = (
-/obj/structure/sign/painting{
+/obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark/side{
@@ -26443,6 +26452,9 @@
 /area/service/library)
 "aXh" = (
 /obj/machinery/light,
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)
 "aXi" = (
@@ -26460,7 +26472,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aXj" = (
-/obj/structure/sign/painting{
+/obj/structure/sign/painting/library{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
@@ -26472,6 +26484,9 @@
 /obj/machinery/camera{
 	c_tag = "Library 1";
 	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 10
@@ -35443,8 +35458,8 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
-/obj/structure/sign/painting{
-	pixel_x = -32
+/obj/structure/sign/painting/library{
+	step_x = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -35459,7 +35459,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /obj/structure/sign/painting/library{
-	step_x = -32
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds public library paintings to Omegastation instead of the empty ones.

## Why It's Good For The Game

You can now submit paintings that will persist in later rounds on Omega, and therefore have another meaningful thing to do on that lowpop map.

## Changelog
:cl:
qol: Public library paintings have been added to Omegastation. You can now submit paintings that will appear in later rounds on that station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
