### PR TITLE
Makes binary translator key not show a wrong description

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,7 +11,7 @@
 
 /obj/item/encryptionkey/Initialize(mapload)
 	. = ..()
-	if(!channels.len)
+	if(!length(channels) && !translate_binary)
 		desc = "An encryption key for a radio headset.  Has no special codes in it. You should probably tell a coder!"
 
 /obj/item/encryptionkey/examine(mob/user)
@@ -22,6 +22,8 @@
 			examine_text_list += "[GLOB.channel_tokens[i]] - [lowertext(i)]"
 
 		. += "<span class='notice'>It can access the following channels; [jointext(examine_text_list, ", ")].</span>"
+	if(translate_binary)
+		. += "<span class='notice'>It also allows access to the special binary channel used by silicons."
 
 /obj/item/encryptionkey/syndicate
 	name = "syndicate encryption key"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now it says "An encryption key for a radio headset.  Has no special codes in it. You should probably tell a coder!", because it allows access to no channels... but accessing channels isn't the intent for it, so this is wrong. Now it shows correct stuff.

## Why It's Good For The Game

It confuses and befuddles unnecessarily.

## Changelog
:cl:
fix: Binary translator key now has a proper description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
