### PR TITLE
Fix tgui dev server on Windows

### DIFF
--- a/tgui/packages/tgui-dev-server/util.js
+++ b/tgui/packages/tgui-dev-server/util.js
@@ -6,6 +6,7 @@
 
 import fs from 'fs';
 import path from 'path';
+
 import { require } from './require.js';
 
 const globPkg = require('glob');
@@ -19,14 +20,14 @@ export const resolveGlob = (...sections) => {
   const unsafePaths = globPkg.sync(path.resolve(...sections), {
     strict: false,
     silent: true,
+    windowsPathsNoEscape: true,
   });
   const safePaths = [];
   for (let path of unsafePaths) {
     try {
       fs.statSync(path);
       safePaths.push(path);
-    }
-    catch {}
+    } catch {}
   }
   return safePaths;
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
***Port of [tgstation#82032](https://github.com/tgstation/tgstation/pull/82032)***

Fixes starting the tgui dev server on Windows machines.

Currently on Windows when starting the tgui dev server, it will be unable to find the Byond cache at any of the predefined paths it searches, and resort to using the registry even if one of the predefined paths should successfully locate it. Then, it will fail to find the tmp# folder inside that cache folder even if it exists.

The reason is that on Windows, the glob package requires forward slashes when you call its methods such as sync(), as documented in the glob module's documentation:

> Note Glob patterns should always use / as a path separator, even on Windows systems, as \ is used to escape glob characters. If you wish to use \ as a path separator instead of using it as an escape character on Windows platforms, you may set windowsPathsNoEscape:true in the options. In this mode, special glob characters cannot be escaped, making it impossible to match a literal * ? and so on in filenames.

The function being used to assemble the path, node's path.resolve(), uses backslashes if you call it on a Windows platform. It does not accept any arguments to alter this, nor are there any delimter-conversion functions in the path package. There is an alternative to change the delimiter, forcing POSIX-style path.resolve() by calling path.posix.resolve(), however this removes the drive letter and does not work as a valid path on Windows.

For example:
What we need to pass to globPkg.sync(): `C:/Users/SomeName/Documents/Byond/cache`
What path.resolve() returns: `C:\Users\SomeName\Documents\Byond\cache`
What path.posix.resolve() returns: `/Users/SomeName/Documents/Byond/cache`

Unfortunately there is not a method in the node path module to return what we need. Instead, we use the workaround provided in glob's documentation and add the windowsPathsNoEscape option. This COULD have a negative effect when searching for * and ? literals, however a search of resolveGlob() callers shows that none of them do this. * and ? in all callers is intended to be a wildcard, not a literal, so this won't have any impact on anything.

## Why It's Good For The Game
Helps development efforts for developers using Windows.