### PR TITLE
drops floor cluwnes (random event max occurrences 0)

### DIFF
--- a/code/modules/events/floorcluwne.dm
+++ b/code/modules/events/floorcluwne.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/floor_cluwne
 	name = "Floor Cluwne"
 	typepath = /datum/round_event/floor_cluwne
-	max_occurrences = 1
+	max_occurrences = 0
 	min_players = 20
 	weight = 10
 


### PR DESCRIPTION
## About The Pull Request
sets floor cluwne random event max occurrences to 0
## Why It's Good For The Game
i dont think anyone enjoys random yog event
## Changelog
:cl:
del: Floor cluwnes can no longer be randomly spawned above 20 pop. This does imply that every floor cluwne in existence from the publication of this changelog is now actually the fault of an admin.
/:cl: