### PR TITLE
Puts Radials on splitting stacks for quick splits

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -4,6 +4,13 @@
 /proc/cmp_numeric_asc(a,b)
 	return a - b
 
+// please don't ask
+/proc/cmp_numeric_text_desc(a, b)
+	return text2num(b) - text2num(a)
+
+/proc/cmp_numeric_text_asc(a, b)
+	return text2num(a) - text2num(b)
+
 /proc/cmp_text_asc(a,b)
 	return sorttext(b,a)
 

--- a/code/datums/elements/object_reskinning.dm
+++ b/code/datums/elements/object_reskinning.dm
@@ -65,7 +65,7 @@
 			icon = to_reskin.unique_reskin[reskin_option]["icon"] ? to_reskin.unique_reskin[reskin_option]["icon"] : to_reskin.icon,
 			icon_state = to_reskin.unique_reskin[reskin_option]["icon_state"] ? to_reskin.unique_reskin[reskin_option]["icon_state"] : to_reskin.icon_state)
 		items += list("[reskin_option]" = item_image)
-	sort_list(items)
+	items = sort_list(items)
 
 	// Display to the user
 	var/pick = show_radial_menu(user, to_reskin, items, custom_check = CALLBACK(src, .proc/check_reskin_menu, user, to_reskin), radius = 38, require_near = TRUE)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -532,7 +532,7 @@
 		if(stackmaterial == "Custom")
 			stackmaterial = round(input(user, "How many sheets do you wish to take out of this stack?\nMax: [max]") as null|num)
 		stackmaterial = isnum(stackmaterial) ? stackmaterial : text2num(stackmaterial)
-	stackmaterial = min(max, stackmaterial)
+	stackmaterial = min(get_amount(), stackmaterial)
 	if(stackmaterial == null || stackmaterial <= 0 || !user.canUseTopic(src, BE_CLOSE, TRUE, FALSE)) //, !iscyborg(user)
 		return
 	split_stack(user, stackmaterial)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -486,8 +486,52 @@
 		return
 	//get amount from user
 	var/max = get_amount()
-	var/stackmaterial = round(input(user,"How many sheets do you wish to take out of this stack? (Maximum  [max])") as null|num)
-	max = get_amount()
+	var/list/quick_split
+	for(var/option in list(1, 2, 3, 4, 5, 6, 7, "One", "Five", "Ten", "Custom"))
+		var/mutable_appearance/option_display = new(src)
+		option_display.filters = null
+		option_display.cut_overlays()
+		option_display.pixel_x = 0
+		option_display.pixel_y = 0
+
+		switch(option)
+			if("Custom")
+				var/list/sort_numbers = quick_split
+				sort_numbers = sort_list(sort_numbers, /proc/cmp_numeric_text_desc)
+				option_display.maptext = MAPTEXT("?")
+				quick_split = list("Custom" = option_display)
+				quick_split += sort_numbers
+			if("One")
+				option = 1
+				option_display.maptext = MAPTEXT("1")
+			if("Five")
+				if(max > 5)
+					option = 5
+					option_display.maptext = MAPTEXT("5")
+				else
+					continue
+			if("Ten")
+				if(max > 10)
+					option = 10
+					option_display.maptext = MAPTEXT("10")
+				else
+					continue
+			else
+				if(max % option == 0)
+					option_display.maptext = MAPTEXT(max / option)
+					option = max / option
+				else
+					continue
+		if(option != "Custom")
+			LAZYSET(quick_split, "[option]", option_display)
+	var/stackmaterial
+	if(length(quick_split) <= 2)
+		stackmaterial = round(input(user, "How many sheets do you wish to take out of this stack?\nMax: [max]") as null|num)
+	else
+		stackmaterial = show_radial_menu(user, get_atom_on_turf(src), quick_split, require_near = TRUE, tooltips = TRUE)
+		if(stackmaterial == "Custom")
+			stackmaterial = round(input(user, "How many sheets do you wish to take out of this stack?\nMax: [max]") as null|num)
+		stackmaterial = isnum(stackmaterial) ? stackmaterial : text2num(stackmaterial)
 	stackmaterial = min(max, stackmaterial)
 	if(stackmaterial == null || stackmaterial <= 0 || !user.canUseTopic(src, BE_CLOSE, TRUE, FALSE)) //, !iscyborg(user)
 		return

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -487,7 +487,7 @@
 	//get amount from user
 	var/max = get_amount()
 	var/list/quick_split
-	for(var/option in list(1, 2, 3, 4, 5, 6, 7, "One", "Five", "Ten", "Custom"))
+	for(var/option in list(2, 3, 4, 5, 6, 7, "One", "Five", "Ten", "Custom"))
 		var/mutable_appearance/option_display = new(src)
 		option_display.filters = null
 		option_display.cut_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of life.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Splitting stacks will present you with a radial full of quick options.
add: Adds text number sorters for coders with VERY SPECIFIC cases.
fix: Object reskinning radials were meant to be sorted alphabetically.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
