### PR TITLE
Makes from-ghost midrounds not roll if no ghosts

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -87,9 +87,10 @@
 		var/threat = round(mode.threat_level/10)
 		if (job_check < required_enemies[threat])
 			return FALSE
-		if (length(dead_players) + length(list_observers) == 0)
-			return FALSE
 	return TRUE
+
+/datum/dynamic_ruleset/midround/from_ghosts/ready(forced = FALSE)
+	return ..() && (length(dead_players) + length(list_observers) >= required_applicants)
 
 /datum/dynamic_ruleset/midround/from_ghosts/execute()
 	var/list/possible_candidates = list()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -87,6 +87,8 @@
 		var/threat = round(mode.threat_level/10)
 		if (job_check < required_enemies[threat])
 			return FALSE
+		if (length(dead_players) + length(list_observers) == 0)
+			return FALSE
 	return TRUE
 
 /datum/dynamic_ruleset/midround/from_ghosts/execute()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Errors in code suggest they shouldn't, but there's no actual check for it, so here's the check for it. This should make dynamic, uh, like. Work.

## Why It's Good For The Game

Dynamic rolling antags that literally cannot physically roll is bad

## Changelog
:cl:
fix: Added a check to from-ghosts midrounds making them not able to roll if there are no ghosts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
