### PR TITLE
FIxes a case of texts_by_atom on flavor text being nulled

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -157,16 +157,16 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 /datum/element/flavor_text/proc/borged_update_flavor_text(mob/new_character, client/C)
 	C = C || GET_CLIENT(new_character)
 	if(!C)
-		LAZYREMOVE(texts_by_atom, new_character)
+		LAZYSET(texts_by_atom, new_character, "")
 		return
 	var/datum/preferences/P = C.prefs
 	if(!P)
-		LAZYREMOVE(texts_by_atom, new_character)
+		LAZYSET(texts_by_atom, new_character, "")
 		return
 	if(P.custom_names["cyborg"] == new_character.real_name)
 		LAZYSET(texts_by_atom, new_character, P.features[save_key])
 	else
-		LAZYREMOVE(texts_by_atom, new_character)
+		LAZYSET(texts_by_atom, new_character, "")
 
 //subtypes with additional hooks for DNA and preferences.
 /datum/element/flavor_text/carbon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
By the way, whoever created the concept of lazy lists should be removed from a list.
As i usually expect from such procs, is that if it is in an invalid state, you get an empty list.
NOT THAT IT GETS COMPLETELY NULLED.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This can cause several runtimes for examine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed flavor texts breaking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
