### PR TITLE
Fixes chat log saving breaking because of unsupported CSS rules

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -443,7 +443,9 @@ class ChatRenderer {
       const cssRules = styleSheets[i].cssRules;
       for (let i = 0; i < cssRules.length; i++) {
         const rule = cssRules[i];
-        cssText += rule.cssText + '\n';
+        if (rule && typeof rule.cssText === 'string') {
+          cssText += rule.cssText + '\n';
+        }
       }
     }
     cssText += 'body, html { background-color: #141414 }\n';


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
***Ports [tgstation/69211](https://github.com/tgstation/tgstation/pull/69211)***

Title explains it. The chat saving wasn't working because what we can only assume to be an invalid CSS rule. I managed to figure out that it was the 38th of a certain stylesheet, and I'm assuming that it's from the FontAwesome one, but I can't be sure and I also couldn't really figure out a sane way to find out which one caused it exactly, as that file is an utter mess.

Stylemistake and AnturK both said it was a good fix, mostly to prevent stuff like this happening in the future.

Huge props to @Valtosin for actually being the one suggesting the fix, and saving me probably a few hours of digging around.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Saving chat logs is an important feature for many people, and it being functional is also quite important.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex, but really Valtosin for suggesting the fix
fix: Chat saving will no longer break if the CSS stylesheets contain unsupported CSS rules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
