### PR TITLE
Play BSLR effects only when replacing lights

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -257,8 +257,17 @@
 		used = TRUE
 		if(istype(A, /obj/machinery/light))
 			if(!proximity && bluespace_toggle)
-				U.Beam(A, icon_state = "rped_upgrade", time = 1 SECONDS)
-				playsound(src, 'sound/items/pshoom.ogg', 40, 1)
+				// Set variable for target light
+				var/obj/machinery/light/target = A
+				
+				// Check light status before playing effects
+				if(target.status != LIGHT_OK)
+					// Display RPED beam
+					U.Beam(A, icon_state = "rped_upgrade", time = 1 SECONDS)
+
+					// Play RPED sound
+					playsound(src, 'sound/items/pshoom.ogg', 40, 1)		
+
 			ReplaceLight(A, U)
 
 	if(!used)


### PR DESCRIPTION
## About The Pull Request
Prevents the Bluespace Light Replacer from playing sounds or displaying a beam when the target's light won't be replaced. Based on the BSRPED's behavior.

## Why It's Good For The Game
Displaying identical effects regardless of result gives the user false feedback. Users may consider the effect more "satisfying" when given an exclusive association with positive results.

## Changelog
:cl:
tweak: Bluespace Light Replacer only fires a beam when replacing lights
/:cl: