### PR TITLE
Some tweaks to untied shoelaces (+ miner boots minor buff)

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -213,6 +213,7 @@
 	heat_protection = FEET|LEGS
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
+	lace_time = 10 SECONDS
 
 /obj/item/clothing/shoes/cult
 	name = "\improper Nar'Sien invoker boots"

--- a/code/modules/events/untie_shoes.dm
+++ b/code/modules/events/untie_shoes.dm
@@ -21,7 +21,7 @@
 			continue
 		if(!is_station_level(C.z) && prob(50))
 			continue
-		if(prob(5)
+		if(prob(5))
 			C.shoes.adjust_laces(SHOES_KNOTTED)
 			budget -= C.shoes.lace_time // doubling up on the budget removal on purpose
 		else

--- a/code/modules/events/untie_shoes.dm
+++ b/code/modules/events/untie_shoes.dm
@@ -19,6 +19,8 @@
 			continue
 		if(!C.shoes || !C.shoes.can_be_tied || C.shoes.tied != SHOES_TIED || C.shoes.lace_time > budget)
 			continue
+		if(!is_station_level(C.z) && prob(50))
+			continue
 		budget -= C.shoes.lace_time
 		if(budget < 5 SECONDS)
 			return

--- a/code/modules/events/untie_shoes.dm
+++ b/code/modules/events/untie_shoes.dm
@@ -21,6 +21,11 @@
 			continue
 		if(!is_station_level(C.z) && prob(50))
 			continue
+		if(prob(5)
+			C.shoes.adjust_laces(SHOES_KNOTTED)
+			budget -= C.shoes.lace_time // doubling up on the budget removal on purpose
+		else
+			C.shoes.adjust_laces(SHOES_UNTIED)
 		budget -= C.shoes.lace_time
 		if(budget < 5 SECONDS)
 			return

--- a/code/modules/events/untie_shoes.dm
+++ b/code/modules/events/untie_shoes.dm
@@ -9,7 +9,7 @@
 	fakeable = FALSE
 
 /datum/round_event/untied_shoes/start()
-	var/iterations = 1
+	var/budget = rand(5 SECONDS,20 SECONDS)
 	for(var/mob/living/carbon/C in shuffle(GLOB.alive_mob_list))
 		if(!C.client)
 			continue
@@ -17,12 +17,8 @@
 			continue
 		if (HAS_TRAIT(C,TRAIT_EXEMPT_HEALTH_EVENTS))
 			continue
-		if(!C.shoes || !C.shoes.can_be_tied || C.shoes.tied != SHOES_TIED)
+		if(!C.shoes || !C.shoes.can_be_tied || C.shoes.tied != SHOES_TIED || C.shoes.lace_time > budget)
 			continue
-		if(prob(5))
-			C.shoes.adjust_laces(SHOES_KNOTTED)
-		else
-			C.shoes.adjust_laces(SHOES_UNTIED)
-		iterations++
-		if(prob(100/iterations))
+		budget -= C.shoes.lace_time
+		if(budget < 5 SECONDS)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Instead of harmonic probabilities, the untied shoelaces now generates a budget and subtracts from that budget. If a pair of shoes would be above the budget, it's ignored. The budget is based on the lace time. The average amount of untied shoelaces should now be about 2.5 (rather than the old *e*, i.e. 2.718), although slightly less due to the fact that harder shoes remove more from the budget.

Also, anyone not on the station Z level has a 50% chance of being skipped anyway.

Also, miner work boots have had their lace time increased from 5 seconds to 10 seconds. This reduces their chance of being caught in the event a bit and otherwise does little.

## Why It's Good For The Game

Miners falling over and just friggin' dying because of a random event isn't very fun.

## Changelog
:cl:
tweak: Untied shoelaces probabilities rework
balance: Miner boots are slightly harder to tie/untie now
/:cl:
