### PR TITLE
Another minor bomb points nerf

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -76,6 +76,6 @@
 #define LARGEST_BOMB				"bomb"
 
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
-#define BOMB_TARGET_SIZE			(world.system_type == MS_WINDOWS ? 240 : 50000) // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
+#define BOMB_TARGET_SIZE			300 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
 // Linux still has old trit fires, so
 #define BOMB_SUB_TARGET_EXPONENT	3 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -76,6 +76,6 @@
 #define LARGEST_BOMB				"bomb"
 
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
-#define BOMB_TARGET_SIZE			300 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
+#define BOMB_TARGET_SIZE			(world.system_type == MS_WINDOWS ? 300 : 5000) // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
 // Linux still has old trit fires, so
 #define BOMB_SUB_TARGET_EXPONENT	3 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -76,6 +76,6 @@
 #define LARGEST_BOMB				"bomb"
 
 #define BOMB_TARGET_POINTS			50000 //Adjust as needed. Actual hard cap is double this, but will never be reached due to hyperbolic curve.
-#define BOMB_TARGET_SIZE			(world.system_type == MS_WINDOWS ? 300 : 5000) // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
+#define BOMB_TARGET_SIZE			300 // The shockwave radius required for a bomb to get TECHWEB_BOMB_MIDPOINT points.
 // Linux still has old trit fires, so
 #define BOMB_SUB_TARGET_EXPONENT	3 // The power of the points curve below the target size. Higher = less points for worse bombs, below target.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

240 midpoint to 300 midpoint. Most of the trit bombs I see are around 330 or whatever, so ~50,000 points should be around ~300 rather than 240.

## Why It's Good For The Game

Bombs are a bit too strong, though only 4-5 minutes of research worth. Either way, goal is to keep them about as strong as before.

## Changelog
:cl:
balance: Research bomb "midpoint" at which it's worth exactly 50000 points from 240->300
code: doesn't snowflake the bomb cap for linux anymore, servers that need to tweak it can do it themselves (I didn't even put it down right, should be 5000 instead of 50000, yikes)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
