### PR TITLE
Makes stasis beds fine for surgery

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -123,6 +123,8 @@
 
 	if(locate(/obj/structure/table/optable, T))
 		propability = 1
+	else if(locate(/obj/machinery/stasis))
+		propability = 0.9
 	else if(locate(/obj/structure/table, T))
 		propability = 0.8
 	else if(locate(/obj/structure/bed, T))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Legitimately I think it was just missed in the porting? It's definitely [intended that stasis beds can be used for surgery.](https://github.com/tgstation/tgstation/blob/686c0a828068612a7e2efed346157d576c6e5e3b/code/modules/surgery/surgery.dm#L128). I didn't even port allowing advanced surgeries on them.

## Why It's Good For The Game

Stasis beds are cool but not being able to finish surgery on them is mildly questionable. This allows you to finish on them, even if you don't start on them.

## Changelog
:cl:
balance: Stasis beds are now 90% as good as surgery tables for surgery
/:cl: