### PR TITLE
comfier disks take longer to summon lone ops (they still will though)

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -664,7 +664,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 		if(disk_comfort_level >= 2) //Sleep tight, disky.
 			if(!(process_tick % 30))
 				visible_message("<span class='notice'>[src] sleeps soundly. Sleep tight, disky.</span>")
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001 / max(disk_comfort_level,1)))
 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 				loneop.weight += 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the comfier the disk, the lower the prob of weight increase. i can't possibly see this going wrong

## Why It's Good For The Game

i am not entirely sure it is but it's funny isn't it

## Changelog
:cl:
tweak: comfy disky no longer wants the station to blow up

/:cl: