### PR TITLE
removes the heirloom toolbox from assistants

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -22,7 +22,6 @@ Assistant
 	threat = 0.2
 	
 	family_heirlooms = list(
-		/obj/item/storage/toolbox/mechanical/old/heirloom,
 		/obj/item/clothing/gloves/cut/family
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

idk why but for some reason this stopped being just a reskinned box and became an actual bulky toolbox assistants became forced to lug around for their mood buff plus at roundstart getting a free weapon

lazy change to just make it so assistants only get the silly insulated gloves as their heirloom because it's probably just the better and safer item balance wise in the long term

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bruh

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
remove: free toolbox get owned
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
