### PR TITLE
Minor improvements to High Luminosity Eyes

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -195,6 +195,34 @@
 	qdel(old_eyes)
 	new_eyes.Insert(quirk_holder)
 
+/datum/quirk/trandening/remove()
+	// Get targets
+	var/obj/item/organ/eyes/old_eyes = quirk_holder.getorganslot(ORGAN_SLOT_EYES)
+	var/mob/living/carbon/human/qurk_mob = quirk_holder
+
+	// Check for eyes existing
+	if(!old_eyes)
+		return
+
+	// Check for quirk eyes
+	if(!istype(old_eyes, /obj/item/organ/eyes/robotic/glow))
+		return
+
+	// Define new eyes
+	var/species_eyes = /obj/item/organ/eyes
+
+	// Check for mutant eyes
+	if(qurk_mob.dna.species && qurk_mob.dna.species.mutanteyes)
+		// Set eyes to mutant type
+		species_eyes = qurk_mob.dna.species.mutanteyes
+
+	// Create new eyes item
+	var/obj/item/organ/eyes/new_eyes = new species_eyes()
+
+	// Replace eyes
+	qdel(old_eyes)
+	new_eyes.Insert(quirk_holder)
+
 /datum/quirk/bloodpressure
 	name = "Polycythemia vera"
 	desc = "You've a treated form of Polycythemia vera that increases the total blood volume inside of you as well as the rate of replenishment!"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -181,10 +181,10 @@
 
 /datum/quirk/trandening
 	name = "High Luminosity Eyes"
-	desc = "When the next big fancy implant came out you had to buy one on impluse!"
+	desc = "When the next big fancy implant came out you had to buy one on impulse! You start the shift with emissive cybernetic eyes that can emit colored beams of light."
 	value = 1
-	gain_text = "<span class='notice'>You have to keep up with the next big thing!.</span>"
-	lose_text = "<span class='danger'>High-tech gizmos are a scam...</span>"
+	gain_text = "<span class='notice'>You've been keeping up with the latest cybernetic trends!</span>"
+	lose_text = "<span class='danger'>High powered eye lasers? What were you thinking...</span>"
 
 /datum/quirk/trandening/on_spawn()
 	// Get targets


### PR DESCRIPTION
## About The Pull Request
This PR does the following:
- Fixes minor typos
- Adjusts flavor text to be more specific
- Increases the amount of information presented
- Restores the character's default eyes when removing the quirk

## Why It's Good For The Game
The quirk's current description does a poor job of explaining what it does, and why users should choose it. Presented text focuses more on "trending" than what the quirk's actual function.

Restoring species eyes on quirk removal is unlikely to contribute anything, but promotes good practices for dealing with quirks.

## Changelog
:cl:
tweak: Updated quirk description for High Luminosity Eyes
tweak: High Luminosity Eyes will be uninstalled if the quirk is removed
/:cl: