### PR TITLE
[PORT] Implement ID card age

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -291,6 +291,7 @@
 #define AGE_MIN					18	// youngest a character can be // CITADEL EDIT - 17 --> 18
 #define AGE_MAX					85	// oldest a character can be randomly generated
 #define AGE_MAX_INPUT			85	// oldest a character's age can be manually set
+#define AGE_MIN_DRINKING		20 	// Youngest a character can legally drink and smoke
 #define WIZARD_AGE_MIN			30	// youngest a wizard can be
 #define APPRENTICE_AGE_MIN		29	// youngest an apprentice can be
 #define SHOES_SLOWDOWN			 0	// How much shoes slow you down by default. Negative values speed you up

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -32,6 +32,9 @@ GLOBAL_LIST_EMPTY(spidermobs)				//all sentient spider mobs
 GLOBAL_LIST_EMPTY(bots_list)
 GLOBAL_LIST_EMPTY(aiEyes)
 
+// Crew below minimum drinking age who have been reported to security for trying to buy things they shouldn't, so they can't spam
+GLOBAL_LIST_EMPTY(narcd_cantdrink)
+
 GLOBAL_LIST_EMPTY(language_datum_instances)
 GLOBAL_LIST_EMPTY(all_languages)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -75,6 +75,8 @@
 	var/custom_price
 	///Price of an item in a vending machine, overriding the premium vending machine price. Define in terms of paycheck defines as opposed to raw numbers.
 	var/custom_premium_price
+	///Whether spessmen with an ID with an age below AGE_MINOR (20 by default) can buy this item
+	var/age_restricted = FALSE
 
 	//List of datums orbiting this atom
 	var/datum/component/orbiter/orbiters

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -75,7 +75,7 @@
 	var/custom_price
 	///Price of an item in a vending machine, overriding the premium vending machine price. Define in terms of paycheck defines as opposed to raw numbers.
 	var/custom_premium_price
-	///Whether spessmen with an ID with an age below AGE_MINOR (20 by default) can buy this item
+	///Whether spessmen with an ID with an age below AGE_MIN_DRINKING (20 by default) can buy this item
 	var/age_restricted = FALSE
 
 	//List of datums orbiting this atom

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -116,6 +116,10 @@
 /obj/item/card/id/examine_more(mob/user)
 	var/list/msg = list("<span class='notice'><i>You examine [src] closer, and note the following...</i></span>")
 
+	// Show age
+	if(registered_age)
+		msg += "The card indicates that the holder is [registered_age] years old."
+	
 	if(mining_points)
 		msg += "There's [mining_points] mining equipment redemption point\s loaded onto this card."
 	if(registered_account)
@@ -198,6 +202,9 @@
 	var/uses_overlays = TRUE
 	var/icon/cached_flat_icon
 
+	// Registered owner's age (Default to blank)
+	var/registered_age = null
+
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
 	if(mapload && access_txt)
@@ -229,8 +236,11 @@
 
 /obj/item/card/id/attack_self(mob/user)
 	if(Adjacent(user))
-		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name].</span>", \
-					"<span class='notice'>You show \the [src.name].</span>")
+		var/age_drinking
+		if(registered_name && registered_age && registered_age < AGE_MIN_DRINKING)
+			age_drinking = " <b>(MLDA)</b>"
+		user.visible_message("<span class='notice'>[user] shows you: [icon2html(src, viewers(user))] [src.name][age_drinking].</span>", \
+					"<span class='notice'>You show \the [src.name][age_drinking].</span>")
 		add_fingerprint(user)
 
 /obj/item/card/id/attackby(obj/item/W, mob/user, params)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -301,6 +301,8 @@
 		C.registered_name = H.real_name
 		C.assignment = J.title
 		C.update_label()
+		if(H.age)
+			C.registered_age = H.age
 		for(var/A in SSeconomy.bank_accounts)
 			var/datum/bank_account/B = A
 			if(B.account_id == H.account_id)

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -33,6 +33,20 @@
 	backpack_contents = list(/obj/item/storage/box/beanbag=1,/obj/item/book/granter/action/drink_fling=1)
 	shoes = /obj/item/clothing/shoes/laceup
 
+/datum/outfit/job/bartender/post_equip(mob/living/carbon/human/human, visualsOnly)
+	. = ..()
+
+	// Get character's ID
+	var/obj/item/card/id/wearer = human.wear_id
+	
+	// Check for legal drinking age
+	if(human.age < AGE_MIN_DRINKING)
+		// Falsify the ID
+		wearer.registered_age = AGE_MIN_DRINKING
+		
+		// Warn the user
+		to_chat(human, span_notice("You're not technically allowed to access or serve alcohol, but your ID has been discreetly modified to hide this fact. Try to keep that a secret!"))
+
 /datum/job/bartender/after_spawn(mob/living/H, client/C, latejoin = FALSE)
 	. = ..()
 	var/datum/action/innate/drink_fling/D = new

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -185,6 +185,23 @@
 			target_id_card.update_label()
 			playsound(computer, "terminal_type", 50, FALSE)
 			return TRUE
+		// Change age
+		/*
+		 * Not implemented, as it would require TGUI updates
+		 *
+		if("PRG_age")
+			if(!computer || !authenticated || !target_id_card)
+				return TRUE
+
+			var/new_age = params["id_age"]
+			if(!isnum(new_age))
+				stack_trace("[key_name(usr)] ([usr]) attempted to set invalid age \[[new_age]\] to [target_id_card]")
+				return TRUE
+
+			target_id_card.registered_age = new_age
+			playsound(computer, SFX_TERMINAL_TYPE, 50, FALSE)
+			return TRUE
+		*/
 		if("PRG_assign")
 			if(!computer || !authenticated || !target_id_card)
 				return

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -32,8 +32,8 @@
 	var/custom_price
 	///Does the item have a custom premium price override
 	var/custom_premium_price
-	///Whether spessmen with an ID with an age below AGE_MINOR (20 by default) can buy this item
-	var/age_restricted = FALSE // @unimplimented
+	///Whether spessmen with an ID with an age below AGE_MIN_DRINKING (20 by default) can buy this item
+	var/age_restricted = FALSE // Implemented
 	///Whether the product can be recolored by the GAGS system
 	var/colorable // @unimplimented
 
@@ -322,7 +322,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		///Prices of vending machines are all increased uniformly.
 		R.custom_price = initial(temp.custom_price)
 		R.custom_premium_price = initial(temp.custom_premium_price)
-		// R.age_restricted = initial(temp.age_restricted)
+		R.age_restricted = initial(temp.age_restricted)
 		// R.colorable = !!(initial(temp.greyscale_config) && initial(temp.greyscale_colors) && (initial(temp.flags_1) & IS_PLAYER_COLORABLE_1))
 		recordlist += R
 
@@ -868,15 +868,15 @@ GLOBAL_LIST_EMPTY(vending_products)
 			flick(icon_deny,src)
 			vend_ready = TRUE
 			return
-		// else if(age_restrictions && R.age_restricted && (!C.registered_age || C.registered_age < AGE_MINOR))
-		// 	say("You are not of legal age to purchase [R.name].")
-		// 	if(!(usr in GLOB.narcd_underages))
-		// 		Radio.set_frequency(FREQ_SECURITY)
-		// 		Radio.talk_into(src, "SECURITY ALERT: Underaged crewmember [usr] recorded attempting to purchase [R.name] in [get_area(src)]. Please watch for substance abuse.", FREQ_SECURITY)
-		// 		GLOB.narcd_underages += usr
-		// 	flick(icon_deny,src)
-		// 	vend_ready = TRUE
-		// 	return
+		else if(age_restrictions && R.age_restricted && (!C.registered_age || C.registered_age < AGE_MIN_DRINKING))
+			say("You are not of legal age to purchase [R.name].")
+			if(!(usr in GLOB.narcd_cantdrink))
+				Radio.set_frequency(FREQ_SECURITY)
+				Radio.talk_into(src, "SECURITY ALERT: Crewmember [usr] recorded attempting to purchase [R.name] in [get_area(src)] without legal clearance. Please watch for substance abuse.", FREQ_SECURITY)
+				GLOB.narcd_cantdrink += usr
+			flick(icon_deny,src)
+			vend_ready = TRUE
+			return
 		var/datum/bank_account/account = C.registered_account
 
 		var/discounts = FALSE


### PR DESCRIPTION
## About The Pull Request
Ports the ID card age display mechanics from current TG.

References to minors and underage crew have been removed. Tightly controlled Nanotransen stations may "enforce" stricter substance usage standards without implying their crew are children.

- Added registered age text when closely examining an ID
- Added an MLDA restriction indicator when presenting an ID
- - Added **unimplemented** ID card age change system for modular computers
- Added minimum legal drinking age (20)
- - Replaces AGE_MINOR with AGE_MIN_DRINKING
- - Replaces narcd_underages with narcd_cantdrink
- Implemented vending machine age restriction check
- - Does not mark any items as restricted

## Why It's Good For The Game
Age flavor text is currently unused outside of security terminals. This change enables non-security crew to use the character creator's age setting.

## Changelog
:cl:
add: Added registered age text when closely examining an ID
add: Added alcohol prohibited indicator (as "MLDA") when presenting an ID
code: Implemented vending machine MLDA restrictions (currently restricts nothing)
/:cl: