### PR TITLE
Adds VSCode launch options for launching with DreamDaemon, and compiling+launching with LOWMEMORYMODE or TESTING

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,44 @@
       "name": "Launch DreamSeeker",
       "preLaunchTask": "Build All",
       "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+    },
+    {
+      "type": "byond",
+      "request": "launch",
+      "name": "Launch DreamDaemon",
+      "preLaunchTask": "Build All",
+      "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+      "dreamDaemon": true
+    },
+    {
+      "type": "byond",
+      "request": "launch",
+      "name": "Launch DreamSeeker (TESTING)",
+      "preLaunchTask": "Build All (TESTING)",
+      "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+    },
+    {
+      "type": "byond",
+      "request": "launch",
+      "name": "Launch DreamDaemon (TESTING)",
+      "preLaunchTask": "Build All (TESTING)",
+      "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+      "dreamDaemon": true
+    },
+    {
+      "type": "byond",
+      "request": "launch",
+      "name": "Launch DreamSeeker (LOWMEMORYMODE)",
+      "preLaunchTask": "Build All (LOWMEMORYMODE)",
+      "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+    },
+    {
+      "type": "byond",
+      "request": "launch",
+      "name": "Launch DreamDaemon (LOWMEMORYMODE)",
+      "preLaunchTask": "Build All (LOWMEMORYMODE)",
+      "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+      "dreamDaemon": true
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,6 +25,56 @@
 			"label": "Build All"
 		},
 		{
+			"type": "process",
+			"command": "tools/build/build",
+			"windows": {
+				"command": ".\\tools\\build\\build.bat"
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": {
+				"kind": "build"
+			},
+			"dependsOn": "dm: reparse",
+			"args": [
+				"-DTESTING"
+			],
+			"label": "Build All (TESTING)"
+		},
+		{
+			"type": "process",
+			"command": "tools/build/build",
+			"windows": {
+				"command": ".\\tools\\build\\build.bat"
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": {
+				"kind": "build"
+			},
+			"dependsOn": "dm: reparse",
+			"args": [
+				"-DLOWMEMORYMODE"
+			],
+			"label": "Build All (LOWMEMORYMODE)"
+		},
+		{
 			"type": "dreammaker",
 			"dme": "tgstation.dme",
 			"problemMatcher": [


### PR DESCRIPTION
No CL since no player-facing changes

This makes it possible to just compile+launch with `LOWMEMORYMODE` or `TESTING` from VSCode without having to manually pass those flags through dm.exe or slapping those flags somewhere in the codebase. Coder QoL basically

![image](https://github.com/Citadel-Station-13/Citadel-Station-13/assets/6356337/6d17e743-5ff7-4e5c-a9f6-ba4e7c69320f)

Handy things, those are!