### PR TITLE
Sanitize screentip colors

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -541,6 +541,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	key_bindings = sanitize_islist(key_bindings, list())
 	modless_key_bindings = sanitize_islist(modless_key_bindings, list())
 	favorite_outfits = SANITIZE_LIST(favorite_outfits)
+	screentip_color = sanitize_hexcolor(screentip_color, 6, 1, initial(screentip_color))
 
 	verify_keybindings_valid()		// one of these days this will runtime and you'll be glad that i put it in a different proc so no one gets their saves wiped
 


### PR DESCRIPTION
## About The Pull Request
Sanitize screentip colors as hexcolor when saving to prevent possible cases of null values that could break the new interaction screentips.

Originally reported by BongaTheProto, with a fix proposed by SandPoot.

## Why It's Good For The Game
Fixes possible null inputs that can break the new interaction screentips.

## Changelog
:cl:
fix: Fixed potential case of left-aligned interaction hints
/:cl: