### PR TITLE
Reworks RBMK to respect gas properties, use auxgm in general, use the same units

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -302,15 +302,6 @@
 #define GAS_FLAG_BREATH_PROC	(1<<1)
 #define GAS_FLAG_CHEMICAL		(1<<2)
 
-//SUPERMATTER DEFINES
-#define HEAT_PENALTY "heat penalties"
-#define TRANSMIT_MODIFIER "transmit"
-#define RADIOACTIVITY_MODIFIER "radioactivity"
-#define HEAT_RESISTANCE "heat resistance"
-#define POWERLOSS_INHIBITION "powerloss inhibition"
-#define ALL_SUPERMATTER_GASES "gases we care about"
-#define POWER_MIX "gas powermix"
-
 //HELPERS
 #define PIPING_LAYER_SHIFT(T, PipingLayer) \
 	if(T.dir & (NORTH|SOUTH)) {									\

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -26,7 +26,7 @@
 	else
 		CRASH("Something that wasn't an atom was given /datum/component/radioactive")
 
-	if(strength > RAD_MINIMUM_CONTAMINATION)
+	if(can_contaminate && strength > RAD_MINIMUM_CONTAMINATION)
 		SSradiation.warn(src)
 
 	//Let's make er glow

--- a/code/modules/atmospherics/auxgm/gas_types.dm
+++ b/code/modules/atmospherics/auxgm/gas_types.dm
@@ -3,9 +3,6 @@
 	specific_heat = 20
 	name = "Oxygen"
 	oxidation_temperature = T0C - 100 // it checks max of this and fire temperature, so rarely will things spontaneously combust
-	powermix = 1
-	heat_penalty = 1
-	transmit_modifier = 1.5
 
 /datum/gas/oxygen/generate_TLV()
 	return new/datum/tlv(16, 19, 40, 50)
@@ -14,8 +11,6 @@
 	id = GAS_N2
 	specific_heat = 20
 	name = "Nitrogen"
-	powermix = -1
-	heat_penalty = -1.5
 	fire_burn_rate = 1
 	fire_temperature = 2300
 	fire_products = list(GAS_NITRIC = 2)
@@ -34,9 +29,6 @@
 	id = GAS_CO2
 	specific_heat = 30
 	name = "Carbon Dioxide"
-	powermix = 1
-	heat_penalty = 0.1
-	powerloss_inhibition = 1
 	breath_results = GAS_O2
 	breath_alert_info = list(
 		not_enough_alert = list(
@@ -61,9 +53,6 @@
 	gas_overlay = "plasma"
 	moles_visible = MOLES_GAS_VISIBLE
 	flags = GAS_FLAG_DANGEROUS
-	heat_penalty = 15
-	transmit_modifier = 4
-	powermix = 1
 	fire_burn_rate = OXYGEN_BURN_RATE_BASE // named when plasma fires were the only fires, surely
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST
 	fire_products = FIRE_PRODUCT_PLASMA
@@ -80,7 +69,6 @@
 	oxidation_rate = 0.5
 	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST + 100
 	enthalpy = 81600
-	heat_resistance = 6
 
 /datum/gas/water_vapor
 	id = GAS_H2O
@@ -90,9 +78,7 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	flags = GAS_FLAG_DANGEROUS
 	fusion_power = 8
-	heat_penalty = 8
 	enthalpy = -241800 // FIRE_HYDROGEN_ENERGY_RELEASED is actually what this was supposed to be
-	powermix = 1
 	breath_reagent = /datum/reagent/water
 
 
@@ -104,10 +90,6 @@
 	oxidation_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 25 // it is VERY stable
 	oxidation_rate = 8 // when it can oxidize, it can oxidize a LOT
 	enthalpy = -2000000 // but it reduces the heat output a great deal (plasma fires add 3000000 per mole)
-	powermix = -1
-	heat_penalty = -1
-	transmit_modifier = -5
-	heat_resistance = 3
 	price = 6
 
 /datum/gas/pluoxium/generate_TLV()
@@ -121,9 +103,6 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	flags = GAS_FLAG_DANGEROUS
 	fusion_power = 1
-	powermix = 1
-	heat_penalty = 10
-	transmit_modifier = 30
 	fire_products = list(GAS_H2O = 1)
 	enthalpy = 300000
 	fire_burn_rate = 2
@@ -139,9 +118,6 @@
 	odor_strength = 1
 	fusion_power = 15
 	enthalpy = 91290
-	heat_resistance = 2
-	powermix = -1
-	heat_penalty = -1
 
 /datum/gas/nitryl
 	id = GAS_NITRYL
@@ -172,9 +148,6 @@
 	moles_visible = MOLES_GAS_VISIBLE
 	color = "#ffe"
 	fusion_power = 0
-	powermix = 1
-	heat_penalty = 3
-	transmit_modifier = 10
 	fire_products = list(GAS_H2O = 1)
 	fire_burn_rate = 2
 	fire_temperature = FIRE_MINIMUM_TEMPERATURE_TO_EXIST - 50
@@ -186,10 +159,7 @@
 	flags = GAS_FLAG_DANGEROUS
 	fusion_power = 8
 	powermix = 1
-	heat_penalty = 5
 	enthalpy = FIRE_CARBON_ENERGY_RELEASED // it is a mystery
-	transmit_modifier = -2
-	radioactivity_modifier = 5
 	price = 3
 
 /datum/gas/stimulum
@@ -220,8 +190,6 @@
 	odor = "natural gas"
 	odor_strength = 2
 	flags = GAS_FLAG_DANGEROUS
-	powerloss_inhibition = 1
-	heat_resistance = 3
 	breath_results = GAS_METHYL_BROMIDE
 	fire_products = list(GAS_CO2 = 1, GAS_H2O = 2)
 	fire_burn_rate = 0.5
@@ -243,8 +211,6 @@
 	id = GAS_METHYL_BROMIDE
 	specific_heat = 42
 	name = "Methyl Bromide"
-	powermix = 1
-	heat_penalty = -1
 	flags = GAS_FLAG_DANGEROUS
 	breath_alert_info = list(
 		not_enough_alert = list(
@@ -294,7 +260,4 @@
 	specific_heat = 10
 	name = "Quark Matter"
 	flags = GAS_FLAG_DANGEROUS
-	powermix = -1
-	transmit_modifier = -10
-	heat_penalty = -10
 	price = 5 // IT'S NOT ACTUALLY THAT HARD TO GET INTO A CANISTER LOL

--- a/code/modules/atmospherics/gasmixtures/auxgm.dm
+++ b/code/modules/atmospherics/gasmixtures/auxgm.dm
@@ -37,7 +37,6 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(GAS_O2, GAS_N2, GAS_CO2, GA
 	var/list/enthalpies = list()
 	var/list/fire_products = list()
 	var/list/fire_burn_rates = list()
-	var/list/supermatter = list()
 	var/list/groups_by_gas = list()
 	var/list/groups = list()
 	var/list/TLVs = list()
@@ -69,12 +68,6 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(GAS_O2, GAS_N2, GAS_CO2, GA
 	var/enthalpy = 0 // Standard enthalpy of formation in joules, used for fires
 	var/fire_burn_rate = 1 // how many moles are burned per product released
 	var/fire_radiation_released = 0 // How much radiation is released when this gas burns
-	var/powermix = 0 // how much this gas contributes to the supermatter's powermix ratio
-	var/heat_penalty = 0 // heat and waste penalty from having the supermatter crystal surrounded by this gas; negative numbers reduce
-	var/transmit_modifier = 0 // bonus to supermatter power generation (multiplicative, since it's % based, and divided by 10)
-	var/radioactivity_modifier = 0 // improves effect of transmit modifiers, must be from -10 to 10
-	var/heat_resistance = 0 // makes the crystal more resistant against heat damage.
-	var/powerloss_inhibition = 0 // Reduces how much power the supermatter loses each tick
 
 /datum/gas/proc/generate_TLV()
 	if(flags & GAS_FLAG_DANGEROUS)
@@ -140,6 +133,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(GAS_O2, GAS_N2, GAS_CO2, GA
 		if(gas.price)
 			prices[g] = gas.price
 		add_supermatter_properties(gas)
+		add_rbmk_properties(gas)
 		_auxtools_register_gas(gas)
 		if(done_initializing)
 			for(var/r in SSair.gas_reactions)
@@ -151,14 +145,6 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(GAS_O2, GAS_N2, GAS_CO2, GA
 /proc/finalize_gas_refs()
 
 /datum/auxgm/New()
-	src.supermatter[HEAT_PENALTY] = list()
-	src.supermatter[TRANSMIT_MODIFIER] = list()
-	src.supermatter[RADIOACTIVITY_MODIFIER] = list()
-	src.supermatter[HEAT_RESISTANCE] = list()
-	src.supermatter[POWERLOSS_INHIBITION] = list()
-	src.supermatter[POWER_MIX] = list()
-	src.supermatter[ALL_SUPERMATTER_GASES] = list()
-
 	for(var/gas_path in subtypesof(/datum/gas))
 		var/datum/gas/gas = new gas_path
 		add_gas(gas)

--- a/code/modules/power/reactor/rbmk.dm
+++ b/code/modules/power/reactor/rbmk.dm
@@ -286,7 +286,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 	//Firstly, heat up the reactor based off of K.
 	var/input_moles = coolant_input.total_moles() //Firstly. Do we have enough moles of coolant?
 	if(input_moles >= minimum_coolant_level)
-		last_coolant_temperature = coolant_input.return_temperature()
+		last_coolant_temperature = coolant_input.return_temperature() - T0C
 		//Important thing to remember, once you slot in the fuel rods, this thing will not stop making heat, at least, not unless you can live to be thousands of years old which is when the spent fuel finally depletes fully.
 		var/new_temp = coolant_input.temperature_share(null, gas_absorption_effectiveness, temperature, 50 + 5*length(fuel_rods)) //Take in the gas as a cooled input, cool the reactor a bit.
 		last_heat_delta = new_temp - temperature

--- a/tgui/packages/tgui/interfaces/RbmkStats.js
+++ b/tgui/packages/tgui/interfaces/RbmkStats.js
@@ -10,7 +10,7 @@ import { useBackend, useLocalState } from '../backend';
 export const RbmkStats = (props, context) => {
   const { act, data } = useBackend(context);
   const powerData = data.powerData.map((value, i) => [i, value]);
-  const psiData = data.psiData.map((value, i) => [i, value]);
+  const pressureData = data.pressureData.map((value, i) => [i, value]);
   const tempInputData = data.tempInputData.map((value, i) => [i, value]);
   const tempOutputdata = data.tempOutputdata.map((value, i) => [i, value]);
   return (
@@ -28,13 +28,13 @@ export const RbmkStats = (props, context) => {
             maxValue={100}
             color="yellow" />
           <br />
-          Reactor Pressure (PSI):
+          Reactor Pressure (kPa):
           <ProgressBar
-            value={data.psi}
+            value={data.pressure}
             minValue={0}
             maxValue={2000}
             color="white" >
-            {data.psi} PSI
+            {data.pressure} kPa
           </ProgressBar>
           Coolant temperature (°C):
           <ProgressBar
@@ -63,8 +63,8 @@ export const RbmkStats = (props, context) => {
             fillColor="rgba(255, 215, 0, 0.1)" />
           <Chart.Line
             fillPositionedParent
-            data={psiData}
-            rangeX={[0, psiData.length - 1]}
+            data={pressureData}
+            rangeX={[0, pressureData.length - 1]}
             rangeY={[0, 1500]}
             strokeColor="rgba(255,250,250, 1)"
             fillColor="rgba(255,250,250, 0.1)" />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Rather than simply calculating the "heat delta" by literally checking the temperature difference ignoring the actual amount of coolant (!!!), the RBMK now uses the pre-existing temperature_share function
2. All instances of PSI have been replaced with kPa. We're not wasting cycles on converting to and from units we don't use elsewhere in the server for literally no reason except to confuse you. Like. Why.
3. All instances of storing temperature in celsius have been replaced with kelvins. See above. At least this one's additive instead of multiplicative.
4. RBMK power output has been halved. 20% is 800 kW at this point, now it's 40% for that. 20% is still enough to power the whole damn station, even, which might still be too much.
5. All the hardcoded get_moles calls have been auxgmified, same way the supermatter is.
6. Supermatter's auxgm integration has been mildly reworked. All properties for RBMK and supermatter gas stuff are now stored in their respective files, rather than being in the big gas_types.dm file. DM lets me do this, I'm using it, sorry.
7. RBMK no longer spams admins with "not enough fuel" messages.
8. Fuel rod radioactivity is now permanent (but cannot contaminate)

## Why It's Good For The Game

Ehh, remains to be seen. Perhaps keeping it simple and hardcoded is for the better, but I sorta doubt it (otherwise I wouldn't have opened this).

## Changelog
:cl:
tweak: RBMK coolant now respects heat capacity and mole amount (!)
tweak: RBMK now uses kelvins and kPa internally instead of celsius and PSI
tweak: RBMK now uses PSI for display instead of celsius (seriously why. WHY)
refactor: Supermatter/RBMK gas info now lives in the supermatter/RBMK files
/:cl: