### PR TITLE
skill mod shuffle pr + implied complaining about why dont they reflect the actual skill xp levels themselves

### DIFF
--- a/code/datums/skills/modifiers/job.dm
+++ b/code/datums/skills/modifiers/job.dm
@@ -35,5 +35,8 @@
 /datum/skill_modifier/job/level/wiring/basic
 	level_mod = JOB_SKILL_BASIC
 
+/datum/skill_modifier/job/level/wiring/expert
+	level_mod = JOB_SKILL_EXPERT
+
 /datum/skill_modifier/job/level/dwarfy/blacksmithing
 	target_skills = /datum/skill/level/dwarfy/blacksmithing

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -21,7 +21,7 @@
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_ENG
 
-	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/basic, /datum/skill_modifier/job/affinity/wiring)
+	starting_modifiers = list(/datum/skill_modifier/job/level/wiring, /datum/skill_modifier/job/affinity/wiring)
 
 	display_order = JOB_DISPLAY_ORDER_ATMOSPHERIC_TECHNICIAN
 	threat = 0.5

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -31,7 +31,7 @@
 	paycheck = PAYCHECK_COMMAND
 	paycheck_department = ACCOUNT_ENG
 
-	starting_modifiers = list(/datum/skill_modifier/job/level/wiring, /datum/skill_modifier/job/affinity/wiring)
+	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/expert, /datum/skill_modifier/job/affinity/wiring)
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_ENGINEER
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/paraplegic, /datum/quirk/insanity)

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -34,6 +34,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_RESEARCH_DIRECTOR
+	starting_modifiers = list(/datum/skill_modifier/job/level/wiring)
 	blacklisted_quirks = list(/datum/quirk/mute, /datum/quirk/brainproblems, /datum/quirk/insanity)
 	threat = 5
 

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -18,7 +18,7 @@
 	minimal_access = list(ACCESS_TOX, ACCESS_TOX_STORAGE, ACCESS_RESEARCH, ACCESS_XENOBIOLOGY, ACCESS_MINERAL_STOREROOM)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_SCI
-
+	starting_modifiers = list(/datum/skill_modifier/job/level/wiring/basic)
 	display_order = JOB_DISPLAY_ORDER_SCIENTIST
 	threat = 1.2
 


### PR DESCRIPTION
## About The Pull Request
shuffles skillmods around:
- CE gets expert wire skill
- atmos gets trained wire skill up from basic
- scientist gets basic wire skill up from none
- RD gets trained wire skill up from none

roboticist and station engineer already had trained wire skill

## Why It's Good For The Game
itd b cool if these guys had a groundwork for wiring
## Changelog
:cl:
tweak: Chief engineers now have expert wiring skills, as befitting a crew member of their assumed caliber. Atmos techs also get more wire skill.
tweak: Research directors now have trained wiring skills, and scientists have basic wiring expertise.
/:cl:
