### PR TITLE
Roundstart species with a quirk blacklist balance points

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -423,7 +423,7 @@
 	coldmod = 3
 	heatmod = 1
 	burnmod = 1
-
+	balance_point_values = TRUE
 	allowed_limb_ids = list(SPECIES_SLIME,SPECIES_STARGAZER,SPECIES_SLIME_LUMI)
 
 ///////////////////////////////////LUMINESCENTS//////////////////////////////////////////

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -26,6 +26,7 @@
 	wings_icons = SPECIES_WINGS_SKELETAL
 
 	ass_image = 'icons/ass/assplasma.png'
+	balance_point_values = TRUE
 	blacklisted_quirks = list(/datum/quirk/paper_skin)
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -17,6 +17,7 @@
 
 	species_category = SPECIES_CATEGORY_SKELETON //they have their own category that's disassociated from undead, paired with plasmapeople
 	wings_icons = SPECIES_WINGS_SKELETAL
+	balance_point_values = TRUE
 	blacklisted_quirks = list(/datum/quirk/paper_skin)
 
 /datum/species/skeleton/New()
@@ -36,6 +37,7 @@
 	id = SPECIES_SKELETON_SPACE
 	limbs_id = SPECIES_SKELETON
 	blacklisted = 1
+	balance_point_values = FALSE
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NOHUNGER,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT, TRAIT_FAKEDEATH, TRAIT_CALCIUM_HEALER)
 
 /datum/species/skeleton/space/check_roundstart_eligible()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Species used to just remove blacklisted quirks without balancing out points, whereas my PR making synths coldblooded added the option to have select species balance their points after blacklisting (Such as Synthetics due to their coldblooded perk)
This extends this behavior to other roundstart species, namely Slimehybrids (not xenobioslimes), Skeletons and Plasmamen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Roundstart species shouldn't have free trait points from selecting blacklisted negative traits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Roundstart species other than Synthetics now also balance their quirk points after removing blacklisted quirks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
