### PR TITLE
Allow AI, mime, clown to have the same name as LITERALLY ANY MOB IN THE WORLD(???)

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -173,10 +173,10 @@ Turf and target are separate in case you want to teleport some distance from a t
 
 	var/banned = jobban_isbanned(src, "appearance")
 
-	while(loop && safety < 5)
-		if(C && C.prefs.custom_names[role] && !safety && !banned)
-			newname = C.prefs.custom_names[role]
-		else
+	if(C && C.prefs.custom_names[role] && !safety && !banned)
+		newname = C.prefs.custom_names[role]
+	else
+		while(loop && safety < 5)
 			switch(role)
 				if("human")
 					newname = random_unique_name(gender)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -173,7 +173,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 
 	var/banned = jobban_isbanned(src, "appearance")
 
-	if(C && C.prefs.custom_names[role] && !safety && !banned)
+	if(C?.prefs?.custom_names[role] && !banned)
 		newname = C.prefs.custom_names[role]
 	else
 		while(loop && safety < 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

yeah turns out the way the apply_pref_name proc was written it renames you automatically if you share a name with ANY MOB, ANYWHERE if you're an AI/mime/borg/clown.

## Why It's Good For The Game

dumb checks for no reason are bad actually!

## Changelog
:cl:
fix: Your custom AI name is no longer stomped if someone decides to name a station pet "Friend" or whatever
/:cl: