### PR TITLE
lets ghosts click a pAI device to download into it without a master

### DIFF
--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -1,12 +1,18 @@
 SUBSYSTEM_DEF(pai)
 	name = "pAI"
 
-	flags = SS_NO_INIT|SS_NO_FIRE
+	flags = SS_NO_FIRE
 
 	var/list/candidates = list()
 	var/ghost_spam = FALSE
 	var/spam_delay = 100
 	var/list/pai_card_list = list()
+	var/list/restricted_areas = list()
+
+/datum/controller/subsystem/pai/Initialize(var/time_of_day)
+	restricted_areas += typesof(/area/command/heads_quarters, /area/ai_monitored) // heads quarters and AI monitored places (like the armory)
+	initialized = TRUE
+	return ..()
 
 /datum/controller/subsystem/pai/Topic(href, href_list)
 	if(href_list["download"])

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -322,6 +322,33 @@
 	else
 		to_chat(user, "Encryption Key ports not configured.")
 
+/obj/item/paicard/attack_ghost(mob/dead/observer/user)
+	if(pai)
+		to_chat(user, "<span class='warning'>This pAI is already in use!</span>")
+		return
+
+	var/area/A = get_area(get_turf(src))
+	if(A.type in SSpai.restricted_areas) // set in subsystem/pai.dm on initialize of the subsystem
+		to_chat(user, "<span class='warning'>You can't download yourself into a restricted area!</span>")
+		return
+
+	var/pai_name = reject_bad_name(stripped_input(usr, "Enter a name for your pAI", "pAI Name", user.name, MAX_NAME_LEN), TRUE)
+	if(!pai_name)
+		to_chat(user, "<span class='warning'>Entered name is not valid.</span>")
+		return
+
+	var/mob/living/silicon/pai/new_pai = new(src)
+	if(!user.name)
+		new_pai.name = pick(GLOB.ninja_names)
+	else
+		new_pai.name = user.name
+	new_pai.real_name = new_pai.name
+	new_pai.key = user.key
+
+	setPersonality(new_pai)
+
+	SSticker.mode.update_cult_icons_removed(pai.mind)
+
 /obj/item/paicard/emag_act(mob/user) // Emag to wipe the master DNA and supplemental directive
 	. = ..()
 	if(!pai)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -338,10 +338,7 @@
 		return
 
 	var/mob/living/silicon/pai/new_pai = new(src)
-	if(!user.name)
-		new_pai.name = pick(GLOB.ninja_names)
-	else
-		new_pai.name = user.name
+	new_pai.name = pai_name
 	new_pai.real_name = new_pai.name
 	new_pai.key = user.key
 


### PR DESCRIPTION
## About The Pull Request
this does not work in head offices or an area the AI monitors (eva, armory, etc)
![image](https://user-images.githubusercontent.com/59849408/187976016-ea18c347-c0e5-46af-b801-aae35c4ae563.png)

this does not work if the pAI is being controlled already (it checks for a mob linked to the card not a client so it's safe to admin ghost still if you're an admin who is controlling a pAI)
![image](https://user-images.githubusercontent.com/59849408/187976042-0a99f374-0bbb-4f29-be67-efe184da0d12.png)

## Why It's Good For The Game
suggested by friend and approved by bhijn
personally i think it's a good way to let people play pAIs without telling their metabuddy to pick a pAI device up

## Changelog
:cl:
add: lets ghosts click a pAI device to download into it without a master
/:cl:

