### PR TITLE
Updated Delta Station medical's surgery room 

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54037,10 +54037,10 @@
 /obj/item/clothing/gloves/color/latex{
 	step_y = 10
 	},
-/obj/item/clothing/mask/surgical{
-	step_y = -10
-	},
 /obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical{
+	step_y = -6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsP" = (
@@ -54057,7 +54057,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsQ" = (
@@ -54077,10 +54077,10 @@
 /obj/item/clothing/gloves/color/latex{
 	step_y = 10
 	},
-/obj/item/clothing/mask/surgical{
-	step_y = -10
-	},
 /obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical{
+	step_y = -6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsR" = (
@@ -55255,22 +55255,22 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/surgical_drapes,
-/obj/item/hemostat{
+/obj/item/cautery{
 	step_x = -10;
 	step_y = 10
 	},
-/obj/item/retractor{
-	step_x = 10;
+/obj/item/scalpel{
+	step_x = 5;
 	step_y = -5
 	},
-/obj/item/cautery{
+/obj/item/surgical_drapes,
+/obj/item/hemostat{
+	step_x = -10;
+	step_y = -10
+	},
+/obj/item/retractor{
 	step_x = 10;
 	step_y = 10
-	},
-/obj/item/scalpel{
-	step_x = -12;
-	step_y = -3
 	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
@@ -55296,18 +55296,20 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/circular_saw,
 /obj/item/circular_saw{
-	step_y = -4
-	},
-/obj/item/surgicaldrill{
-	pixel_y = 5;
-	step_y = 5
+	step_y = 2
 	},
 /obj/item/surgicaldrill{
 	pixel_y = 5;
 	step_y = 5;
 	step_x = 8
+	},
+/obj/item/circular_saw{
+	step_y = -5
+	},
+/obj/item/surgicaldrill{
+	pixel_y = 5;
+	step_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
@@ -55319,22 +55321,22 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/item/surgical_drapes,
+/obj/item/scalpel{
+	step_x = 5;
+	step_y = -5
+	},
 /obj/item/hemostat{
+	step_x = -10;
+	step_y = -10
+	},
+/obj/item/cautery{
 	step_x = -10;
 	step_y = 10
 	},
-/obj/item/cautery{
-	step_x = 10;
-	step_y = 10
-	},
-/obj/item/surgical_drapes,
-/obj/item/scalpel{
-	step_x = -12;
-	step_y = -3
-	},
 /obj/item/retractor{
 	step_x = 10;
-	step_y = -5
+	step_y = 10
 	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
@@ -56009,9 +56011,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dxm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -56641,23 +56645,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
-"dyH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/table/optable,
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
 "dyI" = (
 /obj/structure/cable/white,
 /obj/machinery/power/apc{
@@ -56681,7 +56668,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/limbgrower,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyJ" = (
@@ -177238,7 +177225,7 @@ dsO
 dtR
 dvF
 dxm
-dyH
+dyJ
 dma
 cPy
 cPy

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54013,22 +54013,16 @@
 /turf/closed/wall,
 /area/medical/surgery)
 "dsN" = (
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/surgical_drapes,
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsO" = (
-/obj/item/retractor,
-/obj/item/hemostat,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54040,14 +54034,16 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/clothing/gloves/color/latex{
+	step_y = 10
+	},
+/obj/item/clothing/mask/surgical{
+	step_y = -10
+	},
+/obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsP" = (
-/obj/item/circular_saw,
-/obj/item/surgicaldrill{
-	pixel_y = 5
-	},
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -54061,11 +54057,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsQ" = (
-/obj/item/scalpel,
-/obj/item/cautery,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54079,6 +54074,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/clothing/gloves/color/latex{
+	step_y = 10
+	},
+/obj/item/clothing/mask/surgical{
+	step_y = -10
+	},
+/obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dsR" = (
@@ -55236,9 +55238,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dvF" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -55255,10 +55254,27 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
+/obj/item/surgical_drapes,
+/obj/item/hemostat{
+	step_x = -10;
+	step_y = 10
+	},
+/obj/item/retractor{
+	step_x = 10;
+	step_y = -5
+	},
+/obj/item/cautery{
+	step_x = 10;
+	step_y = 10
+	},
+/obj/item/scalpel{
+	step_x = -12;
+	step_y = -3
+	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvG" = (
-/obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -55279,17 +55295,47 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
+/obj/item/circular_saw,
+/obj/item/circular_saw{
+	step_y = -4
+	},
+/obj/item/surgicaldrill{
+	pixel_y = 5;
+	step_y = 5
+	},
+/obj/item/surgicaldrill{
+	pixel_y = 5;
+	step_y = 5;
+	step_x = 8
+	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvH" = (
-/obj/machinery/holopad,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
+/obj/structure/table/reinforced,
+/obj/item/hemostat{
+	step_x = -10;
+	step_y = 10
+	},
+/obj/item/cautery{
+	step_x = 10;
+	step_y = 10
+	},
+/obj/item/surgical_drapes,
+/obj/item/scalpel{
+	step_x = -12;
+	step_y = -3
+	},
+/obj/item/retractor{
+	step_x = 10;
+	step_y = -5
+	},
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvI" = (
@@ -55973,11 +56019,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/medical/surgery)
 "dxo" = (
 /obj/effect/turf_decal/tile/blue,
@@ -56576,7 +56620,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dyG" = (
-/obj/structure/closet/secure_closet/medical2,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = -32
 	},
@@ -56590,12 +56633,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/surgery)
-"dyH" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
+/turf/open/floor/plasteel/dark,
+/area/medical/surgery)
+"dyH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -56609,6 +56655,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyI" = (
@@ -56634,12 +56681,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/limbgrower,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyJ" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -56650,7 +56695,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/closet/crate/freezer/blood,
+/obj/structure/table/optable,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyK" = (
@@ -56669,7 +56714,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/limbgrower,
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyL" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -55255,23 +55255,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/cautery{
-	step_x = -10;
-	step_y = 10
-	},
-/obj/item/scalpel{
-	step_x = 5;
-	step_y = -5
-	},
-/obj/item/surgical_drapes,
-/obj/item/hemostat{
-	step_x = -10;
-	step_y = -10
-	},
-/obj/item/retractor{
-	step_x = 10;
-	step_y = 10
-	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvG" = (
@@ -55296,21 +55280,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/circular_saw{
-	step_y = 2
-	},
-/obj/item/surgicaldrill{
-	pixel_y = 5;
-	step_y = 5;
-	step_x = 8
-	},
-/obj/item/circular_saw{
-	step_y = -5
-	},
-/obj/item/surgicaldrill{
-	pixel_y = 5;
-	step_y = 5
-	},
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvH" = (
@@ -55321,23 +55291,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/surgical_drapes,
-/obj/item/scalpel{
-	step_x = 5;
-	step_y = -5
-	},
-/obj/item/hemostat{
-	step_x = -10;
-	step_y = -10
-	},
-/obj/item/cautery{
-	step_x = -10;
-	step_y = 10
-	},
-/obj/item/retractor{
-	step_x = 10;
-	step_y = 10
-	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel,
 /area/medical/surgery)
 "dvI" = (


### PR DESCRIPTION
Heyo,

Remolded the medical surgery room and added another surgery table and operating computer.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So for medical in all the other stations it mostly has two surgery tables and two surgery computers in the surgery room area, which is a good start.
Except delta station which had only one surgery table and computer, So I remolded the surgery room to fit two and added more tools to fit the theme of the theater surgery 

Before: 
![image](https://user-images.githubusercontent.com/81808269/206911494-3a6182b4-d248-4500-93e9-843937f95fb0.png)


After:
![image](https://user-images.githubusercontent.com/81808269/207038281-4ec53a33-5cda-44a5-ac7e-ef0326bf1af3.png)



How it looks in-game:
![image](https://user-images.githubusercontent.com/81808269/207039466-59de69cb-5e49-474a-9f9c-03391e485443.png)




<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Medical is one of the most crucial parts of the station, the influx of bodies can start very early and while engineers are busy setting up power doctors may receive many bodies to work on before any engineer is free to remodel or add more surgery equipment to medical, so two tables and computers should make it easier until medical can get more assistance later on if the influx of bodies keep increasing 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog


:cl:
add: One surgery table with an operating computer next to it
add: Extra surgery tools in the surgery room now that there are to tables to operate on
tweak: moved equipment around to make it more fitting with the new design
qol: moved the AI displays one tile to the side to allow for defibrators mounts near the tables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
