### PR TITLE
Fix init_process not preventing processing

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -149,10 +149,11 @@ Class Procs:
 		circuit = new circuit(src)
 		circuit.apply_default_parts(src)
 
-	if(!speed_process && init_process)
-		START_PROCESSING(SSmachines, src)
-	else
-		START_PROCESSING(SSfastprocess, src)
+	if(init_process) // Required to prevent non-speed non-init machines from running
+		if(speed_process)
+			START_PROCESSING(SSfastprocess, src)
+		else
+			START_PROCESSING(SSmachines, src)
 	RegisterSignal(src, COMSIG_ENTER_AREA, .proc/power_change)
 
 	if (occupant_typecache)

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -121,12 +121,12 @@
 	icon_state = "furnace"
 	density = TRUE
 	needs_item_input = TRUE
+	init_process = TRUE
 	var/obj/machinery/mineral/CONSOLE = null
 	var/on = FALSE
 	var/datum/material/selected_material = null
 	var/selected_alloy = null
 	var/datum/techweb/stored_research
-	init_process = TRUE
 
 /obj/machinery/mineral/processing_unit/Initialize(mapload)
 	. = ..()

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -4,7 +4,7 @@
 
 /obj/machinery/mineral
 	speed_process = TRUE
-	init_process = TRUE // Must be true after init_process fix
+	init_process = FALSE
 	/// The current direction of `input_turf`, in relation to the machine.
 	var/input_dir = NORTH
 	/// The current direction, in relation to the machine, that items will be output to.
@@ -126,6 +126,7 @@
 	var/datum/material/selected_material = null
 	var/selected_alloy = null
 	var/datum/techweb/stored_research
+	init_process = TRUE
 
 /obj/machinery/mineral/processing_unit/Initialize(mapload)
 	. = ..()

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -4,7 +4,7 @@
 
 /obj/machinery/mineral
 	speed_process = TRUE
-	init_process = FALSE
+	init_process = TRUE // Must be true after init_process fix
 	/// The current direction of `input_turf`, in relation to the machine.
 	var/input_dir = NORTH
 	/// The current direction, in relation to the machine, that items will be output to.

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -11,6 +11,7 @@
 	output_dir = SOUTH
 	req_access = list(ACCESS_MINERAL_STOREROOM)
 	speed_process = TRUE
+	init_process = TRUE
 	circuit = /obj/item/circuitboard/machine/ore_redemption
 	layer = BELOW_OBJ_LAYER
 	var/points = 0

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -9,6 +9,7 @@
 	input_dir = WEST
 	output_dir = EAST
 	speed_process = TRUE
+	init_process = TRUE
 
 /obj/machinery/mineral/unloading_machine/proc/horrible_quadratic_monster(var/turf/T)
 	set waitfor = FALSE


### PR DESCRIPTION
## About The Pull Request
Prevents machines from running faster when set to both **not** init_process and **not** speed_process. Changes mineral machine init_process to use this fix.

Related to a Sandstorm machine issue here: https://github.com/Sandstorm-Station/Sandstorm-Station-13/pull/276

## Why It's Good For The Game
Setting a machine to not start when constructed should actually do that.

## Changelog
:cl:
fix: Fixed non-autostart machines autostarting
/:cl: