### PR TITLE
Enables proper "green shifts" (goals, sec level) in dynamic

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -342,9 +342,6 @@ GLOBAL_LIST_INIT(pda_reskins, list(PDA_SKIN_CLASSIC = 'icons/obj/pda.dmi', PDA_S
 
 #define INCREMENT_TALLY(L, stat) if(L[stat]){L[stat]++}else{L[stat] = 1}
 
-//TODO Move to a pref
-#define STATION_GOAL_BUDGET  1
-
 //Endgame Results
 #define NUKE_NEAR_MISS 1
 #define NUKE_MISS_STATION 2

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -274,10 +274,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 				. += "<b>Peaceful Waypoint</b></center><BR>"
 				. += "Your station orbits deep within controlled, core-sector systems and serves as a waypoint for routine traffic through Nanotrasen's trade empire. Due to the combination of high security, interstellar traffic, and low strategic value, it makes any direct threat of violence unlikely. Your primary enemies will be incompetence and bored crewmen: try to organize team-building events to keep staffers interested and productive."
 				green_shift = TRUE
-				for(var/T in subtypesof(/datum/station_goal))
-					var/datum/station_goal/G = new T
-					station_goals += G
-					G.on_report()
 			else
 				. += "<b>Core Territory</b></center><BR>"
 				. += "Your station orbits within reliably mundane, secure space. Although Nanotrasen has a firm grip on security in your region, the valuable resources and strategic position aboard your station make it a potential target for infiltrations. Monitor crew for non-loyal behavior, but expect a relatively tame shift free of large-scale destruction. We expect great things from your station."

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -267,12 +267,13 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 /datum/game_mode/dynamic/send_intercept()
 	. = "<b><i>Central Command Status Summary</i></b><hr>"
+	var/green_shift = FALSE
 	switch(round(shown_threat))
 		if(0 to 19)
 			if(!current_players[CURRENT_LIVING_ANTAGS].len)
 				. += "<b>Peaceful Waypoint</b></center><BR>"
 				. += "Your station orbits deep within controlled, core-sector systems and serves as a waypoint for routine traffic through Nanotrasen's trade empire. Due to the combination of high security, interstellar traffic, and low strategic value, it makes any direct threat of violence unlikely. Your primary enemies will be incompetence and bored crewmen: try to organize team-building events to keep staffers interested and productive."
-				lower_security_level(SEC_LEVEL_GREEN)
+				green_shift = TRUE
 				for(var/T in subtypesof(/datum/station_goal))
 					var/datum/station_goal/G = new T
 					station_goals += G
@@ -280,28 +281,22 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			else
 				. += "<b>Core Territory</b></center><BR>"
 				. += "Your station orbits within reliably mundane, secure space. Although Nanotrasen has a firm grip on security in your region, the valuable resources and strategic position aboard your station make it a potential target for infiltrations. Monitor crew for non-loyal behavior, but expect a relatively tame shift free of large-scale destruction. We expect great things from your station."
-				raise_security_level(SEC_LEVEL_BLUE)
 		if(20 to 39)
 			. += "<b>Anomalous Exogeology</b></center><BR>"
 			. += "Although your station lies within what is generally considered Nanotrasen-controlled space, the course of its orbit has caused it to cross unusually close to exogeological features with anomalous readings. Although these features offer opportunities for our research department, it is known that these little understood readings are often correlated with increased activity from competing interstellar organizations and individuals, among them the Wizard Federation and Cult of the Geometer of Blood - all known competitors for Anomaly Type B sites. Exercise elevated caution."
-			raise_security_level(SEC_LEVEL_BLUE)
 		if(40 to 65)
 			. += "<b>Contested System</b></center><BR>"
 			. += "Your station's orbit passes along the edge of Nanotrasen's sphere of influence. While subversive elements remain the most likely threat against your station, hostile organizations are bolder here, where our grip is weaker. Exercise increased caution against elite Syndicate strike forces, or Executives forbid, some kind of ill-conceived unionizing attempt."
-			raise_security_level(SEC_LEVEL_BLUE)
 		if(66 to 79)
 			. += "<b>Uncharted Space</b></center><BR>"
 			. += "Congratulations and thank you for participating in the NT 'Frontier' space program! Your station is actively orbiting a high value system far from the nearest support stations. Little is known about your region of space, and the opportunity to encounter the unknown invites greater glory. You are encouraged to elevate security as necessary to protect Nanotrasen assets."
-			raise_security_level(SEC_LEVEL_BLUE)
 		if(80 to 99)
 			. += "<b>Black Orbit</b></center><BR>"
 			. += "As part of a mandatory security protocol, we are required to inform you that as a result of your orbital pattern directly behind an astrological body (oriented from our nearest observatory), your station will be under decreased monitoring and support. It is anticipated that your extreme location and decreased surveillance could pose security risks. Avoid unnecessary risks and attempt to keep your station in one piece."
-			raise_security_level(SEC_LEVEL_BLUE)
 		if(100)
 			. += "<b>Impending Doom</b></center><BR>"
 			. += "Your station is somehow in the middle of hostile territory, in clear view of any enemy of the corporation. Your likelihood to survive is low, and station destruction is expected and almost inevitable. Secure any sensitive material and neutralize any enemy you will come across. It is important that you at least try to maintain the station.<BR>"
 			. += "Good luck."
-			raise_security_level(SEC_LEVEL_AMBER)
 
 	if(station_goals.len)
 		. += "<hr><b>Special Orders for [station_name()]:</b>"
@@ -310,7 +305,11 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			. += G.get_report()
 
 	print_command_report(., "Central Command Status Summary", announce=FALSE)
-	priority_announce("A summary has been copied and printed to all communications consoles.", "Enemy communication intercepted. Security level elevated.", "intercept")
+	if(green_shift)
+		priority_announce("Thanks to the tireless efforts of our security and intelligence divisions, there are currently no credible threats to [station_name()]. All station construction projects have been authorized. Have a secure shift!", "Security Report", "commandreport")
+	else
+		priority_announce("A summary has been copied and printed to all communications consoles.", "Enemy communication intercepted. Security level elevated.", "intercept")
+
 
 /datum/game_mode/dynamic/proc/show_threatlog(mob/admin)
 	if(!SSticker.HasRoundStarted())

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -257,6 +257,14 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			return rule.round_result()
 	return ..()
 
+/datum/game_mode/dynamic/generate_station_goals()
+	if(shown_threat > 19 || length(current_players[CURRENT_LIVING_ANTAGS]))
+		. = ..()
+	else
+		for(var/T in subtypesof(/datum/station_goal))
+			var/datum/station_goal/G = new T
+			station_goals += G
+
 /datum/game_mode/dynamic/send_intercept()
 	. = "<b><i>Central Command Status Summary</i></b><hr>"
 	switch(round(shown_threat))
@@ -264,25 +272,36 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			if(!current_players[CURRENT_LIVING_ANTAGS].len)
 				. += "<b>Peaceful Waypoint</b></center><BR>"
 				. += "Your station orbits deep within controlled, core-sector systems and serves as a waypoint for routine traffic through Nanotrasen's trade empire. Due to the combination of high security, interstellar traffic, and low strategic value, it makes any direct threat of violence unlikely. Your primary enemies will be incompetence and bored crewmen: try to organize team-building events to keep staffers interested and productive."
+				lower_security_level(SEC_LEVEL_GREEN)
+				for(var/T in subtypesof(/datum/station_goal))
+					var/datum/station_goal/G = new T
+					station_goals += G
+					G.on_report()
 			else
 				. += "<b>Core Territory</b></center><BR>"
 				. += "Your station orbits within reliably mundane, secure space. Although Nanotrasen has a firm grip on security in your region, the valuable resources and strategic position aboard your station make it a potential target for infiltrations. Monitor crew for non-loyal behavior, but expect a relatively tame shift free of large-scale destruction. We expect great things from your station."
+				raise_security_level(SEC_LEVEL_BLUE)
 		if(20 to 39)
 			. += "<b>Anomalous Exogeology</b></center><BR>"
 			. += "Although your station lies within what is generally considered Nanotrasen-controlled space, the course of its orbit has caused it to cross unusually close to exogeological features with anomalous readings. Although these features offer opportunities for our research department, it is known that these little understood readings are often correlated with increased activity from competing interstellar organizations and individuals, among them the Wizard Federation and Cult of the Geometer of Blood - all known competitors for Anomaly Type B sites. Exercise elevated caution."
+			raise_security_level(SEC_LEVEL_BLUE)
 		if(40 to 65)
 			. += "<b>Contested System</b></center><BR>"
 			. += "Your station's orbit passes along the edge of Nanotrasen's sphere of influence. While subversive elements remain the most likely threat against your station, hostile organizations are bolder here, where our grip is weaker. Exercise increased caution against elite Syndicate strike forces, or Executives forbid, some kind of ill-conceived unionizing attempt."
+			raise_security_level(SEC_LEVEL_BLUE)
 		if(66 to 79)
 			. += "<b>Uncharted Space</b></center><BR>"
 			. += "Congratulations and thank you for participating in the NT 'Frontier' space program! Your station is actively orbiting a high value system far from the nearest support stations. Little is known about your region of space, and the opportunity to encounter the unknown invites greater glory. You are encouraged to elevate security as necessary to protect Nanotrasen assets."
+			raise_security_level(SEC_LEVEL_BLUE)
 		if(80 to 99)
 			. += "<b>Black Orbit</b></center><BR>"
 			. += "As part of a mandatory security protocol, we are required to inform you that as a result of your orbital pattern directly behind an astrological body (oriented from our nearest observatory), your station will be under decreased monitoring and support. It is anticipated that your extreme location and decreased surveillance could pose security risks. Avoid unnecessary risks and attempt to keep your station in one piece."
+			raise_security_level(SEC_LEVEL_BLUE)
 		if(100)
 			. += "<b>Impending Doom</b></center><BR>"
 			. += "Your station is somehow in the middle of hostile territory, in clear view of any enemy of the corporation. Your likelihood to survive is low, and station destruction is expected and almost inevitable. Secure any sensitive material and neutralize any enemy you will come across. It is important that you at least try to maintain the station.<BR>"
 			. += "Good luck."
+			raise_security_level(SEC_LEVEL_AMBER)
 
 	if(station_goals.len)
 		. += "<hr><b>Special Orders for [station_name()]:</b>"
@@ -292,8 +311,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 	print_command_report(., "Central Command Status Summary", announce=FALSE)
 	priority_announce("A summary has been copied and printed to all communications consoles.", "Enemy communication intercepted. Security level elevated.", "intercept")
-	if(GLOB.security_level < SEC_LEVEL_BLUE)
-		set_security_level(SEC_LEVEL_BLUE)
 
 /datum/game_mode/dynamic/proc/show_threatlog(mob/admin)
 	if(!SSticker.HasRoundStarted())

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -258,12 +258,12 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	return ..()
 
 /datum/game_mode/dynamic/generate_station_goals()
-	if(shown_threat > 19 || length(current_players[CURRENT_LIVING_ANTAGS]))
-		. = ..()
-	else
-		for(var/T in subtypesof(/datum/station_goal))
-			var/datum/station_goal/G = new T
-			station_goals += G
+	if(round(shown_threat) < 30)
+		if(length(current_players[CURRENT_LIVING_ANTAGS]))
+			station_goal_budget = 2
+		else if(round(shown_threat < 20))
+			station_goal_budget = INFINITY
+	return ..()
 
 /datum/game_mode/dynamic/send_intercept()
 	. = "<b><i>Central Command Status Summary</i></b><hr>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -52,6 +52,8 @@
 	var/setup_error		//What stopepd setting up the mode.
 	var/flipseclevel = FALSE //CIT CHANGE - adds a 10% chance for the alert level to be the opposite of what the gamemode is supposed to have
 
+	var/station_goal_budget = 1 // how many station goals are allowed in this mode
+
 	/// Associative list of current players, in order: living players, living antagonists, dead players and observers.
 	var/list/list/current_players = list(CURRENT_LIVING_PLAYERS = list(), CURRENT_LIVING_ANTAGS = list(), CURRENT_DEAD_PLAYERS = list(), CURRENT_OBSERVERS = list())
 
@@ -593,7 +595,7 @@
 			continue
 		possible += T
 	var/goal_weights = 0
-	while(possible.len && goal_weights < STATION_GOAL_BUDGET)
+	while(possible.len && goal_weights < station_goal_budget)
 		var/datum/station_goal/picked = pick_n_take(possible)
 		goal_weights += initial(picked.weight)
 		station_goals += new picked

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -13,6 +13,14 @@ GLOBAL_LIST_INIT(all_security_levels, list("green", "blue", "amber", "red", "del
 
 //config.alert_desc_blue_downto
 
+/proc/raise_security_level(level)
+	if(GLOB.security_level < level)
+		set_security_level(level)
+
+/proc/lower_security_level(level)
+	if(GLOB.security_level > level)
+		set_security_level(level)
+
 /proc/set_security_level(level)
 	if(!isnum(level))
 		level = GLOB.all_security_levels.Find(level)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Lower threat levels can have more station goals: below 30, you'll always have at least 2.
2. Modes can now set their own station goal budgets. All of them are 1 for now, except dynamic, which has a different one depending on threat level (extended hardcoded gets every station goal, still).
3. "Peaceful Waypoint" dynamic rounds are greenshifts for all intents and purposes now: they have ever station goal and start in green alert instead of blue.

## Why It's Good For The Game

Well, people keep asking for this. I guess it's for something to keep busy on in long rounds, but, like, I'm an atmos tech main, so, uh, I entertain myself automatically and thus might need more feedback.

## Changelog
:cl:
add: Dynamic greenshifts
code: STATION_GOAL_BUDGET define changed to a gamemode-level var
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
