### PR TITLE
shoving severed bodyparts (e.g. heads) in smartfridges imparts organ freezing

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -445,6 +445,10 @@
 	if(isorgan(O))
 		var/obj/item/organ/organ = O
 		organ.organ_flags |= ORGAN_FROZEN
+	if(isbodypart(O))
+		var/obj/item/bodypart/bodypart = O
+		for(var/obj/item/organ/stored in bodypart.contents)
+			stored.organ_flags |= ORGAN_FROZEN
 
 /obj/machinery/smartfridge/organ/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
@@ -463,6 +467,10 @@
 	if(isorgan(AM))
 		var/obj/item/organ/O = AM
 		O.organ_flags &= ~ORGAN_FROZEN
+	if(isbodypart(AM))
+		var/obj/item/bodypart/bodypart = AM
+		for(var/obj/item/organ/stored in bodypart.contents)
+			stored.organ_flags &= ~ORGAN_FROZEN
 
 //cit specific??????
 /obj/machinery/smartfridge/organ/preloaded


### PR DESCRIPTION
## About The Pull Request
tgstation/tgstation#70415 backport
## Why It's Good For The Game
this might come up eventually idk
## Changelog
:cl:
fix: Shoving organ-containing bodyparts e.g. heads into smart organ storages now freezes the organs in the head, too.
/:cl: