### PR TITLE
Add all missing job cartridges to PTech

### DIFF
--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -5,15 +5,34 @@
 	product_slogans = "Carts to go!"
 	icon_state = "cart"
 	icon_deny = "cart-deny"
-	products = list(/obj/item/cartridge/medical = 10,
+	products = list(/obj/item/pda/heads = 10, // PDA
+					// Normal staff cards
+					/obj/item/cartridge/medical = 10,
 					/obj/item/cartridge/engineering = 10,
 					/obj/item/cartridge/security = 10,
 					/obj/item/cartridge/janitor = 10,
 					/obj/item/cartridge/signal/toxins = 10,
 					/obj/item/cartridge/roboticist = 10,
-					/obj/item/pda/heads = 10,
+					/obj/item/cartridge/atmos = 10,
+					/obj/item/cartridge/chemistry = 10,
+					/obj/item/cartridge/detective = 10,
+					/obj/item/cartridge/lawyer = 10,
+					/obj/item/cartridge/curator = 10,
+					/obj/item/cartridge/bartender = 10,
+
+					// Virus cards
+					/obj/item/cartridge/virus/clown = 3,
+					/obj/item/cartridge/virus/mime = 3,
+
+					// Command staff cards
 					/obj/item/cartridge/captain = 3,
-					/obj/item/cartridge/quartermaster = 10)
+					/obj/item/cartridge/quartermaster = 10,
+					/obj/item/cartridge/head = 10,
+					/obj/item/cartridge/hos = 10,
+					/obj/item/cartridge/ce = 10,
+					/obj/item/cartridge/cmo = 10,
+					/obj/item/cartridge/rd = 10)
+
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 50)
 	refill_canister = /obj/item/vending_refill/cart
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
## About The Pull Request
Adds all remaining unavailable job cartridges to the Head of Personnel's PTech vending machine. Carts are sorted by standard job, virus, then command. PDA was moved to the top for easier access.

<details> 
  <summary>Preview image</summary>
   <img src="https://user-images.githubusercontent.com/5933805/211983450-70209214-aa64-4024-9321-96bb0ba1243e.png" />
</details>

## Why It's Good For The Game
Some cartridges are currently only available round-start, and cannot be assigned by the Head of Personnel. Crew that lose their cart or change jobs cannot get a new one.

## Changelog
:cl:
add: Added new PTech vending stock: BreatheDeep, ChemWiz, D.E.T.E.C.T., S.P.A.M., Lib-Tweet, B.O.O.Z.E., Honkworks 5.0, Gestur-O 1000, Easy-Record DELUXE, R.O.B.U.S.T. DELUXE, Power-On DELUXE, Med-U DELUXE, Signal Ace DELUXE
/:cl: