### PR TITLE
Destructive analyzer no longer buy one get 49 free

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -84,15 +84,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	reclaim_materials_from(thing)
 	for(var/mob/M in thing)
 		M.death()
-	if(istype(thing, /obj/item/stack/sheet))
-		var/obj/item/stack/sheet/S = thing
-		if(S.amount > 1 && !innermode)
-			S.amount--
-			loaded_item = S
-		else
-			qdel(S)
-	else
-		qdel(thing)
+	qdel(thing)
 	if (!innermode)
 		update_icon()
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Destructive analyzer gives you the entire stack's materials worth when reclaiming but removes only one item from the stack. This fixes that by just not snowflaking the stack code for literally no reason except to break things (whoops)

## Why It's Good For The Game

I dunno miners shouldn't be made redundant as soon as they get exactly one (1) material

## Changelog
:cl:
fix: Destructive analyzer now does not multiply your stack by 50
/:cl: