### PR TITLE
Fixes Gateway Power (For Realz)

### DIFF
--- a/_maps/RandomZLevels/away_mission/SnowCabin.dmm
+++ b/_maps/RandomZLevels/away_mission/SnowCabin.dmm
@@ -190,21 +190,17 @@
 /area/awaymission/cabin)
 "aD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/smes{
-	charge = 1.5e+006;
-	input_level = 30000;
-	inputting = 0;
-	output_level = 7000
-	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/smes/magical,
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "aE" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/baseturf_helper/asteroid/snow,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -2864,6 +2860,9 @@
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 26
+	},
 /turf/open/floor/plating,
 /area/awaymission/cabin)
 "hw" = (

--- a/_maps/RandomZLevels/away_mission/jungleresort.dmm
+++ b/_maps/RandomZLevels/away_mission/jungleresort.dmm
@@ -1992,6 +1992,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/oil/streak,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/awaymission/jungleresort)
 "BP" = (
@@ -2811,12 +2812,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes{
-	charge = 1.5e+006;
-	input_level = 30000;
-	inputting = 0;
-	output_level = 7000
-	},
+/obj/machinery/power/smes/magical,
 /turf/open/floor/plating,
 /area/awaymission/jungleresort)
 "LR" = (
@@ -3183,6 +3179,9 @@
 /obj/item/stack/sheet/mineral/uranium,
 /obj/item/clothing/glasses/meson/engine,
 /obj/item/storage/belt/utility,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 26
+	},
 /turf/open/floor/plating,
 /area/awaymission/jungleresort)
 "Rm" = (

--- a/_maps/RandomZLevels/away_mission/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/away_mission/undergroundoutpost45.dmm
@@ -6221,6 +6221,7 @@
 	c_tag = "Engineering Secure Storage";
 	network = list("uo45")
 	},
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -7751,12 +7752,7 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "ou" = (
 /obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 1.5e+006;
-	input_level = 30000;
-	inputting = 0;
-	output_level = 7000
-	},
+/obj/machinery/power/smes/magical,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the power issue in these three gateways:
Snow Cabin
Jungle Resort
Underground (Plasma) Outpost

By putting down Magical SMES Units.
As far as I'm aware, this is functionally the same as making the area not need a generator to have power, which we have other gateways do. (Please correct me if I'm wrong however!)
The SMES Units deconstruct into regular SMES Unit boards as well, so there is no risk of taking them onto the station or elsewhere for easy power.

However, I cannot test this as gateways will not load on Local for me.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It turns out RTGs output way way less power than I thought, making the issue Worse.
Yes even when upgraded.
My bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Three gateways will no longer lose power via Magical SMES Units
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
