### PR TITLE
Fixes floor decals and other missing signal-added overlays by making many instances of update_icon properly call its parent

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -296,6 +296,7 @@
 	update_icon()
 
 /atom/movable/screen/robot/lamp/update_icon()
+	. = ..()
 	if(robot?.lamp_enabled)
 		icon_state = "lamp_on"
 	else

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -47,7 +47,7 @@
 
 
 /obj/machinery/button/update_icon()
-	cut_overlays()
+	. = ..()
 	if(panel_open)
 		icon_state = "button-open"
 	else if(stat & (NOPOWER|BROKEN))

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -151,6 +151,7 @@
 // if BROKEN, display blue screen of death icon AI uses
 // if timing=true, run update display function
 /obj/machinery/door_timer/update_icon()
+	. = ..()
 	if(stat & (NOPOWER))
 		icon_state = "frame"
 		return
@@ -169,7 +170,6 @@
 	else
 		if(maptext)
 			maptext = ""
-	return
 
 
 // Adds an icon in case the screen is broken/off, stolen from status_display.dm

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -404,6 +404,7 @@
 		throw_at(thrown_by, throw_range+2, throw_speed, null, TRUE)
 
 /obj/item/melee/baton/boomerang/update_icon()
+	. = ..()
 	if(turned_on)
 		icon_state = "[initial(icon_state)]_active"
 	else if(!cell)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -365,6 +365,7 @@
 	var/list/viewing_ui = list()
 
 /obj/structure/displaycase/forsale/update_icon()	//remind me to fix my shitcode later
+	. = ..()
 	var/icon/I
 	if(open)
 		I = icon('icons/obj/stationobjs.dmi',"laserboxb0")
@@ -379,7 +380,6 @@
 		S.Scale(17,17)
 		I.Blend(S,ICON_UNDERLAY,8,12)
 	src.icon = I
-	return
 
 /obj/structure/displaycase/forsale/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -221,6 +221,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	id = "[idnum][id]"
 
 /obj/structure/bodycontainer/crematorium/update_icon()
+	. = ..()
 	if(!connected || connected.loc != src)
 		icon_state = "crema0"
 	else

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -162,8 +162,6 @@
 /turf/open/floor/blob_act(obj/structure/blob/B)
 	return
 
-/turf/open/floor/update_icon()
-
 /turf/open/floor/attack_paw(mob/user)
 	return attack_hand(user)
 

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -28,6 +28,7 @@
 	return ..()
 
 /turf/open/floor/circuit/update_icon()
+	. = ..()
 	if(on)
 		if(LAZYLEN(SSmapping.nuke_threats))
 			icon_state = "rcircuitanim"

--- a/code/modules/antagonists/blob/blob/theblob.dm
+++ b/code/modules/antagonists/blob/blob/theblob.dm
@@ -77,6 +77,7 @@
 		. = . || (caller.pass_flags & PASSBLOB)
 
 /obj/structure/blob/update_icon() //Updates color based on overmind color if we have an overmind.
+	. = ..()
 	if(overmind)
 		add_atom_colour(overmind.blobstrain.color, FIXED_COLOUR_PRIORITY)
 	else

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -25,6 +25,7 @@
 		playsound(src, 'sound/weapons/handcuffs.ogg', 30, TRUE, -3)
 
 /obj/item/assembly/mousetrap/update_icon()
+	. = ..()
 	if(armed)
 		icon_state = "mousetraparmed"
 	else

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -57,9 +57,9 @@
 	return TRUE
 
 /obj/item/assembly/signaler/update_icon()
+	. = ..()
 	if(holder)
 		holder.update_icon()
-	return
 
 /obj/item/assembly/signaler/ui_status(mob/user)
 	if(is_secured(user))

--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -74,6 +74,7 @@
 	update_icon()
 
 /obj/machinery/atmospherics/components/binary/circulator/update_icon()
+	. = ..()
 	if(!is_operational())
 		icon_state = "circ-p-[flipped]"
 	else if(last_pressure_delta > 0)

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -26,6 +26,7 @@
 	icon_state = "he_map-3"
 
 /obj/machinery/atmospherics/components/unary/heat_exchanger/update_icon()
+	. = ..()
 	if(nodes[1])
 		icon_state = "he1"
 		var/obj/machinery/atmospherics/node = nodes[1]

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -31,6 +31,7 @@
 	return ..(target, given_layer, TRUE)
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/update_icon()
+	. = ..()
 	icon_state = "pipe[nodes[1] ? "1" : "0"][nodes[2] ? "1" : "0"]-[piping_layer]"
 	update_layer()
 	update_alpha()

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -25,6 +25,7 @@
 			initialize_directions = EAST|WEST
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/update_icon()
+	. = ..()
 	icon_state = "pipe[nodes[1] ? "1" : "0"][nodes[2] ? "1" : "0"]-[piping_layer]"
 	update_layer()
 	update_alpha()

--- a/code/modules/atmospherics/machinery/pipes/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/simple.dm
@@ -28,6 +28,7 @@
 			initialize_directions = EAST|WEST
 
 /obj/machinery/atmospherics/pipe/simple/update_icon()
+	. = ..()
 	icon_state = "pipe[nodes[1] ? "1" : "0"][nodes[2] ? "1" : "0"]-[piping_layer]"
 	update_layer()
 	update_alpha()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -388,6 +388,7 @@
 	..()
 
 /obj/item/clothing/glasses/sunglasses/blindfold/white/update_icon(mob/living/carbon/human/user)
+	. = ..()
 	if(ishuman(user) && !colored_before)
 		add_atom_colour("#[user.left_eye_color]", FIXED_COLOUR_PRIORITY)
 		colored_before = TRUE

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -155,6 +155,7 @@
 	..()
 
 /obj/item/clothing/head/kitty/update_icon(mob/living/carbon/human/user)
+	. = ..()
 	if(ishuman(user))
 		add_atom_colour("#[user.hair_color]", FIXED_COLOUR_PRIORITY)
 

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -104,6 +104,7 @@ GLOBAL_LIST_INIT(marker_beacon_colors, list(
 	. += "<span class='notice'>Alt-click to select a color. Current color is [picked_color].</span>"
 
 /obj/structure/marker_beacon/update_icon()
+	. = ..()
 	while(!picked_color || !GLOB.marker_beacon_colors[picked_color])
 		picked_color = pick(GLOB.marker_beacon_colors)
 	icon_state = "[initial(icon_state)][lowertext(picked_color)]-on"

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -186,9 +186,6 @@
 /obj/machinery/stasis/survival_pod/play_power_sound()
 	return
 
-/obj/machinery/stasis/survival_pod/update_icon()
-	return
-
 //NanoMed
 /obj/machinery/vending/wallmed/survival_pod
 	name = "survival pod medical supply"

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -199,6 +199,7 @@ Doesn't work on other aliens/AI.*/
 		add_ranged_ability(user, message, TRUE)
 
 /obj/effect/proc_holder/alien/neurotoxin/update_icon()
+	. = ..()
 	action.button_icon_state = "alien_neurotoxin_[active]"
 	action.UpdateButtons()
 

--- a/code/modules/mob/living/silicon/pai/pai_update_icon.dm
+++ b/code/modules/mob/living/silicon/pai/pai_update_icon.dm
@@ -1,4 +1,5 @@
 /mob/living/silicon/pai/update_icon()
+	. = ..()
 	if(chassis == "custom")			//Make sure custom exists if it's set to custom
 		custom_holoform_icon = client?.prefs?.get_filtered_holoform(HOLOFORM_FILTER_PAI)
 		if(!custom_holoform_icon)

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -276,6 +276,7 @@
 	internal_ext.afterattack(target, user, null)
 
 /mob/living/simple_animal/bot/firebot/update_icon()
+	. = ..()
 	if(!on)
 		icon_state = "firebot0"
 		return

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -380,6 +380,7 @@
 	target = null
 
 /mob/living/simple_animal/bot/floorbot/update_icon()
+	. = ..()
 	icon_state = "floorbot[on]"
 
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -401,6 +401,7 @@
 	action = new(src)
 
 /obj/effect/proc_holder/wrap/update_icon()
+	. = ..()
 	action.button_icon_state = "wrap_[active]"
 	action.UpdateButtons()
 

--- a/code/modules/plumbing/plumbers/acclimator.dm
+++ b/code/modules/plumbing/plumbers/acclimator.dm
@@ -57,6 +57,7 @@
 	reagents.handle_reactions()
 
 /obj/machinery/plumbing/acclimator/update_icon()
+	. = ..()
 	icon_state = initial(icon_state)
 	switch(acclimate_state)
 		if(COOLING)

--- a/code/modules/power/reactor/rbmk.dm
+++ b/code/modules/power/reactor/rbmk.dm
@@ -486,6 +486,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 				WS.fire()
 
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/update_icon()
+	. = ..()
 	icon_state = "reactor_off"
 	switch(temperature)
 		if(0 to 200)

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -7,6 +7,7 @@
 	max_ammo = 20
 
 /obj/item/ammo_box/magazine/recharge/update_icon()
+	. = ..()
 	desc = "[initial(desc)] It has [stored_ammo.len] shot\s left."
 	icon_state = "oldrifle-[round(ammo_count(),4)]"
 

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -7,6 +7,7 @@
 	max_ammo = 10
 
 /obj/item/ammo_box/magazine/m10mm/rifle/update_icon()
+	. = ..()
 	if(ammo_count())
 		icon_state = "75-8"
 	else

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -6,6 +6,7 @@
 	caliber = ".50"
 
 /obj/item/ammo_box/magazine/sniper_rounds/update_icon()
+	. = ..()
 	if(ammo_count())
 		icon_state = "[initial(icon_state)]-ammo"
 	else

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -88,6 +88,7 @@
 	list_reagents = list(/datum/reagent/medicine/adminordrazine/quantum_heal = 80, /datum/reagent/medicine/synaptizine = 20)
 
 /obj/item/reagent_containers/hypospray/combat/nanites/update_icon()
+	. = ..()
 	if(reagents.total_volume > 0)
 		icon_state = initial(icon_state)
 	else
@@ -266,6 +267,7 @@
 	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/salbutamol = 20, /datum/reagent/medicine/spaceacillin = 20)
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure/update_icon()
+	. = ..()
 	if(reagents.total_volume > 30)
 		icon_state = initial(icon_state)
 	else if (reagents.total_volume > 0)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -43,6 +43,7 @@
 
 // update iconstate and dpdir due to dir and type
 /obj/structure/disposalconstruct/update_icon()
+	. = ..()
 	icon_state = initial(pipe_type.icon_state)
 	if(is_pipe())
 		icon_state = "con[icon_state]"

--- a/code/modules/shuttle/spaceship_navigation_beacon.dm
+++ b/code/modules/shuttle/spaceship_navigation_beacon.dm
@@ -30,6 +30,7 @@
 
 // update the icon_state
 /obj/machinery/spaceship_navigation_beacon/update_icon()
+	. = ..()
 	if(powered())
 		icon_state = "core"
 	else

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -40,6 +40,7 @@
 	return
 
 /obj/effect/proc_holder/spell/aimed/update_icon()
+	. = ..()
 	if(!action)
 		return
 	action.button_icon_state = "[base_icon_state][active]"

--- a/code/modules/spells/spell_types/pointed/pointed.dm
+++ b/code/modules/spells/spell_types/pointed/pointed.dm
@@ -57,6 +57,7 @@
 	return
 
 /obj/effect/proc_holder/spell/pointed/update_icon()
+	. = ..()
 	if(!action)
 		return
 	if(active)

--- a/code/modules/spells/spell_types/taeclowndo.dm
+++ b/code/modules/spells/spell_types/taeclowndo.dm
@@ -47,6 +47,7 @@
 	new /obj/item/grown/bananapeel(target)
 
 /obj/effect/proc_holder/spell/aimed/banana_peel/update_icon()
+	. = ..()
 	if(!action)
 		return
 	if(active)
@@ -55,7 +56,6 @@
 		action.button_icon_state = action_icon_state
 
 	action.UpdateButtons()
-	return
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /obj/effect/proc_holder/spell/targeted/touch/megahonk


### PR DESCRIPTION
Exactly what it says on the tin
![image](https://github.com/Citadel-Station-13/Citadel-Station-13/assets/6356337/db3da340-6ec2-4665-b9a3-c4acce38ff37)

Fixing floor decals themselves was literally a one-line fix, as floors overrode `update_icon()` with a no-op for w/e reason.

## Changelog
:cl: Bhijn and Myr
fix: Floor decals now properly render, as floors no longer have a no-op in their update_icon. 
/:cl:
