### PR TITLE
cauteries searing tools and energy scalpels now have heat and can be used to light cigarettes

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -105,6 +105,7 @@
 	attack_verb = list("burnt")
 	tool_behaviour = TOOL_CAUTERY
 	toolspeed = 1
+	heat = 3500
 
 /obj/item/cautery/attack(mob/living/L, mob/user)
 	if(user.a_intent == INTENT_HELP)
@@ -159,6 +160,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "surgicaldrill_a"
 	hitsound = 'sound/items/welder.ogg'
+	heat = 3500
 
 /obj/item/surgicaldrill/advanced/Initialize(mapload)
 	. = ..()
@@ -234,6 +236,7 @@
 	toolspeed = 0.7
 	light_color = LIGHT_COLOR_GREEN
 	sharpness = SHARP_POINTY
+	heat = 3500
 
 /obj/item/scalpel/advanced/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

webedit pr get trolled
also like heat beakers

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

they have heating elements why can they not

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: cauteries searing tools and energy scalpels now have heat and can be used to light cigarettes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
