### PR TITLE
radial menu surgery

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -114,11 +114,13 @@
 			to_chat(user, "<span class='notice'>There are no removable organs in [target]'s [parse_zone(target_zone)]!</span>")
 			return -1
 		else
+			var/list/choices = list()
 			for(var/obj/item/organ/O in organs)
 				O.on_find(user)
 				organs -= O
 				organs[O.name] = O
-			I = input("Remove which organ?", "Surgery", null, null) as null|anything in organs
+				choices[O.name] = image(icon = O.icon, icon_state = O.icon_state)
+			I = show_radial_menu(user, target, choices, require_near = TRUE, tooltips = TRUE)
 			if(I && user && target && user.Adjacent(target) && user.get_active_held_item() == tool)
 				I = organs[I]
 				if(!I)

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -114,13 +114,11 @@
 			to_chat(user, "<span class='notice'>There are no removable organs in [target]'s [parse_zone(target_zone)]!</span>")
 			return -1
 		else
-			var/list/choices = list()
 			for(var/obj/item/organ/O in organs)
 				O.on_find(user)
 				organs -= O
 				organs[O.name] = O
-				choices[O.name] = image(icon = O.icon, icon_state = O.icon_state)
-			I = show_radial_menu(user, target, choices, require_near = TRUE, tooltips = TRUE)
+			I = show_radial_menu(user, target, organs, require_near = TRUE, tooltips = TRUE)
 			if(I && user && target && user.Adjacent(target) && user.get_active_held_item() == tool)
 				I = organs[I]
 				if(!I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![dreamseeker_2022-08-12_13-59-49](https://user-images.githubusercontent.com/18472207/184445497-dd5e22d1-31c6-4f2e-a811-ae8e6e3ef428.png)
Radial menu for organ manipulation instead of a text list of contents.
Could possibly add this to other surgeries if I remember anything else that uses a list of organs, but I don't think anything else does?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Looks prettier than a list? I don't know.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: radial menu to organ manipulation surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
