### PR TITLE
Display job slots out of total during late-join

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -577,13 +577,23 @@
 		for(var/job in category)
 			var/datum/job/job_datum = SSjob.name_occupations[job]
 			if(job_datum && IsJobUnavailable(job_datum.title, TRUE) == JOB_AVAILABLE)
+				// Get currently occupied slots
+				var/num_positions_current = job_datum.current_positions
+				
+				// Get total slots that can be occupied
+				var/num_positions_total = job_datum.total_positions
+				
+				// Change to lemniscate for infinite-slot jobs
+				// This variable should only used to display text!
+				num_positions_total = (num_positions_total == -1 ? "∞" : num_positions_total)
+				
 				var/command_bold = ""
 				if(job in GLOB.command_positions)
 					command_bold = " command"
 				if(job_datum in SSjob.prioritized_jobs)
-					dept_dat += "<a class='job[command_bold]' style='display:block;width:170px'  href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'><span class='priority'>[job_datum.title] ([job_datum.current_positions])</span></a>"
+					dept_dat += "<a class='job[command_bold]' style='display:block;width:170px'  href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'><span class='priority'>[job_datum.title] ([num_positions_current]/[num_positions_total])</span></a>"
 				else
-					dept_dat += "<a class='job[command_bold]' style='display:block;width:170px' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[job_datum.title] ([job_datum.current_positions])</a>"
+					dept_dat += "<a class='job[command_bold]' style='display:block;width:170px' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[job_datum.title] ([num_positions_current]/[num_positions_total])</a>"
 		if(!dept_dat.len)
 			dept_dat += "<span class='nopositions'>No positions open.</span>"
 		dat += jointext(dept_dat, "")


### PR DESCRIPTION
## About The Pull Request
Changes late join text from "Job (current)" to "Job (current/limit)". Infinite-slot jobs display an infinity symbol.

![latejoin_slots_number](https://user-images.githubusercontent.com/5933805/210674357-6ca417b6-b2c1-4d5b-a21a-4e60ae2d9622.png)

## Why It's Good For The Game
Prevents confusion for what the number beside job names means, and gives a clearer indicator for how populated the job can become.

## Changelog
:cl:
tweak: Jobs in late-join panel now show the total job slots
/:cl: