### PR TITLE
Ports Adding radio access to borgs by default from splurt. Credit to NopemanMcHalt for the splurt port and Ayfa212 for the initial work.

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -5,6 +5,7 @@
 	item_state = "walkietalkie"
 	desc = "A basic handheld radio that communicates with local telecommunication networks."
 	dog_fashion = /datum/dog_fashion/back
+	var/list/extra_channels = list() //Allows indivudal channels, used for borgs
 
 	flags_1 = CONDUCT_1 | HEAR_1
 	slot_flags = ITEM_SLOT_BELT
@@ -68,6 +69,11 @@
 			syndie = TRUE
 		if(keyslot.independent)
 			independent = TRUE
+
+	if(extra_channels)
+		for(var/ch_name in extra_channels)
+			if(!(ch_name in channels))
+				channels[ch_name] = extra_channels[ch_name]
 
 	for(var/ch_name in channels)
 		secure_radio_connections[ch_name] = add_radio(src, GLOB.radiochannels[ch_name])

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -16,6 +16,7 @@
 	var/list/modules = list() //holds all the usable modules
 	var/list/added_modules = list() //modules not inherient to the robot module, are kept when the module changes
 	var/list/storages = list()
+	var/list/added_channels = list() //Borg radio stuffs
 
 	var/cyborg_base_icon = "robot" //produces the icon for the borg and, if no special_light_key is set, the lights
 	var/special_light_key //if we want specific lights, use this instead of copying lights in the dmi
@@ -236,6 +237,8 @@
 		R.typing_indicator_state = /obj/effect/overlay/typing_indicator/machine/dogborg
 	else
 		R.typing_indicator_state = /obj/effect/overlay/typing_indicator/machine
+	R.radio.extra_channels = RM.added_channels
+	R.radio.recalculateChannels()
 	R.maxHealth = borghealth
 	R.health = min(borghealth, R.health)
 	qdel(src)
@@ -322,6 +325,7 @@
 
 /obj/item/robot_module/medical
 	name = "Medical"
+	added_channels = list(RADIO_CHANNEL_MEDICAL = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -432,6 +436,7 @@
 
 /obj/item/robot_module/engineering
 	name = "Engineering"
+	added_channels = list(RADIO_CHANNEL_ENGINEERING = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/meson,
@@ -546,6 +551,7 @@
 
 /obj/item/robot_module/security
 	name = "Security"
+	added_channels = list(RADIO_CHANNEL_SECURITY = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -648,6 +654,7 @@
 
 /obj/item/robot_module/peacekeeper
 	name = "Peacekeeper"
+	added_channels = list(RADIO_CHANNEL_SECURITY = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -734,6 +741,7 @@
 
 /obj/item/robot_module/clown
 	name = "Clown"
+	added_channels = list(RADIO_CHANNEL_SERVICE = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -766,6 +774,7 @@
 
 /obj/item/robot_module/butler
 	name = "Service"
+	added_channels = list(RADIO_CHANNEL_SERVICE = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -909,6 +918,7 @@
 
 /obj/item/robot_module/miner
 	name = "Miner"
+	added_channels = list(RADIO_CHANNEL_SUPPLY = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -999,6 +1009,7 @@
 
 /obj/item/robot_module/syndicate
 	name = "Syndicate Assault"
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -1029,6 +1040,7 @@
 
 /obj/item/robot_module/syndicate_medical
 	name = "Syndicate Medical"
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/extinguisher/mini,
@@ -1061,6 +1073,7 @@
 
 /obj/item/robot_module/saboteur
 	name = "Syndicate Saboteur"
+	added_channels = list(RADIO_CHANNEL_SYNDICATE = 1)
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/sight/thermal,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/148. Credit to NopemanMcHalt for the port to splurt.

https://github.com/Skyrat-SS13/Skyrat13/pull/2010 Credit to Ayfa212 for the original pr . 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Borgs now receive access to departmental comms upon picking their module.

## Why It's Good For The Game
Better departmental coordination with borgs.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Borgs now receive access to the comms associated with their department by default!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
