### PR TITLE
ports "Reworks the sanitize_ooccolor proc"

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -157,10 +157,7 @@
 #undef RGB_FORMAT_SHORT
 #undef RGB_FORMAT_LONG
 
+/// Makes sure the input color is text with a # at the start followed by 6 hexadecimal characters. Examples: "#ff1234", "#A38321", COLOR_GREEN_GRAY
 /proc/sanitize_ooccolor(color)
-	if(length(color) != length_char(color))
-		CRASH("Invalid characters in color '[color]'")
-	var/list/HSL = rgb2hsl(hex2num(copytext(color, 2, 4)), hex2num(copytext(color, 4, 6)), hex2num(copytext(color, 6, 8)))
-	HSL[3] = min(HSL[3],0.4)
-	var/list/RGB = hsl2rgb(arglist(HSL))
-	return "#[num2hex(RGB[1],2)][num2hex(RGB[2],2)][num2hex(RGB[3],2)]"
+	var/static/regex/color_regex = regex(@"^#[0-9a-fA-F]{6}$")
+	return findtext(color, color_regex) ? color : GLOB.normal_ooc_colour

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2453,12 +2453,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("ooccolor")
 					var/new_ooccolor = input(user, "Choose your OOC colour:", "Game Preference",ooccolor) as color|null
 					if(new_ooccolor)
-						ooccolor = new_ooccolor
+						ooccolor = sanitize_ooccolor(new_ooccolor)
 
 				if("aooccolor")
 					var/new_aooccolor = input(user, "Choose your Antag OOC colour:", "Game Preference",ooccolor) as color|null
 					if(new_aooccolor)
-						aooccolor = new_aooccolor
+						aooccolor = sanitize_ooccolor(new_aooccolor)
 
 				if("bag")
 					var/new_backbag = input(user, "Choose your character's style of bag:", "Character Preference")  as null|anything in GLOB.backbaglist

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -108,16 +108,38 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	else
 		GLOB.dooc_allowed = !GLOB.dooc_allowed
 
-/client/proc/set_ooc(newColor as color)
+/client/proc/set_ooc()
 	set name = "Set Player OOC Color"
 	set desc = "Modifies player OOC Color"
 	set category = "Admin.Fun"
-	GLOB.OOC_COLOR = sanitize_ooccolor(newColor)
+	if(IsAdminAdvancedProcCall())
+		return
+	var/newColor = input(src, "Please select the new player OOC color.", "OOC color") as color|null
+	if(isnull(newColor))
+		return
+	if(!check_rights(R_FUN))
+		message_admins("[usr.key] has attempted to use the Set Player OOC Color verb!")
+		log_admin("[key_name(usr)] tried to set player ooc color without authorization.")
+		return
+	var/new_color = sanitize_ooccolor(newColor)
+	message_admins("[key_name_admin(usr)] has set the players' ooc color to [new_color].")
+	log_admin("[key_name_admin(usr)] has set the player ooc color to [new_color].")
+	GLOB.OOC_COLOR = new_color
 
 /client/proc/reset_ooc()
 	set name = "Reset Player OOC Color"
 	set desc = "Returns player OOC Color to default"
 	set category = "Admin.Fun"
+	if(IsAdminAdvancedProcCall())
+		return
+	if(alert(usr, "Are you sure you want to reset the OOC color of all players?", "Reset Player OOC Color", "Yes", "No") != "Yes")
+		return
+	if(!check_rights(R_FUN))
+		message_admins("[usr.key] has attempted to use the Reset Player OOC Color verb!")
+		log_admin("[key_name(usr)] tried to reset player ooc color without authorization.")
+		return
+	message_admins("[key_name_admin(usr)] has reset the players' ooc color.")
+	log_admin("[key_name_admin(usr)] has reset player ooc color.")
 	GLOB.OOC_COLOR = null
 
 /client/verb/colorooc() //this is admin and people who bought byond.
@@ -129,11 +151,12 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 			return
 
 	var/new_ooccolor = input(src, "Please select your OOC color.", "OOC color", prefs.ooccolor) as color|null
-	if(new_ooccolor)
-		prefs.ooccolor = sanitize_ooccolor(new_ooccolor)
-		prefs.save_preferences()
+	if(isnull(new_ooccolor))
+		return
+	new_ooccolor = sanitize_ooccolor(new_ooccolor)
+	prefs.ooccolor = new_ooccolor
+	prefs.save_preferences()
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Set OOC Color") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-	return
 
 /client/verb/resetcolorooc()
 	set name = "Reset Your OOC Color"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/54221 
Effectively removes the luminosity limit on setting OOC colour.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Salt PR that I can't make my OOC colour be a proper shade of pink.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Rohesie
tweak: Admins and byond users can now set their OOC color to light values and it will save in the preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
