### PR TITLE
Let's just hard cap QCD research output (per burst)

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -768,8 +768,8 @@
 	if(!(GAS_QCD in largest_values))
 		largest_values[GAS_QCD] = 0
 	var/previous_largest = largest_values[GAS_QCD]
-	var/research_amount = amount * QCD_RESEARCH_AMOUNT
-	if(previous_largest < research_amount)
+	var/research_amount = min(amount * QCD_RESEARCH_AMOUNT, 100000)
+	if(previous_largest <= research_amount)
 		SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_amount)
 		largest_values[GAS_QCD] = research_amount
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yeah turns out you can make tens of millions at a time through basic (well, as advanced as literally possible, but STILL) fusion methods, so, uh. nah

## Why It's Good For The Game

Atmos shouldn't be able to trivialize science?? Sorry??

## Changelog
:cl:
balance: Quark matter research is now capped at 100k points per decomp burst
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
