### PR TITLE
Fix admin command to load away missions.

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -501,8 +501,9 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 	var/away_name
 	var/datum/space_level/away_level
+	possible_options += "Custom"
 
-	var/answer = input("What kind ? ","Away/VR") as null|anything in list(possible_options + "Custom")
+	var/answer = input("What kind ? ","Away/VR") as null|anything in possible_options
 	switch(answer)
 		if(null)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the admin command `/client/proc/admin_away()` by displaying the contents of the list rather than a list object.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Instead of getting: 
![image](https://user-images.githubusercontent.com/76988376/227760944-27a963b6-b0e3-4830-a257-f01cfd37dbbf.png)
You now can load whatever maps the configs allow:
![image](https://user-images.githubusercontent.com/76988376/227760960-3ac6f85c-ba0b-428a-bd14-1e0f2f896c9d.png)![image](https://user-images.githubusercontent.com/76988376/227760968-ca35acf6-03c8-4647-abb8-63f1676b92d6.png)
And they actually load too:
![image](https://user-images.githubusercontent.com/76988376/227760991-e5af5a0b-5847-4a87-b1f0-711c364dff50.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed admin command to load away missions and VR levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
