### PR TITLE
Convert Colorist from quirk to loadout item

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -163,22 +163,7 @@
 	lose_text = "<span class='notice'>You no longer feel like you should be eating trash.</span>"
 	mob_trait = TRAIT_TRASHCAN
 
-/datum/quirk/colorist
-	name = "Colorist"
-	desc = "You like carrying around a hair dye spray to quickly apply color patterns to your hair."
-	value = 0
-	medical_record_text = "Patient enjoys dyeing their hair with pretty colors."
-
-/datum/quirk/colorist/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/dyespray/spraycan = new(get_turf(quirk_holder))
-	H.equip_to_slot(spraycan, ITEM_SLOT_BACKPACK)
-	H.regenerate_icons()
-
-/datum/quirk/colorist/post_add()
-	var/mob/living/carbon/human/H = quirk_holder
-	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
-	to_chat(quirk_holder, "<span class='boldnotice'>You brought some extra dye with you! It's in your bag if you forgot.</span>")
+// Moved Colorist quirk to a loadout item
 
 /datum/quirk/salt_sensitive
 	name = "Sodium Sensitivity"

--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -190,3 +190,8 @@
 	loadout_flags = LOADOUT_CAN_NAME | LOADOUT_CAN_DESCRIPTION
 	subcategory = LOADOUT_SUBCATEGORY_BACKPACK_ACCESSORIES
 	cost = 0
+
+// Moved here from quirks
+/datum/gear/backpack/dyespray
+	name = "Hair dye spray"
+	path = /obj/item/dyespray


### PR DESCRIPTION
## About The Pull Request
Removes the Colorist quirk, and adds Hair Dye Spray to the loadout under backpack items.

## Why It's Good For The Game
The loadout system makes purely item granting quirks unnecessary. This improves consistency with other round-start accessory items.

## Changelog
:cl:
add: Added Hair Dye Spray to the loadout selection
del: Removed the Colorist quirk
/:cl: