### PR TITLE
sandstorm nerf

### DIFF
--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -19,7 +19,7 @@
 	typepath = /datum/round_event/sandstorm
 	weight = 5
 	max_occurrences = 1
-	min_players = 5
+	min_players = 10
 	earliest_start = 20 MINUTES
 
 /datum/round_event/sandstorm
@@ -29,4 +29,4 @@
 	fakeable = FALSE
 
 /datum/round_event/sandstorm/tick()
-	spawn_meteors(10, GLOB.meteorsC)
+	spawn_meteors(rand(6,10), GLOB.meteorsC)

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -28,5 +28,8 @@
 	announceWhen = 0
 	fakeable = FALSE
 
+/datum/round_event/sandstorm/announce(fake)
+	priority_announce("The station is passing through a heavy debris cloud. Watch out for breaches.", "Collision Alert")
+
 /datum/round_event/sandstorm/tick()
 	spawn_meteors(rand(6,10), GLOB.meteorsC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sandstorm now makes 6-10 waves of dust instead of 10 outright and requires 10 players instead of 6. Also, it announces.

## Why It's Good For The Game

sandstorm nerf

Seriously though it's kinda super obnoxious at low pop right now.

## Changelog
:cl:
balance: Sandstorm now happens less often, tends to be less powerful and is announced.
/:cl: