### PR TITLE
Some modsuit updates

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -713,6 +713,12 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	if(istype(head_item, /obj/item/clothing/head/helmet/space) && istype(suit_item, /obj/item/clothing/suit/space))
 		return 1
 
+	if(istype(head_item, /obj/item/clothing/head/mod) && istype(suit_item, /obj/item/clothing/suit/mod))
+		var/obj/item/clothing/suit/mod/modsuit = suit_item
+		var/obj/item/mod/control/mod_control = modsuit.mod
+		if(mod_control && mod_control.active)
+			return 1
+
 	if(T && is_mining_level(T.z) && istype(head_item, /obj/item/clothing/head/hooded/explorer) && istype(suit_item, /obj/item/clothing/suit/hooded/explorer))
 		return 1
 

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -17,7 +17,7 @@
 	var/obj/item/part = locate(part_reference) in mod_parts
 	if(!istype(part) || user.incapacitated())
 		return
-	if((active && part != helmet) || activating) // SKYRAT EDIT - Let the hair flow - ORIGINAL: if(active || activating)
+	if(active || activating)
 		balloon_alert(user, "deactivate the suit first!")
 		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 		return
@@ -217,9 +217,8 @@
 
 /// Finishes the suit's activation, starts processing
 /obj/item/mod/control/proc/finish_activation(on)
-	icon_state = "[skin]-control[on ? "-sealed" : ""]"
-	slowdown = on ? slowdown_active : slowdown_inactive
-	if(on)
+	active = on
+	if(active)
 		for(var/obj/item/mod/module/module as anything in modules)
 			module.on_suit_activation()
 		START_PROCESSING(SSobj, src)
@@ -227,19 +226,23 @@
 		for(var/obj/item/mod/module/module as anything in modules)
 			module.on_suit_deactivation()
 		STOP_PROCESSING(SSobj, src)
-	wearer.update_equipment_speed_mods()
-	active = on
+	update_speed()
+	update_icon_state()
 	wearer.update_inv_back()
+
+/obj/item/mod/control/update_icon_state()
+	icon_state = "[skin]-control[active ? "-sealed" : ""]"
+	return ..()
 
 /// Quickly deploys all the suit parts and if successful, seals them and turns on the suit. Intended mostly for outfits.
 /obj/item/mod/control/proc/quick_activation()
 	var/seal = TRUE
-	for(var/obj/item/part in mod_parts)
+	for(var/obj/item/part as anything in mod_parts)
 		if(!deploy(null, part))
 			seal = FALSE
 	if(!seal)
 		return
-	for(var/obj/item/part in mod_parts)
+	for(var/obj/item/part as anything in mod_parts)
 		seal_part(part, seal = TRUE)
 	finish_activation(on = TRUE)
 

--- a/code/modules/mod/mod_clothes.dm
+++ b/code/modules/mod/mod_clothes.dm
@@ -1,4 +1,4 @@
-/obj/item/clothing/head/helmet/space/mod
+/obj/item/clothing/head/mod
 	name = "MOD helmet"
 	desc = "A helmet for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
@@ -12,27 +12,27 @@
 	cold_protection = HEAD
 	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
-	clothing_flags = THICKMATERIAL
+	clothing_flags = THICKMATERIAL|ALLOWINTERNALS
 	resistance_flags = NONE
 	flash_protect = 0
-	clothing_flags = NONE
 	flags_inv = HIDEFACIALHAIR
 	flags_cover = NONE
 	visor_flags = THICKMATERIAL|STOPSPRESSUREDAMAGE
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	visor_flags_cover = HEADCOVERSMOUTH|HEADCOVERSEYES
+	item_flags = IMMUTABLE_SLOW
 	var/alternate_layer = NECK_LAYER
 	var/obj/item/mod/control/mod
 	mutantrace_variation = STYLE_MUZZLE
 
-/obj/item/clothing/head/helmet/space/mod/Destroy()
+/obj/item/clothing/head/mod/Destroy()
 	if(!QDELETED(mod))
 		mod.helmet = null
 		mod.mod_parts -= src
 		QDEL_NULL(mod)
 	return ..()
 
-/obj/item/clothing/suit/space/mod
+/obj/item/clothing/suit/mod
 	name = "MOD chestplate"
 	desc = "A chestplate for a MODsuit."
 	icon = 'icons/obj/clothing/modsuit/mod_clothing.dmi'
@@ -51,12 +51,13 @@
 	flags_inv = HIDETAUR
 	visor_flags = STOPSPRESSUREDAMAGE
 	visor_flags_inv = HIDEJUMPSUIT
+	item_flags = IMMUTABLE_SLOW
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals)
 	resistance_flags = NONE
 	var/obj/item/mod/control/mod
 	mutantrace_variation = STYLE_DIGITIGRADE
 
-/obj/item/clothing/suit/space/mod/Destroy()
+/obj/item/clothing/suit/mod/Destroy()
 	if(!QDELETED(mod))
 		mod.chestplate = null
 		mod.mod_parts -= src
@@ -78,6 +79,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	clothing_flags = THICKMATERIAL
 	resistance_flags = NONE
+	item_flags = IMMUTABLE_SLOW
 	var/obj/item/mod/control/mod
 	var/obj/item/clothing/overslot
 	mutantrace_variation = STYLE_NO_ANTHRO_ICON
@@ -114,7 +116,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	clothing_flags = THICKMATERIAL
 	resistance_flags = NONE
-	item_flags = NONE
+	item_flags = IMMUTABLE_SLOW
 	var/obj/item/mod/control/mod
 	var/obj/item/clothing/overslot
 	mutantrace_variation = STYLE_DIGITIGRADE

--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -7,13 +7,25 @@
 	name = "MOD helmet"
 	icon_state = "helmet"
 
+/obj/item/mod/construction/helmet/examine(mob/user)
+	. = ..()
+	. += span_notice("You could insert it into a <b>MOD shell</b>...")
+
 /obj/item/mod/construction/chestplate
 	name = "MOD chestplate"
 	icon_state = "chestplate"
 
+/obj/item/mod/construction/chestplate/examine(mob/user)
+	. = ..()
+	. += span_notice("You could insert it into a <b>MOD shell</b>...")
+
 /obj/item/mod/construction/gauntlets
 	name = "MOD gauntlets"
 	icon_state = "gauntlets"
+
+/obj/item/mod/construction/gauntlets/examine(mob/user)
+	. = ..()
+	. += span_notice("You could insert these into a <b>MOD shell</b>...")
 
 /obj/item/mod/construction/boots
 	name = "MOD boots"
@@ -45,15 +57,15 @@
 	qdel(src)
 
 /obj/item/mod/construction/armor
-	name = "MOD armor plates"
-	desc = "Armor plates used to finish a MOD."
+	name = "MOD external plating"
+	desc = "External plating used to finish a MOD control unit."
 	icon_state = "standard-plating"
 	var/datum/mod_theme/theme = /datum/mod_theme
 
 /obj/item/mod/construction/armor/Initialize(mapload)
 	. = ..()
 	var/datum/mod_theme/used_theme = GLOB.mod_themes[theme]
-	name = "MOD [used_theme.name] armor plates"
+	name = "MOD [used_theme.name] external plating"
 	desc = "[desc] [used_theme.desc]"
 	icon_state = "[used_theme.default_skin]-plating"
 

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -11,6 +11,12 @@
 	var/name = "standard"
 	/// Description added to the MOD.
 	var/desc = "A civilian class suit by Nakamura Engineering, doesn't offer much other than slightly quicker movement."
+	/// Extended description on examine_more
+	var/extended_desc = "A third-generation, modular civilian class suit by Nakamura Engineering, \
+		this suit is a staple across the galaxy for civilian applications. These suits are oxygenated, \
+		spaceworthy, resistant to fire and chemical threats, and are immunized against everything between \
+		a sneeze and a bioweapon. However, their combat applications are incredibly minimal due to no \
+		armor plating being installed by default, and their actuators only lead to slightly greater speed than normal."
 	/// Default skin of the MOD.
 	var/default_skin = "standard"
 	/// Armor shared across the MOD pieces.
@@ -35,6 +41,8 @@
 	var/slowdown_active = 0.75
 	/// Theme used by the MOD TGUI.
 	var/ui_theme = "ntos"
+	/// Allowed items in the chestplate's suit storage.
+	var/list/allowed = list(/obj/item/flashlight, /obj/item/tank/internals)
 	/// List of inbuilt modules. These are different from the pre-equipped suits, you should mainly use these for unremovable modules with 0 complexity.
 	var/list/inbuilt_modules = list()
 	/// Modules blacklisted from the MOD.
@@ -45,7 +53,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -68,7 +76,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				UNSEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
 			),
@@ -91,6 +99,11 @@
 /datum/mod_theme/engineering
 	name = "engineering"
 	desc = "An engineer-fit suit with heat and shock resistance. Nakamura Engineering's classic."
+	extended_desc = "A classic by Nakamura Engineering, and surely their claim to fame. This model is an \
+		improvement upon the first-generation prototype models from before the Void War, boasting an array of features. \
+		The modular flexibility of the base design has been combined with an blast-dampening insulated inner layer and \
+		a shock-resistant outer layer, making the suit nigh-invulnerable against even the extremes of high-voltage electricity. \
+		However, the capacity for modification remains the same as civilian-grade suits."
 	default_skin = "engineering"
 	armor = list(MELEE = 10, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 10, BIO = 100, FIRE = 100, ACID = 25, WOUND = 10, RAD = 20)
 	resistance_flags = FIRE_PROOF
@@ -103,7 +116,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -127,6 +140,11 @@
 /datum/mod_theme/atmospheric
 	name = "atmospheric"
 	desc = "An atmospheric-resistant suit by Nakamura Engineering, offering extreme heat resistance compared to the engineer suit."
+	extended_desc = "A modified version of the Nakamura Engineering industrial model. This one has been \
+		augmented with the latest in heat-resistant alloys, paired with a series of advanced heatsinks. \
+		Additionally, the materials used to construct this suit have rendered it extremely hardy against \
+		corrosive gasses and liquids, useful in the world of pipes. \
+		However, the capacity for modification remains the same as civilian-grade suits."
 	default_skin = "atmospheric"
 	armor = list(MELEE = 10, BULLET = 5, LASER = 10, ENERGY = 15, BOMB = 10, BIO = 100, FIRE = 100, ACID = 75, WOUND = 10, RAD = 0)
 	resistance_flags = FIRE_PROOF
@@ -138,7 +156,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDESNOUT,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR,
 				UNSEALED_COVER = HEADCOVERSMOUTH,
@@ -163,6 +181,11 @@
 /datum/mod_theme/advanced
 	name = "advanced"
 	desc = "An advanced version of Nakamura Engineering's classic suit, shining with a white, acid and fire resistant polish."
+	extended_desc = "The flagship version of the Nakamura Engineering industrial model, and their latest product. \
+		Combining all the features of their other industrial model suits inside, with blast resistance almost approaching \
+		some EOD suits, the outside has been coated with a white polish rumored to be a corporate secret. \
+		The paint used is almost entirely immune to corrosives, and certainly looks damn fine. \
+		These come pre-installed with magnetic boots, using an advanced system to toggle them on or off as the user walks."
 	default_skin = "advanced"
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 15, BOMB = 50, BIO = 100, FIRE = 100, ACID = 90, WOUND = 10, RAD = 35)
 	resistance_flags = FIRE_PROOF
@@ -176,7 +199,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -200,6 +223,13 @@
 /datum/mod_theme/mining
 	name = "mining"
 	desc = "A high-power Nanotrasen mining suit, supporting more complexity at a bigger drain."
+	extended_desc = "A high-powered Nanotrasen-designed suit, based off the work of Nakamura Engineering. \
+		While initial designs were built for the rigors of asteroid mining, given blast resistance through inbuilt ceramics, \
+		mining teams have since heavily tweaked the suit themselves. Aftermarket armor plating has been added, \
+		giving way to incredible protection against corrosives and thermal protection good enough for volcanic environments. \
+		The systems have been upgraded as well, giving space for further modification down the line. \
+		However, all of this has proven to be straining on the cell and the actuators of the suit, \
+		making it demand more power in exchange."
 	default_skin = "mining"
 	armor = list(MELEE = 15, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 30, BIO = 100, FIRE = 100, ACID = 75, WOUND = 15, RAD = 0)
 	resistance_flags = FIRE_PROOF
@@ -211,7 +241,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEEARS|HIDEHAIR|HIDESNOUT,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEYES|HIDEFACE,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -235,6 +265,12 @@
 /datum/mod_theme/medical
 	name = "medical"
 	desc = "A lightweight suit by DeForest Medical Corporation, allows for easier movement."
+	extended_desc = "A lightweight suit produced by the DeForest Medical Corporation, based off the work of \
+		Nakamura Engineering. The latest in technology has been employed in this suit to render it immunized against \
+		allergens, airborne toxins, and regular pathogens. The primary asset of this suit is the speed, \
+		fusing high-powered servos and actuators with a carbon-fiber construction. While there's very little armor used, \
+		it is incredibly acid-resistant. It is slightly more demanding of power than civilian-grade models, \
+		and weak against fingers tapping the glass."
 	default_skin = "medical"
 	armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 10, BIO = 100, FIRE = 60, ACID = 75, WOUND = 5, RAD = 0)
 	cell_drain = DEFAULT_CHARGE_DRAIN * 1.5
@@ -245,7 +281,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -268,7 +304,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -292,6 +328,12 @@
 /datum/mod_theme/rescue
 	name = "rescue"
 	desc = "An advanced version of DeForest Medical Corporation's medical suit, designed for quick rescue of bodies from the most dangerous environments."
+	extended_desc = "An upgraded, armor-plated version of DeForest Medical Corporation's medical suit, \
+		designed for quick rescue of bodies from the most dangerous environments. The same advanced leg servos \
+		as the base version are seen here, giving paramedics incredible speed, but the same servos are also in the arms. \
+		Users are capable of quickly hauling even the heaviest crewmembers using this suit, \
+		all while being entirely immune against chemical and thermal threats. \
+		It is slightly more demanding of power than civilian-grade models, and weak against fingers tapping the glass."
 	default_skin = "rescue"
 	armor = list(MELEE = 10, BULLET = 10, LASER = 5, ENERGY = 5, BOMB = 10, BIO = 100, FIRE = 100, ACID = 100, WOUND = 5, RAD = 0)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
@@ -305,7 +347,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -329,20 +371,28 @@
 /datum/mod_theme/research
 	name = "research"
 	desc = "A private military EOD suit by Aussec Armory, intended for explosive research. Bulky, but expansive."
+	extended_desc = "A private military EOD suit by Aussec Armory, based off the work of Nakamura Engineering. \
+		This suit is intended for explosive research, built incredibly bulky and well-covering. \
+		Featuring an inbuilt chemical scanning array, this suit uses two layers of plastitanium armor, \
+		sandwiching an inert layer to dissipate kinetic energy into the suit and away from the user; \
+		outperforming even the best conventional EOD suits. However, despite its immunity against even \
+		missiles and artillery, the armor is no more effective than standard suits against \
+		other weapon types and physical damage; and all the explosive resistance mostly working to keep the user intact, \
+		not alive. The user will also find narrow doorframes nigh-impossible to surmount."
 	default_skin = "research"
 	armor = list(MELEE = 20, BULLET = 15, LASER = 5, ENERGY = 5, BOMB = 100, BIO = 100, FIRE = 100, ACID = 100, WOUND = 15, RAD = 0)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
-	slowdown_inactive = 2
-	slowdown_active = 1.5
+	slowdown_inactive = 1.75
+	slowdown_active = 1.25
 	inbuilt_modules = list(/obj/item/mod/module/reagent_scanner/advanced)
 	skins = list(
 		"research" = list(
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				UNSEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
 			),
@@ -365,6 +415,14 @@
 /datum/mod_theme/security
 	name = "security"
 	desc = "An Apadyne Technologies security suit, offering shock protection and quicker speed, at the cost of carrying capacity."
+	extended_desc = "An Apadyne Technologies classic, this model of MODsuit has been designed for quick response to \
+		hostile situations. These suits have been layered with plating worthy enough for fires or corrosive environments, \
+		and come with composite cushioning and an advanced honeycomb structure underneath the hull to ensure protection \
+		against broken bones or possible avulsions. The suit's legs have been given more rugged actuators, \
+		allowing the suit to do more work in carrying the weight. Lastly, these have been given a shock-absorbing \
+		insulating layer on the gauntlets, making sure the user isn't under risk of electricity. \
+		However, the systems used in these suits are more than a few years out of date, \
+		leading to an overall lower capacity for modules."
 	default_skin = "security"
 	armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 25, BIO = 100, FIRE = 75, ACID = 75, WOUND = 15, RAD = 0)
 	siemens_coefficient = 0
@@ -376,7 +434,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEEARS|HIDEHAIR|HIDESNOUT,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEYES|HIDEFACE,
 				UNSEALED_COVER = HEADCOVERSMOUTH,
@@ -401,6 +459,12 @@
 /datum/mod_theme/safeguard
 	name = "safeguard"
 	desc = "An Apadyne Technologies advanced security suit, offering greater speed and fire protection than the standard security model."
+	extended_desc = "An Apadyne Technologies advanced security suit, and their latest model. This variant has \
+		ditched the presence of a reinforced glass visor entirely, replacing it with a 'blast visor' utilizing a \
+		small camera on the left side to display the outside to the user. The plating on the suit has been \
+		dramatically increased, especially in the pauldrons, giving the wearer an imposing silhouette. \
+		Heatsinks line the sides of the suit, and greater technology has been used in insulating it against \
+		both corrosive environments and sudden impacts to the user's joints."
 	default_skin = "safeguard"
 	armor = list(MELEE = 15, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 40, BIO = 100, FIRE = 100, ACID = 95, WOUND = 15, RAD = 0)
 	resistance_flags = FIRE_PROOF
@@ -414,7 +478,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				UNSEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
 			),
@@ -437,6 +501,15 @@
 /datum/mod_theme/magnate
 	name = "magnate"
 	desc = "A fancy, very protective suit for Nanotrasen's captains. Shock, fire and acid-proof while also having a large capacity and high speed."
+	extended_desc = "They say it costs four hundred thousand credits to run this MODsuit... for twelve seconds. \
+		The Magnate suit is designed for protection, comfort, and luxury for Nanotrasen Captains. \
+		The onboard air filters have been preprogrammed with an additional five hundred different fragrances that can \
+		be pumped into the helmet, all of highly-endangered flowers. A bespoke Tralex mechanical clock has been placed \
+		in the wrist, and the Magnate package comes with carbon-fibre cufflinks to wear underneath. \
+		My God, it even has a granite trim. The double-classified paint that's been painstakingly applied to the hull \
+		provides protection against shock, fire, and the strongest acids. Onboard systems employ meta-positronic learning \
+		and bluespace processing to allow for a wide array of onboard modules to be supported, and only the best actuators \
+		have been employed for speed. The resemblance to a Gorlex Marauder helmet is purely coincidental."
 	default_skin = "magnate"
 	armor = list(MELEE = 20, BULLET = 15, LASER = 15, ENERGY = 15, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 15, RAD = 0)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
@@ -450,7 +523,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -474,17 +547,23 @@
 /datum/mod_theme/cosmohonk
 	name = "cosmohonk"
 	desc = "A suit by Honk Ltd. Protects against low humor environments. Most of the tech went to lower the power cost."
+	extended_desc = "The Cosmohonk MODsuit was originally designed for interstellar comedy in low-humor environments. \
+		It utilizes tungsten electro-ceramic casing and chromium bipolars, coated in zirconium-boron paint underneath \
+		a dermatiraelian subspace alloy. Despite the glaringly obvious optronic vacuum drive pedals, \
+		this particular model does not employ manganese bipolar capacitor cleaners, thank the Honkmother. \
+		All you know is that this suit is mysteriously power-efficient, and far too colorful for the Mime to steal."
 	default_skin = "cosmohonk"
 	armor = list(MELEE = 5, BULLET = 5, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 100, FIRE = 60, ACID = 30, WOUND = 5, RAD = 0)
 	cell_drain = DEFAULT_CHARGE_DRAIN * 0.25
 	slowdown_inactive = 1.75
 	slowdown_active = 1.25
+	/*inbuilt_modules = list(/obj/item/mod/module/waddle)*/ // Waddling element not ported, commented for now as it is a prerequisite.
 	skins = list(
 		"cosmohonk" = list(
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEEARS|HIDEHAIR,
 				SEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEYES|HIDEFACE|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -508,6 +587,13 @@
 /datum/mod_theme/syndicate
 	name = "syndicate"
 	desc = "A suit designed by Gorlex Marauders, offering armor ruled illegal in most of Spinward Stellar."
+	extended_desc = "An advanced combat suit adorned in a sinister crimson red color scheme, produced and manufactured \
+		for special mercenary operations. The build is a streamlined layering consisting of shaped Plasteel, \
+		and composite ceramic, while the under suit is lined with a lightweight Kevlar and durathread hybrid weave \
+		to provide ample protection to the user where the plating doesn't, with an illegal onboard cell powered \
+		ablative shield module to provide resistance against conventional energy firearms. \
+		A small tag hangs off of it reading; 'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
+		All rights reserved, tampering with suit will void warranty."
 	default_skin = "syndicate"
 	armor = list(MELEE = 15, BULLET = 20, LASER = 15, ENERGY = 15, BOMB = 35, BIO = 100, FIRE = 50, ACID = 90, WOUND = 25, RAD = 0)
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
@@ -521,7 +607,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -545,6 +631,12 @@
 /datum/mod_theme/elite
 	name = "elite"
 	desc = "An elite suit upgraded by Cybersun Industries, offering upgraded armor values."
+	extended_desc = "An evolution of the syndicate suit, featuring a bulkier build and a matte black color scheme, \
+		this suit is only produced for high ranking Syndicate officers and elite strike teams. \
+		It comes built with a secondary layering of ceramic and Kevlar into the plating providing it with \
+		exceptionally better protection along with fire and acid proofing. A small tag hangs off of it reading; \
+		'Property of the Gorlex Marauders, with assistance from Cybersun Industries. \
+		All rights reserved, tampering with suit will void life expectancy.'"
 	default_skin = "elite"
 	armor = list(MELEE = 35, BULLET = 30, LASER = 35, ENERGY = 35, BOMB = 55, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25, RAD = 0)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
@@ -559,7 +651,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -583,6 +675,13 @@
 /datum/mod_theme/enchanted
 	name = "enchanted"
 	desc = "The Wizard Federation's relatively low-tech MODsuit. Is very protective, though."
+	extended_desc = "The Wizard Federation's relatively low-tech MODsuit. This armor employs not \
+		plasteel or carbon fibre, but space dragon scales for its protection. Recruits are expected to \
+		gather these themselves, but the effort is well worth it, the suit being well-armored against threats \
+		both mundane and mystic. Rather than wholly relying on the suit's cell, which would surely perish \
+		under the load, several naturally-occurring bluespace gemstones have been utilized as \
+		supplementary means of power. The hood and platform boots are of unknown usage, but it's speculated that \
+		wizards trend towards the dramatic."
 	default_skin = "enchanted"
 	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 50, BOMB = 35, BIO = 100, FIRE = 100, ACID = 100, WOUND = 30, RAD = 0)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
@@ -598,7 +697,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				UNSEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
 			),
@@ -621,12 +720,22 @@
 /datum/mod_theme/prototype
 	name = "prototype"
 	desc = "A prototype modular suit powered by locomotives. While it is comfortable and has a big capacity, it remains very bulky and power-inefficient."
+	extended_desc = "This is a prototype powered exoskeleton, a design not seen in hundreds of years, the first \
+		post-void war era modular suit to ever be safely utilized by an operator. This ancient clunker is still functional, \
+		though it's missing several modern-day luxuries from updated Nakamura Engineering designs. \
+		Primarily, the suit's myoelectric suit layer is entirely non-existant, and the servos do very little to \
+		help distribute the weight evenly across the wearer's body, making it slow and bulky to move in. \
+		Additionally, the armor plating never finished production aside from the shoulders, forearms, and helmet; \
+		making it useless against direct attacks. The internal heads-up display is rendered in nearly unreadable cyan, \
+		as the visor suggests, leaving the user unable to see long distances. \
+		However, the way the helmet retracts is pretty cool."
 	default_skin = "prototype"
 	armor = list(MELEE = 20, BULLET = 5, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 100, FIRE = 100, ACID = 75, WOUND = 5, RAD = 0)
 	resistance_flags = FIRE_PROOF
-	complexity_max = DEFAULT_MAX_COMPLEXITY + 10
-	slowdown_inactive = 2.5
-	slowdown_active = 2
+	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
+	cell_drain = DEFAULT_CHARGE_DRAIN * 2
+	slowdown_inactive = 2
+	slowdown_active = 1.5
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/kinesis)
 	skins = list(
@@ -634,7 +743,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				UNSEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
 			),
@@ -657,6 +766,11 @@
 /datum/mod_theme/responsory
 	name = "responsory"
 	desc = "A high-speed rescue suit by Nanotrasen, intended for its' emergency response teams."
+	extended_desc = "A streamlined suit of Nanotrasen design, these sleek black suits are only worn by \
+		elite emergency response personnel to help save the day. While the slim and nimble design of the suit \
+		cuts the ceramics and ablatives in it down, dropping the protection, \
+		it keeps the wearer safe from the harsh void of space while sacrificing no speed whatsoever. \
+		While wearing it you feel an extreme deference to darkness. "
 	default_skin = "responsory"
 	armor = list(MELEE = 50, BULLET = 40, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 100, ACID = 90, WOUND = 10, RAD = 0)
 	resistance_flags = FIRE_PROOF
@@ -669,7 +783,7 @@
 			HELMET_LAYER = NECK_LAYER,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = NONE,
-				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -692,7 +806,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT,
 				UNSEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
 			),
@@ -715,6 +829,12 @@
 /datum/mod_theme/apocryphal
 	name = "apocryphal"
 	desc = "A high-tech, only technically legal, armored suit created by a collaboration effort between Nanotrasen and Apadyne Technologies."
+	extended_desc = "A bulky and only legal by technicality suit, this ominous black and red MODsuit is only worn by \
+		Nanotrasen Black Ops teams. If you can see this suit, you fucked up. A collaborative joint effort between \
+		Apadyne and Nanotrasen the construction and modules gives the user robust protection against \
+		anything that can be thrown at it, along with acute combat awareness tools for it's wearer. \
+		Whether the wearer uses it or not is up to them. \
+		There seems to be a little inscription on the wrist that reads; \'squiddie', d'aww."
 	default_skin = "apocryphal"
 	armor = list(MELEE = 80, BULLET = 80, LASER = 50, ENERGY = 60, BOMB = 100, BIO = 100, FIRE = 100, ACID = 100, WOUND = 25, RAD = 0)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
@@ -726,7 +846,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEEARS|HIDEHAIR,
 				SEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEMASK|HIDEEYES|HIDEFACE|HIDESNOUT,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -750,6 +870,11 @@
 /datum/mod_theme/corporate
 	name = "corporate"
 	desc = "A fancy, high-tech suit for Nanotrasen's high ranking officers."
+	extended_desc = "An even more costly version of the Magnate model, the corporate suit is a thermally insulated, \
+		anti-corrosion coated suit for high-ranking CentCom Officers, deploying pristine protective armor and \
+		advanced actuators, feeling practically weightless when turned on. Scraping the paint of this suit is \
+		counted as a war-crime and reason for immediate execution in over fifty Nanotrasen space stations. \
+		The resemblance to a Gorlex Marauder helmet is purely coincidental."
 	default_skin = "corporate"
 	armor = list(MELEE = 50, BULLET = 40, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 100, ACID = 100, WOUND = 15, RAD = 0)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
@@ -762,7 +887,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEEARS|HIDEHAIR|HIDESNOUT,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEYES|HIDEFACE,
 				SEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,
@@ -786,6 +911,9 @@
 /datum/mod_theme/debug
 	name = "debug"
 	desc = "Strangely nostalgic."
+	extended_desc = "An advanced suit that has dual ion engines powerful enough to grant a humanoid flight. \
+		Contains an internal self-recharging high-current capacitor for short, powerful bo- \
+		Oh wait, this is not actually a flight suit. Fuck."
 	default_skin = "debug"
 	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 100, BIO = 100, FIRE = 100, ACID = 100, WOUND = 0, RAD = 25)
 	resistance_flags = FIRE_PROOF|ACID_PROOF
@@ -798,7 +926,7 @@
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
 				UNSEALED_CLOTHING = THICKMATERIAL,
-				SEALED_CLOTHING = STOPSPRESSUREDAMAGE,
+				SEALED_CLOTHING = STOPSPRESSUREDAMAGE|ALLOWINTERNALS|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEEARS|HIDEHAIR|HIDESNOUT,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE,
 				UNSEALED_COVER = HEADCOVERSMOUTH,
@@ -823,6 +951,10 @@
 /datum/mod_theme/administrative
 	name = "administrative"
 	desc = "A suit made of adminium. Who comes up with these stupid mineral names?"
+	extended_desc = "Yeah, okay, I guess you can call that an event. What I consider an event is something actually \
+		fun and engaging for the players- instead, most were sitting out, dead or gibbed, while the lucky few got to \
+		have all the fun. If this continues to be a pattern for your \"events\" (Admin Abuse) \
+		there will be an admin complaint. You have been warned."
 	default_skin = "debug"
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 100, BIO = 100, FIRE = 100, ACID = 100, WOUND = 100, RAD = 100)
 	resistance_flags = INDESTRUCTIBLE|LAVA_PROOF|FIRE_PROOF|UNACIDABLE|ACID_PROOF
@@ -835,7 +967,7 @@
 		"debug" = list(
 			HELMET_LAYER = null,
 			HELMET_FLAGS = list(
-				UNSEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE,
+				UNSEALED_CLOTHING = THICKMATERIAL|STOPSPRESSUREDAMAGE|ALLOWINTERNALS,
 				UNSEALED_INVISIBILITY = HIDEFACIALHAIR|HIDEEARS|HIDEHAIR|HIDESNOUT,
 				SEALED_INVISIBILITY = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE,
 				UNSEALED_COVER = HEADCOVERSMOUTH|HEADCOVERSEYES,

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -72,6 +72,7 @@
 		/obj/item/mod/module/storage,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/health_analyzer,
+		/*/obj/item/mod/module/injector,*/ //Injector module unported as of now.
 	)
 
 /obj/item/mod/control/pre_equipped/research
@@ -172,31 +173,41 @@
 		/obj/item/mod/module/holster,
 	)
 	var/insignia_type = /obj/item/mod/module/insignia
+	var/additional_module
 
 /obj/item/mod/control/pre_equipped/responsory/Initialize(mapload, new_theme, new_skin)
 	initial_modules.Insert(1, insignia_type)
+	if(additional_module)
+		initial_modules.Add(additional_module)
 	return ..()
 
 /obj/item/mod/control/pre_equipped/responsory/commander
 	insignia_type = /obj/item/mod/module/insignia/commander
+	additional_module = /obj/item/mod/module/noslip
 
 /obj/item/mod/control/pre_equipped/responsory/security
 	insignia_type = /obj/item/mod/module/insignia/security
+	additional_module = /obj/item/mod/module/gps
 
 /obj/item/mod/control/pre_equipped/responsory/engineer
 	insignia_type = /obj/item/mod/module/insignia/engineer
+	additional_module = /obj/item/mod/module/rad_protection
 
 /obj/item/mod/control/pre_equipped/responsory/medic
 	insignia_type = /obj/item/mod/module/insignia/medic
+	additional_module = /obj/item/mod/module/quick_carry
 
 /obj/item/mod/control/pre_equipped/responsory/janitor
 	insignia_type = /obj/item/mod/module/insignia/janitor
+	additional_module = /obj/item/mod/module/clamp
 
 /obj/item/mod/control/pre_equipped/responsory/clown
 	insignia_type = /obj/item/mod/module/insignia/clown
+	additional_module = /obj/item/mod/module/bikehorn
 
 /obj/item/mod/control/pre_equipped/responsory/chaplain
 	insignia_type = /obj/item/mod/module/insignia/chaplain
+	/*additional_module = /obj/item/mod/module/injector*/ //Injector module unported as of now.
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory
 	initial_modules = list(
@@ -211,15 +222,19 @@
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/commander
 	insignia_type = /obj/item/mod/module/insignia/commander
+	additional_module = /obj/item/mod/module/noslip
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/security
 	insignia_type = /obj/item/mod/module/insignia/security
+	additional_module = /obj/item/mod/module/gps
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/medic
 	insignia_type = /obj/item/mod/module/insignia/medic
+	additional_module = /obj/item/mod/module/quick_carry
 
 /obj/item/mod/control/pre_equipped/responsory/inquisitory/chaplain
 	insignia_type = /obj/item/mod/module/insignia/chaplain
+	/*additional_module = /obj/item/mod/module/injector*/ //Injector module unported as of now.
 
 /obj/item/mod/control/pre_equipped/apocryphal
 	theme = /datum/mod_theme/apocryphal
@@ -250,6 +265,7 @@
 		/obj/item/mod/module/bikehorn,
 		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/tether,
+		/*/obj/item/mod/module/injector,*/ //Injector module unported as of now.
 	) //one of every type of module, for testing if they all work correctly
 
 /obj/item/mod/control/pre_equipped/administrative

--- a/code/modules/mod/modules/modules.dm
+++ b/code/modules/mod/modules/modules.dm
@@ -1,3 +1,15 @@
+//Magic Nullifier
+/obj/item/mod/module/anti_magic
+	name = "MOD magic nullifier module"
+	desc = "A series of obsidian rods installed into critical points around the suit, \
+		vibrated at a certain low frequency to enable them to resonate. \
+		This creates a low-range, yet strong, magic nullification field around the user, \
+		aided by a full replacement of the suit's normal coolant with holy water. \
+		Spells will spall right off this field, though it'll do nothing to help others believe you about all this."
+	icon_state = "magic_nullifier"
+	removable = FALSE
+	incompatible_modules = list(/obj/item/mod/module/anti_magic)
+
 /obj/item/mod/module/anti_magic/on_suit_activation()
 	ADD_TRAIT(mod.wearer, TRAIT_ANTIMAGIC, MOD_TRAIT)
 	ADD_TRAIT(mod.wearer, TRAIT_HOLY, MOD_TRAIT)
@@ -94,3 +106,21 @@
 
 /obj/item/mod/module/insignia/chaplain
 	color = "#f0a00c"
+
+/obj/item/mod/module/noslip
+	name = "MOD anti slip module"
+	desc = "These are a modified variant of standard magnetic boots, utilizing piezoelectric crystals on the soles. \
+		The two plates on the bottom of the boots automatically extend and magnetize as the user steps; \
+		a pull that's too weak to offer them the ability to affix to a hull, but just strong enough to \
+		protect against the fact that you didn't read the wet floor sign. Honk Co. has come out numerous times \
+		in protest of these modules being legal."
+	icon_state = "noslip"
+	complexity = 1
+	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.1
+	incompatible_modules = list(/obj/item/mod/module/noslip)
+
+/obj/item/mod/module/noslip/on_suit_activation()
+	ADD_TRAIT(mod.wearer, TRAIT_NOSLIPWATER, MOD_TRAIT)
+
+/obj/item/mod/module/noslip/on_suit_deactivation()
+	REMOVE_TRAIT(mod.wearer, TRAIT_NOSLIPWATER, MOD_TRAIT)

--- a/code/modules/mod/modules/modules_service.dm
+++ b/code/modules/mod/modules/modules_service.dm
@@ -64,3 +64,33 @@
 	spark_effect_two.set_up(2, 1, microwave_target_loc)
 	spark_effect_two.start()
 	drain_power(use_power_cost)
+
+//Waddle
+
+//Waddling element not yet portee, commented out for now.
+/*
+/obj/item/mod/module/waddle
+	name = "MOD waddle module"
+	desc = "Some of the most primitive technology in use by HonkCo. This module works off an automatic intention system, \
+		utilizing its sensitivity to the pilot's often-limited brainwaves to directly read their next step, \
+		affecting the boots they're installed in. Employing a twin-linked gravitonic drive to create \
+		miniaturized etheric blasts of space-time beneath the user's feet, this enables them to... \
+		to waddle around, bouncing to and fro with a pep in their step."
+	icon_state = "waddle"
+	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.2
+	removable = FALSE
+	incompatible_modules = list(/obj/item/mod/module/waddle)
+
+/obj/item/mod/module/waddle/on_suit_activation()
+	mod.AddComponent(/datum/component/squeak, list('sound/effects/clownstep1.ogg'=1,'sound/effects/clownstep2.ogg'=1), 50, falloff_exponent = 20) //die off quick please
+	mod.wearer.AddElement(/datum/element/waddling)
+	if(is_clown_job(mod.wearer.mind?.assigned_role))
+		SEND_SIGNAL(mod.wearer, COMSIG_ADD_MOOD_EVENT, "clownshoes", /datum/mood_event/clownshoes)
+
+/obj/item/mod/module/waddle/on_suit_deactivation()
+	qdel(mod.GetComponent(/datum/component/squeak))
+	mod.wearer.RemoveElement(/datum/element/waddling)
+	if(is_clown_job(mod.wearer.mind?.assigned_role))
+		SEND_SIGNAL(mod.wearer, COMSIG_CLEAR_MOOD_EVENT, "clownshoes")
+
+*/

--- a/code/modules/research/designs/mod_designs.dm
+++ b/code/modules/research/designs/mod_designs.dm
@@ -91,7 +91,7 @@
 	build_path = /obj/item/mod/construction/armor/mining
 	materials = list(/datum/material/iron = 6000, /datum/material/titanium = 2000, /datum/material/glass = 1000, /datum/material/plasma = 1000)
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO
-	research_icon_state = "atmospheric-mining"
+	research_icon_state = "mining-plating"
 
 /datum/design/mod_plating/medical
 	name = "MOD Medical Plating"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/63749 (minus waddle modules which is commented because we don't have the element, or some few other module changes like to antag modules because we do not have those ported).

Additionally does some updating of my own, such a reverting a skyrat decision to make helmets retractable while the suit is active (contrary to the point of modsuits), aswell as making all modsuit helmets internals-compatible like hardsuits when sealed, and making modsuits count as viable suitlinking targets for Synthetics while active.

(sprites the ported PR adds were already ported in the previous modsuit PR and thus aren't referred to in the CL credits)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Modsuits cool, outdated code not cool.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Fikou, descriptions by Nerevar and Halcyon, additional modifications by DeltaFire15
add: (Port) you can see extended descriptions of modsuit themes by examining them closely.
add: (Port) All MODsuits now have an extended description viewable by examining them closely.
balance: (Port) MODsuits no longer slow you down when undeployed in backpack form (instead applying partial slowdown depending on parts deployed).
balance: (Port) The Research MODsuit type is now slightly faster.
balance: (Port) The  Prototype MODsuit type is now slightly faster but less energy efficient.
fix: (Port) MODsuit chestplates no longer inherit spacesuit slowdown, making you much much slower than intended.
balance: MODsuit helmets are once again not retractable while active.
balance: All MODsuit helmets can now be used as internals connectors while sealed (active).
balance: MODsuits are now valid suitlink targets for Synthetics, provided they are deployed and active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
