### PR TITLE
no more titanium req for durathread reinforcement kit

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -287,7 +287,7 @@
 	name = "Durathread Reinforcement Kit"
 	result = /obj/item/armorkit
 	reqs = list(/obj/item/stack/sheet/durathread = 4)
-	tools = list(/obj/item/stack/sheet/mineral/titanium, TOOL_WIRECUTTER) // tough needle for a tough fabric
+	tools = list(TOOL_WIRECUTTER)
 	time = 40
 	category = CAT_CLOTHING
 


### PR DESCRIPTION
## About The Pull Request
see title

## Why It's Good For The Game
dumb req

## Changelog
:cl:
qol: Durathread reinforcement kits no longer require a titanium sheet to craft.
/:cl: