### PR TITLE
Makes RBMK not early return with a prob(80) when there's food on it

### DIFF
--- a/code/modules/power/reactor/rbmk.dm
+++ b/code/modules/power/reactor/rbmk.dm
@@ -342,7 +342,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 			playsound(src, pick('sound/machines/fryer/deep_fryer_1.ogg', 'sound/machines/fryer/deep_fryer_2.ogg'), 100, TRUE)
 			var/obj/item/reagent_containers/food/grilled_item = I
 			if(prob(80))
-				return //To give the illusion that it's actually cooking omegalul.
+				continue //To give the illusion that it's actually cooking omegalul.
 			switch(power)
 				if(20 to 39)
 					grilled_item.name = "grilled [initial(grilled_item.name)]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

It's a bit stupid??

## Changelog
:cl:
fix: prob(80) return should be prob(80) continue
/:cl: