### PR TITLE
Lets xenohybrids eat junkfood.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/xeno.dm
+++ b/code/modules/mob/living/carbon/human/species_types/xeno.dm
@@ -14,7 +14,7 @@
 	skinned_type = /obj/item/stack/sheet/animalhide/xeno
 	exotic_bloodtype = "X*"
 	damage_overlay_type = "xeno"
-	disliked_food = JUNKFOOD
+	disliked_food = null
 	liked_food = GROSS | MEAT
 	species_category = SPECIES_CATEGORY_ALIEN
 	wings_icons = SPECIES_WINGS_DRAGON //most depictions of xenomorphs with wings are closest to this.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Probably a terrible idea, but it makes junk food a neutral instead of a disliked food. No idea why xenomorphs would have trouble eating anything as is... their blood is made out of acid...


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lets me eat doughnuts again.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Massive gamebreaking balance. Xenohybrids can now eat DOUGHNUTS. Security officers everywhere are afraid.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
