### PR TITLE
Jukebox bugs

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -121,7 +121,7 @@
 			if(!allowed(usr))
 				return
 			if(!active && !playing)
-				activate_music()
+				INVOKE_ASYNC(src, .proc/activate_music)
 			else
 				stop = 0
 			return TRUE
@@ -152,7 +152,7 @@
 			if(active)
 				say("[selectedtrack.song_name] has been added to the queue.")
 			else if(!playing)
-				activate_music()
+				INVOKE_ASYNC(src, .proc/activate_music)
 			playsound(src, 'sound/machines/ping.ogg', 50, TRUE)
 			queuecooldown = world.time + (3 SECONDS)
 			return TRUE
@@ -497,7 +497,7 @@
 			active = FALSE
 			dance_over()
 			if(stop && queuedplaylist.len)
-				activate_music()
+				INVOKE_ASYNC(src, .proc/activate_music)
 			else
 				playsound(src,'sound/machines/terminal_off.ogg',50,1)
 				update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the bug with some jukeboxes where for some reason the proc will halt after calling activate_music() and only run the rest after a song has stopped playing. I have no idea as to why this happens
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I believe this problem can cause lag when adding a lot of songs to the queue
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes a bug when adding songs to a jukebox queue
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
