### PR TITLE
Shocked autolathe will no longer infinitely zap you with the menu open

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -62,13 +62,14 @@
 	if(!is_operational())
 		return
 
-	if(shocked && !(stat & NOPOWER))
-		shock(user,50)
-
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Autolathe", capitalize(src.name))
 		ui.open()
+
+	if(shocked && !(stat & NOPOWER))
+		if(shock(user,50))
+			ui.close() //close the window if they got zapped successfully as to prevent them from getting zapped infinitely.
 
 /obj/machinery/autolathe/ui_data(mob/user)
 	var/list/data = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If the autolathe zaps you via the window being opened, it closes the window.

## Why It's Good For The Game

No more getting shocked into crit.

## Changelog
:cl:
fix: The shocked autolathe will no longer infinitely zap you with the menu open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
