### PR TITLE
Prevent using Nutriment Pump implant with 'no process food' trait

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -20,6 +20,10 @@
 	if(!. || synthesizing)
 		return
 
+	// Check if this user can process nutriment
+	if(HAS_TRAIT(owner, TRAIT_NO_PROCESS_FOOD))
+		return
+
 	if(owner.nutrition <= hunger_threshold)
 		synthesizing = TRUE
 		to_chat(owner, "<span class='notice'>You feel less hungry...</span>")


### PR DESCRIPTION
## About The Pull Request
Prevents the nutriment pump implant from functioning on mobs with TRAIT_NO_PROCESS_FOOD, as this behavior appears to be unintended. The implant could be used on robotic lifeforms that have no way of processing nutriment.

According to the comments in [trait defines](https://github.com/Citadel-Station-13/Citadel-Station-13/blob/master/code/__DEFINES/traits.dm#L223); _"You don't get benefits from nutriment, nor nutrition from reagent consumables"_. 

## Why It's Good For The Game
Fixes an unintended behavior with a game item.

## Changelog
:cl:
fix: Fixed Nutrient Pump functioning on creatures that cannot process food
/:cl: