### PR TITLE
Automatically implant High Luminosity Eyes

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -187,10 +187,13 @@
 	lose_text = "<span class='danger'>High-tech gizmos are a scam...</span>"
 
 /datum/quirk/trandening/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/autosurgeon/gloweyes/gloweyes = new(get_turf(H))
-	H.equip_to_slot(gloweyes, ITEM_SLOT_BACKPACK)
-	H.regenerate_icons()
+	// Get targets
+	var/obj/item/organ/eyes/old_eyes = quirk_holder.getorganslot(ORGAN_SLOT_EYES)
+	var/obj/item/organ/eyes/robotic/glow/new_eyes = new
+	
+	// Replace eyes
+	qdel(old_eyes)
+	new_eyes.Insert(quirk_holder)
 
 /datum/quirk/bloodpressure
 	name = "Polycythemia vera"


### PR DESCRIPTION
## About The Pull Request
Characters with the High Luminosity Eyes quirk will normally spawn with a single-use auto-surgeon in their backpack that can be manually triggered to replace the eye organ. This PR stops granting the auto-surgeon and instead automatically replaces the eyes on spawn.

## Why It's Good For The Game
Prevents the minor inconvenience of needing to manually apply a quirk's effect.

## Changelog
:cl:
tweak: High Luminosity Eyes quirk automatically replaces eyes on spawn
/:cl: