### PR TITLE
Glowing goo no longer has persistence

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -126,7 +126,7 @@
 	icon_state = "greenglow"
 	beauty = -300
 	mergeable_decal = TRUE
-	persistent = TRUE
+	persistent = FALSE
 
 /obj/effect/decal/cleanable/greenglow/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

I just learned that it's entirely possible for the crew to treat a certain ghost-role antagonist just like revenants only they fire **REDACTED REAGENT** everywhere from a smoke machine instead of salt.

Glowing goo is removed from persistence in case that ends up becoming _the meta_. It hasn't yet, but since I vaguely mentioned it, someone might try it one day now (and probably irradiate unsuspecting crewmembers)

_Correction: It doesn't work with smoke machines, though it might work with someone dragging around a chem dispenser or someone with a grenade..._

## Changelog
:cl:
balance: Removes persistence from the cleanable glowing goo. It'll no longer last between rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
