### PR TITLE
hivelord stabilizers on webbing

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -290,6 +290,7 @@
 		/obj/item/stack/ore,
 		/obj/item/reagent_containers/food/drinks,
 		/obj/item/organ/regenerative_core,
+		/obj/item/hivelordstabilizer,
 		/obj/item/wormhole_jaunter,
 		/obj/item/storage/bag/plants,
 		/obj/item/stack/marker_beacon


### PR DESCRIPTION
## About The Pull Request
tgstation#70803
## Why It's Good For The Game
literally look at the pr above
## Changelog
:cl:
qol: Stabilizing serum (for cores) now fits on explorer's webbing.
/:cl:
