### PR TITLE
Fixed shuttle runtime

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -891,7 +891,7 @@
 	var/range = (engine_coeff * max(width, height))
 	var/long_range = range * 2.5
 	var/atom/distant_source
-	if(engine_list[1])
+	if(length(engine_list))
 		distant_source = engine_list[1]
 	else
 		for(var/A in areas)


### PR DESCRIPTION
Engine list is empty for custom shuttles.
This doesn't fix that bug but it makes the list check that was already there actually work.
If(list index 1) only works if the list index 1 is null

There's no circumstance in which a strict object list should even have nills in them.