### PR TITLE
Untied shoes: a minor event of little consequence

### DIFF
--- a/code/modules/events/untie_shoes.dm
+++ b/code/modules/events/untie_shoes.dm
@@ -15,7 +15,7 @@
 			continue
 		if(C.stat == DEAD)
 			continue
-		if (HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
+		if (HAS_TRAIT(C,TRAIT_EXEMPT_HEALTH_EVENTS))
 			continue
 		if(!C.shoes || !C.shoes.can_be_tied || C.shoes.tied != SHOES_TIED)
 			continue

--- a/code/modules/events/untie_shoes.dm
+++ b/code/modules/events/untie_shoes.dm
@@ -1,0 +1,28 @@
+/datum/round_event_control/untied_shoes
+	name = "Untied Shoes"
+	typepath = /datum/round_event/untied_shoes
+	weight = 100
+	max_occurrences = 20
+	alert_observers = FALSE
+
+/datum/round_event/untied_shoes
+	fakeable = FALSE
+
+/datum/round_event/untied_shoes/start()
+	var/iterations = 1
+	for(var/mob/living/carbon/C in shuffle(GLOB.alive_mob_list))
+		if(!C.client)
+			continue
+		if(C.stat == DEAD)
+			continue
+		if (HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
+			continue
+		if(!C.shoes || !C.shoes.can_be_tied || C.shoes.tied != SHOES_TIED)
+			continue
+		if(prob(5))
+			C.shoes.adjust_laces(SHOES_KNOTTED)
+		else
+			C.shoes.adjust_laces(SHOES_UNTIED)
+		iterations++
+		if(prob(100/iterations))
+			return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2155,6 +2155,7 @@
 #include "code\modules\events\supermatter_surge.dm"
 #include "code\modules\events\supernova.dm"
 #include "code\modules\events\travelling_trader.dm"
+#include "code\modules\events\untie_shoes.dm"
 #include "code\modules\events\vent_clog.dm"
 #include "code\modules\events\wisdomcow.dm"
 #include "code\modules\events\wormholes.dm"


### PR DESCRIPTION
## About The Pull Request

Adds an event that happens randomly with no fanfare that unties ~2 peoples' shoes (on average). 5% chance of knotting them instead.

## Why It's Good For The Game

It's kinda funny and more minor events of little consequence are good actually

## Changelog
:cl:
add: Random shoe untying
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
