### PR TITLE
returns NT IRN being able to access dept budgets

### DIFF
--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -79,6 +79,7 @@
 	if(id_card?.registered_account)
 		if((ACCESS_HEADS in id_card.access) || (ACCESS_QM in id_card.access))
 			requestonly = FALSE
+			buyer = SSeconomy.get_dep_account(id_card.registered_account.account_job.paycheck_department)
 			can_approve_requests = TRUE
 		else
 			requestonly = TRUE
@@ -235,7 +236,8 @@
 				return
 
 			if(!self_paid && ishuman(usr) && !account)
-				account = SSeconomy.get_dep_account(ACCOUNT_CAR)
+				var/obj/item/card/id/id_card = card_slot?.GetID()
+				account = SSeconomy.get_dep_account(id_card?.registered_account?.account_job.paycheck_department)
 
 			var/turf/T = get_turf(src)
 			var/datum/supply_order/SO = new(pack, name, rank, ckey, reason, account)
@@ -261,7 +263,9 @@
 			var/id = text2num(params["id"])
 			for(var/datum/supply_order/SO in SSshuttle.requestlist)
 				if(SO.id == id)
-					SO.paying_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
+					var/obj/item/card/id/id_card = card_slot?.GetID()
+					if(id_card && id_card?.registered_account)
+						SO.paying_account = SSeconomy.get_dep_account(id_card?.registered_account?.account_job.paycheck_department)
 					SSshuttle.requestlist -= SO
 					SSshuttle.shoppinglist += SO
 					. = TRUE


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#15375
## what
allows departments to use their budgets on cargo purchase

## why
what the hell else are you gonna use that budget for

## changelog

:cl:
balance: After realizing that they should probably be pretending they have cash moving places, Nanotrasen has reenabled the ability for departments to use their budgets on cargo purchases.
/:cl: