### PR TITLE
Make QCD matter not react infinitely, thus generating 200,000 science per second

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -760,6 +760,8 @@
 
 /datum/gas_reaction/hagedorn/react(datum/gas_mixture/air, datum/holder)
 	var/initial_energy = air.thermal_energy()
+	if(air.get_moles(GAS_QCD))
+		return
 	for(var/g in air.get_gases())
 		air.set_moles(g, 0)
 	var/amount = initial_energy / (air.return_temperature() * GLOB.gas_data.specific_heats[GAS_QCD])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

what else is there to say

## Why It's Good For The Game

see above

## Changelog
:cl:
fix: QCD matter can no longer be made from QCD matter, generating 100,000 science points each time this happens
/:cl: