### PR TITLE
Makes countdown objects follow their targets better

### DIFF
--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -9,6 +9,8 @@
 	anchored = TRUE
 	layer = GHOST_LAYER
 	color = "#ff0000" // text color
+	appearance_flags = NO_CLIENT_COLOR | RESET_ALPHA | RESET_COLOR | RESET_TRANSFORM
+	vis_flags = VIS_INHERIT_ID
 	var/text_size = 3 // larger values clip when the displayed text is larger than 2 digits.
 	var/started = FALSE
 	var/displayed_text
@@ -17,6 +19,10 @@
 /obj/effect/countdown/Initialize(mapload)
 	. = ..()
 	attach(loc)
+	RegisterSignal(loc, COMSIG_PARENT_QDELETING, .proc/on_parent_deleting)
+
+/obj/effect/countdown/proc/on_parent_deleting(atom/being_deleted, force)
+	qdel(src)
 
 /obj/effect/countdown/examine(mob/user)
 	. = ..()
@@ -24,7 +30,12 @@
 
 /obj/effect/countdown/proc/attach(atom/A)
 	attached_to = A
-	forceMove(get_turf(A))
+	if(ismovable(A))
+		var/atom/movable/M = A
+		moveToNullspace()
+		M.vis_contents |= src
+	else
+		forceMove(get_turf(A))
 
 /obj/effect/countdown/proc/start()
 	if(!started)
@@ -44,7 +55,8 @@
 /obj/effect/countdown/process()
 	if(!attached_to || QDELETED(attached_to))
 		qdel(src)
-	forceMove(get_turf(attached_to))
+	if(!ismovable(attached_to))
+		forceMove(get_turf(attached_to))
 	var/new_val = get_value()
 	if(new_val == displayed_text)
 		return
@@ -56,8 +68,9 @@
 		maptext = null
 
 /obj/effect/countdown/Destroy()
-	attached_to = null
 	STOP_PROCESSING(SSfastprocess, src)
+	UnregisterSignal(attached_to, COMSIG_PARENT_QDELETING)
+	attached_to = null
 	. = ..()
 
 /obj/effect/countdown/ex_act(severity, target, origin) //immune to explosions


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title, if you attempt adding a countdown to something, if it is an /atom/movable, it will be added to vis_contents, otherwise it will utilize old behavior.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better info view.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Countdowns follow their attached object more smoothly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
