### PR TITLE
Nitric oxide second pass (+ some prettiness stuff in the UI)

### DIFF
--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -135,12 +135,13 @@
 	id = GAS_NITRIC
 	specific_heat = 20
 	name = "Nitric oxide"
-	flags = GAS_FLAG_DANGEROUS
 	odor = "sharp sweetness"
 	odor_strength = 1
 	fusion_power = 15
 	enthalpy = 91290
 	heat_resistance = 2
+	powermix = -1
+	heat_penalty = -1
 
 /datum/gas/nitryl
 	id = GAS_NITRYL

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -729,11 +729,11 @@
 /datum/gas_reaction/nitric_oxide/react(datum/gas_mixture/air, datum/holder)
 	var/nitric = air.get_moles(GAS_NITRIC)
 	var/oxygen = air.get_moles(GAS_O2)
-	var/max_amount = max(nitric / 10, MINIMUM_MOLE_COUNT)
-	var/enthalpy = air.return_temperature() * (air.heat_capacity() + R_IDEAL_GAS_EQUATION * air.total_moles());
+	var/max_amount = max(nitric / 8, MINIMUM_MOLE_COUNT)
+	var/enthalpy = air.return_temperature() * (air.heat_capacity() + R_IDEAL_GAS_EQUATION * air.total_moles())
 	var/list/enthalpies = GLOB.gas_data.enthalpies
 	if(oxygen > MINIMUM_MOLE_COUNT)
-		var/reaction_amount = min(max_amount, oxygen)
+		var/reaction_amount = min(max_amount, oxygen)/4
 		air.adjust_moles(GAS_NITRIC, -reaction_amount*2)
 		air.adjust_moles(GAS_O2, -reaction_amount)
 		air.adjust_moles(GAS_NITRYL, reaction_amount*2)

--- a/tgui/packages/tgui/constants.js
+++ b/tgui/packages/tgui/constants.js
@@ -182,6 +182,12 @@ const GASES = [
     'color': 'red',
   },
   {
+    'id': 'no',
+    'name': 'Nitric Oxide',
+    'label': 'NO',
+    'color': 'red',
+  },
+  {
     'id': 'no2',
     'name': 'Nitryl',
     'label': 'NO₂',
@@ -222,6 +228,24 @@ const GASES = [
     'name': 'Hydrogen',
     'label': 'H₂',
     'color': 'white',
+  },
+  {
+    'id': 'methane',
+    'name': 'Methane',
+    'label': 'CH₄',
+    'color': 'grey',
+  },
+  {
+    'id': 'methyl_bromide',
+    'name': 'Methyl Bromide',
+    'label': 'CH₃Br',
+    'color': 'brown',
+  },
+  {
+    'id': 'qcd',
+    'name': 'Quark Matter',
+    'label': 'QGP',
+    'color': 'pink',
   },
 ];
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I didn't make nitric oxide remove powermix like nitrogen does; this was actually an oversight, and makes supermatter delaminations where it gets hot a bit harder to deal with.

Nitric oxide having its full name when nitrogen dioxide and nitrous oxide don't in the filters was ugly, so I've fixed that ("Nitric Oxide" -> "NO")

Nitric oxide just made too much nitrogen dioxide. I increased the rate at which nitric oxide decomposes into nitrogen/oxygen, but simultaneously decreased the rate at which it turns into nitrogen dioxide in the presence of oxygen.

I also added shortenings for methane and methyl bromide while I was at it, plus colors for all these in the supermatter.

## Why It's Good For The Game

Polish polish.

## Changelog
:cl:
tweak: Various gases now have shortened names for filters
balance: Nitric oxide now removes from the power mix like nitrogen/pluoxium do
balance: Nitric oxide now becomes, at most, 20% nitrogen dioxide instead of 50%
/:cl: