### PR TITLE
crusher UNIQUE_RENAME + 350 chr limit custom descs

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -19,6 +19,7 @@
 	attack_verb = list("smashed", "crushed", "cleaved", "chopped", "pulped")
 	sharpness = SHARP_EDGED
 	actions_types = list(/datum/action/item_action/toggle_light)
+	obj_flags = UNIQUE_RENAME
 	var/list/trophies = list()
 	var/charged = TRUE
 	var/charge_time = 15

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -173,7 +173,7 @@
 				O.renamedByPlayer = TRUE
 
 		if(penchoice == "Change description")
-			var/input = stripped_input(user,"Describe [O] here:", ,"[O.desc]", 140)
+			var/input = stripped_input(user,"Describe [O] here:", ,"[O.desc]", 350)
 			var/olddesc = O.desc
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return


### PR DESCRIPTION
## About The Pull Request
allows crushers to have their name/desc changed via pen
also increases custom descs to 350 characters because 140 characters is a bit limiting
## Why It's Good For The Game
i want to give stupid reference names to my melee mining tool
## Changelog
:cl:
tweak: Proto-kinetic crushers and variants can now be renamed via pen.
tweak: Custom descriptions on items tagged with UNIQUE_RENAME can now go to 350 characters, up from 140.
/:cl: