### PR TITLE
Omega Map Tweaks

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -22320,13 +22320,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -23041,6 +23041,9 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -34691,6 +34694,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"bYG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "bZq" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -34920,6 +34937,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"cYu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "dai" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -35078,13 +35107,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"dZa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "dZL" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -35523,20 +35545,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"fMf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "fMP" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -36596,23 +36604,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"jMF" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/command/gateway)
 "jMP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -36644,16 +36635,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"jTh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "jXc" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -36905,13 +36886,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"lbC" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
-/turf/closed/wall,
-/area/medical/medbay/zone3)
 "lcW" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
@@ -37079,21 +37053,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
-"lFU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "lIM" = (
 /turf/closed/wall/rust,
 /area/hallway/primary/aft)
+"lJs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "lMu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37189,6 +37158,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
+"mje" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mkF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -37238,6 +37221,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"mtk" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "mvB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -37415,6 +37410,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"nul" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/gateway)
 "nvk" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -37514,20 +37526,6 @@
 /obj/machinery/pool/drain,
 /turf/open/pool,
 /area/maintenance/starboard/aft)
-"nXr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit)
 "oaV" = (
 /obj/structure/grille,
 /obj/machinery/meter,
@@ -37870,18 +37868,6 @@
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
-"pus" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "pvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -38138,6 +38124,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"quy" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
+/turf/closed/wall,
+/area/medical/medbay/zone3)
 "qyQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -38281,16 +38274,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/starboard/fore)
-"riz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port/aft)
 "rjQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
@@ -40834,6 +40817,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tMo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "tPn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -79036,7 +79029,7 @@ aMg
 aKM
 aID
 aOU
-riz
+aQc
 ail
 ail
 aFo
@@ -80591,7 +80584,7 @@ bxT
 aYL
 aZH
 bay
-lbC
+quy
 aUn
 aWb
 bdT
@@ -82904,7 +82897,7 @@ aYa
 aYU
 aZQ
 baG
-fMf
+mje
 bbv
 baG
 baG
@@ -86510,7 +86503,7 @@ beL
 nKi
 bfP
 bgp
-pus
+mtk
 bhO
 ibv
 biX
@@ -87505,7 +87498,7 @@ azT
 aAZ
 aCg
 ank
-dZa
+lJs
 aly
 aFX
 aGX
@@ -88272,7 +88265,7 @@ acx
 axf
 oyD
 aRz
-jTh
+tMo
 sJN
 aRz
 aRz
@@ -89564,7 +89557,7 @@ sGy
 sHb
 aRz
 bxM
-lFU
+cYu
 axW
 aae
 sIU
@@ -90077,7 +90070,7 @@ aRz
 aSD
 sHd
 aRz
-nXr
+bYG
 bsC
 sIG
 aRz
@@ -90582,7 +90575,7 @@ bvg
 xMZ
 uIq
 pcD
-jMF
+nul
 kQz
 xWb
 sEQ

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -23788,16 +23788,13 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aRG" = (
@@ -24341,7 +24338,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/vending/tool,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aSQ" = (
@@ -33164,6 +33161,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bjH" = (
@@ -34327,6 +34325,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
 	},
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_x = -28
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "bwW" = (
@@ -34763,18 +34765,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"cfN" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "cgb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35064,6 +35054,20 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engineering/atmos)
+"dIK" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dMl" = (
 /obj/structure/sign/warning/fire,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -35097,20 +35101,6 @@
 	dir = 4
 	},
 /area/maintenance/starboard/aft)
-"dTv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dXv" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -35155,6 +35145,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"ebS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "eew" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -35768,16 +35765,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"gFl" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "gGq" = (
 /obj/machinery/mass_driver{
 	dir = 4;
@@ -35823,6 +35810,13 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/starboard/fore)
+"gMF" = (
+/mob/living/simple_animal/slime,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "gNH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -35840,6 +35834,12 @@
 /obj/machinery/vr_sleeper,
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
+"gRa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "gRe" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -36013,20 +36013,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
-"hFK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit)
 "hGN" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/exile,
@@ -36157,6 +36143,20 @@
 "hVE" = (
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"hWW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "hXc" = (
 /turf/closed/wall/rust,
 /area/science/mixing)
@@ -36251,12 +36251,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"iEe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "iGT" = (
 /turf/closed/wall,
 /area/service/lawoffice)
@@ -36530,13 +36524,6 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
-"jtR" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
-/turf/closed/wall,
-/area/medical/medbay/zone3)
 "jtZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -36875,12 +36862,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"kFg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "kHA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -37089,6 +37070,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"lBN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lCg" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -37167,9 +37160,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
-"lXh" = (
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "lXk" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
@@ -37188,16 +37178,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"mbS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "mdx" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -37565,6 +37545,13 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/maintenance/disposal/incinerator)
+"nWW" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
+/turf/closed/wall,
+/area/medical/medbay/zone3)
 "nXb" = (
 /obj/machinery/pool/drain,
 /turf/open/pool,
@@ -37802,6 +37789,9 @@
 	dir = 1
 	},
 /area/science/mixing)
+"pej" = (
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "pgH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -37947,6 +37937,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"pDm" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/gateway)
 "pEt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/starboard/fore";
@@ -38224,13 +38231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
-"qLm" = (
-/mob/living/simple_animal/slime,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "qMr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38296,6 +38296,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"rbN" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "ria" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
@@ -38321,6 +38333,16 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"rll" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rlq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -38417,18 +38439,6 @@
 /obj/item/lighter,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
-"sdl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "sdL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -38476,23 +38486,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"soK" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/command/gateway)
 "spw" = (
 /obj/machinery/computer/bank_machine,
 /turf/open/floor/circuit/green,
@@ -38580,6 +38573,12 @@
 "sxC" = (
 /turf/closed/wall/r_wall/rust,
 /area/ai_monitored/turret_protected/ai)
+"syb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "syC" = (
 /turf/closed/wall/r_wall/rust,
 /area/command/teleporter)
@@ -38660,6 +38659,16 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/central)
+"sCW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "sDl" = (
 /turf/closed/wall/rust,
 /area/commons/dorms)
@@ -40781,16 +40790,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall/rust,
 /area/engineering/atmos)
-"tcq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "tdN" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -40839,13 +40838,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/lawoffice)
-"trb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "ttp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -41304,18 +41296,6 @@
 /mob/living/simple_animal/opossum/poppy,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"uZn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "ver" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -41876,6 +41856,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xjR" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
+"xlL" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "xoR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/monkeycubes,
@@ -80679,7 +80681,7 @@ bxT
 aYL
 aZH
 bay
-jtR
+nWW
 aUn
 aWb
 bdT
@@ -82992,7 +82994,7 @@ aYa
 aYU
 aZQ
 baG
-dTv
+dIK
 bbv
 baG
 baG
@@ -85828,15 +85830,15 @@ sOV
 bfP
 bgm
 bgY
-lXh
+pej
 ibv
 bgm
 bgY
-lXh
+pej
 ibv
 bgm
 bgY
-lXh
+pej
 bfP
 aad
 jpG
@@ -86083,16 +86085,16 @@ bei
 beL
 aTS
 sKZ
-iEe
+gRa
 bgZ
 bhM
 ibv
-iEe
+gRa
 bgZ
 bhM
 ibv
-iEe
-lXh
+gRa
+pej
 bhM
 sKZ
 aad
@@ -86598,7 +86600,7 @@ beL
 nKi
 bfP
 bgp
-cfN
+rbN
 bhO
 ibv
 biX
@@ -86858,11 +86860,11 @@ bgq
 bhc
 bhP
 bfN
-gFl
+xjR
 pLb
 bhP
 bgc
-uZn
+xlL
 bjq
 bjD
 bgg
@@ -87115,7 +87117,7 @@ bgr
 bhd
 bhQ
 plz
-mbS
+sCW
 jBG
 iVw
 biD
@@ -87593,7 +87595,7 @@ azT
 aAZ
 aCg
 ank
-trb
+ebS
 aly
 aFX
 aGX
@@ -87882,12 +87884,12 @@ ben
 beP
 bfn
 bfP
-iEe
-lXh
+gRa
+pej
 bnS
 ibv
-iEe
-lXh
+gRa
+pej
 bnS
 xFw
 bjb
@@ -88139,13 +88141,13 @@ beo
 aZl
 sPK
 bfP
-kFg
+syb
 bhg
-lXh
+pej
 ibv
 gBW
-qLm
-lXh
+gMF
+pej
 bfP
 bjc
 bjv
@@ -88360,7 +88362,7 @@ acx
 axf
 oyD
 aRz
-tcq
+rll
 sJN
 aRz
 aRz
@@ -88396,13 +88398,13 @@ bep
 aZl
 sPI
 bfP
-lXh
+pej
 bhi
-lXh
+pej
 ibv
-lXh
+pej
 bhi
-lXh
+pej
 sKZ
 bjd
 bjw
@@ -89652,7 +89654,7 @@ sGy
 sHb
 aRz
 bxM
-sdl
+lBN
 axW
 aae
 sIU
@@ -90165,7 +90167,7 @@ aRz
 aSD
 sHd
 aRz
-hFK
+hWW
 bsC
 sIG
 aRz
@@ -90670,7 +90672,7 @@ bvg
 xMZ
 uIq
 pcD
-soK
+pDm
 kQz
 xWb
 sEQ

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -34682,6 +34682,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"bSi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "bVs" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating,
@@ -34694,20 +34706,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"bYG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit)
 "bZq" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -34816,6 +34814,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"cxe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "cBf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34937,18 +34942,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"cYu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "dai" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -35530,6 +35523,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)
+"fHY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "fIN" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -35846,6 +35853,7 @@
 /area/asteroid/nearstation)
 "heH" = (
 /obj/structure/table/reinforced,
+/mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -36172,6 +36180,20 @@
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"irj" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "irp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall/rust,
@@ -36635,6 +36657,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"jWx" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
+/turf/closed/wall,
+/area/medical/medbay/zone3)
 "jXc" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -37056,13 +37085,6 @@
 "lIM" = (
 /turf/closed/wall/rust,
 /area/hallway/primary/aft)
-"lJs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "lMu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -37158,20 +37180,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/command/gateway)
-"mje" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "mkF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -37221,18 +37229,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"mtk" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "mvB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -37255,6 +37251,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/fore)
+"mFa" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/gateway)
 "mJP" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
@@ -37410,23 +37423,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"nul" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/command/gateway)
 "nvk" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -38124,13 +38120,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
-"quy" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
-/turf/closed/wall,
-/area/medical/medbay/zone3)
 "qyQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -38286,6 +38275,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"rmk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rmZ" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood{
@@ -40817,16 +40816,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"tMo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "tPn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -40842,6 +40831,18 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"tUF" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "tWh" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
@@ -80584,7 +80585,7 @@ bxT
 aYL
 aZH
 bay
-quy
+jWx
 aUn
 aWb
 bdT
@@ -82897,7 +82898,7 @@ aYa
 aYU
 aZQ
 baG
-mje
+irj
 bbv
 baG
 baG
@@ -86503,7 +86504,7 @@ beL
 nKi
 bfP
 bgp
-mtk
+tUF
 bhO
 ibv
 biX
@@ -87498,7 +87499,7 @@ azT
 aAZ
 aCg
 ank
-lJs
+cxe
 aly
 aFX
 aGX
@@ -88265,7 +88266,7 @@ acx
 axf
 oyD
 aRz
-tMo
+rmk
 sJN
 aRz
 aRz
@@ -89557,7 +89558,7 @@ sGy
 sHb
 aRz
 bxM
-cYu
+bSi
 axW
 aae
 sIU
@@ -90070,7 +90071,7 @@ aRz
 aSD
 sHd
 aRz
-bYG
+fHY
 bsC
 sIG
 aRz
@@ -90575,7 +90576,7 @@ bvg
 xMZ
 uIq
 pcD
-nul
+mFa
 kQz
 xWb
 sEQ

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1562,10 +1562,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Bridge Center";
-	dir = 1
-	},
 /obj/item/storage/fancy/donut_box,
 /obj/item/clothing/mask/cigarette/cigar/havana{
 	pixel_x = -3
@@ -1869,7 +1865,6 @@
 /turf/closed/wall,
 /area/command/heads_quarters/captain/private)
 "adI" = (
-/obj/structure/filingcabinet,
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
@@ -1881,6 +1876,7 @@
 	dir = 4;
 	name = "command camera"
 	},
+/obj/structure/closet/secure_closet/captains,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "adJ" = (
@@ -1893,16 +1889,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Captain's Quarters";
-	dir = 1
-	},
+/obj/structure/filingcabinet,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -2565,13 +2555,15 @@
 /turf/open/floor/plating,
 /area/cargo/qm)
 "aeS" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/delivery,
-/obj/item/toy/figure/cargotech,
-/turf/open/floor/plasteel,
-/area/cargo/storage)
+/obj/machinery/camera{
+	c_tag = "MiniSat External Southwest";
+	dir = 8;
+	network = list("minisat");
+	start_active = 1
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/asteroid/nearstation)
 "aeT" = (
-/obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/cargo/storage)
@@ -3362,10 +3354,6 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
-	dir = 1
-	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -3455,6 +3443,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/toy/figure/cargotech,
+/obj/structure/closet/crate,
 /turf/open/floor/plasteel,
 /area/cargo/storage)
 "agA" = (
@@ -4092,10 +4082,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/structure/closet/secure_closet/captains,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/cap_wardrobe,
 /turf/open/floor/plasteel/dark,
 /area/command/heads_quarters/captain/private)
 "ahI" = (
@@ -5287,7 +5277,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "ajO" = (
@@ -7293,6 +7282,13 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/button/door{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_x = -25;
+	pixel_y = 7;
+	req_access_txt = "10"
+	},
 /turf/open/floor/plasteel,
 /area/command/heads_quarters/ce)
 "anw" = (
@@ -8093,6 +8089,9 @@
 /obj/item/stack/cable_coil/white,
 /obj/item/hand_labeler,
 /obj/item/hand_labeler_refill,
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
 "aoO" = (
@@ -8462,12 +8461,6 @@
 "aps" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
-	},
-/obj/machinery/button/door{
-	id = "engstorage";
-	name = "Engineering Secure Storage Control";
-	pixel_y = 24;
-	req_access_txt = "10"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -8854,6 +8847,9 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
@@ -11951,7 +11947,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/commons/toilet/restrooms)
 "avx" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
@@ -11959,6 +11954,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/dark/side,
 /area/engineering/atmos)
 "avy" = (
@@ -18082,8 +18078,9 @@
 	},
 /obj/machinery/door/window/southright,
 /obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
@@ -19083,6 +19080,10 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westright{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "aIQ" = (
@@ -19758,6 +19759,11 @@
 /obj/item/reagent_containers/food/snacks/grown/pumpkin,
 /obj/item/reagent_containers/food/snacks/grown/grapes,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
 "aJW" = (
@@ -21798,7 +21804,7 @@
 	name = "Cloning Lab";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "aNR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -23042,10 +23048,6 @@
 "aPX" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
-	},
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway South-West";
-	dir = 1
 	},
 /turf/open/floor/plasteel{
 	heat_capacity = 1e+006
@@ -25230,6 +25232,10 @@
 	name = "Virology Access";
 	req_access_txt = "39"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
 "aUL" = (
@@ -25832,7 +25838,7 @@
 	name = "Crematorium";
 	req_access_txt = "27"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aVZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26220,6 +26226,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aWJ" = (
@@ -26247,8 +26256,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = 24;
+	req_access_txt = "39"
 	},
 /turf/open/floor/plasteel,
 /area/medical/virology)
@@ -26264,6 +26277,10 @@
 	name = "Virology Access";
 	req_access_txt = "39"
 	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "aWN" = (
@@ -26276,7 +26293,7 @@
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "aWO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -26418,7 +26435,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
@@ -26428,6 +26444,13 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = -24;
+	req_access_txt = "39"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aXe" = (
@@ -26435,6 +26458,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/white{
 	icon_state = "1-8"
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -26800,10 +26826,6 @@
 /area/medical/medbay/zone3)
 "aXQ" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
 	pixel_y = 24
@@ -26820,6 +26842,11 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/gun/syringe/dart,
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXR" = (
@@ -27224,7 +27251,7 @@
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "aYK" = (
 /obj/effect/turf_decal/delivery,
@@ -27254,6 +27281,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aYN" = (
@@ -27340,7 +27368,7 @@
 	name = "Medbay";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "aYU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27683,7 +27711,7 @@
 	name = "Medbay Storage";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "aZG" = (
 /obj/structure/cable/white{
@@ -27819,7 +27847,7 @@
 	name = "Medbay";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "aZQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -28190,11 +28218,15 @@
 /area/medical/medbay/zone3)
 "bay" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
@@ -28886,6 +28918,7 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/bot,
+/obj/item/bot_assembly/cleanbot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bbN" = (
@@ -29060,15 +29093,15 @@
 	},
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/zone3)
 "bce" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -29123,6 +29156,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "bck" = (
@@ -29132,10 +29170,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Desk";
-	req_access_txt = "5"
+	id_tag = "MedbayFoyer";
+	name = "Paramedic's Office";
+	req_access_txt = "5;6;12;64"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bcl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29521,9 +29560,7 @@
 	},
 /area/medical/medbay/zone3)
 "bda" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
+/obj/machinery/suit_storage_unit/paramedic,
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -29532,7 +29569,6 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -29545,17 +29581,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bdc" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -30132,7 +30161,7 @@
 	name = "Surgery Theatre";
 	req_access_txt = "45"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/zone3)
 "bdU" = (
 /obj/machinery/firealarm{
@@ -30181,23 +30210,23 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_x = -26;
 	pixel_y = -26
+	},
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
 /area/medical/medbay/zone3)
 "bdY" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -30205,16 +30234,27 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	frequency = 1485;
+	listening = 0;
+	name = "Station Intercom (Medbay)";
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bdZ" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = -26
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -30225,23 +30265,23 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/paramedic,
+/obj/machinery/camera{
+	c_tag = "Paramedic Disbatch";
+	dir = 10;
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bea" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = 6
+/obj/machinery/camera{
+	c_tag = "MiniSat External South";
+	dir = 6;
+	network = list("minisat");
+	start_active = 1
 	},
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/syringe,
-/obj/machinery/door/window/westleft{
-	name = "Medbay Desk";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/medical/medbay/zone3)
+/turf/open/space/basic,
+/area/space)
 "beb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/white,
@@ -31613,9 +31653,6 @@
 	dir = 4
 	},
 /area/hallway/primary/aft)
-"bgm" = (
-/turf/open/floor/plasteel/dark,
-/area/science/xenobiology)
 "bgn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -31912,11 +31949,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bgZ" = (
 /mob/living/simple_animal/slime,
-/turf/open/floor/circuit/green,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bha" = (
 /obj/structure/cable/white{
@@ -31946,7 +31983,6 @@
 	},
 /area/science/xenobiology)
 "bhc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -31959,10 +31995,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bhd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -31981,16 +32019,19 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bhg" = (
-/turf/open/floor/circuit/green,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bhi" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bhj" = (
 /obj/effect/turf_decal/sand/plating,
@@ -32247,7 +32288,7 @@
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "bhN" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -32637,7 +32678,7 @@
 	name = "Chapel Quarters";
 	req_access_txt = "27"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/grimy,
 /area/service/chapel/main)
 "biI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32676,7 +32717,7 @@
 	name = "Chapel Office";
 	req_access_txt = "27"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/service/chapel/main)
 "biN" = (
 /obj/machinery/light_switch{
@@ -32850,7 +32891,7 @@
 	name = "server vent";
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bje" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
@@ -32863,7 +32904,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bjf" = (
 /obj/structure/dresser,
@@ -33014,13 +33055,13 @@
 /area/science/xenobiology)
 "bjw" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bjx" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bjy" = (
 /obj/machinery/airalarm{
@@ -33105,7 +33146,7 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bjI" = (
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bjJ" = (
 /obj/machinery/photocopier,
@@ -33695,7 +33736,7 @@
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "boD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34800,9 +34841,6 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35040,6 +35078,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"dZa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "dZL" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -35171,12 +35216,12 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
@@ -35478,6 +35523,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"fMf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fMP" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -35666,7 +35725,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "gGq" = (
 /obj/machinery/mass_driver{
@@ -36472,9 +36531,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jCi" = (
@@ -36539,6 +36596,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"jMF" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/gateway)
 "jMP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -36570,6 +36644,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"jTh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "jXc" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -36821,6 +36905,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"lbC" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
+/turf/closed/wall,
+/area/medical/medbay/zone3)
 "lcW" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
@@ -36988,6 +37079,18 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
+"lFU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lIM" = (
 /turf/closed/wall/rust,
 /area/hallway/primary/aft)
@@ -37411,10 +37514,24 @@
 /obj/machinery/pool/drain,
 /turf/open/pool,
 /area/maintenance/starboard/aft)
+"nXr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "oaV" = (
 /obj/structure/grille,
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "ogx" = (
@@ -37753,6 +37870,18 @@
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"pus" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "pvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
@@ -37829,15 +37958,13 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "pMh" = (
@@ -38154,6 +38281,16 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/starboard/fore)
+"riz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port/aft)
 "rjQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
@@ -38195,6 +38332,9 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -38923,15 +39063,15 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
 /obj/machinery/camera{
 	c_tag = "Departures Hallway";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit)
@@ -39956,6 +40096,12 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/sand/plating,
+/obj/machinery/camera{
+	c_tag = "MiniSat External SouthEast";
+	dir = 4;
+	network = list("minisat");
+	start_active = 1
+	},
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNj" = (
@@ -41435,6 +41581,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/cleanbot{
+	auto_patrol = 1;
+	icon_state = "cleanbot1";
+	name = "Rustbucket"
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -41573,17 +41724,12 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "wUL" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/science/xenobiology)
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel,
+/area/cargo/storage)
 "wWj" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -41828,6 +41974,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -41946,9 +42095,6 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -78890,7 +79036,7 @@ aMg
 aKM
 aID
 aOU
-aQc
+riz
 ail
 ail
 aFo
@@ -80445,7 +80591,7 @@ bxT
 aYL
 aZH
 bay
-aSh
+lbC
 aUn
 aWb
 bdT
@@ -81475,8 +81621,8 @@ aZL
 baC
 aHs
 aSi
-aWK
-aWK
+aSh
+aSh
 aSh
 aVg
 aWa
@@ -82504,7 +82650,7 @@ aXR
 aSh
 aSh
 aWK
-bea
+aWK
 beG
 aUi
 aWv
@@ -82758,7 +82904,7 @@ aYa
 aYU
 aZQ
 baG
-bbv
+fMf
 bbv
 baG
 baG
@@ -84743,7 +84889,7 @@ aad
 aad
 aad
 aad
-aac
+aeS
 aac
 aaa
 sdX
@@ -85592,17 +85738,17 @@ beh
 sKP
 sOV
 bfP
-bgm
+bhg
 bgY
-bgm
+bhg
 ibv
-bgm
+bhg
 bgY
-bgm
+bhg
 ibv
-bgm
+bhg
 bgY
-bgm
+bhg
 bfP
 aad
 jpG
@@ -85774,7 +85920,7 @@ sMV
 sNl
 sNA
 sMr
-aaa
+bea
 aaa
 aae
 aaa
@@ -85849,15 +85995,15 @@ bei
 beL
 aTS
 sKZ
-bgm
+bhg
 bgZ
 bhM
 ibv
-bgm
+bhg
 bgZ
 bhM
 ibv
-bgm
+bhg
 bhg
 bhM
 sKZ
@@ -86364,11 +86510,11 @@ beL
 nKi
 bfP
 bgp
-bhb
+pus
 bhO
 ibv
 biX
-wUL
+bhb
 bhO
 nTi
 jdD
@@ -87359,7 +87505,7 @@ azT
 aAZ
 aCg
 ank
-aly
+dZa
 aly
 aFX
 aGX
@@ -87648,12 +87794,12 @@ ben
 beP
 bfn
 bfP
-bgm
-bgm
+bhg
+bhg
 bnS
 ibv
-bgm
-bgm
+bhg
+bhg
 bnS
 xFw
 bjb
@@ -87905,13 +88051,13 @@ beo
 aZl
 sPK
 bfP
-bgm
 bhg
-bgm
+bhg
+bhg
 ibv
 gBW
 bgZ
-bgm
+bhg
 bfP
 bjc
 bjv
@@ -88126,7 +88272,7 @@ acx
 axf
 oyD
 aRz
-sEK
+jTh
 sJN
 aRz
 aRz
@@ -88162,13 +88308,13 @@ bep
 aZl
 sPI
 bfP
-bgm
+bhg
 bhi
-bgm
+bhg
 ibv
-bgm
+bhg
 bhi
-bgm
+bhg
 sKZ
 bjd
 bjw
@@ -88874,9 +89020,9 @@ aeb
 aeP
 adu
 aec
-aeS
+ajI
 afF
-agx
+wUL
 aii
 adp
 aiL
@@ -89418,7 +89564,7 @@ sGy
 sHb
 aRz
 bxM
-bsC
+lFU
 axW
 aae
 sIU
@@ -89931,7 +90077,7 @@ aRz
 aSD
 sHd
 aRz
-bxM
+nXr
 bsC
 sIG
 aRz
@@ -90436,7 +90582,7 @@ bvg
 xMZ
 uIq
 pcD
-ria
+jMF
 kQz
 xWb
 sEQ

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -31656,6 +31656,12 @@
 	dir = 4
 	},
 /area/hallway/primary/aft)
+"bgm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "bgn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -31675,6 +31681,9 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bgp" = (
@@ -31692,13 +31701,16 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 9
 	},
 /area/science/xenobiology)
 "bgq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -31709,6 +31721,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -31952,6 +31967,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bgZ" = (
@@ -32028,6 +32046,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bhg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bhi" = (
@@ -32834,6 +32855,9 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "biX" = (
@@ -32844,6 +32868,9 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -32994,9 +33021,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bjq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -33005,6 +33029,9 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -34682,18 +34709,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"bSi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "bVs" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating,
@@ -34748,6 +34763,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
+"cfN" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/science/xenobiology)
 "cgb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34814,13 +34841,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/hydroponics)
-"cxe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "cBf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35077,6 +35097,20 @@
 	dir = 4
 	},
 /area/maintenance/starboard/aft)
+"dTv" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -30
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dXv" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -35107,6 +35141,9 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -35523,20 +35560,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/service/library)
-"fHY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/exit)
 "fIN" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -35740,7 +35763,20 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
 /turf/open/floor/engine,
+/area/science/xenobiology)
+"gFl" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gGq" = (
 /obj/machinery/mass_driver{
@@ -35977,6 +36013,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
+"hFK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/exit)
 "hGN" = (
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/exile,
@@ -36180,20 +36230,6 @@
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
-"irj" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "irp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall/rust,
@@ -36215,6 +36251,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"iEe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "iGT" = (
 /turf/closed/wall,
 /area/service/lawoffice)
@@ -36392,6 +36434,9 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
@@ -36485,6 +36530,13 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
+"jtR" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom";
+	pixel_y = 26
+	},
+/turf/closed/wall,
+/area/medical/medbay/zone3)
 "jtZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -36657,13 +36709,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"jWx" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 26
-	},
-/turf/closed/wall,
-/area/medical/medbay/zone3)
 "jXc" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -36830,6 +36875,12 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"kFg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "kHA" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -37116,6 +37167,9 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"lXh" = (
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "lXk" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/delivery,
@@ -37134,6 +37188,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engineering/atmos)
+"mbS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "mdx" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -37251,23 +37315,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/fore)
-"mFa" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/command/gateway)
 "mJP" = (
 /obj/machinery/igniter{
 	id = "Incinerator"
@@ -38177,6 +38224,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/bar/atrium)
+"qLm" = (
+/mob/living/simple_animal/slime,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "qMr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38275,16 +38329,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"rmk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "rmZ" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood{
@@ -38373,6 +38417,18 @@
 /obj/item/lighter,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"sdl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "sdL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -38420,6 +38476,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"soK" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/command/gateway)
 "spw" = (
 /obj/machinery/computer/bank_machine,
 /turf/open/floor/circuit/green,
@@ -40178,6 +40251,7 @@
 	uses = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNr" = (
@@ -40707,6 +40781,16 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall/r_wall/rust,
 /area/engineering/atmos)
+"tcq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "tdN" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -40755,6 +40839,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/service/lawoffice)
+"trb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "ttp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable/white{
@@ -40831,18 +40922,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"tUF" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/science/xenobiology)
 "tWh" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
@@ -41225,6 +41304,18 @@
 /mob/living/simple_animal/opossum/poppy,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"uZn" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "ver" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
@@ -41316,6 +41407,9 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/stripes/line,
 /obj/item/extinguisher/mini,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -80585,7 +80679,7 @@ bxT
 aYL
 aZH
 bay
-jWx
+jtR
 aUn
 aWb
 bdT
@@ -82898,7 +82992,7 @@ aYa
 aYU
 aZQ
 baG
-irj
+dTv
 bbv
 baG
 baG
@@ -85732,17 +85826,17 @@ beh
 sKP
 sOV
 bfP
-bhg
+bgm
 bgY
-bhg
+lXh
 ibv
-bhg
+bgm
 bgY
-bhg
+lXh
 ibv
-bhg
+bgm
 bgY
-bhg
+lXh
 bfP
 aad
 jpG
@@ -85989,16 +86083,16 @@ bei
 beL
 aTS
 sKZ
-bhg
+iEe
 bgZ
 bhM
 ibv
-bhg
+iEe
 bgZ
 bhM
 ibv
-bhg
-bhg
+iEe
+lXh
 bhM
 sKZ
 aad
@@ -86504,7 +86598,7 @@ beL
 nKi
 bfP
 bgp
-tUF
+cfN
 bhO
 ibv
 biX
@@ -86764,11 +86858,11 @@ bgq
 bhc
 bhP
 bfN
-bhP
+gFl
 pLb
 bhP
 bgc
-bhP
+uZn
 bjq
 bjD
 bgg
@@ -87021,7 +87115,7 @@ bgr
 bhd
 bhQ
 plz
-iVw
+mbS
 jBG
 iVw
 biD
@@ -87499,7 +87593,7 @@ azT
 aAZ
 aCg
 ank
-cxe
+trb
 aly
 aFX
 aGX
@@ -87788,12 +87882,12 @@ ben
 beP
 bfn
 bfP
-bhg
-bhg
+iEe
+lXh
 bnS
 ibv
-bhg
-bhg
+iEe
+lXh
 bnS
 xFw
 bjb
@@ -88045,13 +88139,13 @@ beo
 aZl
 sPK
 bfP
+kFg
 bhg
-bhg
-bhg
+lXh
 ibv
 gBW
-bgZ
-bhg
+qLm
+lXh
 bfP
 bjc
 bjv
@@ -88266,7 +88360,7 @@ acx
 axf
 oyD
 aRz
-rmk
+tcq
 sJN
 aRz
 aRz
@@ -88302,13 +88396,13 @@ bep
 aZl
 sPI
 bfP
-bhg
+lXh
 bhi
-bhg
+lXh
 ibv
-bhg
+lXh
 bhi
-bhg
+lXh
 sKZ
 bjd
 bjw
@@ -89558,7 +89652,7 @@ sGy
 sHb
 aRz
 bxM
-bSi
+sdl
 axW
 aae
 sIU
@@ -90071,7 +90165,7 @@ aRz
 aSD
 sHd
 aRz
-fHY
+hFK
 bsC
 sIG
 aRz
@@ -90576,7 +90670,7 @@ bvg
 xMZ
 uIq
 pcD
-mFa
+soK
 kQz
 xWb
 sEQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See changelog.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Parity man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: [Omega] Cleanbot named "Rustbucket" to the Bridge
add: [Omega] Securitron "Pingsky" to AI Sat
add: [Omega] External AI Sat cams around the south
add: [Omega] Unfinished cleanbot to Robotics
add: [Omega] More status displays and AI displays
add: [Omega] Captain's Wardrobe vendor
add: [Omega] Engineering Supermatter Room now has a YouTool
add: [Omega] Hydroponics front desk now has windoors
add: [Omega] Bar monkey Punpun placed at the Bar
add: [Omega] Paramedical room
add: [Omega] Scrubbers to Xenobiology slime pens
add: [Omega] Xenobiology now has one canister of BZ
del: [Omega] Tiny Medbay reception desk
del: [Omega] Overlapping cams and window-sitting cams
del: [Omega] Defibrillator outside of Medbay Surgery
del: [Omega] Rogue isolated power wire under East Maintenence Airlock
tweak: [Omega] Virology now has a cycling airlock
tweak: [Omega] Xenobiology slime pen floors and kill room floor now match other stations
tweak: [Omega] Xenobiology main scrubber and vent shifted around
tweak: [Omega] Medbay intercoms are now largely on the unique frequency other stations use
tweak: [Omega] Certain floors under airlocks now properly match their surroundings
tweak: [Omega] Atmospherics now has layer adaptors
tweak: [Omega] Cargo's starting crates are shifted around to better show which belt goes to the shuttle
tweak: [Omega] Engineering Secure Storage button is now in Chief Engineer's office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
