### PR TITLE
Fixes rad collectors to use correct units

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -182,7 +182,7 @@
 	. = ..()
 	if(active)
 		if(!bitcoinmining)
-			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayEnergy(stored_power)]</b>, and is processing <b>[DisplayPower((RAD_COLLECTOR_OUTPUT)*(1 SECONDS/SSmachines.wait))]</b>. <br>The <b>plasma</b> within it's tank is being irradiated into <b>tritium</b>.</span>"
+			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayEnergy(stored_power)]</b>, and is processing <b>[DisplayPower((RAD_COLLECTOR_OUTPUT)*((1 SECONDS)/SSmachines.wait))]</b>. <br>The <b>plasma</b> within it's tank is being irradiated into <b>tritium</b>.</span>"
 		else
 			. += "<span class='notice'>[src]'s display states that it's producing a total of <b>[(last_push*RAD_COLLECTOR_MINING_CONVERSION_RATE)*((60 SECONDS)/SSmachines.wait)]</b> research points per minute. <br>The <b>tritium</b> and <b>oxygen</b> within it's tank is being combusted into <b>carbon dioxide</b>.</span>"
 	else

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -182,7 +182,7 @@
 	. = ..()
 	if(active)
 		if(!bitcoinmining)
-			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayEnergy(stored_power)]</b>, and is processing <b>[DisplayPower((RAD_COLLECTOR_OUTPUT)SSmachines.wait))]</b>. <br>The <b>plasma</b> within it's tank is being irradiated into <b>tritium</b>.</span>"
+			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayEnergy(stored_power)]</b>, and is processing <b>[DisplayPower((RAD_COLLECTOR_OUTPUT)*(1 SECONDS/SSmachines.wait))]</b>. <br>The <b>plasma</b> within it's tank is being irradiated into <b>tritium</b>.</span>"
 		else
 			. += "<span class='notice'>[src]'s display states that it's producing a total of <b>[(last_push*RAD_COLLECTOR_MINING_CONVERSION_RATE)*((60 SECONDS)/SSmachines.wait)]</b> research points per minute. <br>The <b>tritium</b> and <b>oxygen</b> within it's tank is being combusted into <b>carbon dioxide</b>.</span>"
 	else

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -182,7 +182,7 @@
 	. = ..()
 	if(active)
 		if(!bitcoinmining)
-			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayPower(stored_power)]</b>, and is processing <b>[DisplayPower((RAD_COLLECTOR_OUTPUT)*((60 SECONDS)/SSmachines.wait))]</b> per minute. <br>The <b>plasma</b> within it's tank is being irradiated into <b>tritium</b>.</span>"
+			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayEnergy(stored_power)]</b>, and is processing <b>[DisplayPower((RAD_COLLECTOR_OUTPUT)SSmachines.wait))]</b>. <br>The <b>plasma</b> within it's tank is being irradiated into <b>tritium</b>.</span>"
 		else
 			. += "<span class='notice'>[src]'s display states that it's producing a total of <b>[(last_push*RAD_COLLECTOR_MINING_CONVERSION_RATE)*((60 SECONDS)/SSmachines.wait)]</b> research points per minute. <br>The <b>tritium</b> and <b>oxygen</b> within it's tank is being combusted into <b>carbon dioxide</b>.</span>"
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

imagine this is as condescending as possible: it's not storing megawatts, it's storing megajoules, and it's not processing "megawatts per minute", it's just processing... megawatts.

## Why It's Good For The Game

clarity

## Changelog
:cl:
fix: rad collectors display the right units now
/:cl: