### PR TITLE
Removes mob emote spam in chat

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -57,12 +57,13 @@
 	user.log_message(msg, LOG_EMOTE)
 	msg = "<span class='emote'><b>[user]</b> [msg]</span>"
 
-	for(var/mob/M in GLOB.dead_mob_list)
-		if(!M.client || isnewplayer(M) || !user.client)
-			continue
-		var/T = get_turf(user)
-		if(M.stat == DEAD && M.client && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
-			M.show_message(msg)
+	if(user.client)
+		for(var/mob/M in GLOB.dead_mob_list)
+			if(!M.client || isnewplayer(M))
+				continue
+			var/T = get_turf(user)
+			if(M.stat == DEAD && M.client && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
+				M.show_message(msg)
 
 	if(emote_type == EMOTE_AUDIBLE)
 		user.audible_message(msg)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -58,7 +58,7 @@
 	msg = "<span class='emote'><b>[user]</b> [msg]</span>"
 
 	for(var/mob/M in GLOB.dead_mob_list)
-		if(!M.client || isnewplayer(M))
+		if(!M.client || isnewplayer(M) || !user.client)
 			continue
 		var/T = get_turf(user)
 		if(M.stat == DEAD && M.client && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does what the title says. Emotes from mobs without a client that are far away will no longer be displayed in chat for ghosts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes observing and keeping track of things so much more bearable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Mobs without clients no longer send emotes to ghosts, unless they are close.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
