### PR TITLE
Rebalances some events

### DIFF
--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -2,7 +2,6 @@
 	name = "Anomaly: Hyper-Energetic Flux"
 	typepath = /datum/round_event/anomaly/anomaly_flux
 
-	min_players = 10
 	max_occurrences = 5
 	weight = 20
 

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -2,6 +2,7 @@
 	name = "Anomaly: Pyroclastic"
 	typepath = /datum/round_event/anomaly/anomaly_pyro
 
+	min_players = 5
 	max_occurrences = 5
 	weight = 20
 

--- a/code/modules/events/atmos_speed.dm
+++ b/code/modules/events/atmos_speed.dm
@@ -3,11 +3,11 @@
 	typepath = /datum/round_event/atmos_flux
 	max_occurrences = 5
 	weight = 10
-	endWhen = 600
-	var/original_speed
 
 /datum/round_event/atmos_flux
 	announceWhen = 1
+	endWhen = 600
+	var/original_speed
 
 /datum/round_event/atmos_flux/announce(fake)
 	priority_announce("Atmospheric flux in your sector detected. Sensors show that air may move [(SSair.share_max_steps_target > original_speed) ? "faster" : "slower"] than usual for some time.", "Atmos Alert")

--- a/code/modules/events/atmos_speed.dm
+++ b/code/modules/events/atmos_speed.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/atmos_flux
 	name = "Atmospheric Flux"
 	typepath = /datum/round_event/atmos_flux
-	max_occurrences = 1
-	weight = 5
+	max_occurrences = 5
+	weight = 10
 	endWhen = 600
 	var/original_speed
 

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -6,7 +6,7 @@
 
 /datum/round_event_control/brain_trauma/canSpawnEvent(var/players_amt, var/gamemode)
 	if(!..()) return FALSE
-	var/list/enemy_roles = list("Medical Doctor","Chief Medical Officer","Paramedic")
+	var/list/enemy_roles = list("Medical Doctor","Chief Medical Officer","Paramedic","AI","Chemist","Virologist","Captain","Head of Personnel","Roboticist")
 	for (var/mob/M in GLOB.alive_mob_list)
 		if(M.stat != DEAD && (M.mind?.assigned_role in enemy_roles))
 			return TRUE

--- a/code/modules/events/cat_surgeon.dm
+++ b/code/modules/events/cat_surgeon.dm
@@ -2,7 +2,7 @@
     name = "Cat Surgeon"
     typepath = /datum/round_event/cat_surgeon
     max_occurrences = 1
-    weight = 8
+    weight = 5
 
 /datum/round_event/cat_surgeon/announce(fake)
 	priority_announce("One of our... ahem... 'special' cases has escaped. As it happens their last known location before their tracker went dead is your station so keep an eye out for them. On an unrelated note, has anyone seen our cats?",

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -2,7 +2,7 @@
 	name = "Disease Outbreak"
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 1
-	min_players = 10
+	min_players = 3
 	weight = 5
 
 /datum/round_event/disease_outbreak
@@ -12,6 +12,13 @@
 
 	var/max_severity = 3
 
+/datum/round_event_control/disease_outbreak/canSpawnEvent(var/players_amt, var/gamemode)
+	if(!..()) return FALSE
+	var/list/enemy_roles = list("Medical Doctor","Chief Medical Officer","Paramedic","AI","Chemist","Virologist","Captain","Head of Personnel", "Geneticist")
+	for (var/mob/M in GLOB.alive_mob_list)
+		if(M.stat != DEAD && (M.mind?.assigned_role in enemy_roles))
+			return TRUE
+	return FALSE
 
 /datum/round_event/disease_outbreak/announce(fake)
 	priority_announce("Confirmed outbreak of level 7 viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", "outbreak7")
@@ -22,7 +29,10 @@
 
 /datum/round_event/disease_outbreak/start()
 	var/advanced_virus = FALSE
-	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
+	var/player_count = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
+	max_severity = 1 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
+	max_severity += player_count > 5
+	max_severity += player_count > 10
 	if(prob(20 + (10 * max_severity)))
 		advanced_virus = TRUE
 

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -17,9 +17,10 @@
 /datum/round_event_control/sandstorm
 	name = "Sandstorm"
 	typepath = /datum/round_event/sandstorm
-	weight = 0
-	max_occurrences = 0
-	earliest_start = 0 MINUTES
+	weight = 5
+	max_occurrences = 1
+	min_players = 5
+	earliest_start = 20 MINUTES
 
 /datum/round_event/sandstorm
 	startWhen = 1

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -1,9 +1,17 @@
 /datum/round_event_control/heart_attack
 	name = "Random Heart Attack"
 	typepath = /datum/round_event/heart_attack
-	weight = 20
+	weight = 10
 	max_occurrences = 2
-	min_players = 40 // To avoid shafting lowpop
+	min_players = 10 // To avoid shafting lowpop
+
+/datum/round_event_control/heart_attack/canSpawnEvent(var/players_amt, var/gamemode)
+	if(!..()) return FALSE
+	var/list/enemy_roles = list("Medical Doctor","Chief Medical Officer","Paramedic","Chemist")
+	for (var/mob/M in GLOB.alive_mob_list)
+		if(M.stat != DEAD && (M.mind?.assigned_role in enemy_roles))
+			return TRUE
+	return FALSE
 
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -2,7 +2,7 @@
 	name = "Mass Hallucination"
 	typepath = /datum/round_event/mass_hallucination
 	weight = 10
-	max_occurrences = 2
+	max_occurrences = 5
 	min_players = 1
 	var/forced_hallucination
 

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -2,7 +2,7 @@
 	name = "Supermatter Surge"
 	typepath = /datum/round_event/supermatter_surge
 	weight = 20
-	max_occurrences = 4
+	max_occurrences = 5
 	earliest_start = 10 MINUTES
 
 /datum/round_event_control/supermatter_surge/canSpawnEvent()
@@ -37,7 +37,7 @@
 
 /datum/round_event/supermatter_surge/start()
 	var/obj/machinery/power/supermatter_crystal/supermatter = GLOB.main_supermatter_engine
-	var/power_proportion = supermatter.powerloss_inhibitor/2 // what % of the power goes into matter power, at most 50%
+	var/power_proportion = supermatter.powerloss_inhibitor * 0.75 // what % of the power goes into matter power, at most 50%
 	// we reduce the proportion that goes into actual matter power based on powerloss inhibitor
 	// primarily so the supermatter doesn't tesla the instant these happen
 	supermatter.matter_power += power * power_proportion

--- a/code/modules/events/supernova.dm
+++ b/code/modules/events/supernova.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/supernova
 	name = "Supernova"
 	typepath = /datum/round_event/supernova
-	weight = 10
-	max_occurrences = 2
+	weight = 5
+	max_occurrences = 1
 	min_players = 2
 
 /datum/round_event/supernova

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -3,7 +3,6 @@
 	typepath = /datum/round_event/vent_clog
 	weight = 10
 	max_occurrences = 3
-	min_players = 25
 
 /datum/round_event/vent_clog
 	announceWhen	= 1
@@ -11,7 +10,7 @@
 	endWhen			= 35
 	var/interval 	= 2
 	var/list/vents  = list()
-	var/randomProbability = 1
+	var/randomProbability = 0
 	var/reagentsAmount = 100
 	var/list/saferChems = list(
 		/datum/reagent/water,
@@ -92,7 +91,7 @@
 
 	var/datum/reagents/R = new/datum/reagents(1000)
 	R.my_atom = vent
-	if (prob(randomProbability))
+	if (randomProbability && prob(randomProbability))
 		R.add_reagent(get_random_reagent_id(), reagentsAmount)
 	else
 		R.add_reagent(pick(saferChems), reagentsAmount)
@@ -106,7 +105,7 @@
 	name = "Clogged Vents: Threatening"
 	typepath = /datum/round_event/vent_clog/threatening
 	weight = 4
-	min_players = 35
+	min_players = 15
 	max_occurrences = 1
 	earliest_start = 35 MINUTES
 
@@ -118,7 +117,7 @@
 	name = "Clogged Vents: Catastrophic"
 	typepath = /datum/round_event/vent_clog/catastrophic
 	weight = 2
-	min_players = 45
+	min_players = 25
 	max_occurrences = 1
 	earliest_start = 45 MINUTES
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2109,6 +2109,7 @@
 #include "code\modules\events\anomaly_grav.dm"
 #include "code\modules\events\anomaly_pyro.dm"
 #include "code\modules\events\anomaly_vortex.dm"
+#include "code\modules\events\atmos_speed.dm"
 #include "code\modules\events\aurora_caelus.dm"
 #include "code\modules\events\blob.dm"
 #include "code\modules\events\brain_trauma.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some events required just way too many players at minimum. This lowers them.

- Flux anomaly
  - Min player count 10->0
- Pyroclastic anomaly
  - Min player count 0->5
- Atmospheric flux
  - Makes gas move quicker or slower for a while
  - Enabled (whoops, it was in the files but never ticked)
  - Weight 5->10
- Random brain trauma
  - Can now trigger if there's an AI, chemist, virologist, captain, HoP or roboticist, as well MD, CMO, paramedic
- Cat surgeon
  - Weight 8->5
- Disease outbreak
  - Min players 10->3
  - Needs anyone with chemistry access or who can give chemistry access to fire
  - Disease outbreaks at low pop (<5, <10) will be less severe
- Sandstorm
  - It's just space dust x10, it's not as bad as major dust storm
  - Weight 0->5
  - Max occurrences 0->1
  - Min players 0->1
  - Earliest start 0->20 minutes
- Heart attack
  - Min players 40->10
  - Requires MD, CMO, Paramedic or Chemist
- Mass hallucination
  - Max occurrences 2->5
- Supermatter surge
  - Max occurrences 4->5
  - Now more weighted towards power increase rather than burping hot gas, though this approaches its old value with increasing CO2 proportion
- Supernova
  - Weight 10->5
  - Max occurrences 2->1
- Vent clog
  - Normal
    - Min players 25->0
    - Probability of completely random (rather than whitelisted) chem 1%->0%
  - Threatening
    - Min players 35->15
  - Catastrophic
    - Min players 45->25
    
## Why It's Good For The Game

I mean, a lot of these were just way too high. What's up with vent clog? Anyway, here's the reasoning for each change:

- Flux anomalies cause an explosion with a small breach when they pop. This isn't really that bad, and can be handled by even one player.
- Pyroclastic anomalies are worse than flux anomalies, straight-up. They cause more of a mess before they pop and cause *just as much* of a mess when they do. They should not be considered less threatening than flux anomalies, not in their current state.
- Atmospheric flux not being enabled was a mistake, first off. Anyway, it's a low-impact event that fills out the pool with more, uh, interesting stuff.
- Random brain trauma is annoying, but the changes made it a bit rare for how annoying it is. Now you can still be sure *someone* can handle it, but it's more likely to happen.
- Cat surgeon's weight of 8 is higher than, say, spiders, but it has a lower min player count. This is a bit funny, since cat surgeon is, to be frank, *more dangerous* than spiders. The real oddity is that all of these have the same weight as xenos, but hey.
- Disease outbreak's high minimum players is mostly to prevent low pop from getting screwed over. Requiring certain roles does this, too, so that's been introduced. Just as an extra bit, it also lowers the severity of the disease if there are few players.
- Sandstorm just isn't that bad, might as well allow it.
- Heart attack is not much worse than appendicitis and the stated reason is "not to screw low pop". The idea that 40 players is low pop is kinda funny, isn't it? The weight was definitely real high for the danger, though.
- Mass hallucination is low-impact, sure, but there's no particular reason to limit it to only two, especially since it's funny.
- Supermatter surges can blow up "basic" setups due to the quantity/heat of the gas that goes in, which was really not my intent. Now basic setups are half-strength on this metric. CO2 setups, however, should be a challenge, and as such are unchanged.
- Supernova is just way, way too long-lasting and annoying to be so common and to potentially happen *twice* in one round.
- Vent clog requiring 25 players was, frankly, ridiculous, even with a 1% chance of completely random chemicals. Vent Clog: Catastrophic's numbers suggested it's the *most dangerous event that can possibly happen*, being 5 times as rare as blob and requiring 10 more players. I don't even know what to say about that.

## Changelog
:cl:
add: Atmospheric flux event (properly)
add: Sandstorm event (was in files, just disabled; 10 space dusts all at once)
tweak: Random brain trauma can now trigger if there's an AI, chemist, virologist, captain, HoP or roboticist
balance: Flux anomaly min player count 10->0
balance: Pyroclastic anomaly min player count 0->5
balance: Cat surgeon weight 8->5
balance: Disease outbreak min player count 10->3, now requires medbay
balance: Heart attack min player count 40->10, now requires medbay
balance: Mass hallucination max occurrences 2->5
balance: Supermatter surge max occurrences 2->5, now half as strong on CO2less setups (lerping up to old value for 100% CO2)
balance: Supernova max occurrences 2->1, weight 10->5
balance: Vent Clog: Normal min players 25->0, random chem prob 1%->0%
balance: Vent Clog: Threatening min players 35->15
balance: Vent Clog: Catastrophic min players 45->25
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
