### PR TITLE
Protolathe material ejection improvements

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -232,9 +232,12 @@
 		var/amount = materials.mat_container.materials[mat_id]
 		var/ref = REF(M)
 		l += "* [amount] of [M.name]: "
-		if(amount >= MINERAL_MATERIAL_AMOUNT) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=1'>Eject</A> [RDSCREEN_NOBREAK]"
+		if(amount >= MINERAL_MATERIAL_AMOUNT) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=1'>1x</A> [RDSCREEN_NOBREAK]"
 		if(amount >= MINERAL_MATERIAL_AMOUNT*5) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=5'>5x</A> [RDSCREEN_NOBREAK]"
-		if(amount >= MINERAL_MATERIAL_AMOUNT) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=50'>All</A>[RDSCREEN_NOBREAK]"
+		if(amount >= MINERAL_MATERIAL_AMOUNT*10) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=10'>10x</A> [RDSCREEN_NOBREAK]"
+		if(amount >= MINERAL_MATERIAL_AMOUNT*20) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=20'>20x</A> [RDSCREEN_NOBREAK]"
+		if(amount >= MINERAL_MATERIAL_AMOUNT*50) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=50'>50x</A> [RDSCREEN_NOBREAK]"
+		if(amount >= MINERAL_MATERIAL_AMOUNT) l += "<A href='?src=[REF(src)];ejectsheet=[ref];eject_amt=50'>Max Stack</A>[RDSCREEN_NOBREAK]"
 		l += ""
 	l += "</div>[RDSCREEN_NOBREAK]"
 	return l


### PR DESCRIPTION
## About The Pull Request
This PR makes the following changes to the protolathe material ejection UI:
- Added buttons for 10x, 20x, and 50x
- Renamed "Eject" to "1x"
- Renamed "All" to "Max Stack"

![protolathe_amounts](https://user-images.githubusercontent.com/5933805/212605347-c5433ef2-106e-482b-baa0-63db7706790a.png)

The 50x and Max Stack buttons are _usually_ redundant, but give clearer feedback.

## Why It's Good For The Game
Gathering materials from a protolathe can be a confusion and tedious process. An attempt to fix this is as follows, respectively to the changes:
- Adding additional button reduces the amount of interactions required for intermediary amounts.
- "Eject" and "All" could be interpreted to mean the machine will completely empty the (linked) storage.

## Changelog
:cl:
tweak: Protolathes ejection button names adjusted for clarity
tweak: Protolathes can now eject in three additional preset quantities
/:cl: