### PR TITLE
Fix shuttle catastrophe happening during transit

### DIFF
--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -9,6 +9,8 @@
 /datum/round_event_control/shuttle_catastrophe/canSpawnEvent(players, gamemode)
 	if(SSshuttle.emergency.name == "Build your own shuttle kit")
 		return FALSE //don't undo manual player engineering, it also would unload people and ghost them, there's just a lot of problems
+	if(SSshuttle.emergency.in_flight())
+		return FALSE //ditto, problems
 	return ..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title.

## Why It's Good For The Game

This strands everyone on it at centcom (yikes) and prevents the round from ending correctly (YIKES). Best fix it.

## Changelog
:cl:
fix: Shuttle catastrophe no longer happens during transit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
