### PR TITLE
Randomizing station names trait no longer hides announcements

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_INIT(randomizing_station_name_messages, world.file2list("strings/ran
 
 	set_station_name(new_name)
 
-	print_command_report(centcom_announcement)
+	priority_announce(centcom_announcement)
 
 /datum/station_trait/randomizing_station_name/fast
 	name = "Randomizing station name - Fast"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It was never meant to hide, it made my entire work with the goofy messages useless!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Randomizing station names trait no longer hides announcements.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
