### PR TITLE
TGUI compile fix: brings in TGstation PRs 63314, 64461, and 64513

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,8 +11,8 @@ export BYOND_MINOR=1556
 export RUST_G_VERSION=0.4.10
 
 #node version
-export NODE_VERSION=12
-export NODE_VERSION_PRECISE=12.22.4
+export NODE_VERSION=16
+export NODE_VERSION_PRECISE=16.13.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7

--- a/tgui/.yarnrc.yml
+++ b/tgui/.yarnrc.yml
@@ -10,6 +10,8 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
 
+pnpEnableEsmLoader: false
+
 preferAggregateCacheInfo: true
 
 preferInteractive: true

--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,11 +1,5 @@
 @echo off
-where node.exe >nul 2>nul
-if %errorlevel% == 0 (
-	echo | set /p printed_str="Using system-wide Node "
-	call node.exe --version
-	call node.exe %*
-	goto exit_with_last_error_level
-)
+set NODE_SKIP_PLATFORM_CHECK=1
 call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
 	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -30,8 +30,8 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
 $NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
-$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x86/node.exe"
-$NodeTargetDir = "$Cache\node-v$NodeVersion"
+$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
+$NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"
 
 ## Just print the path and exit


### PR DESCRIPTION
(except for downgrading nodejs to 14.)

This ports the following PRs:
tgstation/tgstation/pull/63314
tgstation/tgstation/pull/64461
tgstation/tgstation/pull/64513

This means that you can now compile the codebase on modern hardware even if you have a modern version of Node already installed on your system.

No CL since no player-facing changes