### PR TITLE
Add cyborg upgrade: Automatic Scrubber

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -291,6 +291,24 @@ as performing this in action() will cause the upgrade to end up in the borg inst
 		R.module.basic_modules += M
 		R.module.add_module(M, FALSE, TRUE)
 
+/obj/item/borg/upgrade/mop_automatic
+	name = "janitor cyborg auto-scrubber"
+	desc = "An advanced replacement for mops everywhere. Cleans floors while you walk!"
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = list(/obj/item/robot_module/butler)
+	module_flags = BORG_MODULE_JANITOR
+
+/obj/item/borg/upgrade/mop_automatic/action(mob/living/silicon/robot/R)
+	. = ..()
+	if(.)
+		R.AddElement(/datum/element/cleaning)
+
+/obj/item/borg/upgrade/mop_automatic/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		R.RemoveElement(/datum/element/cleaning)
+
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -805,7 +805,7 @@
 		/obj/item/borg/sight/xray/truesight_lens)
 	moduleselect_icon = "service"
 	hat_offset = 0
-	clean_on_move = TRUE
+	clean_on_move = FALSE
 
 /obj/item/robot_module/butler/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
 	..()

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -787,6 +787,15 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_mop_automatic
+	name = "Cyborg Upgrade (Automatic Scrubber)"
+	id = "borg_upgrade_mop_automatic"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/mop_automatic
+	materials = list(/datum/material/iron=10000, /datum/material/glass=200, /datum/material/titanium=1000)
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_expand
 	name = "Cyborg Upgrade (Expand)"
 	id = "borg_upgrade_expand"

--- a/code/modules/research/techweb/nodes/robotics_nodes.dm
+++ b/code/modules/research/techweb/nodes/robotics_nodes.dm
@@ -51,7 +51,7 @@
 	display_name = "Cyborg Upgrades: Utility"
 	description = "Utility upgrades for cyborgs."
 	prereq_ids = list("engineering", "robotics")
-	design_ids = list("borg_upgrade_lavaproof", "borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_rped")
+	design_ids = list("borg_upgrade_lavaproof", "borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_mop_automatic", "borg_upgrade_rped")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
 /datum/techweb_node/cyborg_upg_med


### PR DESCRIPTION
## About The Pull Request
Removes the service cyborg's innate ability to automatically clean floors, and makes it into an upgrade module.

## Why It's Good For The Game
Prevents service cyborgs from rendering mops obsolete, and requires them to interact with robotics to become ~~overpowered~~ advanced janitor replacements.

## Changelog
:cl:
add: Added cyborg module: Automatic Scrubber
tweak: Service cyborgs no longer automatically clean floors
/:cl: