### PR TITLE
Separate character max age into max generated and max input

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -289,7 +289,8 @@
 
 // MINOR TWEAKS/MISC
 #define AGE_MIN					18	// youngest a character can be // CITADEL EDIT - 17 --> 18
-#define AGE_MAX					85	// oldest a character can be
+#define AGE_MAX					85	// oldest a character can be randomly generated
+#define AGE_MAX_INPUT			85	// oldest a character's age can be manually set
 #define WIZARD_AGE_MIN			30	// youngest a wizard can be
 #define APPRENTICE_AGE_MIN		29	// youngest an apprentice can be
 #define SHOES_SLOWDOWN			 0	// How much shoes slow you down by default. Negative values speed you up

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1746,9 +1746,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
 				if("age")
-					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
+					var/new_age = input(user, "Choose your character's age:\n(Minimum: [AGE_MIN])", "Character Preference") as num|null
 					if(new_age)
-						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
+						age = max(min( round(text2num(new_age)), INFINITY),AGE_MIN)
 
 				if("security_records")
 					var/rec = stripped_multiline_input(usr, "Set your security record note section. This should be IC!", "Security Records", html_decode(security_records), MAX_FLAVOR_LEN, TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1746,9 +1746,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
 				if("age")
-					var/new_age = input(user, "Choose your character's age:\n(Minimum: [AGE_MIN])", "Character Preference") as num|null
+					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX_INPUT])", "Character Preference") as num|null
 					if(new_age)
-						age = max(min( round(text2num(new_age)), SHORT_REAL_LIMIT),AGE_MIN)
+						age = max(min( round(text2num(new_age)), AGE_MAX_INPUT),AGE_MIN)
 
 				if("security_records")
 					var/rec = stripped_multiline_input(usr, "Set your security record note section. This should be IC!", "Security Records", html_decode(security_records), MAX_FLAVOR_LEN, TRUE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1748,7 +1748,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("age")
 					var/new_age = input(user, "Choose your character's age:\n(Minimum: [AGE_MIN])", "Character Preference") as num|null
 					if(new_age)
-						age = max(min( round(text2num(new_age)), INFINITY),AGE_MIN)
+						age = max(min( round(text2num(new_age)), SHORT_REAL_LIMIT),AGE_MIN)
 
 				if("security_records")
 					var/rec = stripped_multiline_input(usr, "Set your security record note section. This should be IC!", "Security Records", html_decode(security_records), MAX_FLAVOR_LEN, TRUE)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -905,7 +905,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	shirt_color = sanitize_hexcolor(shirt_color, 6, FALSE, initial(shirt_color))
 	socks = sanitize_inlist(socks, GLOB.socks_list)
 	socks_color = sanitize_hexcolor(socks_color, 6, FALSE, initial(socks_color))
-	age = sanitize_integer(age, AGE_MIN, SHORT_REAL_LIMIT, initial(age))
+	age = sanitize_integer(age, AGE_MIN, AGE_MAX_INPUT, initial(age))
 	hair_color = sanitize_hexcolor(hair_color, 6, FALSE)
 	facial_hair_color = sanitize_hexcolor(facial_hair_color, 6, FALSE)
 	grad_style = sanitize_inlist(grad_style, GLOB.hair_gradients_list, "None")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -905,7 +905,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	shirt_color = sanitize_hexcolor(shirt_color, 6, FALSE, initial(shirt_color))
 	socks = sanitize_inlist(socks, GLOB.socks_list)
 	socks_color = sanitize_hexcolor(socks_color, 6, FALSE, initial(socks_color))
-	age = sanitize_integer(age, AGE_MIN, INFINITY, initial(age))
+	age = sanitize_integer(age, AGE_MIN, SHORT_REAL_LIMIT, initial(age))
 	hair_color = sanitize_hexcolor(hair_color, 6, FALSE)
 	facial_hair_color = sanitize_hexcolor(facial_hair_color, 6, FALSE)
 	grad_style = sanitize_inlist(grad_style, GLOB.hair_gradients_list, "None")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -905,7 +905,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	shirt_color = sanitize_hexcolor(shirt_color, 6, FALSE, initial(shirt_color))
 	socks = sanitize_inlist(socks, GLOB.socks_list)
 	socks_color = sanitize_hexcolor(socks_color, 6, FALSE, initial(socks_color))
-	age = sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
+	age = sanitize_integer(age, AGE_MIN, INFINITY, initial(age))
 	hair_color = sanitize_hexcolor(hair_color, 6, FALSE)
 	facial_hair_color = sanitize_hexcolor(facial_hair_color, 6, FALSE)
 	grad_style = sanitize_inlist(grad_style, GLOB.hair_gradients_list, "None")


### PR DESCRIPTION
## About The Pull Request
Adds a method to set maximum character age _input_ separately from _randomly generated_ maximum character age. When using the character age setting dialog, and when saving that value, the code will reference AGE_MAX_INPUT instead of AGE_MAX. By default; these two definitions are identical.

Originally requested as a method to remove maximum age for S.P.L.U.R.T. [in this PR](https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pull/618), but deemed too difficult to introduce as modular.

## Why It's Good For The Game
Allows raising or unrestricting the maximum character age a user can set _without_ causing age to randomly generate in the new range.

## Changelog
:cl:
code: Added definition for maximum character age input
/:cl:
