### PR TITLE
Adds decal patterns to LGBT holidays + Pansexual and Panromantic Awareness Day holiday

### DIFF
--- a/code/__DEFINES/color/colors.dm
+++ b/code/__DEFINES/color/colors.dm
@@ -188,10 +188,42 @@
 #define CIRCUIT_COLOR_ENGINEERING "#F8D700"
 #define CIRCUIT_COLOR_SUPPLY "#C47749"
 
-/// Colors for pride week
+/// === LGBT Colors Start ===
+/// Black and white colors will not be covered for the flags that do have them. We'll just use COLOR_WHITE and COLOR_BLACK.
+/// Colors for pride
 #define COLOR_PRIDE_RED "#FF6666"
 #define COLOR_PRIDE_ORANGE "#FC9F3C"
 #define COLOR_PRIDE_YELLOW "#EAFF51"
 #define COLOR_PRIDE_GREEN "#41FC66"
 #define COLOR_PRIDE_BLUE "#42FFF2"
 #define COLOR_PRIDE_PURPLE "#5D5DFC"
+
+/// Colors for transgender flag
+#define COLOR_TRANS_BLUE "#5ACFFA"
+#define COLOR_TRANS_PINK "#F5ABB9"
+
+/// Colors for lesbian flag
+#define COLOR_LESBIAN_ORANGERED "#D62900"
+#define COLOR_LESBIAN_SANDYBROWN "#FF9B55"
+#define COLOR_LESBIAN_PALEVIOLETRED "#D462A5"
+#define COLOR_LESBIAN_DARKMAGENTA "#A50062"
+
+/// Colors for bisexual flag
+#define COLOR_BISEXUAL_MEDIUMVIOLETRED "#D70071"
+#define COLOR_BISEXUAL_DARKORCHID "#9C4E97"
+#define COLOR_BISEXUAL_DARKBLUE "#0035A9"
+
+/// Colors for intersex flag
+#define COLOR_INTERSEX_GOLD "#FFD900"
+#define COLOR_INTERSEX_DARKMAGENTA "#7A00AB"
+
+/// Colors for asexual flag
+#define COLOR_ACE_DARKGRAY "#A4A5A4"
+#define COLOR_ACE_PURPLE "#810081"
+
+/// Colors for pansexual flag
+#define COLOR_PAN_DEEPPINK "#FF1B8D"
+#define COLOR_PAN_GOLD "#FFD900"
+#define COLOR_PAN_DODGERBLUE "#1BB3FF"
+
+/// === LGBT Colors End ===

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -4,6 +4,25 @@
 	layer = TURF_PLATING_DECAL_LAYER
 	alpha = 110
 
+#define LGBT_ALPHA 60
+
+/obj/effect/turf_decal/tile/Initialize()
+	if(SSevents.holidays)
+		if (SSevents.holidays[APRIL_FOOLS])
+			color = "#[random_short_color()]"
+		else
+			for(var/H in SSevents.holidays)
+				if(istype(H,/datum/holiday/lgbt))
+					var/datum/holiday/lgbt/L = H
+					color = L.get_floor_tile_color(src)
+
+					// It looks garish at different alphas, and it's not possible to get a
+					// consistent color palette without this.
+					alpha = LGBT_ALPHA
+	return ..()
+
+#undef LGBT_ALPHA
+
 /obj/effect/turf_decal/tile/blue
 	name = "blue corner"
 	color = "#52B4E9"

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -26,7 +26,7 @@
 	var/i = findtext(name," ")
 	return copytext(name, 1, i)
 
-// Return 1 if this holidy should be celebrated today
+// Return 1 if this holiday should be celebrated today
 /datum/holiday/proc/shouldCelebrate(dd, mm, yy, ww, ddd)
 	if(always_celebrate)
 		return TRUE
@@ -189,12 +189,40 @@
 	begin_day = 22
 	begin_month = APRIL
 
-/datum/holiday/lesbianvisibility
+/datum/holiday/lgbt
+	name = "Pride Week"
+	begin_month = JUNE
+	begin_day = 23
+	end_day = 29
+	//Will take place during pride month for one week. Stonewall was June 28th, so this captures its week.
+
+	var/list/holiday_colors = list(
+		COLOR_PRIDE_PURPLE,
+		COLOR_PRIDE_BLUE,
+		COLOR_PRIDE_GREEN,
+		COLOR_PRIDE_YELLOW,
+		COLOR_PRIDE_ORANGE,
+		COLOR_PRIDE_RED
+	)
+
+/datum/holiday/lgbt/proc/get_floor_tile_color(atom/atom)
+	var/turf/turf = get_turf(atom)
+	return holiday_colors[(turf.y % holiday_colors.len) + 1]
+
+/datum/holiday/lgbt/lesbianvisibility
 	name = "Lesbian Visibility Day"
 	begin_day = 26
 	begin_month = APRIL
 
-/datum/holiday/lesbianvisibility/greet()
+	holiday_colors = list( //using the 2018 5-pattern flag
+		COLOR_LESBIAN_ORANGERED,
+		COLOR_LESBIAN_SANDYBROWN,
+		COLOR_WHITE,
+		COLOR_LESBIAN_PALEVIOLETRED,
+		COLOR_LESBIAN_DARKMAGENTA
+	)
+
+/datum/holiday/lgbt/lesbianvisibility/greet()
 	return "Today is Lesbian Visibility Day!"
 
 /datum/holiday/labor
@@ -300,12 +328,20 @@
 /datum/holiday/programmers/getStationPrefix()
 	return pick("span>","DEBUG: ","null","/list","EVENT PREFIX NOT FOUND") //Portability
 
-/datum/holiday/bivisibility
+/datum/holiday/lgbt/bivisibility
 	name = "Bisexual Visibility Day"
 	begin_day = 23
 	begin_month = SEPTEMBER
 
-/datum/holiday/bivisibility/greet()
+	holiday_colors = list(
+		COLOR_BISEXUAL_MEDIUMVIOLETRED,
+		COLOR_BISEXUAL_MEDIUMVIOLETRED,
+		COLOR_BISEXUAL_DARKORCHID,
+		COLOR_BISEXUAL_DARKBLUE,
+		COLOR_BISEXUAL_DARKBLUE
+	)
+
+/datum/holiday/lgbt/bivisibility/greet()
 	return "Today is Bisexual Visibility Day!"
 
 /datum/holiday/questions
@@ -341,12 +377,18 @@
 	begin_month = OCTOBER
 	drone_hat = /obj/item/clothing/head/that
 
-/datum/holiday/intersexawareness
+/datum/holiday/lgbt/intersexawareness
 	name = "Intersex Awareness Day"
 	begin_day = 26
 	begin_month = OCTOBER
 
-/datum/holiday/intersexawareness/greet()
+	holiday_colors = list( //Intersex's flag isn't a striped pattern so this is the best we got
+		COLOR_INTERSEX_GOLD,
+		COLOR_INTERSEX_DARKMAGENTA,
+		COLOR_INTERSEX_GOLD
+	)
+
+/datum/holiday/lgbt/intersexawareness/greet()
 	return "Today is Intersex Awareness Day! It has been [text2num(time2text(world.timeofday, "YYYY")) - 1996] years since the first public protest speaking out against the human rights issues faced by intersex people."
 
 /datum/holiday/halloween
@@ -388,21 +430,35 @@
 	begin_month = NOVEMBER
 	drone_hat = /obj/item/reagent_containers/food/snacks/grown/moonflower
 
-/datum/holiday/transawareness
+/datum/holiday/lgbt/transawareness
 	name = "Transgender Awareness Week"
 	begin_day = 13
 	begin_month = NOVEMBER
 	end_day = 19
 
-/datum/holiday/transawareness/greet()
+	holiday_colors = list(
+		COLOR_TRANS_BLUE,
+		COLOR_TRANS_PINK,
+		COLOR_WHITE,
+		COLOR_TRANS_PINK //loops back to blue
+	)
+
+/datum/holiday/lgbt/transawareness/greet()
 	return "This week is Transgender Awareness Week!"
 
-/datum/holiday/transremembrance
+/datum/holiday/lgbt/transremembrance
 	name = "Transgender Day of Remembrance"
 	begin_day = 20
 	begin_month = NOVEMBER
 
-/datum/holiday/transremembrance/greet()
+	holiday_colors = list(
+		COLOR_TRANS_BLUE,
+		COLOR_TRANS_PINK,
+		COLOR_WHITE,
+		COLOR_TRANS_PINK //loops back to blue
+	)
+
+/datum/holiday/lgbt/transremembrance/greet()
 	return "Today is the Transgender Day of Remembrance."
 
 /datum/holiday/hello
@@ -443,14 +499,21 @@
 	begin_month = OCTOBER
 	begin_weekday = MONDAY
 
-/datum/holiday/aceawareness
+/datum/holiday/lgbt/aceawareness
 	name = "Asexual Awareness Week"
 	begin_month = OCTOBER
 
-/datum/holiday/aceawareness/greet()
+	holiday_colors = list(
+		COLOR_BLACK,
+		COLOR_ACE_DARKGRAY,
+		COLOR_ACE_PURPLE,
+		COLOR_WHITE
+	)
+
+/datum/holiday/lgbt/aceawareness/greet()
 	return "This week is Asexual Awareness Week!"
 
-/datum/holiday/aceawareness/shouldCelebrate(dd, mm, yy, ww, ddd) //Ace awareness week falls on the last full week of October.
+/datum/holiday/lgbt/aceawareness/shouldCelebrate(dd, mm, yy, ww, ddd) //Ace awareness week falls on the last full week of October.
 	if(mm != begin_month)
 		return FALSE //it's not even the right month
 	var/daypointer = world.timeofday - ((WEEKDAY2NUM(ddd) - 1) * 24 HOURS)
@@ -478,7 +541,7 @@
 	begin_month = JUNE
 	begin_weekday = SUNDAY
 
-/datum/holiday/pride
+/datum/holiday/pride //Won't be typing this as /lgbt/ because the typing is meant for LGBT holidays that will change the station's decals. Having a full month of pride decals seems a bit long.
 	name = PRIDE_MONTH
 	begin_day = 1
 	begin_month = JUNE
@@ -487,13 +550,30 @@
 /datum/holiday/pride/getStationPrefix()
 	return pick("Pride", "Gay", "Bi", "Trans", "Lesbian", "Ace", "Aro", "Agender", pick("Enby", "Enbie"), "Pan", "Intersex", "Demi", "Poly", "Closeted", "Genderfluid")
 
-/datum/holiday/stonewall
+/datum/holiday/stonewall //decal patterns covered in "Pride Week"
 	name = "Stonewall Riots Anniversary"
 	begin_day = 28
 	begin_month = JUNE
 
 /datum/holiday/stonewall/greet() //Not gonna lie, I was fairly tempted to make this use the IC year instead of the IRL year, but I was worried that it would have caused too much confusion.
 	return "Today marks the [text2num(time2text(world.timeofday, "YYYY")) - 1969]\th anniversary of the riots at the Stonewall Inn!"
+
+/datum/holiday/lgbt/pan
+	name = "Pansexual and Panromantic Awareness Day"
+	begin_day = 24
+	begin_month = MAY
+
+	holiday_colors = list(
+		COLOR_PAN_DEEPPINK,
+		COLOR_PAN_GOLD,
+		COLOR_PAN_DODGERBLUE
+	)
+
+/datum/holiday/lgbt/pan/greet()
+	return "Today is Pansexual and Panromantic Awareness Day!"
+
+/datum/holiday/lgbt/pan/getStationPrefix()
+	return pick("Pansexual","Panromantic")
 
 /datum/holiday/moth
 	name = "Moth Week"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Port of TGStation's pride week, but with a few Citadel additions.
https://github.com/tgstation/tgstation/pull/59250

Currently the decals won't be visible due to a bug happening here irrelevant to this PR that'll hopefully be fixed soon, but certain downstreams should be able to benefit from this meanwhile.

Also added Pansexual and Panromantic Awareness Day as a new holiday.

April Fool's will also have randomized decals. Chaos.

## Why It's Good For The Game

It's fun and gives the holidays more theming.

## Changelog
:cl: Mothblocks and BlueWildrose
add: LGBT-flag-esque patterns for the pride holidays.
add: Pansexual and Panromantic Awareness Day holiday
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
