### PR TITLE
Replace `harvest_userless` with `harvest`

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -23,7 +23,7 @@
 	var/seed_count = yield
 	if(prob(getYield() * 20))
 		seed_count++
-		var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc
+		var/output_loc = (user && parent.Adjacent(user)) ? user.loc : parent.loc
 		for(var/i in 1 to seed_count)
 			var/obj/item/seeds/starthistle/harvestseeds = Copy()
 			harvestseeds.forceMove(output_loc)

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -137,7 +137,7 @@
 		var/seed_count = 1
 		if(prob(getYield() * 20))
 			seed_count++
-		var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
+		var/output_loc = (user && parent.Adjacent(user)) ? user.loc : parent.loc //needed for TK
 		for(var/i=0,i<seed_count,i++)
 			var/obj/item/seeds/replicapod/harvestseeds = src.Copy()
 			result.Add(harvestseeds)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -182,13 +182,13 @@
 	///List of plants all harvested from the same batch.
 	var/list/result = list()
 	///Tile of the harvester to deposit the growables.
-	var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
+	var/output_loc = (user && parent.Adjacent(user)) ? user.loc : parent.loc //needed for TK
 	///Name of the grown products.
 	var/product_name
 	///The Number of products produced by the plant, typically the yield.
 	var/product_count = getYield()
 
-	parent.investigate_log("manual harvest by [key_name(user)] of [getYield()] of [src], with seed traits [english_list(genes)] and reagents_add [english_list_assoc(reagents_add)] and potency [potency].", INVESTIGATE_BOTANY)
+	parent.investigate_log("[user ? "manual harvest by [key_name(user)]" : "automatic harvest"] of [getYield()] of [src], with seed traits [english_list(genes)] and reagents_add [english_list_assoc(reagents_add)] and potency [potency].", INVESTIGATE_BOTANY)
 
 	while(t_amount < product_count)
 		var/obj/item/reagent_containers/food/snacks/grown/t_prod
@@ -227,32 +227,6 @@
 		SSblackbox.record_feedback("tally", "food_harvested", getYield(), product_name)
 	parent.update_tray(user)
 
-	return result
-
-/obj/item/seeds/proc/harvest_userless()
-	var/obj/machinery/hydroponics/parent = loc //for ease of access
-	var/t_amount = 0
-	var/list/result = list()
-	var/output_loc =  parent.loc
-	var/product_name
-	while(t_amount < getYield())
-		var/obj/item/reagent_containers/food/snacks/grown/t_prod = new product(output_loc, src)
-		if(parent.myseed.plantname != initial(parent.myseed.plantname))
-			t_prod.name = lowertext(parent.myseed.plantname)
-		if(productdesc)
-			t_prod.desc = productdesc
-		t_prod.seed.name = parent.myseed.name
-		t_prod.seed.desc = parent.myseed.desc
-		t_prod.seed.plantname = parent.myseed.plantname
-		result.Add(t_prod) // User gets a consumable
-		if(!t_prod)
-			return
-		t_amount++
-		product_name = parent.myseed.plantname
-	if(getYield() >= 1)
-		SSblackbox.record_feedback("tally", "food_harvested", getYield(), product_name)
-	parent.investigate_log("autmoatic harvest of [getYield()] of [src], with seed traits [english_list(genes)] and reagents_add [english_list(reagents_add)] and potency [potency].", INVESTIGATE_BOTANY)
-	parent.update_tray()
 	return result
 
 /obj/item/seeds/proc/prepare_result(var/obj/item/reagent_containers/food/snacks/grown/T)

--- a/code/modules/plumbing/plumbers/autohydro.dm
+++ b/code/modules/plumbing/plumbers/autohydro.dm
@@ -34,7 +34,7 @@
 		name = initial(name)
 		desc = initial(desc)
 	if(harvest)
-		myseed.harvest_userless()
+		myseed.harvest()
 		harvest = 0
 		lastproduce = age
 		if(!myseed.get_gene(/datum/plant_gene/trait/repeated_harvest))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes `harvest_userless` and replaces usages of it with `harvest`. Fixes replica pods spawning humonkeys and starthistle dropping nothing when automatically harvesting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

`harvest_userless` wasn't getting overridden by anything anyway.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed harvest_userless
tweak: harvest accounts for user being optional
tweak: harvest overrides for starthistle and replica pods account for user being optional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
