### PR TITLE
Grant Arachnid Abilities to Driders

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -103,11 +103,12 @@
 #define STYLE_SNEK_TAURIC		(1<<2) //taur-friendly suits
 #define STYLE_PAW_TAURIC		(1<<3)
 #define STYLE_HOOF_TAURIC		(1<<4)
-#define STYLE_ALL_TAURIC		(STYLE_SNEK_TAURIC|STYLE_PAW_TAURIC|STYLE_HOOF_TAURIC)
+#define STYLE_ALL_TAURIC		(STYLE_SNEK_TAURIC|STYLE_PAW_TAURIC|STYLE_HOOF_TAURIC|STYLE_ARACHNID_TAURIC)
 #define STYLE_NO_ANTHRO_ICON	(1<<5) //When digis fit the default sprite fine and need no copypasted states. This is the case of skirts and winter coats, for example.
 #define USE_SNEK_CLIP_MASK		(1<<6)
 #define USE_QUADRUPED_CLIP_MASK	(1<<7)
 #define USE_TAUR_CLIP_MASK		(USE_SNEK_CLIP_MASK|USE_QUADRUPED_CLIP_MASK)
+#define STYLE_ARACHNID_TAURIC   (1<<8)
 
 //digitigrade legs settings.
 #define NOT_DIGITIGRADE				0

--- a/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/legs_and_taurs.dm
@@ -97,6 +97,7 @@
 	icon_state = "drider"
 	color_src = MUTCOLORS
 	extra = TRUE
+	taur_mode = STYLE_ARACHNID_TAURIC
 
 /datum/sprite_accessory/taur/eevee
 	name = "Eevee"

--- a/code/modules/mob/living/carbon/human/innate_abilities/customization.dm
+++ b/code/modules/mob/living/carbon/human/innate_abilities/customization.dm
@@ -116,7 +116,7 @@
 		if(new_snout)
 			H.dna.features["mam_snouts"] = new_snout
 		H.update_body()
-		
+
 	else if (select_alteration == "Wings")
 		var/new_color = input(owner, "Choose your wing color:", "Race change","#"+H.dna.features["wings_color"]) as color|null
 		if(new_color)
@@ -167,6 +167,10 @@
 			H.dna.features["mam_tail"] = new_tail
 			if(new_tail != "None")
 				H.dna.features["taur"] = "None"
+				var/datum/action/innate/spin_web/SW = locate(/datum/action/innate/spin_web) in H.actions
+				var/datum/action/innate/spin_cocoon/SC = locate(/datum/action/innate/spin_cocoon) in H.actions
+				SC?.Remove(H)
+				SW?.Remove(H)
 		H.update_body()
 
 	else if (select_alteration == "Taur body")
@@ -182,7 +186,16 @@
 		var/new_taur
 		new_taur = input(owner, "Choose your character's tauric body:", "Tauric Alteration") as null|anything in snowflake_taur_list
 		if(new_taur)
+			var/datum/action/innate/spin_web/SW = locate(/datum/action/innate/spin_web) in H.actions
+			var/datum/action/innate/spin_cocoon/SC = locate(/datum/action/innate/spin_cocoon) in H.actions
+			SC?.Remove(H)
+			SW?.Remove(H)
 			H.dna.features["taur"] = new_taur
+			if(new_taur == "Drider")
+				SW = new
+				SC = new
+				SC.Grant(H)
+				SW.Grant(H)
 			if(new_taur != "None")
 				H.dna.features["mam_tail"] = "None"
 		H.update_body()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -527,6 +527,12 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 						H.physiology.footstep_type = FOOTSTEP_MOB_CLAW
 					if(STYLE_SNEK_TAURIC)
 						H.physiology.footstep_type = FOOTSTEP_MOB_CRAWL
+					if(STYLE_ARACHNID_TAURIC)
+						if(!istype(H.dna.species,/datum/species/arachnid))
+							var/datum/action/innate/spin_web/SW = new
+							var/datum/action/innate/spin_cocoon/SC = new
+							SC.Grant(H)
+							SW.Grant(H)
 					else
 						H.physiology.footstep_type = null
 			else
@@ -601,6 +607,13 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 	if((TRAIT_ROBOTIC_ORGANISM in inherent_traits) && C.hud_used)
 		C.hud_used.coolant_display.clear()
+
+	if(ishuman(C))
+		var/mob/living/carbon/human/H = C
+		var/datum/action/innate/spin_web/SW = locate(/datum/action/innate/spin_web) in H.actions
+		var/datum/action/innate/spin_cocoon/SC = locate(/datum/action/innate/spin_cocoon) in H.actions
+		SC?.Remove(H)
+		SW?.Remove(H)
 
 	SEND_SIGNAL(C, COMSIG_SPECIES_LOSS, src)
 

--- a/code/modules/mob/living/carbon/human/species_types/arachnid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/arachnid.dm
@@ -54,10 +54,6 @@
 
 /datum/species/arachnid/on_species_loss(mob/living/carbon/human/H)
 	. = ..()
-	var/datum/action/innate/spin_web/SW = locate(/datum/action/innate/spin_web) in H.actions
-	var/datum/action/innate/spin_cocoon/SC = locate(/datum/action/innate/spin_cocoon) in H.actions
-	SC?.Remove(H)
-	SW?.Remove(H)
 
 /datum/action/innate/spin_web
 	name = "Spin Web"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Self-explanatory, allows other races to use "spin web" and "spin cocoon" with the drider taur option

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

One would assume that half-spider-half-humans would be just as capable of spinning webs as humanoid spiders. That aside, I have no real justification for the change other than "driders hot, web bondage hot"

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: `STYLE_ARACHNID_TAURIC` taur mode and added to Drider taur type
tweak: move removal of arachnid abilities from `/datum/species/arachnid` to its parent's class
tweak: grant arachnid abilities if Drider taur type is used on any other race
tweak: slime customization accounts for the ability to change/remove taur legs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
