### PR TITLE
throttles mouse movement calls

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -92,7 +92,11 @@
 	. = 1
 
 //Please don't roast me too hard
+//Oh don't worry, We Will.
 /client/MouseMove(object, location, control, params)
+	if(next_mousemove > world.time)
+		return
+	next_mousemove = world.time + world.tick_lag
 	mouseParams = params
 	mouse_location_ref = WEAKREF(location)
 	mouse_object_ref = WEAKREF(object)

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -94,9 +94,9 @@
 //Please don't roast me too hard
 //Oh don't worry, We Will.
 /client/MouseMove(object, location, control, params)
-	if(next_mousemove > world.time)
+	if(!COOLDOWN_FINISHED(src, next_mousemove))
 		return
-	next_mousemove = world.time + world.tick_lag
+	COOLDOWN_START(src, next_mousemove, 0) //COOLDOWN_FINISHED() sees the world tick and cooldown timer being equal as a state wherein the cooldown has not finished. So the cooldown timer here is 0 to throttle only for the rest of the tick.
 	mouseParams = params
 	mouse_location_ref = WEAKREF(location)
 	mouse_object_ref = WEAKREF(object)
@@ -110,6 +110,9 @@
 	..()
 
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
+	if(!COOLDOWN_FINISHED(src, next_mousedrag))
+		return
+	COOLDOWN_START(src, next_mousedrag, 0) //See comment in MouseMove() for why this is 0.
 	mouseParams = params
 	mouse_location_ref = WEAKREF(over_location)
 	mouse_object_ref = WEAKREF(over_object)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -189,3 +189,6 @@
 
 	/// AFK tracking
 	var/last_activity = 0
+
+	/// The next point in time at which the client is allowed to send a mousemove()
+	var/next_mousemove = 0

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -190,5 +190,6 @@
 	/// AFK tracking
 	var/last_activity = 0
 
-	/// The next point in time at which the client is allowed to send a mousemove()
-	var/next_mousemove = 0
+	/// The next point in time at which the client is allowed to send a mousemove() or mousedrag()
+	COOLDOWN_DECLARE(next_mousemove)
+	COOLDOWN_DECLARE(next_mousedrag)


### PR DESCRIPTION
So right now it's possible to DoS a citmain-running server by simply cranking your client framerate up as far as your computer can handle, turning on combat mode, and shaking the ever-living Fuck out of your mouse. This causes Dreamseeker to send the server a mouse movement command for *every single pixel your mouse moves*

That is, needless to say, not ideal!

Even moreso considering `MouseMove()` has some distinctly non-negligible costs associated with it (most notably: a signal call).

So this PR makes the cost of `MouseMove()` far more consistent (scaling far more predictably with playercounts) with one simple trick: shrimply throttling the proc.

Judging from a quick test at both 0fps (server tickrate locked) and 100fps, it seems like this works.