### PR TITLE
Fix infinite blood trails

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -709,6 +709,8 @@
 
 	var/bleed_amount = bleedDragAmount()
 	blood_volume = max(blood_volume - bleed_amount, 0) 					//that depends on our brute damage.
+	if(bleed_amount < 0.1)
+		return
 	var/newdir = get_dir(target_turf, start)
 	if(newdir != direction)
 		newdir = newdir | direction


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

sorry, you've done it one too many times

## Why It's Good For The Game

It's for the best that only stuff that actually lowers blood volume speads blood around, given that more blood = higher slaughter demon chance

## Changelog
:cl:
tweak: Infinite blood trails are no longer possible
/:cl: