### PR TITLE
Fixes encoded langauge so people can speak it, also redoes xeno tongue.

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -321,7 +321,7 @@ GLOBAL_LIST_INIT(wisdoms, world.file2list("strings/wisdoms.txt"))
 
 //LANGUAGE CHARACTER CUSTOMIZATION
 GLOBAL_LIST_INIT(speech_verbs, list("default","says","gibbers", "states", "chitters", "chimpers", "declares", "bellows", "buzzes" ,"beeps", "chirps", "clicks", "hisses" ,"poofs" , "puffs", "rattles", "mewls" ,"barks", "blorbles", "squeaks", "squawks", "flutters", "warbles", "caws", "gekkers", "clucks"))
-GLOBAL_LIST_INIT(roundstart_tongues, list("default","human tongue" = /obj/item/organ/tongue, "lizard tongue" = /obj/item/organ/tongue/lizard, "skeleton tongue" = /obj/item/organ/tongue/bone, "fly tongue" = /obj/item/organ/tongue/fly, "ipc tongue" = /obj/item/organ/tongue/robot/ipc, "xeno tongue" = /obj/item/organ/tongue/alien))
+GLOBAL_LIST_INIT(roundstart_tongues, list("default","human tongue" = /obj/item/organ/tongue, "lizard tongue" = /obj/item/organ/tongue/lizard, "skeleton tongue" = /obj/item/organ/tongue/bone, "fly tongue" = /obj/item/organ/tongue/fly, "ipc tongue" = /obj/item/organ/tongue/robot/ipc, "xeno tongue" = /obj/item/organ/tongue/alien/hybrid))
 
 /proc/get_roundstart_languages()
 	var/list/languages = subtypesof(/datum/language)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -15,6 +15,7 @@
 	var/list/accents = list() //done in order of priority (please always apply abductor accent and stuttering last)
 	var/static/list/languages_possible_base = typecacheof(list(
 		/datum/language/common,
+		/datum/language/machine,
 		/datum/language/draconic,
 		/datum/language/codespeak,
 		/datum/language/monkey,
@@ -142,7 +143,7 @@
 	icon_state = "tonguexeno"
 	say_mod = "hisses"
 	taste_sensitivity = 10 // LIZARDS ARE ALIENS CONFIRMED
-	maxHealth = 500 //They've a little mouth for a tongue, so it's pretty rhobust
+	maxHealth = 500 //They've a little mouth for a tongue, so it's pretty robust
 	initial_accents = list(/datum/accent/alien)
 	var/static/list/languages_possible_alien = typecacheof(list(
 		/datum/language/xenocommon,
@@ -154,6 +155,13 @@
 /obj/item/organ/tongue/alien/Initialize(mapload)
 	. = ..()
 	languages_possible = languages_possible_alien
+
+/obj/item/organ/tongue/alien/hybrid
+	name = "xenohybrid tongue"
+
+/obj/item/organ/tongue/alien/hybrid/Initialize(mapload)
+	. = ..()
+	languages_possible = languages_possible_base
 
 /obj/item/organ/tongue/bone
 	name = "bone \"tongue\""
@@ -248,6 +256,7 @@
 	taste_sensitivity = 101 // Not a tongue, they can't taste shit
 	var/static/list/languages_possible_ethereal = typecacheof(list(
 		/datum/language/common,
+		/datum/language/machine,
 		/datum/language/draconic,
 		/datum/language/codespeak,
 		/datum/language/monkey,
@@ -269,6 +278,7 @@
 	say_mod = "chitters"
 	var/static/list/languages_possible_arachnid = typecacheof(list(
 		/datum/language/common,
+		/datum/language/machine,
 		/datum/language/draconic,
 		/datum/language/codespeak,
 		/datum/language/monkey,


### PR DESCRIPTION
…e so it can speak same langauges as rest of crew.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know that no one could speak encoded despite it being an available language? Whacky right! Also fixes for xeno tongue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Someone mentioned it was a bug, so I decided to take a look at it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: makes it some people can speak the encoded langauge.
fix: makes the xenotongue a xenohybrid tongue so that people with it can speak other langauges.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
